### PR TITLE
Use lookup table for uint8 inputs in mul-add kernel

### DIFF
--- a/dali/kernels/imgproc/pointwise/multiply_add.h
+++ b/dali/kernels/imgproc/pointwise/multiply_add.h
@@ -73,8 +73,8 @@ struct MultiplyAddElementCpu<Out, In, true> {
     }
   }
 
-  Out operator()(InUnsigned element) {
-    return lut_[element];
+  Out operator()(In val) {
+    return lut_[static_cast<InUnsigned>(val)];
   }
 
   Out lut_[kRangeSize];

--- a/dali/kernels/imgproc/pointwise/multiply_add.h
+++ b/dali/kernels/imgproc/pointwise/multiply_add.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,17 +15,72 @@
 #ifndef DALI_KERNELS_IMGPROC_POINTWISE_MULTIPLY_ADD_H_
 #define DALI_KERNELS_IMGPROC_POINTWISE_MULTIPLY_ADD_H_
 
+#include <limits>
+#include <tuple>
 #include <utility>
-#include "dali/util/ocv.h"
 #include "dali/core/common.h"
 #include "dali/core/convert.h"
-#include "dali/core/geom/box.h"
 #include "dali/core/error_handling.h"
-#include "dali/kernels/kernel.h"
+#include "dali/core/geom/box.h"
 #include "dali/kernels/imgproc/roi.h"
+#include "dali/kernels/kernel.h"
+#include "dali/util/ocv.h"
 
 namespace dali {
 namespace kernels {
+
+template <typename T, typename... TS>
+struct AnyOf {
+  static constexpr bool value = (std::is_same_v<T, TS> || ...);
+};
+
+template <typename T>
+struct MakeUnsigned {
+  using type = std::make_unsigned_t<T>;
+};
+
+template <>
+struct MakeUnsigned<bool> {
+  using type = bool;
+};
+
+template <typename Out, typename In, bool use_lut = AnyOf<In, uint8_t, int8_t, bool>::value>
+struct MultiplyAddElementCpu;
+
+template <typename Out, typename In>
+struct MultiplyAddElementCpu<Out, In, false> {
+  MultiplyAddElementCpu(float addend, float multiplier)
+      : addend_{addend}, multiplier_{multiplier} {}
+
+  Out operator()(In element) {
+    return ConvertSat<Out>(element * multiplier_ + addend_);
+  }
+
+  float addend_;
+  float multiplier_;
+};
+
+template <typename Out, typename In>
+struct MultiplyAddElementCpu<Out, In, true> {
+  using InSigned = typename MakeUnsigned<In>::type;
+  static constexpr int kRangeSize = std::numeric_limits<InSigned>::max() + 1;
+  // if that's deliberate you can always lift the restriction
+  static_assert(kRangeSize <= 256, "Using lut for bigger types may not be a good idea");
+
+  MultiplyAddElementCpu(float addend, float multiplier) : addend_{addend}, multiplier_{multiplier} {
+    for (int val = std::numeric_limits<In>::min(); val <= std::numeric_limits<In>::max(); val++) {
+      lut_[static_cast<InSigned>(val)] = ConvertSat<Out>(val * multiplier_ + addend_);
+    }
+  }
+
+  Out operator()(InSigned element) {
+    return lut_[element];
+  }
+
+  Out lut_[kRangeSize];
+  float addend_;
+  float multiplier_;
+};
 
 template<typename OutputType, typename InputType, int ndims = 3>
 class MultiplyAddCpu {
@@ -34,6 +89,7 @@ class MultiplyAddCpu {
 
  public:
   using Roi = Box<spatial_dims, int>;
+  using ElementOp = MultiplyAddElementCpu<OutputType, InputType>;
 
 
   KernelRequirements
@@ -66,11 +122,13 @@ class MultiplyAddCpu {
     auto image_width = in.shape[1];
     auto ptr = out.data;
 
+    ElementOp op(addend, multiplier);
+
     ptrdiff_t row_stride = image_width * num_channels;
     auto *row = in.data + adjusted_roi.lo.y * row_stride;
     for (int y = adjusted_roi.lo.y; y < adjusted_roi.hi.y; y++) {
       for (int xc = adjusted_roi.lo.x * num_channels; xc < adjusted_roi.hi.x * num_channels; xc++)
-        *ptr++ = ConvertSat<OutputType>(row[xc] * multiplier + addend);
+        *ptr++ = op(row[xc]);
       row += row_stride;
     }
   }

--- a/dali/kernels/imgproc/pointwise/multiply_add.h
+++ b/dali/kernels/imgproc/pointwise/multiply_add.h
@@ -62,18 +62,18 @@ struct MultiplyAddElementCpu<Out, In, false> {
 
 template <typename Out, typename In>
 struct MultiplyAddElementCpu<Out, In, true> {
-  using InSigned = typename MakeUnsigned<In>::type;
-  static constexpr int kRangeSize = std::numeric_limits<InSigned>::max() + 1;
+  using InUnsigned = typename MakeUnsigned<In>::type;
+  static constexpr int kRangeSize = std::numeric_limits<InUnsigned>::max() + 1;
   // if that's deliberate you can always lift the restriction
   static_assert(kRangeSize <= 256, "Using lut for bigger types may not be a good idea");
 
   MultiplyAddElementCpu(float addend, float multiplier) : addend_{addend}, multiplier_{multiplier} {
     for (int val = std::numeric_limits<In>::min(); val <= std::numeric_limits<In>::max(); val++) {
-      lut_[static_cast<InSigned>(val)] = ConvertSat<Out>(val * multiplier_ + addend_);
+      lut_[static_cast<InUnsigned>(val)] = ConvertSat<Out>(val * multiplier_ + addend_);
     }
   }
 
-  Out operator()(InSigned element) {
+  Out operator()(InUnsigned element) {
     return lut_[element];
   }
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Use lookup table for CPU MullAdd kernel with uint8 as an input type.
For `batch_size=128` (DALI_extra, "synthetic", i.e. in-memory, loaded through ext source), `num_threads=4`, it's 9x speed-up.. 
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
brightness, brightness_contrast and contrast ops
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply (operator_1 test_brightness_contrast.test_vs_ref)
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
