### PR TITLE
Fix the regex that recognizes CuPy arrays.

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -601,7 +601,6 @@ int Executor<WorkspacePolicy, QueuePolicy>::InferBatchSize(
   int batch_size;
   try {
     batch_size = bsps[0]->NextBatchSize();
-    assert(batch_size > 0);
     for (auto &bsp : bsps) {
       bsp->Advance();
     }

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -390,7 +390,7 @@ def _get_device_id_for_array(array):
         return None
 
 
-_cupy_array_type_regex = re.compile('.*cupy\..*\.ndarray.*')        # noqa: W605
+_cupy_array_type_regex = re.compile('.*cupy.*\..*ndarray.*')        # noqa: W605
 
 
 def _is_cupy_array(value):

--- a/dali/test/python/test_external_source_cupy.py
+++ b/dali/test/python/test_external_source_cupy.py
@@ -36,7 +36,7 @@ use_cupy()
 import cupy as cp  # noqa:E402  - we need to call this after use_cupy()
 
 
-assert nvidia.dali.types._is_cupy_array(cp.array([1,2,3])), "CuPy array not recognized"
+assert nvidia.dali.types._is_cupy_array(cp.array([1, 2, 3])), "CuPy array not recognized"
 
 
 def test_external_source_with_iter_cupy_stream():

--- a/dali/test/python/test_external_source_cupy.py
+++ b/dali/test/python/test_external_source_cupy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ from nose.plugins.attrib import attr
 from test_external_source_impl import *  # noqa:F403, F401
 from test_external_source_impl import use_cupy
 from test_utils import check_output, check_output_pattern
+import nvidia.dali
 from nvidia.dali import Pipeline, pipeline_def
 import nvidia.dali.fn as fn
 from nvidia.dali.tensors import TensorGPU
@@ -33,6 +34,9 @@ use_cupy()
 
 # extra tests, GPU-specific
 import cupy as cp  # noqa:E402  - we need to call this after use_cupy()
+
+
+assert nvidia.dali.types._is_cupy_array(cp.array([1,2,3])), "CuPy array not recognized"
 
 
 def test_external_source_with_iter_cupy_stream():

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -397,6 +397,7 @@ def check_output(outputs, ref_out, ref_is_list_of_outputs=None):
             out = out.as_cpu()
         for i in range(len(out)):
             if not np.array_equal(out[i], ref[i]):
+                print("Mismatch at sample", i)
                 print("Out: ", out.at(i))
                 print("Ref: ", ref[i])
             assert np.array_equal(out[i], ref[i])


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
CuPy structure was flattened and now ndarray is located directly in cupy (`cupy.ndarray`). This PR makes the regex more flexible in that regard.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Added an assertion in test_external_source_cupy that will make the script fail if cupy recognizer doesn't work.

- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
