### PR TITLE
Update fix assert error messages in base_iterator.py

### DIFF
--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -215,7 +215,9 @@ class _DaliBaseIterator(object):
             readers_meta = [p.reader_meta(self._reader_name) for p in self._pipes]
 
             def err_msg_gen(err_msg):
-                return 'Reader Operator should have the same {} in all the pipelines.'.format(err_msg)
+                return 'Reader Operator should have the same {} in all the pipelines.'.format(
+                    err_msg
+                )
 
             def check_equality_and_get(input_meta, name, err_msg):
                 assert np.all(np.equal([meta[name] for meta in input_meta], input_meta[0][name])), \

--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -215,7 +215,7 @@ class _DaliBaseIterator(object):
             readers_meta = [p.reader_meta(self._reader_name) for p in self._pipes]
 
             def err_msg_gen(err_msg):
-                'Reader Operator should have the same {} in all the pipelines.'.format(err_msg)
+                return 'Reader Operator should have the same {} in all the pipelines.'.format(err_msg)
 
             def check_equality_and_get(input_meta, name, err_msg):
                 assert np.all(np.equal([meta[name] for meta in input_meta], input_meta[0][name])), \


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
Function without return always return None so error have no information about missing metadata 
before
```python3
assert np.all(np.equal([meta[name] for meta in input_meta], input_meta[0][name])), \
                       err_msg_gen(err_msg) # err_msg_gen returns None not formated string

AssertionError: None
```
after
```python3
AssertionError: Reader Operator should have the same size value in all the pipelines.
```

### Tests:
- [x] N/A

### Documentation
- [x] N/A
