### PR TITLE
[AA] Add auto augmentation wrapper

### DIFF
--- a/dali/python/nvidia/dali/auto_aug/__init__.py
+++ b/dali/python/nvidia/dali/auto_aug/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/dali/python/nvidia/dali/auto_aug/core/__init__.py
+++ b/dali/python/nvidia/dali/auto_aug/core/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali.auto_aug.core._augmentation import Augmentation as _Augmentation
+from nvidia.dali.auto_aug.core.decorator import augmentation
+
+__all__ = ("augmentation", "_Augmentation")

--- a/dali/python/nvidia/dali/auto_aug/core/__init__.py
+++ b/dali/python/nvidia/dali/auto_aug/core/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nvidia.dali.auto_aug.core._augmentation import Augmentation as _Augmentation
+from nvidia.dali.auto_aug.core._augmentation import signed_bin, Augmentation as _Augmentation
 from nvidia.dali.auto_aug.core.decorator import augmentation
 
-__all__ = ("augmentation", "_Augmentation")
+__all__ = ("signed_bin", "augmentation", "_Augmentation")

--- a/dali/python/nvidia/dali/auto_aug/core/_args.py
+++ b/dali/python/nvidia/dali/auto_aug/core/_args.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+
+
+class MissingArgException(Exception):
+
+    def __init__(self, message, augmentation, missing_args):
+        super().__init__(message)
+        self.augmentation = augmentation
+        self.missing_args = missing_args
+
+
+class UnusedArgException(Exception):
+
+    def __init__(self, message, unused_args):
+        super().__init__(message)
+        self.unused_args = unused_args
+
+
+def filter_extra_accepted_kwargs(fun, kwargs, skip_positional=0):
+    sig = inspect.signature(fun)
+    # the params from signature with up to skip_positional filtered out
+    # (less only if there is not enough of positional args)
+    params = [(name, param) for i, (name, param) in enumerate(sig.parameters.items())
+              if i >= skip_positional or param.kind not in
+              [inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.POSITIONAL_ONLY]]
+    extra = [
+        name for (name, param) in params
+        if param.kind in [inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY]
+    ]
+    return {name: value for name, value in kwargs.items() if name in extra}
+
+
+def get_required_kwargs(fun, skip_positional=0):
+    sig = inspect.signature(fun)
+    # the params from signature with up to skip_positional filtered out
+    # (less only if there is not enough of positional args)
+    params = [(name, param) for i, (name, param) in enumerate(sig.parameters.items())
+              if i >= skip_positional or param.kind not in
+              [inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.POSITIONAL_ONLY]]
+    return [
+        name for name, param in params if param.default is inspect.Parameter.empty
+        and param.kind in [inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY]
+    ]
+
+
+def get_num_positional_args(fun):
+    sig = inspect.signature(fun)
+    return len([
+        name for name, param in sig.parameters.items() if param.kind in
+        [inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.POSITIONAL_ONLY]
+    ])
+
+
+def get_missing_kwargs(fun, kwargs, skip_positional=0):
+    required = get_required_kwargs(fun, skip_positional=skip_positional)
+    return [name for name in required if name not in kwargs]
+
+
+def filter_unused_args(augmentations, kwargs):
+    used_kwargs = set(kwarg_name for augment in augmentations
+                      for kwarg_name in filter_extra_accepted_kwargs(augment.op, kwargs, 2))
+    return [kwarg_name for kwarg_name in kwargs if kwarg_name not in used_kwargs]
+
+
+def forbid_unused_kwargs(augmentations, kwargs, call_name):
+    unused_args = filter_unused_args(augmentations, kwargs)
+    if unused_args:
+        subject, verb = ("kwarg", "is") if len(unused_args) == 1 else ("kwargs", "are")
+        unused_kwargs_str = ", ".join(unused_args)
+        raise UnusedArgException(
+            f"The {call_name} got unexpected {subject}. "
+            f"The {subject} `{unused_kwargs_str}` {verb} not used by any of the augmentations.",
+            unused_args=unused_args)

--- a/dali/python/nvidia/dali/auto_aug/core/_augmentation.py
+++ b/dali/python/nvidia/dali/auto_aug/core/_augmentation.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+from typing import Callable, Tuple, Optional, Union
+
+from nvidia.dali import fn, types
+from nvidia.dali.data_node import DataNode as _DataNode
+from nvidia.dali.auto_aug.core._args import filter_extra_accepted_kwargs, \
+    get_missing_kwargs, get_num_positional_args, MissingArgException
+
+try:
+    import numpy as np
+except ImportError:
+    raise RuntimeError(
+        "Could not import numpy. DALI's automatic augmentation examples depend on numpy. "
+        "Please install numpy to use the examples.")
+
+from numpy import typing as npt
+
+
+class _UndefinedParam:
+    """Use _UndefinedParam as a kwarg default when it matters to distinguish between `kwarg=None`
+    and not specifying the kwarg"""
+
+
+class Augmentation:
+    """
+    Wrapper for transformations implemented with DALI that are meant to be used with
+    automatic augmentations. You should not need to instantiate this class directly,
+    use `@augmentation` decorator instead.
+    """
+
+    def __init__(
+        self,
+        op: Callable[..., _DataNode],
+        mag_range: Optional[Union[Tuple[float, float], np.ndarray]] = None,
+        randomly_negate: Optional[bool] = None,
+        as_param: Optional[Callable[[float], npt.ArrayLike]] = None,
+        param_device: Optional[str] = None,
+        name: Optional[str] = None,
+    ):
+        self._op = op
+        self._mag_range = mag_range
+        self._randomly_negate = randomly_negate
+        self._as_param = as_param
+        self._param_device = param_device
+        self._name = name
+        self._validate_op_sig()
+
+    def __repr__(self):
+        params = [
+            f"{name}={repr(val)}" for name, val in self._get_config().items() if val is not None
+        ]
+        return f"Augmentation({', '.join([repr(self.op)] + params)})"
+
+    def __call__(self, sample: _DataNode, *, magnitude_bin: Optional[Union[int, _DataNode]] = None,
+                 num_magnitude_bins: Optional[int] = None, random_sign: Optional[_DataNode] = None,
+                 **kwargs) -> _DataNode:
+        """
+        Applies the decorated transformation to the `sample` as if by calling
+        `self.op(sample, param, **kwargs)` where
+        `param = as_param(magnitudes[magnitude_bin] * ((-1) ** random_sign))`.
+
+        Parameter
+        ---------
+        sample : DataNode
+            A batch of samples to be transformed.
+        magnitude_bin: int or DataNode
+            The magnitude bin from range `[0, num_magnitude_bins - 1]`. The bin is used to get
+            parameter for the transformation. The parameter is computed as if by calling
+            `as_param(magnitudes[magnitude_bin] * ((-1) ** random_sign))`, where
+            `magnitudes=linspace(mag_range[0], mag_range[1], num_magnitude_bins)`.
+            If the `mag_range` is custom `nd.array`, it will be used as `magnitudes` directly.
+        num_magnitude_bins: int
+            The total number of magnitude bins (limits the accepted range of
+            `magnitude_bin` to `[0, num_magnitude_bins - 1]`).
+        random_sign : DataNode
+            A batch of {0, 1} integers that, in principle, should be sampled uniformly at random.
+            For augmentations declared with `random_negate=True`, it determines if the magnitude
+            is negated (for 1) or not (for 0).
+        kwargs
+            Dictionary with extra arguments to pass to the `self.op`. The op's signature
+            is checked for any additional arguments (apart from the sample and parameter) and the
+            arguments with matching names are passed to the call.
+
+        Returns
+        -------
+        DataNode
+            A batch of transformed samples.
+    """
+        assert magnitude_bin is None or isinstance(magnitude_bin, (_DataNode, int))
+        num_mandatory_positional_args = 2
+        params = self._get_param(magnitude_bin, num_magnitude_bins, random_sign)
+        op_kwargs = filter_extra_accepted_kwargs(self.op, kwargs, num_mandatory_positional_args)
+        missing_args = get_missing_kwargs(self.op, kwargs, num_mandatory_positional_args)
+        if missing_args:
+            raise MissingArgException(
+                f"The augmentation `{self.name}` requires following named argument(s) "
+                f"which were not provided to the call: {', '.join(missing_args)}. "
+                f"Please make sure to pass the required arguments when calling the "
+                f"augmentation.", augmentation=self, missing_args=missing_args)
+        return self.op(sample, params, **op_kwargs)
+
+    @property
+    def op(self):
+        return self._op
+
+    @property
+    def mag_range(self):
+        return self._mag_range
+
+    @property
+    def as_param(self):
+        return self._as_param or _np_wrap
+
+    @property
+    def randomly_negate(self):
+        return self._randomly_negate or False
+
+    @property
+    def param_device(self):
+        return self._param_device or "cpu"
+
+    @property
+    def name(self):
+        return self._name or self.op.__name__
+
+    def augmentation(self, mag_range=_UndefinedParam, randomly_negate=_UndefinedParam,
+                     as_param=_UndefinedParam, param_device=_UndefinedParam, name=_UndefinedParam,
+                     augmentation_cls=None):
+        """
+        The method to update augmentation parameters specified with `@augmentation` decorator.
+        Returns a new augmentation with the original operation decorated but updated parameters.
+        Parameters that are not specified are kept as in the initial augmentation.
+        """
+        cls = augmentation_cls or self.__class__
+        config = self._get_config()
+        for key, value in dict(mag_range=mag_range, randomly_negate=randomly_negate,
+                               as_param=as_param, param_device=param_device, name=name).items():
+            assert key in config
+            if value is not _UndefinedParam:
+                config[key] = value
+        return cls(self.op, **config)
+
+    def _get_config(self):
+        return {
+            "mag_range": self._mag_range,
+            "as_param": self._as_param,
+            "randomly_negate": self._randomly_negate,
+            "param_device": self._param_device,
+            "name": self._name,
+        }
+
+    def _has_custom_magnitudes(self):
+        return isinstance(self.mag_range, np.ndarray)
+
+    def _map_mag_to_param(self, magnitude):
+        param = self.as_param(magnitude)
+        if _contains_data_node(param):
+            raise Exception(
+                f"The `as_param` callback of `{self.name}` augmentation returned `DataNode`, "
+                f"i.e. an output of DALI pipelined operator, which is not supported there. "
+                f"Instead, the `as_param` callback must return parameter that is `np.ndarray` "
+                f"or is directly convertible to `np.ndarray`, so that the all parameters can "
+                f"be precomputed and reused across iterations.\n\n"
+                f"You can move DALI operators from `as_param` callback to the "
+                f"decorated augmentation code or replace the DALI operators in `as_param` "
+                f"callback with their `dali.experimental.eger` counterparts.\n\n"
+                f"Error in augmentation: {self}.")
+        return np.array(param)
+
+    def _map_mags_to_params(self, magnitudes):
+        params = [self._map_mag_to_param(magnitude) for magnitude in magnitudes]
+        if len(params) >= 2:
+            ref_shape = params[0].shape
+            ref_dtype = params[0].dtype
+            for param, mag in zip(params, magnitudes):
+                if param.shape != ref_shape or param.dtype != ref_dtype:
+                    raise Exception(
+                        f"The `as_param` callback of `{self.name}` augmentation must return the "
+                        f"arrays of the same type and shape for different magnitudes. "
+                        f"Got param of shape {ref_shape} and {ref_dtype} type for magnitude "
+                        f"{magnitudes[0]}, but for magnitude {mag} the returned array "
+                        f"has shape {param.shape} and type {param.dtype}.\n\n"
+                        f"Error in augmentation: {self}.")
+        return np.array(params)
+
+    def _get_magnitudes(self, num_magnitude_bins):
+        mag_range = self.mag_range
+        if mag_range is None:
+            return None
+        if self._has_custom_magnitudes():
+            if num_magnitude_bins is not None and len(mag_range) != num_magnitude_bins:
+                raise Exception(
+                    f"The augmentation `{self.name}` has nd.array of length {len(mag_range)} "
+                    f"specified as the `mag_range`. However, the `num_magnitude_bins` "
+                    f"passed to the call is {num_magnitude_bins}.")
+            return mag_range
+        if num_magnitude_bins is None:
+            raise Exception(
+                f"The `num_magnitude_bins` argument is missing in the call of "
+                f"the `{self.name}` augmentation. Please specify the `num_magnitude_bins` "
+                f"along with the samples and magnitude_bin."
+                f"\nError in augmentation: {self}.")
+        if not hasattr(mag_range, '__len__') or len(mag_range) != 2:
+            raise Exception(
+                f"The `mag_range` must be a tuple of (low, high) ends of magnitude range or "
+                f"nd.array of explicitly defined magnitudes. Got `{self.mag_range}` for "
+                f"augmentation `{self.name}`.")
+        lo, hi = mag_range
+        return np.linspace(lo, hi, num_magnitude_bins, dtype=np.float32)
+
+    def _get_param(self, magnitude_bin, num_magnitude_bins, random_sign=None):
+        assert random_sign is None or isinstance(random_sign, _DataNode)
+        if self.randomly_negate and random_sign is None:
+            warnings.warn(
+                f"The augmentation `{self.name}` was declared with `random_negate=True`, "
+                f"but was called without `random_sign`. A default random source will be "
+                f"created for this call instead. However, if you split batch processing "
+                f"between multiple augmentations, it is best to provide a single common "
+                f"`random_sign` batch manually.", Warning)
+            random_sign = fn.random.uniform(values=[0, 1], dtype=types.INT32)
+        magnitudes = self._get_magnitudes(num_magnitude_bins)
+        if magnitudes is None:
+            return None
+        if magnitude_bin is None:
+            raise Exception(
+                f"The augmentation `{self.name}` has `mag_range` specified, so when called, "
+                f"it requires `magnitude_bin` parameter to select the magnitude from the "
+                f"`mag_range`.\nError in augmentation: {self}.")
+        # if the bin is runtime defined, create Constant node with the array of params
+        # for any possible bin and use subscript to take the right one at each iteration
+        if isinstance(magnitude_bin, _DataNode):
+            if self.randomly_negate:
+                magnitudes = _remap_bins_to_signed_magnitudes(magnitudes)
+                magnitude_bin = 2 * magnitude_bin + random_sign
+            params = self._map_mags_to_params(magnitudes)
+            params = types.Constant(params, device=self.param_device)
+            return params[magnitude_bin]
+        else:
+            # if the bin is static int, then just compute the corresponding param and
+            # make it a constant node
+            if not self.randomly_negate:
+                magnitude = magnitudes[magnitude_bin]
+                param = self._map_mag_to_param(magnitude)
+                return types.Constant(param, device=self.param_device)
+            # if the magnitude is randomly negated, compute param for negated and not
+            # negated magnitude and choose the param on runtime with a sub-script op
+            else:
+                magnitudes = [magnitudes[magnitude_bin]]
+                magnitudes = _remap_bins_to_signed_magnitudes(magnitudes)
+                params = self._map_mags_to_params(magnitudes)
+                params = types.Constant(params, device=self.param_device)
+                return params[random_sign]
+
+    def _validate_op_sig(self):
+        num_positional = get_num_positional_args(self.op)
+        if num_positional <= 1:
+            raise Exception(
+                f"The {self.op} accepts {num_positional} positional argument(s), "
+                f"but the functions decorated with `@augmentation` must accept at least two "
+                f"positional arguments: the samples and parameters.\nError in: {self}.")
+
+
+def _np_wrap(mag):
+    return np.array(mag)
+
+
+def _remap_bins_to_signed_magnitudes(magnitudes):
+
+    def remap_bin_idx(bin_idx):
+        magnitude = magnitudes[bin_idx // 2]
+        if bin_idx % 2:
+            magnitude = -magnitude
+        return magnitude
+
+    return np.array([remap_bin_idx(bin_idx) for bin_idx in range(2 * len(magnitudes))])
+
+
+def _contains_data_node(obj):
+    if isinstance(obj, (tuple, list)):
+        return any(_contains_data_node(el) for el in obj)
+    return isinstance(obj, _DataNode)

--- a/dali/python/nvidia/dali/auto_aug/core/decorator.py
+++ b/dali/python/nvidia/dali/auto_aug/core/decorator.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Type, Tuple, Optional, Union
+
+from nvidia.dali.data_node import DataNode as _DataNode
+from nvidia.dali.auto_aug.core._augmentation import Augmentation
+
+try:
+    import numpy as np
+except ImportError:
+    raise RuntimeError(
+        "Could not import numpy. DALI's automatic augmentation examples depend on numpy. "
+        "Please install numpy to use the examples.")
+
+from numpy import typing as npt
+
+
+def augmentation(function: Optional[Callable[..., _DataNode]] = None, *,
+                 mag_range: Optional[Union[Tuple[float, float], np.ndarray]] = None,
+                 randomly_negate: Optional[bool] = None,
+                 as_param: Optional[Callable[[float], npt.ArrayLike]] = None,
+                 param_device: Optional[str] = None, name: Optional[str] = None,
+                 augmentation_cls: Type[Augmentation] = None):
+    """
+    A decorator turning transformations implemented with DALI into augmentations that
+    can be used by automatic augmentations (e.g. AutoAugment, RandAugment, TrivialAugment).
+
+    The `function` must accept at least two args: a sample and a parameter.
+    The decorator handles computation of the parameter. Instead of the parameter, the
+    decorated augmentation accepts magnitude bin and the total number of bins.
+    Then, the bin is used to compute the parameter as if by calling
+    `as_param(magnitudes[magnitude_bin] * ((-1) ** random_sign))`, where
+    `magnitudes=linspace(mag_range[0], mag_range[1], num_magnitude_bins)`.
+
+    Parameter
+    ---------
+    function : callable
+        A function that accepts at least two positional args: a batch
+        (represented as DataNode) to be processed, and a parameter of the transformation.
+        The function must use DALI operators to process the batch and return a single output
+        of such processing.
+    mag_range : (number, number) or np.ndarray
+        Specifies the range of applicable magnitudes for the operation.
+        If the tuple is provided, the magnitudes will be computed as
+        `linspace(mag_range[0], mag_range[1], num_magnitude_bins)`.
+        If the np.ndarray is provided, it will be used directly instead of the linspace.
+        If no `mag_range` is specified, the parameter passed to the `function` will be `None`.
+    randomly_negate: bool
+        If `True`, the magnitude from the mag_range will be randomly negated for every sample.
+    as_param: callable
+        A callback that transforms the magnitude into a parameter. The parameter will be passed to
+        the decorated operation instead of the plain magnitude. This way, the parameters for the
+        range of magnitudes can be computed once in advance and stored as a Constant node.
+        Note, the callback must return numpy arrays or data directly convertible to numpy arrays
+        (in particular, no pipelined DALI operators can be used in the callback).
+        The output type and dimensionality must be consistent and not depend on the magnitude.
+    param_device: str
+        A "cpu" or "gpu", describes where to store the precomputed parameters.
+    name: str
+        Name of the augmentation. By default, the name of the decorated function is used.
+
+    Returns
+    -------
+    Augmentation
+        The operation wrapped with the Augmentation class so that it can be used with the `auto_aug`
+        transforms.
+    """
+
+    def decorator(function):
+        cls = augmentation_cls or Augmentation
+        return cls(function, mag_range=mag_range, as_param=as_param,
+                   randomly_negate=randomly_negate, param_device=param_device, name=name)
+
+    if function is None:
+        return decorator
+    else:
+        if not callable(function):
+            raise Exception(f"The `@augmentation` decorator was used to decorate the object that "
+                            f"is not callable: {function}.")
+        elif isinstance(function, Augmentation):
+            # it's not clear if we should go with "update the setup" or
+            # "discard and create" semantics here
+            raise Exception(
+                f"The `@augmentation` was applied to already decorated Augmentation. "
+                f"Please call `{function.name}.augmentation` method to modify the augmentation "
+                f"setup or apply the decorator to the underlying `{function.name}.op` directly.\n"
+                f"Error in augmentation: {function}.")
+        return decorator(function)

--- a/dali/test/python/auto_aug/test_augmentation_decorator.py
+++ b/dali/test/python/auto_aug/test_augmentation_decorator.py
@@ -1,0 +1,392 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import nvidia.dali.tensors as _tensors
+from nvidia.dali import pipeline_def, fn, types
+from nvidia.dali.auto_aug.core import augmentation
+from nvidia.dali.auto_aug.core._args import forbid_unused_kwargs
+from nose2.tools import params
+
+from test_utils import check_batch
+from nose_utils import assert_warns, assert_raises
+
+
+def sample_info(cb):
+
+    def idx_in_batch_cb(sample_info):
+        return np.array(cb(sample_info), dtype=np.int32)
+
+    return fn.external_source(idx_in_batch_cb, batch=False)
+
+
+def ref_param(mag_range, mag_range_num_elements, bins_batch, mag_signs_batch=None, as_param=None):
+    if isinstance(mag_range, tuple):
+        assert len(mag_range) == 2
+        lo, hi = mag_range
+        mag_range = np.linspace(lo, hi, mag_range_num_elements)
+    magnitudes = [mag_range[mag_bin] for mag_bin in bins_batch]
+    if mag_signs_batch is not None:
+        assert len(mag_signs_batch) == len(magnitudes)
+        magnitudes = [mag * ((-1)**negate) for mag, negate in zip(magnitudes, mag_signs_batch)]
+    as_param = as_param if as_param is not None else np.array
+    return np.array([as_param(mag) for mag in magnitudes])
+
+
+def test_magnitude_is_none():
+
+    @augmentation
+    def pass_through_sample(sample, param):
+        assert param is None, "If the `mag_range` is not specified the param should be None"
+        return sample
+
+    sample = types.Constant(42)
+    assert pass_through_sample(sample, magnitude_bin=42) is sample
+
+
+def test_lo_hi_mag_range():
+    mag_range = (100, 110)
+    batch_size = 11
+    const_bin = 2
+
+    @augmentation(mag_range=mag_range)
+    def pass_through_mag(sample, param):
+        return param
+
+    @pipeline_def
+    def pipeline():
+        idx_in_batch = sample_info(lambda info: info.idx_in_batch)
+        const_mag = pass_through_mag(types.Constant(42), magnitude_bin=const_bin,
+                                     num_magnitude_bins=5)
+        dyn_mag = pass_through_mag(types.Constant(42), magnitude_bin=idx_in_batch,
+                                   num_magnitude_bins=11)
+        return const_mag, dyn_mag
+
+    p = pipeline(num_threads=4, device_id=0, batch_size=batch_size)
+    p.build()
+    const_mag, dyn_mag = p.run()
+    const_mag_ref = ref_param(mag_range, 5, [const_bin] * batch_size)
+    dyn_mag_ref = ref_param(mag_range, 11, list(range(batch_size)))
+    check_batch(const_mag, const_mag_ref)
+    check_batch(dyn_mag, dyn_mag_ref)
+
+
+def test_explicit_mag_range():
+    mag_range = np.array([1, 1, 2, 3, 5, 8, 13, 21])
+    batch_size = 8
+    const_bin = 7
+
+    @augmentation(mag_range=mag_range)
+    def pass_through_mag(sample, param):
+        return param
+
+    @pipeline_def
+    def pipeline():
+        idx_in_batch = sample_info(lambda info: info.idx_in_batch)
+        const_mag = pass_through_mag(types.Constant(42), magnitude_bin=const_bin)
+        dyn_mag = pass_through_mag(types.Constant(42), magnitude_bin=idx_in_batch)
+        return const_mag, dyn_mag
+
+    p = pipeline(num_threads=4, device_id=0, batch_size=batch_size)
+    p.build()
+    const_mag, dyn_mag = p.run()
+    const_mag_ref = ref_param(mag_range, None, [const_bin] * batch_size)
+    dyn_mag_ref = ref_param(mag_range, None, list(range(batch_size)))
+    check_batch(const_mag, const_mag_ref)
+    check_batch(dyn_mag, dyn_mag_ref)
+
+
+@params((((201, 260), 60, False, 0)), (((301, 330), 30, True, 29)), (((101, 150), 50, False, None)),
+        (((701, 710), 10, True, None)))
+def test_randomly_negate(mag_range, num_magnitude_bins, use_implicit_sign, const_mag):
+    batch_size = 64
+
+    @augmentation(mag_range=mag_range, randomly_negate=True)
+    def pass_through_mag(sample, param):
+        return param
+
+    @pipeline_def
+    def pipeline():
+        mag_sign = None if use_implicit_sign else sample_info(lambda info: info.idx_in_batch % 2)
+        magnitude_bin = const_mag if const_mag is not None else sample_info(
+            lambda info: info.idx_in_batch % num_magnitude_bins)
+
+        return pass_through_mag(types.Constant(42), magnitude_bin=magnitude_bin,
+                                num_magnitude_bins=num_magnitude_bins, random_sign=mag_sign)
+
+    if not use_implicit_sign:
+        p = pipeline(num_threads=4, device_id=0, batch_size=batch_size)
+    else:
+        warn_glob = "The augmentation `pass_through_mag` was * called without `random_sign`"
+        with assert_warns(Warning, glob=warn_glob):
+            p = pipeline(num_threads=4, device_id=0, batch_size=batch_size)
+    p.build()
+    magnitudes, = p.run()
+    magnitudes = [np.array(el) for el in magnitudes]
+    if use_implicit_sign:
+        # the implicit sign is random, just sanity check if
+        # there are some positive and negative magnitudes
+        assert any(el < 0 for el in magnitudes)
+        assert any(el > 0 for el in magnitudes)
+        magnitudes = [np.abs(el) for el in magnitudes]
+
+    mag_sign = None if use_implicit_sign else [i % 2 for i in range(batch_size)]
+    magnitude_bin = [const_mag] * batch_size if const_mag is not None else [
+        i % num_magnitude_bins for i in range(batch_size)
+    ]
+    ref_magnitudes = ref_param(mag_range, num_magnitude_bins, magnitude_bin,
+                               mag_signs_batch=mag_sign)
+    check_batch(magnitudes, ref_magnitudes)
+
+
+@params((4, ), (None, ))
+def test_no_randomly_negate(const_mag):
+    mag_range = (0, 10)
+    num_magnitude_bins = 11
+    batch_size = 17
+
+    @augmentation(mag_range=mag_range)
+    def pass_through_mag(sample, param):
+        return param
+
+    @pipeline_def
+    def pipeline():
+        mag_sign = sample_info(lambda info: info.idx_in_batch % 2)
+        magnitude_bin = const_mag if const_mag is not None else sample_info(
+            lambda info: info.idx_in_batch % num_magnitude_bins)
+
+        # make sure that the augmentation declared without `randomly_negate` ignores the random_sign
+        return pass_through_mag(types.Constant(42), magnitude_bin=magnitude_bin,
+                                num_magnitude_bins=num_magnitude_bins, random_sign=mag_sign)
+
+    p = pipeline(num_threads=4, device_id=0, batch_size=batch_size)
+    p.build()
+    magnitudes, = p.run()
+    magnitude_bin = [const_mag] * batch_size if const_mag is not None else [
+        i % num_magnitude_bins for i in range(batch_size)
+    ]
+    ref_magnitudes = ref_param(mag_range, 11, magnitude_bin)
+    check_batch(magnitudes, ref_magnitudes)
+
+
+@params((((201, 211), 11, 7, np.uint16, "cpu")), (((101, 107), 7, None, np.float32, "gpu")))
+def test_as_param(mag_range, num_magnitude_bins, const_mag, dtype, param_device):
+    batch_size = 31
+
+    def as_param(magnitude):
+        return np.array([magnitude, magnitude + 2, 42], dtype=dtype)
+
+    @augmentation(mag_range=mag_range, randomly_negate=True, as_param=as_param,
+                  param_device=param_device)
+    def pass_through_mag(sample, param):
+        return param
+
+    @pipeline_def
+    def pipeline():
+        mag_sign = sample_info(lambda info: info.idx_in_batch % 2)
+        magnitude_bin = const_mag if const_mag is not None else sample_info(
+            lambda info: info.idx_in_batch % num_magnitude_bins)
+
+        return pass_through_mag(types.Constant(42), magnitude_bin=magnitude_bin,
+                                num_magnitude_bins=num_magnitude_bins, random_sign=mag_sign)
+
+    p = pipeline(num_threads=4, device_id=0, batch_size=batch_size)
+    p.build()
+    magnitudes, = p.run()
+    if param_device == "cpu":
+        assert isinstance(magnitudes, _tensors.TensorListCPU)
+    else:
+        assert isinstance(magnitudes, _tensors.TensorListGPU)
+        magnitudes = magnitudes.as_cpu()
+    magnitudes = [np.array(el) for el in magnitudes]
+
+    mag_sign = [i % 2 for i in range(batch_size)]
+    magnitude_bin = [const_mag] * batch_size if const_mag is not None else [
+        i % num_magnitude_bins for i in range(batch_size)
+    ]
+    ref_magnitudes = ref_param(mag_range, num_magnitude_bins, magnitude_bin,
+                               mag_signs_batch=mag_sign, as_param=as_param)
+    assert np.array(magnitudes).dtype == np.array(ref_magnitudes).dtype
+    check_batch(magnitudes, ref_magnitudes)
+
+
+def test_augmentation_setup_update():
+
+    def dummy_as_param(magnitude):
+        return magnitude + 1
+
+    initial = {
+        "mag_range": (0, 10),
+        "randomly_negate": True,
+        "as_param": dummy_as_param,
+        "param_device": "gpu",
+        "name": "some_other_dummy_name",
+    }
+
+    @augmentation
+    def default_aug(sample, _):
+        return sample
+
+    defaults = {attr: getattr(default_aug, attr) for attr in initial}
+    defaults["name"] = "dummy"
+
+    @augmentation(**initial)
+    def dummy(sample, _):
+        return sample
+
+    for reset_attr in initial:
+        reset_attr_aug = dummy.augmentation(**{reset_attr: None})
+        for attr in initial:
+            reset = getattr(reset_attr_aug, attr)
+            ref = (defaults if attr == reset_attr else initial)[attr]
+            assert reset == ref, f"{attr}: {reset}, {ref} ({reset_attr})"
+
+
+def test_augmentation_nested_decorator_fail():
+
+    @augmentation
+    def dummy(sample, _):
+        return sample
+
+    with assert_raises(Exception,
+                       glob="The `@augmentation` was applied to already decorated Augmentation."):
+        augmentation(dummy, mag_range=(5, 10))
+
+
+def test_as_param_data_node_fail():
+
+    def shear(magnitude):
+        return fn.transforms.shear(shear=magnitude)
+
+    @augmentation(mag_range=(0, 250), as_param=shear)
+    def illegal_shear(sample, shear_mt):
+        return fn.warp_affine(sample, mt=shear_mt)
+
+    @pipeline_def
+    def pipeline():
+        sample = types.Constant(np.full((100, 100, 3), 42, dtype=np.uint8))
+        return illegal_shear(sample, magnitude_bin=5, num_magnitude_bins=10)
+
+    glob_msg = "callback must return parameter that is `np.ndarray` or"
+    with assert_raises(Exception, glob=glob_msg):
+        pipeline(num_threads=4, device_id=0, batch_size=8)
+
+
+@params((True, False), (False, True))
+def test_as_param_non_uniform_fail(non_uniform_shape, non_uniform_type):
+    shape_lo = (2, )
+    shape_hi = (3, )
+
+    def as_param(magnitude):
+        shape = shape_lo if not non_uniform_shape or magnitude < 5 else shape_hi
+        dtype = np.uint8 if not non_uniform_type or magnitude < 3 else np.uint16
+        return np.full(shape, 42, dtype=dtype)
+
+    @augmentation(mag_range=(0, 10), as_param=as_param)
+    def pass_param(sample, param):
+        return param
+
+    @pipeline_def
+    def pipeline():
+        sample = types.Constant(np.full((100, 100, 3), 42, dtype=np.uint8))
+        mag_bin = sample_info(lambda si: si.idx_in_batch)
+        return pass_param(sample, magnitude_bin=mag_bin, num_magnitude_bins=11)
+
+    glob_msg = (f"augmentation must return the arrays of the same type and shape *"
+                f"has shape {shape_hi if non_uniform_shape else shape_lo} and type "
+                f"{'uint16' if non_uniform_type else 'uint8'}.")
+    with assert_raises(Exception, glob=glob_msg):
+        pipeline(num_threads=4, device_id=0, batch_size=8)
+
+
+def test_lack_of_positional_args_fail():
+
+    def no_args():
+        pass
+
+    def one_arg(arg):
+        pass
+
+    def one_kwarg_only(arg, *, kwarg_only):
+        pass
+
+    def kwarg_only(*, kwarg1, kwarg2):
+        pass
+
+    for i, fun in enumerate((no_args, kwarg_only, one_arg, one_kwarg_only)):
+        msg = f"accepts {i // 2} positional argument(s), but the functions decorated"
+        with assert_raises(Exception, glob=msg):
+            augmentation(fun)
+
+
+def test_no_required_kwargs():
+
+    @augmentation
+    def aug(sample, param, extra, another_extra, extra_with_default=None):
+        pass
+
+    @pipeline_def(batch_size=3, num_threads=4, device_id=0)
+    def pipeline(aug, aug_kwargs):
+        return aug(types.Constant(42), **aug_kwargs)
+
+    pipeline(aug, {'extra': None, 'another_extra': 42, 'extra_with_default': 7})
+    pipeline(aug, {'extra': None, 'another_extra': 42})
+
+    with assert_raises(Exception, glob=f"not provided to the call: another_extra"):
+        pipeline(aug, {'extra': None})
+
+    with assert_raises(Exception, glob=f"not provided to the call: extra"):
+        pipeline(aug, {'another_extra': 42})
+
+    with assert_raises(Exception, glob=f"not provided to the call: extra, another_extra"):
+        pipeline(aug, {})
+
+
+def test_unused_kwargs():
+
+    @augmentation
+    def no_extra(sample, _):
+        pass
+
+    @augmentation
+    def aug(sample, param, one_param, another_param):
+        pass
+
+    @augmentation
+    def another_aug(sample, _, another_param, yet_another_param):
+        pass
+
+    augments = (no_extra, aug, another_aug)
+
+    forbid_unused_kwargs(augments, {}, 'dummy')
+    forbid_unused_kwargs(augments, {
+        'one_param': 1,
+        'another_param': 2,
+        'yet_another_param': 3
+    }, 'dummy')
+
+    with assert_raises(Exception, glob="The kwarg `amnother_param` is not used"):
+        forbid_unused_kwargs(augments, {
+            'one_param': 1,
+            'amnother_param': 2,
+            'yet_another_param': 3
+        }, 'dummy')
+
+    with assert_raises(Exception, glob="The kwargs `amnother_param, yemt_another_param` are"):
+        forbid_unused_kwargs(augments, {
+            'one_param': 1,
+            'amnother_param': 2,
+            'yemt_another_param': 3
+        }, 'dummy')

--- a/dali/test/python/auto_aug/test_augmentation_decorator.py
+++ b/dali/test/python/auto_aug/test_augmentation_decorator.py
@@ -79,8 +79,8 @@ def test_lo_hi_mag_range():
     const_mag, dyn_mag = p.run()
     const_mag_ref = ref_param(mag_range, 5, [const_bin] * batch_size)
     dyn_mag_ref = ref_param(mag_range, 11, list(range(batch_size)))
-    check_batch(const_mag, const_mag_ref)
-    check_batch(dyn_mag, dyn_mag_ref)
+    check_batch(const_mag, const_mag_ref, max_allowed_error=0)
+    check_batch(dyn_mag, dyn_mag_ref, max_allowed_error=0)
 
 
 def test_explicit_mag_range():
@@ -104,8 +104,8 @@ def test_explicit_mag_range():
     const_mag, dyn_mag = p.run()
     const_mag_ref = ref_param(mag_range, None, [const_bin] * batch_size)
     dyn_mag_ref = ref_param(mag_range, None, list(range(batch_size)))
-    check_batch(const_mag, const_mag_ref)
-    check_batch(dyn_mag, dyn_mag_ref)
+    check_batch(const_mag, const_mag_ref, max_allowed_error=0)
+    check_batch(dyn_mag, dyn_mag_ref, max_allowed_error=0)
 
 
 @params((((201, 260), 60, False, 0)), (((301, 330), 30, True, 29)), (((101, 150), 50, False, None)),
@@ -148,7 +148,7 @@ def test_randomly_negate(mag_range, num_magnitude_bins, use_implicit_sign, const
     ]
     ref_magnitudes = ref_param(mag_range, num_magnitude_bins, magnitude_bin,
                                mag_signs_batch=mag_sign)
-    check_batch(magnitudes, ref_magnitudes)
+    check_batch(magnitudes, ref_magnitudes, max_allowed_error=0)
 
 
 @params((4, ), (None, ))
@@ -178,7 +178,7 @@ def test_no_randomly_negate(const_mag):
         i % num_magnitude_bins for i in range(batch_size)
     ]
     ref_magnitudes = ref_param(mag_range, 11, magnitude_bin)
-    check_batch(magnitudes, ref_magnitudes)
+    check_batch(magnitudes, ref_magnitudes, max_allowed_error=0)
 
 
 @params((((201, 211), 11, 7, np.uint16, "cpu")), (((101, 107), 7, None, np.float32, "gpu")))
@@ -219,7 +219,7 @@ def test_as_param(mag_range, num_magnitude_bins, const_mag, dtype, param_device)
     ref_magnitudes = ref_param(mag_range, num_magnitude_bins, magnitude_bin,
                                mag_signs_batch=mag_sign, as_param=as_param)
     assert np.array(magnitudes).dtype == np.array(ref_magnitudes).dtype
-    check_batch(magnitudes, ref_magnitudes)
+    check_batch(magnitudes, ref_magnitudes, max_allowed_error=0)
 
 
 def test_augmentation_setup_update():
@@ -344,13 +344,13 @@ def test_no_required_kwargs():
     pipeline(aug, {'extra': None, 'another_extra': 42, 'extra_with_default': 7})
     pipeline(aug, {'extra': None, 'another_extra': 42})
 
-    with assert_raises(Exception, glob=f"not provided to the call: another_extra"):
+    with assert_raises(Exception, glob="not provided to the call: another_extra"):
         pipeline(aug, {'extra': None})
 
-    with assert_raises(Exception, glob=f"not provided to the call: extra"):
+    with assert_raises(Exception, glob="not provided to the call: extra"):
         pipeline(aug, {'another_extra': 42})
 
-    with assert_raises(Exception, glob=f"not provided to the call: extra, another_extra"):
+    with assert_raises(Exception, glob="not provided to the call: extra, another_extra"):
         pipeline(aug, {})
 
 

--- a/qa/TL0_python-self-test-core/test_body.sh
+++ b/qa/TL0_python-self-test-core/test_body.sh
@@ -23,6 +23,7 @@ test_py() {
 test_autograph() {
     ${python_new_invoke_test} -s autograph
     ${python_new_invoke_test} -s conditionals
+    ${python_new_invoke_test} -s auto_aug
 }
 
 test_pytorch() {


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
This is a prerequisite for automatic augmentation library (https://github.com/NVIDIA/DALI/pull/4648).

The automatic augmentations in this context are just different schemes of random selection of augmentation per sample. 

The common idea is that, apart from sampling the augmentation, the schemes provide parameters to the randomly selected augmentations. In order to do that in abstract way, they use the notion of magnitude: each operation has adimissible magnitude range, which is divided into a number of bins. The automatic augmentation schemere selects the magnitude bin and the augmentation's role is to understand how it maps to exact paramter. For example, for `fn.rotate` magnitude is an angle.

This PR adds `@augmentation` decorator that lets user wrap a function that uses DALI processing so that it can adhere to automatic augmentation scheme "protocol".

The user who is interested in only running a standard suite for [Auto/Rand/Trivial]Augment should not need to use any of the utils here directly. 

The simplest interaction needed is changeing augmenation setup (such as magnitudes range), which is supposed to look as follows (to change the range of angles to (0, 60), randomly negated for each sample:

```
rotate = a.rotate.augmentation((0, 60), randomly_negate=True)
```

For more advanced cases, the `@augmentation` is the user-facing tool for wrapping custom code as an augmentation.

```
@augmentation(mag_range=(0, 30), randomly_negate=True)
def rotate(sample, angle, fill_value=0, interp_type=None):
    return fn.rotate(sample, angle=angle, fill_value=fill_value, interp_type=interp_type)
```

```
def warp_x_param(magnitude):
    return [magnitude, 0]

@augmentation(mag_range=(0, 0.3), randomly_negate=True, as_param=warp_x_param)
def shear_x(sample, shear, fill_value=0, interp_type=None):
    mt = fn.transforms.shear(shear=shear)
    return fn.warp_affine(sample, matrix=mt, fill_value=fill_value, interp_type=interp_type,
                          inverse_map=False)

```

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3230
<!--- DALI-XXXX or NA --->
