### PR TITLE
Add CPU filter operator

### DIFF
--- a/dali/operators/generic/roi_random_crop.cc
+++ b/dali/operators/generic/roi_random_crop.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ The operator produces an output representing the cropping window start coordinat
 If provided, the cropping window start will be selected so that the cropping window is within the
 bounds of the input.
 
-..note::
+.. note::
   Providing ``in_shape`` is incompatible with feeding the input data directly as a positional input.
 )code", nullptr, true)
     .NumInput(0, 1)

--- a/dali/operators/image/convolution/filter.cc
+++ b/dali/operators/image/convolution/filter.cc
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
 #include <vector>
 
+#include <opencv2/opencv.hpp>
+
 #include "dali/operators/image/convolution/filter.h"
+#include "dali/pipeline/data/sequence_utils.h"
+#include "dali/pipeline/operator/arg_helper.h"
 #include "dali/pipeline/operator/common.h"
+#include "dali/util/ocv.h"
 
 namespace dali {
 
@@ -41,7 +47,11 @@ for example, a video with ``"FCHW"`` layout is supported, but ``"CFHW"`` samples
 Samples with the following types are supported:
 int8, int16, uint8, uint16, float16, float32.
 
-Please note that the intermediate type used for the computation is always float32.)code")
+Please note that the intermediate type used for the computation is always float32.
+
+..note::
+  The CPU variant does not support volumetric (3D) data, nor inputs of type int8 and float16.
+)code")
     .InputDox(1, "filter", "TensorList", R"code(Batch of filters.
 
 For inputs with two spatial dimensions (images or video), each filter must be a 2D array
@@ -106,5 +116,241 @@ If not set, the input type is used.
   The intermediate type used for actual computation is float32. If the output is of integral type,
   the values will be clamped to the output type range.
 )code");
+
+namespace filter {
+
+namespace ocv {
+using namespace boundary;  // NOLINT(build/namespaces)
+struct BorderSimple {
+  BorderSimple(int border_type) : border_type_{border_type} {}  // NOLINT(runtime/explicit)
+
+  void operator()(const cv::Mat& in_img, cv::Mat& out_img, int d_depth, const cv::Mat& filter_mat,
+                  int anchor_x, int anchor_y) {
+    cv::filter2D(in_img, out_img, d_depth, filter_mat, {anchor_x, anchor_y}, 0, border_type_);
+  }
+
+ protected:
+  int border_type_;
+};
+
+
+template <typename In>
+struct BorderConstant {
+  BorderConstant(In fill_val) : fill_val_{fill_val} {}  // NOLINT(runtime/explicit)
+
+  void operator()(const cv::Mat& in_img, cv::Mat& out_img, int d_depth, const cv::Mat& filter_mat,
+                  int anchor_x, int anchor_y) {
+    if (fill_val_ == 0) {
+      cv::filter2D(in_img, out_img, d_depth, filter_mat, {anchor_x, anchor_y}, 0,
+                   cv::BORDER_CONSTANT);
+    } else {
+      cv::Mat in_padded;
+      int top = anchor_y, bottom = filter_mat.rows - anchor_y - 1;
+      int left = anchor_x, right = filter_mat.cols - anchor_x - 1;
+      cv::copyMakeBorder(in_img, in_padded, top, bottom, left, right, cv::BORDER_CONSTANT,
+                         cv::Scalar(fill_val_, fill_val_, fill_val_));
+      auto roi = cv::Rect(left, top, in_img.cols, in_img.rows);
+      auto in_roi = in_padded(roi);
+      cv::filter2D(in_roi, out_img, d_depth, filter_mat, {anchor_x, anchor_y}, 0);
+    }
+  }
+
+ protected:
+  In fill_val_;
+};
+
+
+struct BorderWrap {
+  void operator()(const cv::Mat& in_img, cv::Mat& out_img, int d_depth, const cv::Mat& filter_mat,
+                  int anchor_x, int anchor_y) {
+    cv::Mat in_padded;
+    int top = anchor_y, bottom = filter_mat.rows - anchor_y - 1;
+    int left = anchor_x, right = filter_mat.cols - anchor_x - 1;
+    cv::copyMakeBorder(in_img, in_padded, top, bottom, left, right, cv::BORDER_WRAP);
+    auto roi = cv::Rect(left, top, in_img.cols, in_img.rows);
+    auto in_roi = in_padded(roi);
+    cv::filter2D(in_roi, out_img, d_depth, filter_mat, {anchor_x, anchor_y}, 0);
+  }
+};
+
+struct BorderValidOnly {
+  void operator()(const cv::Mat& in_img, cv::Mat& out_img, int d_depth, const cv::Mat& filter_mat,
+                  int anchor_x, int anchor_y) {
+    auto roi = cv::Rect(anchor_x, anchor_y, in_img.cols - filter_mat.cols + 1,
+                        in_img.rows - filter_mat.rows + 1);
+    auto in_roi = in_img(roi);
+    cv::filter2D(in_roi, out_img, d_depth, filter_mat, {anchor_x, anchor_y}, 0);
+  }
+};
+
+template <typename In, typename Cb>
+void with_border_handler(bool is_valid_mode, BoundaryType border_type, int sample_idx,
+                         TensorListView<StorageCPU, In, 0>& fill_values, Cb&& cb) {
+  if (is_valid_mode) {
+    cb(BorderValidOnly{});
+  } else if (border_type == BoundaryType::CONSTANT) {
+    BorderConstant<In> handler =
+        fill_values.num_samples() == 0 ? 0 : fill_values[sample_idx].data[0];
+    cb(handler);
+  } else if (border_type == BoundaryType::WRAP) {
+    cb(BorderWrap{});
+  } else {
+    cb(BorderSimple{OCVBorderForDALIBoundary(border_type)});
+  }
+}
+
+}  // namespace ocv
+
+template <typename Out, typename In, int num_seq_dims>
+class FilterOpCpuImpl : public OpImplBase<CPUBackend> {
+  static constexpr int axes = 2;
+
+ public:
+  /**
+   * @param spec  Pointer to a persistent OpSpec object,
+   *              which is guaranteed to be alive for the entire lifetime of this object
+   */
+  explicit FilterOpCpuImpl(const OpSpec* spec, InputDesc input_desc)
+      : spec_{*spec},
+        input_desc_{input_desc},
+        anchor_arg_{"anchor", spec_},
+        border_type_{parse_filter_border_type(spec_.GetArgument<std::string>("border"))} {}
+
+  bool SetupImpl(std::vector<OutputDesc>& output_desc, const Workspace& ws) override {
+    const auto& input = ws.template Input<CPUBackend>(0);
+    int num_samples = input.num_samples();
+    anchor_arg_.Acquire(spec_, ws, num_samples, TensorShape<1>{axes});
+    output_desc.resize(1);
+    output_desc[0].type = type2id<Out>::value;
+    output_desc[0].shape = infer_output_shape(input.shape(), ws.GetInputShape(1), input_desc_);
+    return true;
+  }
+
+  void RunImpl(Workspace& ws) override {
+    const auto& input = ws.template Input<CPUBackend>(0);
+    const auto& filter = ws.template Input<CPUBackend>(1);
+    auto& output = ws.template Output<CPUBackend>(0);
+    output.SetLayout(input.GetLayout());
+    auto in_view = view<const In>(input);
+    auto filter_view = view<const float, axes>(filter);
+    auto anchor_view = anchor_arg_.get();
+    auto out_view = view<Out>(output);
+    int num_samples = input.num_samples();
+    auto& tp = ws.GetThreadPool();
+    TensorListView<StorageCPU, const In, 0> fill_values;
+    if (ws.NumInput() >= 3) {
+      fill_values = view<const In, 0>(ws.template Input<CPUBackend>(2));
+    }
+    for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
+      auto planes_range = sequence_utils::unfolded_views_range<num_seq_dims>(out_view[sample_idx],
+                                                                             in_view[sample_idx]);
+      const auto& in_range = planes_range.template get<1>();
+      auto slice_shape = in_range.SliceShape();
+      // by `input_desc.num_seq_dims + input_desc.axes + input_desc.has_channels == ndim`
+      // in ShouldExpand, the `DALI_ENFORCE(num_axes == 2)` in get_filter_cpu_op_impl
+      // and `unfolded_views_range<num_seq_dims>` above
+      int sample_dim = slice_shape.sample_dim();
+      assert(sample_dim == 2 || sample_dim == 3);
+      int num_channels = sample_dim == 2 ? 1 : slice_shape[2];
+      DALI_ENFORCE(
+          1 <= num_channels && num_channels <= CV_CN_MAX,
+          make_string("The CPU filter operator supports images with number of channels in [1, ",
+                      CV_CN_MAX, "] channels. However, the sample at index ", sample_idx, " has ",
+                      num_channels, " channels."));
+      DALI_ENFORCE(slice_shape[0] <= std::numeric_limits<int>::max() &&
+                       slice_shape[1] <= std::numeric_limits<int>::max(),
+                   make_string("The image height and width must not exceed the ",
+                               std::numeric_limits<int>::max(), ". However, the sample at index ",
+                               sample_idx, " has shape ", in_view[sample_idx].shape, "."));
+      auto sample_filter = filter_view[sample_idx];
+      auto sample_anchor = anchor_view[sample_idx];
+      for (int dim = 0; dim < axes; dim++) {
+        DALI_ENFORCE(
+            -1 <= sample_anchor.data[dim] && sample_anchor.data[dim] < sample_filter.shape[dim],
+            make_string("Anchor must lie within the filter. Got anchor ",
+                        vec2{sample_anchor.data[0], sample_anchor.data[1]},
+                        " with a filter of shape ", sample_filter.shape, " for sample of idx ",
+                        sample_idx, "."));
+      }
+      ocv::with_border_handler(
+          input_desc_.is_valid_mode, border_type_, sample_idx, fill_values, [&](auto ocv_handler) {
+            for (auto&& views : planes_range) {
+              tp.AddWork(
+                  [this, views, sample_filter, sample_anchor, ocv_handler](int) {
+                    auto& [sample_out, sample_in] = views;
+                    RunSample(sample_out, sample_filter, sample_in, sample_anchor, ocv_handler);
+                  },
+                  in_range.SliceSize());
+            }
+          });
+    }
+    tp.RunAll();
+  }
+
+ protected:
+  template <typename OcvHandler, int ndim>
+  void RunSample(TensorView<StorageCPU, Out, ndim> out,
+                 TensorView<StorageCPU, const float, axes> filter,
+                 TensorView<StorageCPU, const In, ndim> in,
+                 TensorView<StorageCPU, const int, 1> anchor, OcvHandler handler) {
+    auto& filter_shape = filter.shape;
+    int sample_dim = in.shape.sample_dim();
+    int num_channels = sample_dim == 2 ? 1 : in.shape[2];
+    assert((out.shape.sample_dim() == 2 ? 1 : out.shape[2]) == num_channels);
+    int in_flag = type2ocv<In>::value(num_channels);
+    int out_flag = type2ocv<Out>::value(num_channels);
+    const cv::Mat in_img = CreateMatFromPtr(in.shape[0], in.shape[1], in_flag, in.data);
+    const cv::Mat filter_mat =
+        CreateMatFromPtr(filter_shape[0], filter_shape[1], CV_32F, filter.data);
+    cv::Mat out_img = CreateMatFromPtr(out.shape[0], out.shape[1], out_flag, out.data);
+    static_assert(std::is_same_v<In, Out> || std::is_same_v<Out, float>);
+    int d_depth = std::is_same_v<In, Out> ? -1 : CV_32F;
+    int anchor_y = anchor.data[0] < 0 ? filter_shape[0] / 2 : anchor.data[0];
+    int anchor_x = anchor.data[1] < 0 ? filter_shape[1] / 2 : anchor.data[1];
+    handler(in_img, out_img, d_depth, filter_mat, anchor_x, anchor_y);
+  }
+
+  const OpSpec& spec_;
+  InputDesc input_desc_;
+  ArgValue<int, 1> anchor_arg_;
+  BoundaryType border_type_;
+  std::vector<ivec2> anchors_;
+};
+
+template <typename Out, typename In>
+std::unique_ptr<OpImplBase<CPUBackend>> get_filter_cpu_op_impl(const OpSpec& spec_,
+                                                               const InputDesc& input_desc) {
+  int num_axes = input_desc.axes;
+  std::string hint;
+  if (num_axes == 3) {
+    hint =
+        "If you are processing images with channels, please make sure to mark the "
+        "layout accordingly (`HWC` or `CHW`).";
+  }
+  DALI_ENFORCE(num_axes == 2,
+               make_string("Unsupported input data dimensionality. ", "Got input with ", num_axes,
+                           " spatial dimensions. CPU filter operator supports only 2-dimensional ",
+                           "convolutions. ", hint));
+  VALUE_SWITCH(input_desc.num_seq_dims, NumSeqDims, (0, 1, 2), (
+      return std::make_unique<FilterOpCpuImpl<Out, In, NumSeqDims>>(&spec_, input_desc);
+    ), (  // NOLINT
+      DALI_FAIL(make_string("Unsupported number of outermost channel/frame dimensions: `",
+        input_desc.num_seq_dims,
+        "`. The input layout can start with at most two such extents "
+        "(`F`, `C` or `FC`)."));
+    ));  // NOLINT
+}
+
+}  // namespace filter
+
+template <>
+template <typename Out, typename In, typename W>
+std::unique_ptr<OpImplBase<CPUBackend>> Filter<CPUBackend>::GetFilterImpl(
+    const OpSpec& spec, const filter::InputDesc& input_desc) {
+  static_assert(std::is_same_v<W, float>, "The CPU filter supports only float windows");
+  return filter::get_filter_cpu_op_impl<Out, In>(spec, input_desc);
+}
+
+DALI_REGISTER_OPERATOR(experimental__Filter, Filter<CPUBackend>, CPU);
 
 }  // namespace dali

--- a/dali/operators/image/convolution/filter.cc
+++ b/dali/operators/image/convolution/filter.cc
@@ -49,8 +49,8 @@ int8, int16, uint8, uint16, float16, float32.
 
 Please note that the intermediate type used for the computation is always float32.
 
-..note::
-  The CPU variant does not support volumetric (3D) data, nor inputs of type int8 and float16.
+.. note::
+  The CPU variant does not support volumetric (3D) data, nor inputs of types: int8 and float16.
 )code")
     .InputDox(1, "filter", "TensorList", R"code(Batch of filters.
 

--- a/dali/operators/image/convolution/filter.cu
+++ b/dali/operators/image/convolution/filter.cu
@@ -39,14 +39,6 @@ EXTERN_FILTER_SPECIALIZATION(float, float)
 
 }  // namespace filter
 
-// Passing to the kernel less samples (not split into frames) speeds-up
-// the processing, so expand frames dim only if some argument was specified per-frame
-template <>
-bool Filter<GPUBackend>::ShouldExpand(const Workspace& ws) {
-  return SequenceOperator<GPUBackend>::ShouldExpand(ws) &&
-         (HasPerFramePositionalArgs(ws) || HasPerFrameArgInputs(ws));
-}
-
 template <>
 template <typename Out, typename In, typename W>
 std::unique_ptr<OpImplBase<GPUBackend>> Filter<GPUBackend>::GetFilterImpl(

--- a/dali/operators/image/convolution/filter_gpu.h
+++ b/dali/operators/image/convolution/filter_gpu.h
@@ -120,12 +120,10 @@ class FilterOpGpu : public OpImplBase<GPUBackend> {
       }
       ivec<axes> filter_extents = shape2vec(filter_shapes[sample_idx]);
       ivec<axes> anchor = shape2vec(anchor_shape);
-      for (int dim = 0; dim < axes; dim++) {
-        DALI_ENFORCE(all_coords(-1 <= anchor) && all_coords(anchor < filter_extents),
-                     make_string("Anchor must lie within the filter. Got anchor ", anchor_shape,
-                                 " with a filter of shape ", filter_shapes[sample_idx],
-                                 " for sample of idx ", sample_idx, "."));
-      }
+      DALI_ENFORCE(all_coords(-1 <= anchor) && all_coords(anchor < filter_extents),
+                    make_string("Anchor must lie within the filter. Got anchor ", anchor_shape,
+                                " with a filter of shape ", filter_shapes[sample_idx],
+                                " for sample of idx ", sample_idx, "."));
       for (int dim = 0; dim < axes; dim++) {
         anchor[dim] = anchor[dim] == -1 ? filter_extents[dim] / 2 : anchor[dim];
       }
@@ -163,7 +161,7 @@ class FilterOpGpu : public OpImplBase<GPUBackend> {
 template <typename Out, typename In, typename W>
 std::unique_ptr<OpImplBase<GPUBackend>> get_filter_gpu_op_impl(const OpSpec& spec_,
                                                                const InputDesc& input_desc) {
-  VALUE_SWITCH(input_desc.axes, Axes, FILTER_INPUT_SUPPORTED_SPATIAL_NDIM, (
+  VALUE_SWITCH(input_desc.axes, Axes, FILTER_INPUT_SUPPORTED_SPATIAL_NDIM_GPU, (
     BOOL_SWITCH(
       input_desc.num_seq_dims > 0, IsSequence, (
         BOOL_SWITCH(input_desc.has_channels, HasChannels, (

--- a/dali/test/python/operator_2/test_filter.py
+++ b/dali/test/python/operator_2/test_filter.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import os
 
 import numpy as np
@@ -65,11 +66,13 @@ def create_sample_source(shapes, dtype):
 
 
 @pipeline_def
-def images_pipeline(shapes, border, in_dtype, mode):
+def images_pipeline(dev, shapes, border, in_dtype, mode):
     images, _ = fn.readers.file(name="Reader", file_root=images_dir, prefetch_queue_depth=2,
                                 random_shuffle=True, seed=42)
-    images = fn.experimental.decoders.image(images, device="mixed", output_type=types.RGB,
+    images = fn.experimental.decoders.image(images, device="cpu", output_type=types.RGB,
                                             dtype=np_type_to_dali(in_dtype))
+    if dev == "gpu":
+        images = images.gpu()
     filters, anchors = fn.external_source(source=create_filter_anchor_source(shapes), batch=False,
                                           num_outputs=2)
     fill_val_limit = 1 if not np.issubdtype(in_dtype, np.integer) else np.iinfo(in_dtype).max
@@ -84,7 +87,7 @@ def images_pipeline(shapes, border, in_dtype, mode):
 
 
 @pipeline_def
-def sample_pipeline(sample_shapes, sample_layout, filter_shapes, border, in_dtype, mode):
+def sample_pipeline(sample_shapes, sample_layout, filter_shapes, border, in_dtype, mode, dev):
     samples = fn.external_source(source=create_sample_source(sample_shapes, in_dtype), batch=False,
                                  layout=sample_layout)
     filters, anchors = fn.external_source(source=create_filter_anchor_source(filter_shapes),
@@ -94,40 +97,51 @@ def sample_pipeline(sample_shapes, sample_layout, filter_shapes, border, in_dtyp
     fill_values = fn.random.uniform(range=[0, fill_val_limit],
                                     dtype=np_type_to_dali(rand_fill_dtype))
     fill_values = fn.cast_like(fill_values, samples)
+    in_samples = samples.gpu() if dev == "gpu" else samples
     if border == "constant":
-        convolved = fn.experimental.filter(samples.gpu(), filters, fill_values, anchor=anchors,
+        convolved = fn.experimental.filter(in_samples, filters, fill_values, anchor=anchors,
                                            border=border, mode=mode)
     else:
-        convolved = fn.experimental.filter(samples.gpu(), filters, anchor=anchors, border=border,
+        convolved = fn.experimental.filter(in_samples, filters, anchor=anchors, border=border,
                                            mode=mode)
     return convolved, samples, filters, anchors, fill_values
 
 
-@params(
-    (np.uint8, 16, "101", "same"),
-    (np.uint8, 11, "clamp", "same"),
-    (np.uint8, 4, "constant", "same"),
-    (np.int8, 7, "1001", "same"),
-    (np.int16, 8, "wrap", "same"),
-    (np.int16, 1, "constant", "same"),
-    (np.float32, 11, "constant", "same"),
-    (np.float32, 13, "101", "same"),
-    (np.uint8, 4, "constant", "valid"),
-    (np.float32, 7, "101", "valid"),
-)
-def test_image_pipeline(dtype, batch_size, border, mode):
+@params(*tuple((dev, ) + params for dev, params in itertools.product(
+    ["cpu", "gpu"],
+    [
+        (np.uint8, 16, "101", "same"),
+        (np.uint8, 11, "clamp", "same"),
+        (np.uint8, 4, "constant", "same"),
+        (np.int8, 7, "1001", "same"),
+        (np.int8, 5, "wrap", "same"),
+        (np.int16, 8, "wrap", "same"),
+        (np.int16, 1, "constant", "same"),
+        (np.uint16, 5, "clamp", "same"),
+        (np.uint16, 2, "1001", "same"),
+        (np.float32, 11, "constant", "same"),
+        (np.float32, 13, "101", "same"),
+        (np.uint8, 4, "constant", "valid"),
+        (np.float32, 7, "101", "valid"),
+    ],
+    # for cpu, skip int8 and border wrap cases, as those are not supported by opencv's filter2d
+) if dev != "cpu" or params[0] != np.int8))
+def test_image_pipeline(dev, dtype, batch_size, border, mode):
     shapes = [(3, 3), (8, 8), (31, 1), (1, 31), (1, 1), (51, 3), (3, 51), (2, 40), (2, 40), (2, 2),
               (27, 27)]
     num_iters = 2
 
     pipe = images_pipeline(batch_size=batch_size, num_threads=4, device_id=0, border=border,
-                           in_dtype=dtype, shapes=shapes, mode=mode)
+                           in_dtype=dtype, shapes=shapes, mode=mode, dev=dev)
     pipe.build()
     atol = 1 if np.issubdtype(dtype, np.integer) else 1e-5
     for _ in range(num_iters):
         filtered_imgs, imgs, kernels, anchors, fill_values = pipe.run()
-        filtered_imgs = [np.array(img) for img in filtered_imgs.as_cpu()]
-        imgs = [np.array(img) for img in imgs.as_cpu()]
+        if dev == "gpu":
+            filtered_imgs = filtered_imgs.as_cpu()
+            imgs = imgs.as_cpu()
+        filtered_imgs = [np.array(img) for img in filtered_imgs]
+        imgs = [np.array(img) for img in imgs]
         kernels = [np.array(kernel) for kernel in kernels]
         anchors = [np.array(anchor) for anchor in anchors]
         fill_values = [np.array(fv) for fv in fill_values]
@@ -139,51 +153,57 @@ def test_image_pipeline(dtype, batch_size, border, mode):
         check_batch(filtered_imgs, baseline, max_allowed_error=atol)
 
 
-@attr('slow')
-@params(
-    # test 2D
-    (np.float16, "HWC", [(501, 127, 3), (600, 600, 1), (128, 256, 5),
-                         (200, 500, 2)], [(3, 3), (8, 5), (10, 4), (70, 1),
-                                          (1, 70)], 8, "101", "same"),
-    (np.int8, "HWC", [(403, 201, 150), (128, 256, 5), (200, 500, 70)], [(3, 3), (31, 2), (2, 32),
-                                                                        (5, 5)], 4, "101", "same"),
-    (np.uint8, "HW", [(501, 127), (600, 600), (128, 256),
-                      (200, 500)], [(3, 3), (8, 5), (10, 4), (70, 1), (1, 70)], 8, "1001", "same"),
-    (np.float16, "CHW", [(3, 501, 127), (1, 600, 600), (10, 1026, 741),
-                         (7, 200, 500)], [(3, 3), (8, 5), (10, 4), (70, 1),
-                                          (1, 70)], 8, "wrap", "same"),
-    (np.uint8, "CHW", [(3, 501, 127), (1, 600, 600), (10, 1026, 741),
-                       (7, 200, 500)], [(3, 3), (8, 5), (10, 4), (70, 1),
-                                        (1, 70)], 8, "wrap", "valid"),
-    (np.uint16, "FCHW", [(4, 3, 501, 127), (5, 1, 600, 600),
-                         (2, 10, 1026, 741), (1, 7, 200, 500)], [(3, 3), (8, 5), (10, 4), (70, 1),
-                                                                 (1, 70)], 8, "clamp", "same"),
-    (np.int8, "HWC", [(501, 127, 3), (4096, 1, 3), (1, 4096, 2),
-                      (1, 1, 1)], [(3, 3), (8, 5), (10, 4), (70, 1), (1, 70)], 8, "wrap", "same"),
-    (np.float32, "HW", [(1024 * 1024, 1), (1, 1024 * 1024)], [(256, 1), (1, 256), (1, 257),
-                                                              (257, 1)], 4, "101", "same"),
-    # test 3D
-    (np.uint8, "DHWC", [(300, 300, 300, 3),
-                        (128, 256, 50, 1), (200, 500, 200, 2)], [(3, 3, 3), (31, 1, 1), (1, 31, 1),
-                                                                 (1, 1, 31)], 4, "101", "same"),
-    (np.float32, "CDHW", [(3, 300, 300, 300), (1, 128, 256, 50)], [(4, 3, 2),
-                                                                   (7, 1, 2)], 4, "1001", "same"),
-    (np.uint16, "DHW", [(300, 300, 300),
-                        (128, 256, 50), (200, 500, 200)], [(3, 3, 3), (31, 1, 1), (1, 31, 1),
-                                                           (1, 1, 31)], 4, "constant", "same"),
-    (np.float32, "DHW", [(1024 * 1024, 1, 1), (1, 1024 * 1024, 1),
-                         (1, 1, 1024 * 1024)], [(256, 1, 1), (1, 257, 1),
-                                                (1, 1, 258)], 3, "101", "same"),
-    (np.float32, "DHW", [(1024 * 1024, 1, 1), (1, 1024 * 1024, 1),
-                         (1, 1, 1024 * 1024)], [(1, 256, 1), (1, 1, 257),
-                                                (258, 1, 1)], 3, "101", "same"),
+sample_2d_cases = tuple((dev, ) + params for dev, params in itertools.product(
+    ["cpu", "gpu"],
+    [
+        (np.float16, "HWC", [(501, 127, 3), (600, 600, 1), (128, 256, 5), (200, 500, 2)],
+         [(3, 3), (8, 5), (10, 4), (70, 1), (1, 70)], 8, "101", "same"),
+        (np.int8, "HWC", [(403, 201, 150), (128, 256, 5), (200, 500, 70)],
+         [(3, 3), (31, 2), (2, 32), (5, 5)], 4, "101", "same"),
+        (np.uint8, "HW", [(501, 127), (600, 600), (128, 256), (200, 500)],
+         [(3, 3), (8, 5), (10, 4), (70, 1), (1, 70)], 8, "1001", "same"),
+        (np.float16, "CHW", [(3, 501, 127), (1, 600, 600), (10, 1026, 741), (7, 200, 500)],
+         [(3, 3), (8, 5), (10, 4), (70, 1), (1, 70)], 8, "wrap", "same"),
+        (np.uint8, "CHW", [(3, 501, 127), (1, 600, 600), (10, 1026, 741), (7, 200, 500)],
+         [(3, 3), (8, 5), (10, 4), (70, 1), (1, 70)], 8, "wrap", "valid"),
+        (np.uint16, "FCHW", [(4, 3, 501, 127), (5, 1, 600, 600), (2, 10, 1026, 741), (1, 7, 200,
+                                                                                      500)],
+         [(3, 3), (8, 5), (10, 4), (70, 1), (1, 70)], 8, "clamp", "same"),
+        (np.int8, "HWC", [(501, 127, 3), (4096, 1, 3), (1, 4096, 2), (1, 1, 1)],
+         [(3, 3), (8, 5), (10, 4), (70, 1), (1, 70)], 8, "wrap", "same"),
+        (np.float32, "HW", [(1024 * 1024, 1), (1, 1024 * 1024)],
+         [(256, 1), (1, 256), (1, 257), (257, 1)], 4, "101", "same"),
+    ],
+) if dev == "gpu" or (params[0] not in [np.float16, np.int8]))
+
+sample_3d_cases = (
+    ("gpu", np.uint8, "DHWC", [(300, 300, 300, 3), (128, 256, 50, 1), (200, 200, 200, 2),
+                               (128, 64, 50, 1)], [(3, 3, 3), (31, 1, 1), (1, 31, 1),
+                                                   (1, 1, 31)], 4, "101", "same"),
+    ("gpu", np.float32, "CDHW", [(3, 300, 300, 300),
+                                 (1, 128, 256, 50)], [(4, 3, 2), (7, 1, 2)], 2, "1001", "same"),
+    ("gpu", np.uint16, "DHW", [(300, 300, 300), (128, 256, 50),
+                               (200, 500, 200)], [(3, 3, 3), (31, 1, 1), (1, 31, 1),
+                                                  (1, 1, 31)], 4, "constant", "same"),
+    ("gpu", np.float32, "DHW", [(1024 * 1024, 1, 1), (1, 1024 * 1024, 1),
+                                (1, 1, 1024 * 1024)], [(256, 1, 1), (1, 257, 1),
+                                                       (1, 1, 258)], 3, "101", "same"),
+    ("gpu", np.float32, "DHW", [(1024 * 1024, 1, 1), (1, 1024 * 1024, 1),
+                                (1, 1, 1024 * 1024)], [(1, 256, 1), (1, 1, 257),
+                                                       (258, 1, 1)], 3, "101", "same"),
 )
-def slow_test_samples(dtype, sample_layout, sample_shapes, filter_shapes, batch_size, border, mode):
+
+
+@attr('slow')
+@params(*(sample_2d_cases + sample_3d_cases))
+def slow_test_samples(dev, dtype, sample_layout, sample_shapes, filter_shapes, batch_size, border,
+                      mode):
     num_iters = 2
 
     pipe = sample_pipeline(batch_size=batch_size, num_threads=4, device_id=0,
                            sample_shapes=sample_shapes, sample_layout=sample_layout,
-                           filter_shapes=filter_shapes, border=border, in_dtype=dtype, mode=mode)
+                           filter_shapes=filter_shapes, border=border, in_dtype=dtype, mode=mode,
+                           dev=dev)
     pipe.build()
     if dtype == np.float32:
         atol = 1e-5
@@ -194,7 +214,9 @@ def slow_test_samples(dtype, sample_layout, sample_shapes, filter_shapes, batch_
         atol = 1
     for _ in range(num_iters):
         flt_samples, samples, kernels, anchors, fill_values = pipe.run()
-        flt_samples = [np.array(img) for img in flt_samples.as_cpu()]
+        if dev == "gpu":
+            flt_samples = flt_samples.as_cpu()
+        flt_samples = [np.array(img) for img in flt_samples]
         samples = [np.array(sample) for sample in samples]
         kernels = [np.array(kernel) for kernel in kernels]
         anchors = [np.array(anchor) for anchor in anchors]

--- a/dali/util/ocv.cc
+++ b/dali/util/ocv.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ int OCVInterpForDALIInterp(DALIInterpType type, int *ocv_type) {
 }
 
 int GetOpenCvChannelType(size_t c) {
-  return ( c == 3 ) ? CV_8UC3 : CV_8UC1;
+  return type2ocv<uint8_t>::value(c);
 }
 
 static cv::ColorConversionCodes GetOpenCvColorConversionCode(

--- a/dali/util/ocv.h
+++ b/dali/util/ocv.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,11 +16,35 @@
 #define DALI_UTIL_OCV_H_
 
 #include <opencv2/opencv.hpp>
+#include "dali/core/boundary.h"
 #include "dali/core/common.h"
 
 namespace dali {
 
 int DLL_PUBLIC OCVInterpForDALIInterp(DALIInterpType type, int *ocv_type);
+
+int inline OCVBorderForDALIBoundary(boundary::BoundaryType border_type) {
+  using namespace boundary;  // NOLINT(build/namespaces)
+  switch (border_type) {
+    case BoundaryType::CONSTANT:
+      return cv::BORDER_CONSTANT;
+    case BoundaryType::CLAMP:
+      return cv::BORDER_REPLICATE;
+    case BoundaryType::REFLECT_1001:
+      return cv::BORDER_REFLECT;
+    case BoundaryType::REFLECT_101:
+      return cv::BORDER_REFLECT_101;
+    case BoundaryType::WRAP:
+      return cv::BORDER_WRAP;
+    case BoundaryType::TRANSPARENT:
+      return cv::BORDER_TRANSPARENT;
+    case BoundaryType::ISOLATED:
+      return cv::BORDER_ISOLATED;
+    default:
+      throw std::runtime_error(make_string("Provided border type is not supported by OpenCV `",
+                                           to_string(border_type), "`."));
+  }
+}
 
 template <typename T>
 inline cv::Mat DLL_PUBLIC CreateMatFromPtr(int H,
@@ -33,6 +57,51 @@ inline cv::Mat DLL_PUBLIC CreateMatFromPtr(int H,
   // (that I know of) without making the input argument non-const.
   return cv::Mat(H, W, type, const_cast<T*>(ptr), step);
 }
+
+template <typename T>
+struct type2ocv {};
+
+template <>
+struct type2ocv<uint8_t> {
+  static int value(int c) {
+    return CV_8UC(c);
+  }
+};
+
+template <>
+struct type2ocv<int8_t> {
+  static int value(int c) {
+    return CV_8SC(c);
+  }
+};
+
+template <>
+struct type2ocv<uint16_t> {
+  static int value(int c) {
+    return CV_16UC(c);
+  }
+};
+
+template <>
+struct type2ocv<int16_t> {
+  static int value(int c) {
+    return CV_16SC(c);
+  }
+};
+
+template <>
+struct type2ocv<int32_t> {
+  static int value(int c) {
+    return CV_32SC(c);
+  }
+};
+
+template <>
+struct type2ocv<float> {
+  static int value(int c) {
+    return CV_32FC(c);
+  }
+};
 
 int DLL_PUBLIC GetOpenCvChannelType(size_t c);
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
This PR adds CPU backend to the `expermimental.filter` operator. The backend simply wraps opencv's filter2d. For this reason, the volumteric data is not supported by the CPU backend, similarily input of int8 and float16 types are not supported.

Both "same" and "valid" modes are supported, the first with all supported border modes. 
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

Due to limitations of OCV, the constant and wrap border modes must have been implemented with extra calls to manually pad the input with proper border.

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: FILTER.01 (FILTER.01-FILTER.04, FILTER.06-FILTER.12)
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3263
<!--- DALI-XXXX or NA --->
