### PR TITLE
Fix memory leak in host JPEG decoder

### DIFF
--- a/dali/imgcodec/decoders/jpeg/jpeg_mem.cc
+++ b/dali/imgcodec/decoders/jpeg/jpeg_mem.cc
@@ -96,8 +96,9 @@ std::unique_ptr<uint8[]> UncompressLow(const void* srcdata, FewerArgsForCompiler
   // if empty image, return
   if (datasize == 0 || srcdata == nullptr) return nullptr;
 
-  // Declare temporary buffer pointer here so that we can free on error paths
+  // Declare buffers here so that we can free on error paths
   std::unique_ptr<JSAMPLE[]> temp;
+  std::unique_ptr<uint8[]> dstdata;
   JSAMPLE *tempdata = nullptr;
 
   // Initialize libjpeg structures to have a memory source
@@ -229,8 +230,6 @@ std::unique_ptr<uint8[]> UncompressLow(const void* srcdata, FewerArgsForCompiler
   argball->height_ = target_output_height;
   argball->stride_ = stride;
 
-
-  std::unique_ptr<uint8[]> dstdata;
 #if !defined(LIBJPEG_TURBO_VERSION)
   if (flags.crop)
     dstdata.reset(new JSAMPLE[stride * target_output_height]);


### PR DESCRIPTION
- the JPEG decoder is based on TensorFlow implementation and
  uses setjmp/longjmp for exception handling. At the same time
  to avoid leaks of dynamically allocated memory the allocations
  are wrapped by unique_ptrs. However, when the pointer is created
  on stack after the context was preserved by setjmp and the
  exceptional situation occurs, the context is restored and the
  pointer is forgotten but the destructor is not called (so the
  managed memory is not freed). This PR moves the instantiation
  of the unique pointer to place before the context capture so when
  the function exits its destructor is properly called.


<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- the JPEG decoder is based on TensorFlow implementation and
  uses setjmp/longjmp for exception handling. At the same time
  to avoid leaks of dynamically allocated memory the allocations
  are wrapped by unique_ptrs. However, when the pointer is created
  on stack after the context was preserved by setjmp and the
  exceptional situation occurs, the context is restored and the
  pointer is forgotten but the destructor is not called (so the
  managed memory is not freed). This PR moves the instantiation
  of the unique pointer to place before the context capture so when
  the function exits its destructor is properly called.
- relates to https://github.com/NVIDIA/DALI/issues/4740

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- dali/imgcodec/decoders/jpeg/jpeg_mem.cc
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_imgcodec.py
  - test_image.py
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
