### PR TITLE
Change WDS index version representation to integer.

### DIFF
--- a/dali/imgcodec/decoders/nvjpeg/nvjpeg.cc
+++ b/dali/imgcodec/decoders/nvjpeg/nvjpeg.cc
@@ -16,7 +16,7 @@
 #include <string>
 #include <utility>
 #include "dali/core/device_guard.h"
-#include "dali/core/util.h"
+#include "dali/core/version_util.h"
 #include "dali/imgcodec/decoders/nvjpeg/nvjpeg.h"
 #include "dali/imgcodec/decoders/nvjpeg/nvjpeg_helper.h"
 #include "dali/imgcodec/decoders/nvjpeg/nvjpeg_memory.h"

--- a/dali/imgcodec/decoders/nvjpeg/nvjpeg.cc
+++ b/dali/imgcodec/decoders/nvjpeg/nvjpeg.cc
@@ -38,7 +38,7 @@ int nvjpegGetVersion() {
   GetVersionProperty(nvjpegGetProperty, &major, MAJOR_VERSION, NVJPEG_STATUS_SUCCESS);
   GetVersionProperty(nvjpegGetProperty, &minor, MINOR_VERSION, NVJPEG_STATUS_SUCCESS);
   GetVersionProperty(nvjpegGetProperty, &patch, PATCH_LEVEL, NVJPEG_STATUS_SUCCESS);
-  return GetVersionNumber(major, minor, patch);
+  return MakeVersionNumber(major, minor, patch);
 }
 
 }  // namespace

--- a/dali/kernels/signal/fft/cufft_helper.cc
+++ b/dali/kernels/signal/fft/cufft_helper.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "dali/kernels/signal/fft/cufft_helper.h"
-#include "dali/core/util.h"
+#include "dali/core/version_util.h"
 
 namespace dali {
 

--- a/dali/kernels/signal/fft/cufft_helper.cc
+++ b/dali/kernels/signal/fft/cufft_helper.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ DLL_PUBLIC int cufftGetVersion() {
   GetVersionProperty(cufftGetProperty, &major, MAJOR_VERSION, CUFFT_SUCCESS);
   GetVersionProperty(cufftGetProperty, &minor, MINOR_VERSION, CUFFT_SUCCESS);
   GetVersionProperty(cufftGetProperty, &patch, PATCH_LEVEL, CUFFT_SUCCESS);
-  return GetVersionNumber(major, minor, patch);
+  return MakeVersionNumber(major, minor, patch);
 }
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ DLL_PUBLIC int nvjpegGetVersion() {
   GetVersionProperty(nvjpegGetProperty, &major, MAJOR_VERSION, NVJPEG_STATUS_SUCCESS);
   GetVersionProperty(nvjpegGetProperty, &minor, MINOR_VERSION, NVJPEG_STATUS_SUCCESS);
   GetVersionProperty(nvjpegGetProperty, &patch, PATCH_LEVEL, NVJPEG_STATUS_SUCCESS);
-  return GetVersionNumber(major, minor, patch);
+  return MakeVersionNumber(major, minor, patch);
 }
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "dali/operators/decoder/nvjpeg/nvjpeg_helper.h"
-#include "dali/core/util.h"
+#include "dali/core/version_util.h"
 
 namespace dali {
 

--- a/dali/operators/reader/loader/webdataset_loader.cc
+++ b/dali/operators/reader/loader/webdataset_loader.cc
@@ -70,7 +70,7 @@ inline void ParseSampleDesc(std::vector<SampleDesc>& samples_container,
   // Reading consecutive components
   ComponentDesc component;
   while (components_stream >> component.ext) {
-    if (index_version == MakeVersion(1, 2)) {
+    if (index_version == MakeVersionNumber(1, 2)) {
       DALI_ENFORCE(
           components_stream >> component.offset >> component.size >> component.filename,
           IndexFileErrMsg(
@@ -106,7 +106,7 @@ inline int ParseIndexVersion(const string& version_str) {
   assert(s);
   s++;
   int minor = atoi(s);
-  return MakeVersion(major, minor);
+  return MakeVersionNumber(major, minor);
 }
 
 inline void ParseIndexFile(std::vector<SampleDesc>& samples_container,

--- a/dali/operators/reader/loader/webdataset_loader.cc
+++ b/dali/operators/reader/loader/webdataset_loader.cc
@@ -20,6 +20,7 @@
 #include <tuple>
 #include <utility>
 #include "dali/core/common.h"
+#include "dali/core/version_util.h"
 #include "dali/core/error_handling.h"
 #include "dali/operators/reader/loader/webdataset/tar_utils.h"
 #include "dali/pipeline/data/types.h"

--- a/dali/operators/reader/loader/webdataset_loader.h
+++ b/dali/operators/reader/loader/webdataset_loader.h
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 #include "dali/core/bitmask.h"
+#include "dali/core/version_util.h"
 #include "dali/operators/reader/loader/loader.h"
 #include "dali/pipeline/data/tensor.h"
 #include "dali/util/file.h"
@@ -38,10 +39,6 @@ constexpr char kExtDelim = ';';
 const std::set<DALIDataType> kSupportedTypes = {DALI_UINT8,   DALI_UINT16, DALI_UINT32, DALI_UINT64,
                                                 DALI_INT8,    DALI_INT16,  DALI_INT32,  DALI_INT64,
                                                 DALI_FLOAT16, DALI_FLOAT,  DALI_FLOAT64};
-
-constexpr int MakeVersion(int major, int minor) {
-  return major * 1000 * minor;
-}
 
 enum class MissingExtBehavior {
   Empty,

--- a/dali/operators/reader/loader/webdataset_loader.h
+++ b/dali/operators/reader/loader/webdataset_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,10 @@ constexpr char kExtDelim = ';';
 const std::set<DALIDataType> kSupportedTypes = {DALI_UINT8,   DALI_UINT16, DALI_UINT32, DALI_UINT64,
                                                 DALI_INT8,    DALI_INT16,  DALI_INT32,  DALI_INT64,
                                                 DALI_FLOAT16, DALI_FLOAT,  DALI_FLOAT64};
+
+constexpr int MakeVersion(int major, int minor) {
+  return major * 1000 * minor;
+}
 
 enum class MissingExtBehavior {
   Empty,

--- a/dali/operators/reader/loader/webdataset_loader.h
+++ b/dali/operators/reader/loader/webdataset_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@
 #include <utility>
 #include <vector>
 #include "dali/core/bitmask.h"
-#include "dali/core/version_util.h"
 #include "dali/operators/reader/loader/loader.h"
 #include "dali/pipeline/data/tensor.h"
 #include "dali/util/file.h"

--- a/dali/operators/util/npp.cc
+++ b/dali/operators/util/npp.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ DLL_PUBLIC int NPPGetVersion() {
   auto version_s = nppGetLibVersion();
   int version = -1;
   if (version_s) {
-    version = GetVersionNumber(version_s->major, version_s->minor, version_s->build);
+    version = MakeVersionNumber(version_s->major, version_s->minor, version_s->build);
   }
   return version;
 }

--- a/dali/operators/util/npp.cc
+++ b/dali/operators/util/npp.cc
@@ -15,7 +15,7 @@
 #include "dali/npp/npp.h"
 #include "dali/core/error_handling.h"
 #include "dali/core/cuda_error.h"
-#include "dali/core/util.h"
+#include "dali/core/version_util.h"
 
 namespace dali {
 

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -441,25 +441,5 @@ inline auto flatten(span<const std::array<T, N>, extent> in) {
 }
 
 }  // namespace dali
-
-/// @brief Returns the product of all elements in shape
-/// @param getter - function obtaining property
-/// @param value - value where to put the property, in case of failure it gets -1
-/// @param property - enum for the select right property
-/// @param success_status - enum value for success status of getter
-template <typename F, typename E, typename S>
-void GetVersionProperty(F getter, int *value, E property, S success_status) {
-  if (getter(property, value) != success_status) {
-    *value = -1;
-  }
-}
-
-// gets single int that can be represented as int value
-static int GetVersionNumber(int major, int minor, int patch) {
-  if (major < 0 || minor < 0 || patch < 0) {
-    return -1;
-  }
-  return major*1000 + minor*10 + patch;
-}
 
 #endif  // DALI_CORE_UTIL_H_

--- a/include/dali/core/version_util.h
+++ b/include/dali/core/version_util.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_VERSION_UTIL_H_
+#define DALI_CORE_VERSION_UTIL_H_
+
+namespace dali {
+
+/// @brief Returns the product of all elements in shape
+/// @param getter - function obtaining property
+/// @param value - value where to put the property, in case of failure it gets `invalid_value`
+/// @param property - enum for the select right property
+/// @param success_status - enum value for success status of getter
+/// @param invalid_value - the value returned when the getter fails
+template <typename F, typename V, typename E, typename S>
+void GetVersionProperty(F getter, V *value, E property, S success_status, V invalid_value = -1) {
+  if (getter(property, value) != success_status) {
+    *value = invalid_value;
+  }
+}
+
+// gets single int that can be represented as int value
+constexpr int MakeVersionNumber(int major, int minor, int patch = 0) {
+  if (major < 0 || minor < 0 || patch < 0) {
+    return -1;
+  }
+  return major*1000 + minor*10 + patch;
+}
+
+}  // namespace dali
+
+#endif  // DALI_CORE_VERSION_UTIL_H_


### PR DESCRIPTION
## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
It changes the representation of the WDS index from a string to integer. It improves performance and it would help with comparisons.

## Additional information:

### Affected modules and functionalities:
WDS reader


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
`dali/test/python/reader/test_webdataset_*.py`

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2557
<!--- DALI-XXXX or NA --->
