### PR TITLE
Support CPU samples in predefined automatic augmentations

### DIFF
--- a/dali/python/nvidia/dali/auto_aug/augmentations.py
+++ b/dali/python/nvidia/dali/auto_aug/augmentations.py
@@ -147,7 +147,7 @@ def sharpness_kernel_shifted(magnitude):
 
 
 @augmentation(mag_range=(0, 0.9), randomly_negate=True, mag_to_param=sharpness_kernel,
-              param_device="gpu")
+              param_device="auto")
 def sharpness(sample, kernel):
     """
     The outputs correspond to PIL's ImageEnhance.Sharpness with the exception for 1px
@@ -173,12 +173,12 @@ def poster_mask_uint8(magnitude):
     return np.array(np.uint8(255) ^ removal_mask, dtype=np.uint8)
 
 
-@augmentation(mag_range=(0, 4), mag_to_param=poster_mask_uint8, param_device="gpu")
+@augmentation(mag_range=(0, 4), mag_to_param=poster_mask_uint8, param_device="auto")
 def posterize(sample, mask):
     return sample & mask
 
 
-@augmentation(mag_range=(256, 0), param_device="gpu")
+@augmentation(mag_range=(256, 0), param_device="auto")
 def solarize(sample, threshold):
     sample_inv = types.Constant(255, dtype=types.UINT8) - sample
     mask_unchanged = sample < threshold
@@ -192,7 +192,7 @@ def solarize_add_shift(shift):
     return np.uint8(shift)
 
 
-@augmentation(mag_range=(0, 110), param_device="gpu", mag_to_param=solarize_add_shift)
+@augmentation(mag_range=(0, 110), param_device="auto", mag_to_param=solarize_add_shift)
 def solarize_add(sample, shift):
     mask_shifted = sample < types.Constant(128, dtype=types.UINT8)
     mask_id = mask_shifted ^ True

--- a/dali/python/nvidia/dali/auto_aug/auto_augment.py
+++ b/dali/python/nvidia/dali/auto_aug/auto_augment.py
@@ -45,7 +45,7 @@ def auto_augment(sample: _DataNode, policy_name: str = 'image_net',
     ---------
     sample : DataNode
         A batch of samples to be processed. The samples should be images of `HWC` layout,
-        `uint8` type and reside on GPU.
+        `uint8` type.
     policy_name : str, optional
         The name of predefined policy. Acceptable values are: `image_net`,
         `reduced_image_net`, `svhn`, `reduced_cifar10`. Defaults to `image_net`.

--- a/dali/python/nvidia/dali/auto_aug/core/_augmentation.py
+++ b/dali/python/nvidia/dali/auto_aug/core/_augmentation.py
@@ -190,7 +190,8 @@ class Augmentation:
             A batch of transformed samples.
     """
         num_mandatory_positional_args = 2
-        params = self._get_param(magnitude_bin, num_magnitude_bins)
+        param_device = self._infer_param_device(sample)
+        params = self._get_param(magnitude_bin, num_magnitude_bins, param_device)
         op_kwargs = filter_extra_accepted_kwargs(self.op, kwargs, num_mandatory_positional_args)
         missing_args = get_missing_kwargs(self.op, kwargs, num_mandatory_positional_args)
         if missing_args:
@@ -252,6 +253,11 @@ class Augmentation:
             "name": self._name,
         }
 
+    def _infer_param_device(self, sample : _DataNode):
+        if self.param_device != "auto":
+            return self.param_device
+        return sample.device or "cpu"
+
     def _has_custom_magnitudes(self):
         return isinstance(self.mag_range, np.ndarray)
 
@@ -311,7 +317,7 @@ class Augmentation:
         lo, hi = mag_range
         return np.linspace(lo, hi, num_magnitude_bins, dtype=np.float32)
 
-    def _get_param(self, magnitude_bin, num_magnitude_bins):
+    def _get_param(self, magnitude_bin, num_magnitude_bins, param_device):
         magnitudes = self._get_magnitudes(num_magnitude_bins)
         if magnitudes is None:
             return None
@@ -339,7 +345,7 @@ class Augmentation:
                 param_idx = magnitude_bin.signed_magnitude_idx
             magnitudes = _SignedMagnitudeBin._remap_to_signed_magnitudes(magnitudes)
             params = self._map_mags_to_params(magnitudes)
-            params = types.Constant(params, device=self.param_device)
+            params = types.Constant(params, device=param_device)
             return params[param_idx]
         else:
             # other augmentations in the suite may need sign and we got it along the magnitude bin,
@@ -349,10 +355,10 @@ class Augmentation:
             if isinstance(bin_idx, int):
                 magnitude = magnitudes[bin_idx]
                 param = self._map_mag_to_param(magnitude)
-                return types.Constant(param, device=self.param_device)
+                return types.Constant(param, device=param_device)
             else:
                 params = self._map_mags_to_params(magnitudes)
-                params = types.Constant(params, device=self.param_device)
+                params = types.Constant(params, device=param_device)
                 return params[bin_idx]
 
     def _validate_op_sig(self):

--- a/dali/python/nvidia/dali/auto_aug/core/_augmentation.py
+++ b/dali/python/nvidia/dali/auto_aug/core/_augmentation.py
@@ -253,7 +253,7 @@ class Augmentation:
             "name": self._name,
         }
 
-    def _infer_param_device(self, sample : _DataNode):
+    def _infer_param_device(self, sample: _DataNode):
         if self.param_device != "auto":
             return self.param_device
         return sample.device or "cpu"

--- a/dali/python/nvidia/dali/auto_aug/core/decorator.py
+++ b/dali/python/nvidia/dali/auto_aug/core/decorator.py
@@ -74,7 +74,9 @@ def augmentation(function: Optional[Callable[..., _DataNode]] = None, *,
         (in particular, no pipelined DALI operators can be used in the callback).
         The output type and dimensionality must be consistent and not depend on the magnitude.
     param_device: str
-        A "cpu" or "gpu", describes where to store the precomputed parameters.
+        A "cpu", "gpu", or "auto"; defaults to "cpu". Describes where to store the precomputed
+        parameters (i.e. the `mag_to_param` outputs). If "auto" is specified, the CPU or GPU
+        backend will be selected to match the `sample`'s backend.
     name: str
         Name of the augmentation. By default, the name of the decorated function is used.
 

--- a/dali/python/nvidia/dali/auto_aug/rand_augment.py
+++ b/dali/python/nvidia/dali/auto_aug/rand_augment.py
@@ -42,7 +42,7 @@ def rand_augment(sample: _DataNode, n: int, m: int, num_magnitude_bins: int = 31
     ---------
     sample : DataNode
         A batch of samples to be processed. The samples should be images of `HWC` layout,
-        `uint8` type and reside on GPU.
+        `uint8` type.
     n: int
         The number of randomly sampled operations to be applied to a sample.
     m: int

--- a/dali/python/nvidia/dali/auto_aug/trivial_augment.py
+++ b/dali/python/nvidia/dali/auto_aug/trivial_augment.py
@@ -40,7 +40,7 @@ def trivial_augment_wide(sample: _DataNode, num_magnitude_bins: int = 31,
     ---------
     sample : DataNode
         A batch of samples to be processed. The samples should be images of `HWC` layout,
-        `uint8` type and reside on GPU.
+        `uint8` type.
     num_magnitude_bins: int, optional
         The number of bins to divide the magnitude ranges into.
     fill_value: int, optional
@@ -110,8 +110,7 @@ def apply_trivial_augment(augmentations: List[_Augmentation], sample: _DataNode,
     augmentations : List[core._Augmentation]
         List of augmentations to be sampled and applied in TrivialAugment fashion.
     sample : DataNode
-        A batch of samples to be processed. The samples should be images of `HWC` layout,
-        `uint8` type and reside on GPU.
+        A batch of samples to be processed.
     num_magnitude_bins: int, optional
         The number of bins to divide the magnitude ranges into.
     seed: int, optional

--- a/dali/test/python/auto_aug/test_rand_augment.py
+++ b/dali/test/python/auto_aug/test_rand_augment.py
@@ -31,10 +31,11 @@ data_root = get_dali_extra_path()
 images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
 
 
-@params(*tuple(enumerate(itertools.product((True, False), (True, False), (None, 0),
-                                           (True, False)))))
+@params(*tuple(
+    enumerate(
+        itertools.product(("cpu", "gpu"), (True, False), (True, False), (None, 0), (True, False)))))
 def test_run_rand_aug(i, args):
-    uniformly_resized, use_shape, fill_value, specify_translation_bounds = args
+    dev, uniformly_resized, use_shape, fill_value, specify_translation_bounds = args
     batch_sizes = [1, 8, 7, 64, 13, 64, 128]
     ns = [1, 2, 3, 4]
     ms = [0, 15, 30]
@@ -46,7 +47,7 @@ def test_run_rand_aug(i, args):
                   seed=43)
     def pipeline():
         encoded_image, _ = fn.readers.file(name="Reader", file_root=images_dir)
-        image = fn.decoders.image(encoded_image, device="mixed")
+        image = fn.decoders.image(encoded_image, device="cpu" if dev == "cpu" else "mixed")
         if uniformly_resized:
             image = fn.resize(image, size=(244, 244))
         extra = {} if not use_shape else {"shape": fn.peek_image_shape(encoded_image)}

--- a/dali/test/python/auto_aug/test_trivial_augment.py
+++ b/dali/test/python/auto_aug/test_trivial_augment.py
@@ -29,10 +29,11 @@ data_root = get_dali_extra_path()
 images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
 
 
-@params(*tuple(enumerate(itertools.product((True, False), (True, False), (None, 0),
-                                           (True, False)))))
+@params(*tuple(
+    enumerate(
+        itertools.product(("cpu", "gpu"), (True, False), (True, False), (None, 0), (True, False)))))
 def test_run_trivial(i, args):
-    uniformly_resized, use_shape, fill_value, specify_translation_bounds = args
+    dev, uniformly_resized, use_shape, fill_value, specify_translation_bounds = args
     batch_sizes = [1, 8, 7, 64, 13, 64, 128]
     num_magnitude_bin_cases = [1, 11, 31, 40]
     batch_size = batch_sizes[i % len(batch_sizes)]
@@ -42,7 +43,7 @@ def test_run_trivial(i, args):
                   seed=43)
     def pipeline():
         encoded_image, _ = fn.readers.file(name="Reader", file_root=images_dir)
-        image = fn.decoders.image(encoded_image, device="mixed")
+        image = fn.decoders.image(encoded_image, device="cpu" if dev == "cpu" else "mixed")
         if uniformly_resized:
             image = fn.resize(image, size=(244, 244))
         extra = {} if not use_shape else {"shape": fn.peek_image_shape(encoded_image)}


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Now, that all predefined augmentations support CPU inputs, we can make the AutoAugment, RandAugment and TrivialAugment support the CPU samples. It is mostly a docs and tests update.

One extra thing is a change to the `@augmentation` decorator's  `param_device` arg. It controls the backend of the Constant node with the precomputed argument for the augmentation. Initially, it supported simply cpu or gpu. For the most part, if the parameter is used in the augmentation as a named argument to some operator, it must be cpu. However, in some cases it is used as a positional argument (or implicitly so, with arithmetic operators). Then, it makes sense to put it on gpu if samples are on gpu too. For this reason, the third option is added, the "auto" option which infers the cpu, gpu backend from the sample's DataNode.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3296
<!--- DALI-XXXX or NA --->
