### PR TITLE
Fix buffer exhaustion in the frames_decoder_gpu

### DIFF
--- a/dali/test/python/decoder/test_video.py
+++ b/dali/test/python/decoder/test_video.py
@@ -158,6 +158,8 @@ def test_multi_gpu_video(device):
 
     def input_gen(batch_size):
         filenames = glob.glob(f'{get_dali_extra_path()}/db/video/[cv]fr/*.mp4')
+        # test overflow of frame_buffer_
+        filenames.append(f'{get_dali_extra_path()}/db/video/cfr_test.mp4')
         filenames = filter(lambda filename: 'mpeg4' not in filename, filenames)
         filenames = filter(lambda filename: 'hevc' not in filename, filenames)
         filenames = cycle(filenames)


### PR DESCRIPTION
- frames_decoder_gpu keeps the internal buffer of the num_decode_surfaces_
  length as it is the maximal number of frames that needs to be decoded
  to maintain the display order. The decoder accepts the raw packets as
  long as there is a free place in the buffer. In some cases, after receiving
  the packet two frames could be produced (as the N-1 frame may require N-the packet).
  In this case, we receive more frames and there is spare space. This PR
  adds functionality to enlarge the buffer if there is an additional frame
  to keep. Also, it makes sure we don't try to have more than num_decode_surfaces_
  frames decoded at the time.

Relates to https://github.com/NVIDIA/DALI/issues/4498

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- frames_decoder_gpu keeps the internal buffer of the num_decode_surfaces_
  length as it is the maximal number of frames that needs to be decoded
  to maintain the display order. The decoder accepts the raw packets as
  long as there is a free place in the buffer. In some cases, after receiving
  the packet two frames could be produced (as the N-1 frame may require N-the packet).
  In this case, we receive more frames and there is spare space. This PR
  adds functionality to enlarge the buffer if there is an additional frame
  to keep. Also, it makes sure we don't try to have more than num_decode_surfaces_
  frames decoded at the time.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- frames_decoder_gpu
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_video.test_multi_gpu_video has been extended
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
