### PR TITLE
Move the `--pending` inside the critical section to prevent `cv.notify_all()` from being unobserved

### DIFF
--- a/dali/pipeline/util/for_each_thread.h
+++ b/dali/pipeline/util/for_each_thread.h
@@ -54,10 +54,10 @@ void ForEachThread(ThreadPool &tp, Func &&func) {
         err = std::current_exception();
       }
 
+      std::unique_lock lock(m);
       if (--pending == 0) {
         cv.notify_all();
       } else {
-        std::unique_lock lock(m);
         cv.wait(lock, [&]() { return pending == 0; });
       }
       if (err)  // if there's an error, we can rethrow it now


### PR DESCRIPTION

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Previously it could so happen that the order of execution was:
```
Thread A            Thread B
--pending > 0   
std::unique_lock    lock(m);
                    --pending == 0
                    cv.notify_all()
cv.wait() <-- hang, ^^^ went noticed
```

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Imgcodec tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
