### PR TITLE
Add "repeat_last" option to ExternalSource and handle it in Pipeline.

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -601,7 +601,6 @@ int Executor<WorkspacePolicy, QueuePolicy>::InferBatchSize(
   int batch_size;
   try {
     batch_size = bsps[0]->NextBatchSize();
-    assert(batch_size > 0);
     for (auto &bsp : bsps) {
       bsp->Advance();
     }

--- a/dali/pipeline/operator/builtin/caching_list.h
+++ b/dali/pipeline/operator/builtin/caching_list.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <stdexcept>
 #include <list>
 #include <memory>
+#include <iostream>
 
 namespace dali {
 /**

--- a/dali/pipeline/operator/builtin/caching_list.h
+++ b/dali/pipeline/operator/builtin/caching_list.h
@@ -18,7 +18,6 @@
 #include <stdexcept>
 #include <list>
 #include <memory>
-#include <iostream>
 
 namespace dali {
 /**
@@ -107,17 +106,6 @@ class CachingList {
 
 
   const T &PeekProphet() {
-    bool found = false;
-    int i = 0;
-    for (auto it = full_data_.begin(); it != full_data_.end(); ++it, ++i)
-      if (it == prophet_) {
-        found = true;
-        break;
-      }
-    if (!found)
-      std::cout << "Prophet doesn't point to any entry in full_data_" << std::endl;
-    else
-      std::cout << "Prophet points to entry #" << i << " in the list" << std::endl;
     if (prophet_ == full_data_.end())
       throw std::out_of_range(
               "Attempted to peek element that doesn't exist. Add more elements to CachingList "

--- a/dali/pipeline/operator/builtin/caching_list.h
+++ b/dali/pipeline/operator/builtin/caching_list.h
@@ -62,6 +62,8 @@ class CachingList {
     assert(!full_data_.empty());  // Can't pop from an empty list
     std::list<T> tmp;
     tmp.splice(tmp.begin(), full_data_, full_data_.begin());
+    if (tmp.begin() == prophet_)
+      prophet_ = full_data_.begin();
     return tmp;
   }
 
@@ -104,6 +106,17 @@ class CachingList {
 
 
   const T &PeekProphet() {
+    bool found = false;
+    int i = 0;
+    for (auto it = full_data_.begin(); it != full_data_.end(); ++it, ++i)
+      if (it == prophet_) {
+        found = true;
+        break;
+      }
+    if (!found)
+      std::cout << "Prophet doesn't point to any entry in full_data_" << std::endl;
+    else
+      std::cout << "Prophet points to entry #" << i << " in the list" << std::endl;
     if (prophet_ == full_data_.end())
       throw std::out_of_range(
               "Attempted to peek element that doesn't exist. Add more elements to CachingList "

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -66,6 +66,8 @@ of dimensions in the layout.
 Specifying the input dimensionality will be required starting from DALI 2.0)code", nullptr)
                 .AddOptionalArg<TensorLayout>("layout",
                                               "If provided, sets the layout of the data.", nullptr)
+                .AddOptionalArg("repeat_last", R"(If set, the last batch is re-fed when running
+the operator and no new data was provided since the previous run.)", false)
                 .AddParent("InputOperatorBase");
 
 

--- a/dali/pipeline/operator/builtin/input_operator.h
+++ b/dali/pipeline/operator/builtin/input_operator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -246,6 +246,16 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
    */
   virtual DALIDataType in_dtype() const = 0;
 
+  bool WouldCopy(InputOperatorNoCopyMode no_copy) const {
+    switch (no_copy) {
+      case InputOperatorNoCopyMode::FORCE_COPY:
+        return true;
+      case InputOperatorNoCopyMode::FORCE_NO_COPY:
+        return false;
+      default:
+        return !no_copy_;
+    }
+  }
 
  protected:
   /**
@@ -478,7 +488,6 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
       state_.push_back({false, false});
     }
   }
-
 
   template<typename SrcBackend>
   void SetDataSourceHelper(const TensorList<SrcBackend> &batch, std::optional<std::string> data_id,

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -570,13 +570,13 @@ void Pipeline::RunCPU() {
   DALI_ENFORCE(built_,
       "\"Build()\" must be called prior to executing the pipeline.");
   repeat_last_.Refeed<CPUBackend>(*this);
+  repeat_last_.Refeed<GPUBackend>(*this);
   executor_->RunCPU();
 }
 
 void Pipeline::RunGPU() {
   DALI_ENFORCE(built_,
       "\"Build()\" must be called prior to executing the pipeline.");
-  repeat_last_.Refeed<GPUBackend>(*this);
   executor_->RunMixed();
   executor_->RunGPU();
 }
@@ -1038,6 +1038,8 @@ void Pipeline::RepeatLastInputs::FindNodes(const OpGraph &graph) {
       gpu_nodes_[node.instance_name] = { &node };
     else if (node.op_type == OpType::CPU)
       cpu_nodes_[node.instance_name] = { &node };
+    else if (node.op_type == OpType::MIXED)
+      mixed_nodes_[node.instance_name] = { &node };
     else
       assert(!"Unexpected backend for an ExternalSource node.");
   }

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -135,12 +135,16 @@ class DLL_PUBLIC Pipeline {
   void SetDataSourceHelper(
           const string &name, const TensorList<TensorListBackend> &tl,
           std::optional<std::string> data_id, OperatorBase *op_ptr, AccessOrder order = {},
-          InputOperatorSettingMode in_op_setting_mode = {}) {
-    auto *source = dynamic_cast<InputOperator<OperatorBackend> *>(op_ptr);
-    DALI_ENFORCE(source != nullptr,
-                 "Input name '" + name + "' is not marked as an InputOperator.");
-    source->template SetDataSource<TensorListBackend>(tl, order, in_op_setting_mode,
-                                                      std::move(data_id));
+          InputOperatorSettingMode in_op_setting_mode = {},
+          bool is_refeeding = false) {
+    if (is_refeeding ||
+        !repeat_last_.SetLast<OperatorBackend>(name, tl, data_id, order, in_op_setting_mode)) {
+      auto *source = dynamic_cast<InputOperator<OperatorBackend> *>(op_ptr);
+      DALI_ENFORCE(source != nullptr,
+                  "Input name '" + name + "' is not marked as an InputOperator.");
+      source->template SetDataSource<TensorListBackend>(tl, order, in_op_setting_mode,
+                                                        std::move(data_id));
+    }
   }
 
 
@@ -156,7 +160,8 @@ class DLL_PUBLIC Pipeline {
   template<typename Backend>
   void SetExternalInputHelper(const string &name, const TensorList<Backend> &tl,
                               std::optional<std::string> data_id, AccessOrder order = {},
-                              InputOperatorSettingMode ext_src_setting_mode = {}) {
+                              InputOperatorSettingMode ext_src_setting_mode = {},
+                              bool is_refeeding = false) {
     OpType op_type;
     OpNodeId node_id = -1;
 
@@ -180,15 +185,15 @@ class DLL_PUBLIC Pipeline {
     switch (op_type) {
       case OpType::CPU:
         SetDataSourceHelper<Backend, CPUBackend>(name, tl, std::move(data_id), op_ptr, order,
-                                                 ext_src_setting_mode);
+                                                 ext_src_setting_mode, is_refeeding);
         break;
       case OpType::MIXED:
         SetDataSourceHelper<Backend, MixedBackend>(name, tl, std::move(data_id), op_ptr, order,
-                                                   ext_src_setting_mode);
+                                                   ext_src_setting_mode, is_refeeding);
         break;
       case OpType::GPU:
         SetDataSourceHelper<Backend, GPUBackend>(name, tl, std::move(data_id), op_ptr, order,
-                                                 ext_src_setting_mode);
+                                                 ext_src_setting_mode, is_refeeding);
         break;
       default:
         assert(false);  // This shouldn't happen.
@@ -216,10 +221,8 @@ class DLL_PUBLIC Pipeline {
     DALI_ENFORCE(tl.num_samples() > 0, "The input batch cannot be empty.");
 
     InputOperatorSettingMode mode{sync, use_copy_kernel, no_copy_mode};
-    if (!repeat_last_.SetLast(name, tl, data_id, order, mode)) {
-      // if SetLast succeeds, the data will be forcibly _shared_ (zero copy) upon Refeed
-      SetExternalInputHelper(name, tl, std::move(data_id), order, mode);
-    }
+    // if SetLast succeeds, the data will be forcibly _shared_ (zero copy) upon Refeed
+    SetExternalInputHelper(name, tl, std::move(data_id), order, mode, false);
   }
 
 
@@ -666,27 +669,35 @@ class DLL_PUBLIC Pipeline {
   struct RepeatLastInputs {
     void FindNodes(const OpGraph &graph);
 
-    template <typename Backend>
-    bool SetLast(const std::string &name, const TensorList<Backend> &data,
+    template <typename OperatorBackend, typename DataBackend>
+    bool SetLast(const std::string &name, const TensorList<DataBackend> &data,
                  const std::optional<std::string> &data_id,
                  AccessOrder order,
                  InputOperatorSettingMode ext_src_setting_mode) {
-      auto &nodes = GetNodes<Backend>();
+      auto &nodes = GetNodes<OperatorBackend>();
       auto it = nodes.find(name);
       if (it == nodes.end())
         return false;
 
       auto &node = it->second;
-      auto &inp = dynamic_cast<InputOperator<Backend>&>(*node.op_node->op);
+      auto &inp = dynamic_cast<InputOperator<OperatorBackend>&>(*node.op_node->op);
 
-      if (inp.WouldCopy(ext_src_setting_mode.no_copy_mode)) {
+      auto do_copy = [&]() {
         node.last_input.Reset();
         node.last_input.set_order(order);
         node.last_input.Copy(data, order, ext_src_setting_mode.use_copy_kernel);
         if (ext_src_setting_mode.sync)
           AccessOrder::host().wait(order);
+      };
+
+      if constexpr (std::is_same_v<OperatorBackend, DataBackend>) {
+        if (inp.WouldCopy(ext_src_setting_mode.no_copy_mode)) {
+          do_copy();
+        } else {
+          node.last_input.ShareData(data);
+        }
       } else {
-        node.last_input.ShareData(data);
+        do_copy();
       }
       node.data_id = data_id;
 
@@ -699,20 +710,24 @@ class DLL_PUBLIC Pipeline {
     template <typename Backend>
     struct RepeatLastInput {
       const OpNode *op_node = nullptr;
-      TensorList<Backend> last_input;
+      using InputBackend = std::conditional_t<std::is_same_v<Backend, MixedBackend>,
+                                             CPUBackend, Backend>;
+      TensorList<InputBackend> last_input;
       std::optional<std::string> data_id;
     };
 
     std::map<std::string, RepeatLastInput<CPUBackend>> cpu_nodes_;
     std::map<std::string, RepeatLastInput<GPUBackend>> gpu_nodes_;
+    std::map<std::string, RepeatLastInput<MixedBackend>> mixed_nodes_;
 
     template <typename Backend>
     std::map<std::string, RepeatLastInput<Backend>> &GetNodes() {
-      static_assert(std::is_same_v<Backend, CPUBackend> || std::is_same_v<Backend, GPUBackend>);
       if constexpr (std::is_same_v<Backend, CPUBackend>)
         return cpu_nodes_;
-      else
+      else if constexpr (std::is_same_v<Backend, GPUBackend>)
         return gpu_nodes_;
+      else
+        return mixed_nodes_;
     }
   };
 
@@ -723,8 +738,10 @@ template <typename Backend>
 void Pipeline::RepeatLastInputs::Refeed(Pipeline &owner) {
   auto &nodes = GetNodes<Backend>();
   for (auto &[name, node] : nodes) {
+    print(std::cout, "Refeeding ", name, "\n");
     owner.SetExternalInputHelper(name, node.last_input, node.data_id, {},
-      InputOperatorSettingMode{false, false, InputOperatorNoCopyMode::FORCE_NO_COPY});
+      InputOperatorSettingMode{false, false, InputOperatorNoCopyMode::FORCE_NO_COPY},
+      true);
   }
 }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -738,7 +738,6 @@ template <typename Backend>
 void Pipeline::RepeatLastInputs::Refeed(Pipeline &owner) {
   auto &nodes = GetNodes<Backend>();
   for (auto &[name, node] : nodes) {
-    print(std::cout, "Refeeding ", name, "\n");
     owner.SetExternalInputHelper(name, node.last_input, node.data_id, {},
       InputOperatorSettingMode{false, false, InputOperatorNoCopyMode::FORCE_NO_COPY},
       true);

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -218,8 +218,6 @@ class DLL_PUBLIC Pipeline {
                    bool sync = false, bool use_copy_kernel = false,
                    InputOperatorNoCopyMode no_copy_mode = InputOperatorNoCopyMode::DEFAULT,
                    std::optional<std::string> data_id = std::nullopt) {
-    DALI_ENFORCE(tl.num_samples() > 0, "The input batch cannot be empty.");
-
     InputOperatorSettingMode mode{sync, use_copy_kernel, no_copy_mode};
     // if SetLast succeeds, the data will be forcibly _shared_ (zero copy) upon Refeed
     SetExternalInputHelper(name, tl, std::move(data_id), order, mode, false);
@@ -738,7 +736,7 @@ template <typename Backend>
 void Pipeline::RepeatLastInputs::Refeed(Pipeline &owner) {
   auto &nodes = GetNodes<Backend>();
   for (auto &[name, node] : nodes) {
-    owner.SetExternalInputHelper(name, node.last_input, node.data_id, {},
+    owner.SetExternalInputHelper(name, node.last_input, node.data_id, node.last_input.order(),
       InputOperatorSettingMode{false, false, InputOperatorNoCopyMode::FORCE_NO_COPY},
       true);
   }

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -522,17 +522,17 @@ Keyword Args
 
 `repeat_last` : bool, optional, default = False
     .. note::
-        This is an advanced setting that is usable mainly with Triron inference server
+        This is an advanced setting that is usable mainly with Triton Inference Server
         with decoupled models.
 
-    Normally, ``external_source`` consumes its and expects new ones to be fed in the upcoming
-    iteration. Setting ``repeat_last=True`` changes this behavior so that ``external_source``
-    will detect that no new data was fed between the previous pipeline run and the currnet one
-    and will refeed the most recently data.
+    Normally, ``external_source`` consumes its input data and expects new ones to be fed in the
+    upcoming iteration. Setting ``repeat_last=True`` changes this behavior so that
+    ``external_source`` will detect that no new data was fed between the previous pipeline run and
+    the currnet one and will self-refeed with the most recent data.
 
     Setting ``repeat_last`` to `True` only makes sense in "push" mode, i.e. when the data is
-    actively provided by the user via a call to ``feed_input`` and is incompatible with specifying
-    the ``source``, which makes the ``external_source`` operate in "pull" mode.
+    actively provided by the user via a call to ``feed_input``. Enabling this option is incompatible
+    with specifying the ``source``, which makes the ``external_source`` operate in "pull" mode.
 
 `prefetch_queue_depth` : int, optional, default = 1
     When run in ``parallel=True`` mode, specifies the number of batches to be computed in

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -520,6 +520,20 @@ Keyword Args
         Python process, but due to their state it is not possible to calculate more
         than one batch at a time.
 
+`repeat_last` : bool, optional, default = False
+    .. note::
+        This is an advanced setting that is usable mainly with Triron inference server
+        with decoupled models.
+
+    Normally, ``external_source`` consumes its and expects new ones to be fed in the upcoming
+    iteration. Setting ``repeat_last=True`` changes this behavior so that ``external_source``
+    will detect that no new data was fed between the previous pipeline run and the currnet one
+    and will refeed the most recently data.
+
+    Setting ``repeat_last`` to `True` only makes sense in "push" mode, i.e. when the data is
+    actively provided by the user via a call to ``feed_input`` and is incompatible with specifying
+    the ``source``, which makes the ``external_source`` operate in "pull" mode.
+
 `prefetch_queue_depth` : int, optional, default = 1
     When run in ``parallel=True`` mode, specifies the number of batches to be computed in
     advance and stored in the internal buffer, otherwise parameter is ignored.
@@ -547,7 +561,7 @@ Keyword Args
     def __init__(self, source=None, num_outputs=None, *, cycle=None, layout=None, dtype=None,
                  ndim=None, name=None, device="cpu", cuda_stream=None, use_copy_kernel=None,
                  batch=None, parallel=None, no_copy=None, prefetch_queue_depth=None,
-                 bytes_per_sample_hint=None, batch_info=None, **kwargs):
+                 bytes_per_sample_hint=None, batch_info=None, repeat_last=False, **kwargs):
         self._schema = _b.GetSchema("ExternalSource")
         self._spec = _b.OpSpec("ExternalSource")
         self._device = device
@@ -575,8 +589,10 @@ Keyword Args
         self._prefetch_queue_depth = prefetch_queue_depth
         self._bytes_per_sample_hint = bytes_per_sample_hint
         self._batch_info = batch_info
+        self._repeat_last = repeat_last
 
         self._spec.AddArg("device", device)
+        self._spec.AddArg("repeat_last", repeat_last)
         for key, value in kwargs.items():
             self._spec.AddArg(key, value)
 
@@ -598,7 +614,8 @@ Keyword Args
 
     def __call__(self, *, source=None, cycle=None, name=None, layout=None, dtype=None, ndim=None,
                  cuda_stream=None, use_copy_kernel=None, batch=None, parallel=None, no_copy=None,
-                 prefetch_queue_depth=None, bytes_per_sample_hint=None, batch_info=None, **kwargs):
+                 prefetch_queue_depth=None, bytes_per_sample_hint=None, batch_info=None,
+                 repeat_last=False, **kwargs):
         ""
         from nvidia.dali.ops import _OperatorInstance
         if batch_info is None:
@@ -627,6 +644,10 @@ Keyword Args
 
             # Keep the metadata for Pipeline inspection
             self._source_desc = source_desc
+
+        if callback is not None and repeat_last:
+            raise ValueError("``repeat_last`` must not be set when using the ``source`` argument "
+                             "It's usable only with manually fed ``external_source``.")
 
         if parallel is None:
             parallel = self._parallel or False
@@ -746,7 +767,7 @@ Keyword Args
             'batch_info': batch_info,
             'parallel': parallel,
             'prefetch_queue_depth': prefetch_queue_depth,
-            'bytes_per_sample_hint': bytes_per_sample_hint,
+            'bytes_per_sample_hint': bytes_per_sample_hint
         }
 
         if self._num_outputs is not None:
@@ -828,7 +849,7 @@ def _has_external_source(pipeline):
 
 def external_source(source=None, num_outputs=None, *, cycle=None, name=None, device="cpu",
                     layout=None, dtype=None, ndim=None, cuda_stream=None, use_copy_kernel=None,
-                    batch=True, **kwargs):
+                    batch=True, repeat_last=False, **kwargs):
     """Creates a data node which is populated with data from a Python source.
 The data can be provided by the ``source`` function or iterable, or it can be provided by
 ``pipeline.feed_input(name, data, layout, cuda_stream)`` inside ``pipeline.iter_setup``.
@@ -853,7 +874,7 @@ provided memory is copied to the internal buffer.
 
     def _external_source(source=None, num_outputs=None, *, cycle=None, name=None, device="cpu",
                          layout=None, dtype=None, ndim=None, cuda_stream=None, use_copy_kernel=None,
-                         batch=True, **kwargs):
+                         repeat_last=False, batch=True, **kwargs):
         if batch is None:
             batch = True
 
@@ -866,7 +887,8 @@ provided memory is copied to the internal buffer.
 
         op = ExternalSource(device=device, num_outputs=num_outputs, source=source, cycle=cycle,
                             layout=layout, dtype=dtype, ndim=ndim, cuda_stream=cuda_stream,
-                            use_copy_kernel=use_copy_kernel, batch=batch, **kwargs)
+                            use_copy_kernel=use_copy_kernel, batch=batch, repeat_last=repeat_last,
+                            **kwargs)
         return op(name=name)
 
     # Wrapper around external_source to switch between standard and debug mode.
@@ -874,11 +896,12 @@ provided memory is copied to the internal buffer.
     if getattr(current_pipeline, '_debug_on', False):
         result = current_pipeline._external_source(
             source=source, num_outputs=num_outputs, cycle=cycle, name=name, device=device,
-            layout=layout, batch=batch, **kwargs)
+            layout=layout, batch=batch, repeat_last=repeat_last, **kwargs)
     else:
         result = _external_source(source, num_outputs, cycle=cycle, name=name, device=device,
                                   layout=layout, dtype=dtype, ndim=ndim, cuda_stream=cuda_stream,
-                                  use_copy_kernel=use_copy_kernel, batch=batch, **kwargs)
+                                  use_copy_kernel=use_copy_kernel, batch=batch,
+                                  repeat_last=repeat_last, **kwargs)
     if _conditionals.conditionals_enabled():
         _conditionals.register_data_nodes(result)
     return result

--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import random
-import nvidia.dali as dali
 import nvidia.dali.fn as fn
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
@@ -584,6 +583,7 @@ def test_empty_es():
         pipe.build()
         pipe.run()
 
+
 def to_tensor_list_gpu(data):
     @pipeline_def(batch_size=len(data), num_threads=4, device_id=0, prefetch_queue_depth=1)
     def convert_pipe():
@@ -592,6 +592,7 @@ def to_tensor_list_gpu(data):
     pipe.build()
     out, = pipe.run()
     return out
+
 
 def test_repeat_last():
     @pipeline_def
@@ -722,19 +723,18 @@ def test_repeat_last_var_batch(device):
 
     pipe.feed_input("es", data2)
     a, b = pipe.run()
-    check_batch(a, data1)  # data1 still in the queue
+    check_batch(a, data1)  # <- still the old value
     assert len(b) == len(data1)
 
-    a, b = pipe.run()  # data2 should bubble up now
+    a, b = pipe.run()  # <- new value visible
     check_batch(a, data2)
     assert len(b) == len(data2)
 
-
     pipe.feed_input("es", data1)
     a, b = pipe.run()
-    check_batch(a, data2)  # data2 still in the queue
+    check_batch(a, data2)  # <- still 2, the most recent change not visible
     assert len(b) == len(data2)
 
-    a, b = pipe.run()  # data1 should bubble up now
+    a, b = pipe.run()  # <- new value visible
     check_batch(a, data1)
     assert len(b) == len(data1)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:
Previously external source had to be fed before each iteration. This PR adds an option for external source to be automatically re-fed with the most recent value. This option does not work with `source` argument and only works with "push" mode external source.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
test_external_source_dali.py:test_repeat_last
test_external_source_dali.py:test_repeat_last_queue (with prefetching)

- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [X] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3359
<!--- DALI-XXXX or NA --->
