### PR TITLE
Support numerical types in `if` predicate and `not` expression

### DIFF
--- a/dali/pipeline/operator/builtin/conditional/split.cc
+++ b/dali/pipeline/operator/builtin/conditional/split.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,7 @@ bool Split<Backend>::SetupImpl(std::vector<OutputDesc> &output_desc, const Works
   const auto &input = ws.template Input<Backend>(0);
   const auto &predicate = ws.ArgumentInput("predicate");
   if (if_stmt_implementation_) {
-    // TODO(klecki): As a next step, lift the restriction on boolean input type.
-    EnforceConditionalInputKind(predicate, "if", "if-stmt", true);
+    EnforceConditionalInputKind(predicate, "if", "if-stmt", false);
   }
 
   DALI_ENFORCE(

--- a/dali/pipeline/operator/builtin/conditional/validation.cc
+++ b/dali/pipeline/operator/builtin/conditional/validation.cc
@@ -74,7 +74,7 @@ std::string GetRestrictionMessage(const std::string &name, bool enforce_type) {
  * @brief Get the string describing the placement of the input.
  *
  * @param name One of kAllowedNames, name of the expression of statement that is checked
- * @param where One of kAllowedNames, name of the expression of statement that is checked
+ * @param where One of kAllowedWheres, argument position that is checked
  */
 std::string GetSourcePlacementMessage(const std::string &name, const std::string &where) {
   if (name == "if") {

--- a/dali/pipeline/operator/builtin/conditional/validation.h
+++ b/dali/pipeline/operator/builtin/conditional/validation.h
@@ -21,6 +21,12 @@
 
 namespace dali {
 
+// Types that can be used as input to not expression or in a predicate and be evaluated to boolean.
+#define LOGICALLY_EVALUATABLE_TYPES                                                                \
+  (bool, uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float16, float, \
+  double)
+
+
 /**
  * @brief Check if the inputs to logical expression are scalars (and optionally booleans).
  *

--- a/docs/examples/general/conditionals.ipynb
+++ b/docs/examples/general/conditionals.ipynb
@@ -153,7 +153,7 @@
     "\n",
     "### Requirements\n",
     "There are several requirements that needs to be met when using the conditionals within DALI pipeline:\n",
-    "1. The `if` condition must be a DALI DataNode and the underlying data must be of type Bool.\n",
+    "1. The `if` condition must be a DALI DataNode and the underlying data must be of type `BOOL` or other numerical type that can be evaluated to True or False in accordance with Python semantics.\n",
     "The reason for this is the condition must be traceable during DALI pipeline run, and must represent a batch - each sample gets its associated condition value.\n",
     "\n",
     "If the condition is some other Python value, the code is executed with regular Python semantics, only one branch is taken and no conditional operation is captured by DALI pipeline graph.\n",


### PR DESCRIPTION


<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **New feature**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
 (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Evaluate scalar numerical types treating them as truthy and falsy values.
Utilize regular promotion from numeric types to boolean. We can do it safely as `not` produces a new value and the predicate in `if` is not related to the output.
`and` and `or` expression stay limited to `bool` inputs to not risk creating scenarios where batches of mixed types can arise.



## Additional information:

### Affected modules and functionalities:
Conditional expressions, split/merge.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
Existing test was modified to not expect exception when non-boolean type is passed as `if` predicate or into `not`.
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [x] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
