### PR TITLE
Simplify AutoAugment graph

### DIFF
--- a/dali/python/nvidia/dali/auto_aug/core/_augmentation.py
+++ b/dali/python/nvidia/dali/auto_aug/core/_augmentation.py
@@ -52,13 +52,17 @@ class _SignedMagnitudeBin:
         self._signed_magnitude_idx = signed_magnitude_idx
 
     def __getitem__(self, idx: int):
+        """
+        Indexing simplifies creation of "signed magnitude bins" in cases when a single sample
+        may be processed by a sequence of random augmentations - we can sample random signs once
+        for the full sequence and then use indexing to access each single signed magnitude bin.
+        """
         if isinstance(self._magnitude_bin, int):
             magnitude_bin = self._magnitude_bin
         else:
             magnitude_bin = self._magnitude_bin[idx]
-        random_sign = self._random_sign[idx]
-        signed_magnitude_idx = self._signed_magnitude_idx[idx]
-        return self.__class__(magnitude_bin, random_sign, signed_magnitude_idx)
+        cls = self.__class__
+        return cls(magnitude_bin, self._random_sign[idx], self._signed_magnitude_idx[idx])
 
     @classmethod
     def create_from_bin(cls, magnitude_bin: Union[int, _DataNode],

--- a/dali/python/nvidia/dali/auto_aug/rand_augment.py
+++ b/dali/python/nvidia/dali/auto_aug/rand_augment.py
@@ -159,10 +159,11 @@ def apply_rand_augment(augmentations: List[_Augmentation], sample: _DataNode, n:
     op_idx = fn.random.uniform(values=list(range(len(augmentations))), seed=seed, shape=shape,
                                dtype=types.INT32)
     use_signed_magnitudes = any(aug.randomly_negate for aug in augmentations)
+    mag_bin = signed_bin(m, seed=seed, shape=shape) if use_signed_magnitudes else m
     _forbid_unused_kwargs(augmentations, kwargs, 'apply_rand_augment')
     for level_idx in range(n):
-        magnitude_bin = signed_bin(m) if use_signed_magnitudes else m
-        op_kwargs = dict(sample=sample, magnitude_bin=magnitude_bin,
+        level_mag_bin = mag_bin if not use_signed_magnitudes or n == 1 else mag_bin[level_idx]
+        op_kwargs = dict(sample=sample, magnitude_bin=level_mag_bin,
                          num_magnitude_bins=num_magnitude_bins, **kwargs)
         level_op_idx = op_idx if n == 1 else op_idx[level_idx]
         sample = _pretty_select(augmentations, level_op_idx, op_kwargs,

--- a/dali/python/nvidia/dali/auto_aug/trivial_augment.py
+++ b/dali/python/nvidia/dali/auto_aug/trivial_augment.py
@@ -127,7 +127,7 @@ def apply_trivial_augment(augmentations: List[_Augmentation], sample: _DataNode,
                                       seed=seed)
     use_signed_magnitudes = any(aug.randomly_negate for aug in augmentations)
     if use_signed_magnitudes:
-        magnitude_bin = signed_bin(magnitude_bin)
+        magnitude_bin = signed_bin(magnitude_bin, seed=seed)
     _forbid_unused_kwargs(augmentations, kwargs, 'apply_trivial_augment')
     op_kwargs = dict(sample=sample, magnitude_bin=magnitude_bin,
                      num_magnitude_bins=num_magnitude_bins, **kwargs)

--- a/dali/test/python/auto_aug/test_auto_augment.py
+++ b/dali/test/python/auto_aug/test_auto_augment.py
@@ -250,11 +250,11 @@ def test_sub_policy(randomly_negate, dev, batch_size):
 @params(("cpu", ), ("gpu", ))
 def test_op_skipping(dev):
 
-    num_magnitude_bins = 16
-    batch_size = 1024
+    num_magnitude_bins = 20
+    batch_size = 2400
 
     @augmentation(
-        mag_range=(0, 15),
+        mag_range=(0, 19),
         mag_to_param=mag_to_param_with_op_id(1),
         randomly_negate=True,
         param_device=dev,
@@ -263,7 +263,7 @@ def test_op_skipping(dev):
         return fn.cat(sample, op_id_mag_id)
 
     @augmentation(
-        mag_range=(0, 15),
+        mag_range=(0, 19),
         mag_to_param=mag_to_param_with_op_id(2),
         randomly_negate=True,
         param_device=dev,
@@ -272,11 +272,27 @@ def test_op_skipping(dev):
         return fn.cat(sample, op_id_mag_id)
 
     @augmentation(
-        mag_range=(0, 15),
+        mag_range=(0, 19),
         mag_to_param=mag_to_param_with_op_id(3),
         param_device=dev,
     )
     def third(sample, op_id_mag_id):
+        return fn.cat(sample, op_id_mag_id)
+
+    @augmentation(
+        mag_range=(0, 19),
+        mag_to_param=mag_to_param_with_op_id(4),
+        param_device=dev,
+    )
+    def first_stage_only(sample, op_id_mag_id):
+        return fn.cat(sample, op_id_mag_id)
+
+    @augmentation(
+        mag_range=(0, 19),
+        mag_to_param=mag_to_param_with_op_id(5),
+        param_device=dev,
+    )
+    def second_stage_only(sample, op_id_mag_id):
         return fn.cat(sample, op_id_mag_id)
 
     sub_policies = [
@@ -287,6 +303,8 @@ def test_op_skipping(dev):
         [(third, 1, 9), (third, 0.75, 10)],
         [(third, 0.3, 11), (first, 0.22, 12)],
         [(second, 0.6, 13), (third, 0, 14)],
+        [(first_stage_only, 0.5, 15), (third, 0.7, 16)],
+        [(third, 0.8, 17), (second_stage_only, 0.6, 18)],
     ]
 
     # sub_policy_cases = [[] for _ in range(len(sub_policies))]
@@ -309,6 +327,9 @@ def test_op_skipping(dev):
             mags = (left_sign * left_mag, right_sign * right_mag)
             expected_counts[mags] = prob / len(sign_cases)
     expected_counts = {mag: prob * batch_size for mag, prob in expected_counts.items() if prob > 0}
+    assert all(num_elements >= 5 for num_elements in expected_counts.values()), \
+        f"The batch size is too small (i.e. some output cases are expected less " \
+        f"than five times in the output): {expected_counts}"
 
     policy = Policy("MyPolicy", num_magnitude_bins=num_magnitude_bins, sub_policies=sub_policies)
     p = concat_aug_pipeline(batch_size=batch_size, dev=dev, policy=policy)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
This PR combines a couple of improvements to AutoAugment processing graph.

1. The list of augmentations to split processing into is created independently for each stage - this can reduces the size of split-merge tree generated by the `select` operation.

For example, the default v0 policy uses 25 sub-policies, each sub-policy is a sequence of (at most) 2 augmentations. Even though there are 25 sub-policies, there are only 11 unique augmentations present in those sub-polcies. DALI already splits the computation only in 11 parts. However, it can be further improved if the operators used in given stages of sub-policies form even smaller groups. In case of the default v0 policy, it is 8 vs 11.

In other words, when the comutation is split to apply the "i-th" augmentation in a sequence according to selected sub-polciy, there is no need to take into account all augmentations present in all sub-polcies, but only the augmentations at the i-th position in all sub-policies.


2. The `signed_bin` helper that handles random negation of magnitudes can now accept additional shape parameter. With that, if you have a multiple random augmentations to apply in a sequence, you can generate the random signs of magnitudes once for all stages, rather than do it for every stage separately.

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
AutoAugment (points 1., 2.), RandAugment (point 2.).
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3357
<!--- DALI-XXXX or NA --->
