### PR TITLE
Add `"depleted"` operator trace

### DIFF
--- a/dali/operators/input/video_input.h
+++ b/dali/operators/input/video_input.h
@@ -390,6 +390,9 @@ void VideoInput<Backend, FramesDecoder>::VideoInputRunImpl(Workspace &ws) {
     }
   }
 
+  // If true, this operator can be run again, after this Run.
+  bool will_return_next = true;
+
   // There won't be any more output using the current input.
   bool input_sample_depleted = !full_sequence || frames_decoders_[0]->NextFrameIdx() == -1;
 
@@ -402,12 +405,15 @@ void VideoInput<Backend, FramesDecoder>::VideoInputRunImpl(Workspace &ws) {
        * "next_output_data_id" trace.
        */
       LoadDataFromInputOperator(GetThreadPool(ws));
+    } else {
+      will_return_next = false;
     }
   }
 
   if (data_id_) {
     SetNextDataIdTrace(ws, *data_id_);
   }
+  InputOperator<Backend>::SetDepletedOperatorTrace(ws, !will_return_next);
 }
 
 }  // namespace dali

--- a/dali/operators/input/video_input_test.cc
+++ b/dali/operators/input/video_input_test.cc
@@ -122,8 +122,8 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
 
       DoesDataIdTraceExist(h, i, test_file_idx);
       IsDataIdTraceCorrect(h, i, test_file_idx);
-      DoesDepletedTraceExist(h);
-      IsDepletedTraceCorrect(h, false);
+      AssertDepletedTraceExists(h);
+      AssertDepletedTraceValue(h, false);
     }
     /*
      * The last iteration of the pipeline shall carry a different result.
@@ -134,8 +134,8 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
     daliRun(h);
     daliOutput(h);
     EXPECT_EQ(daliHasOperatorTrace(h, video_input_name_.c_str(), data_id_trace_name_.c_str()), 0);
-    DoesDepletedTraceExist(h);
-    IsDepletedTraceCorrect(h, true);
+    AssertDepletedTraceExists(h);
+    AssertDepletedTraceValue(h, true);
   }
 
 
@@ -205,7 +205,7 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
   /**
    * Check, if the "depleted" trace exists.
    */
-  void DoesDepletedTraceExist(daliPipelineHandle *h) {
+  void AssertDepletedTraceExists(daliPipelineHandle *h) {
     // The "depleted" trace should always exist.
     ASSERT_TRUE(daliHasOperatorTrace(h, video_input_name_.c_str(), depleted_trace_name_.c_str()));
   }
@@ -215,7 +215,7 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
    * Verify the value of "depleted" trace.
    * @param shall_be_depleted Expected value.
    */
-  void IsDepletedTraceCorrect(daliPipelineHandle *h, bool shall_be_depleted) {
+  void AssertDepletedTraceValue(daliPipelineHandle *h, bool shall_be_depleted) {
     ASSERT_STREQ(daliGetOperatorTrace(h, video_input_name_.c_str(), depleted_trace_name_.c_str()),
                  shall_be_depleted ? "true" : "false");
   }

--- a/dali/operators/input/video_input_test.cc
+++ b/dali/operators/input/video_input_test.cc
@@ -120,10 +120,10 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
       daliRun(h);
       daliOutput(h);
 
-      DoesDataIdTraceExist(h, i, test_file_idx);
-      IsDataIdTraceCorrect(h, i, test_file_idx);
+      AssertDataIdTraceExist(h, i, test_file_idx);
+      CheckDataIdTraceValue(h, i, test_file_idx);
       AssertDepletedTraceExists(h);
-      AssertDepletedTraceValue(h, false);
+      CheckDepletedTraceValue(h, false);
     }
     /*
      * The last iteration of the pipeline shall carry a different result.
@@ -135,7 +135,7 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
     daliOutput(h);
     EXPECT_EQ(daliHasOperatorTrace(h, video_input_name_.c_str(), data_id_trace_name_.c_str()), 0);
     AssertDepletedTraceExists(h);
-    AssertDepletedTraceValue(h, true);
+    CheckDepletedTraceValue(h, true);
   }
 
 
@@ -176,7 +176,7 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
   /**
    * Check, if the "next_output_data_id" trace exists, provided it should.
    */
-  void DoesDataIdTraceExist(daliPipelineHandle *h, int iteration_idx, int test_file_idx) {
+  void AssertDataIdTraceExist(daliPipelineHandle *h, int iteration_idx, int test_file_idx) {
     bool has_data_id = daliHasOperatorTrace(h, video_input_name_.c_str(),
                                             data_id_trace_name_.c_str());
     ASSERT_EQ(
@@ -190,7 +190,7 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
   /**
    * Verify, if the "next_output_data_id" trace has a correct value (provided it should exist).
    */
-  void IsDataIdTraceCorrect(daliPipelineHandle *h, int iteration_idx, int test_file_idx) {
+  void CheckDataIdTraceValue(daliPipelineHandle *h, int iteration_idx, int test_file_idx) {
     bool has_data_id = daliHasOperatorTrace(h, video_input_name_.c_str(),
                                             data_id_trace_name_.c_str());
     if (has_data_id) {
@@ -215,8 +215,8 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
    * Verify the value of "depleted" trace.
    * @param shall_be_depleted Expected value.
    */
-  void AssertDepletedTraceValue(daliPipelineHandle *h, bool shall_be_depleted) {
-    ASSERT_STREQ(daliGetOperatorTrace(h, video_input_name_.c_str(), depleted_trace_name_.c_str()),
+  void CheckDepletedTraceValue(daliPipelineHandle *h, bool shall_be_depleted) {
+    EXPECT_STREQ(daliGetOperatorTrace(h, video_input_name_.c_str(), depleted_trace_name_.c_str()),
                  shall_be_depleted ? "true" : "false");
   }
 
@@ -370,15 +370,15 @@ TYPED_TEST(VideoInputNextOutputDataIdTest, MultipleInputFilesParallelTest) {
          iteration_idx < num_iterations_per_input[test_file_idx] - 1; iteration_idx++) {
       daliRun(&h);
       daliOutput(&h);
-      this->DoesDataIdTraceExist(&h, iteration_idx, test_file_idx);
-      this->IsDataIdTraceCorrect(&h, iteration_idx, test_file_idx);
+      this->AssertDataIdTraceExist(&h, iteration_idx, test_file_idx);
+      this->CheckDataIdTraceValue(&h, iteration_idx, test_file_idx);
     }
     daliRun(&h);
     daliOutput(&h);
-    this->DoesDataIdTraceExist(&h, num_iterations_per_input[test_file_idx] - 1,
-                               next_test_file_idx);
-    this->IsDataIdTraceCorrect(&h, num_iterations_per_input[test_file_idx] - 1,
-                               next_test_file_idx);
+    this->AssertDataIdTraceExist(&h, num_iterations_per_input[test_file_idx] - 1,
+                                 next_test_file_idx);
+    this->CheckDataIdTraceValue(&h, num_iterations_per_input[test_file_idx] - 1,
+                                next_test_file_idx);
   }
   // The last test file should just clear the "next_output_data_id" trace after it's done.
   auto test_file_idx = test_files_order.back();
@@ -386,8 +386,8 @@ TYPED_TEST(VideoInputNextOutputDataIdTest, MultipleInputFilesParallelTest) {
        iteration_idx < num_iterations_per_input[test_file_idx] - 1; iteration_idx++) {
     daliRun(&h);
     daliOutput(&h);
-    this->DoesDataIdTraceExist(&h, iteration_idx, test_file_idx);
-    this->IsDataIdTraceCorrect(&h, iteration_idx, test_file_idx);
+    this->AssertDataIdTraceExist(&h, iteration_idx, test_file_idx);
+    this->CheckDataIdTraceValue(&h, iteration_idx, test_file_idx);
   }
   daliRun(&h);
   daliOutput(&h);

--- a/dali/operators/input/video_input_test.cc
+++ b/dali/operators/input/video_input_test.cc
@@ -177,11 +177,13 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
    * Check, if the "next_output_data_id" trace exists, provided it should.
    */
   void DoesDataIdTraceExist(daliPipelineHandle *h, int iteration_idx, int test_file_idx) {
-    bool has_data_id = daliHasOperatorTrace(h, video_input_name_.c_str(), data_id_trace_name_.c_str());
+    bool has_data_id = daliHasOperatorTrace(h, video_input_name_.c_str(),
+                                            data_id_trace_name_.c_str());
     ASSERT_EQ(
             has_data_id,
             !test_files_[test_file_idx].data_id.empty())
-            << "Failed at iteration " << iteration_idx << " of file with index " << test_file_idx;
+                          << "Failed at iteration " << iteration_idx << " of file with index "
+                          << test_file_idx;
   }
 
 
@@ -189,7 +191,8 @@ class VideoInputNextOutputDataIdTest : public ::testing::Test {
    * Verify, if the "next_output_data_id" trace has a correct value (provided it should exist).
    */
   void IsDataIdTraceCorrect(daliPipelineHandle *h, int iteration_idx, int test_file_idx) {
-    bool has_data_id = daliHasOperatorTrace(h, video_input_name_.c_str(), data_id_trace_name_.c_str());
+    bool has_data_id = daliHasOperatorTrace(h, video_input_name_.c_str(),
+                                            data_id_trace_name_.c_str());
     if (has_data_id) {
       EXPECT_STREQ(
               daliGetOperatorTrace(h, video_input_name_.c_str(), data_id_trace_name_.c_str()),
@@ -388,8 +391,8 @@ TYPED_TEST(VideoInputNextOutputDataIdTest, MultipleInputFilesParallelTest) {
   }
   daliRun(&h);
   daliOutput(&h);
-  EXPECT_EQ(daliHasOperatorTrace(&h, this->video_input_name_.c_str(), this->data_id_trace_name_.c_str()),
-            0);
+  EXPECT_EQ(daliHasOperatorTrace(&h, this->video_input_name_.c_str(),
+                                 this->data_id_trace_name_.c_str()), 0);
   daliDeletePipeline(&h);
 }
 

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -23,7 +23,7 @@ void ExternalSource<CPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
   auto &thread_pool = ws.GetThreadPool();
   ForwardCurrentData(output, data_id_, thread_pool);
-  SetDepletedOperatorTrace(ws, !(repeats_last_ || HasDataInQueue()));
+  SetDepletedOperatorTrace(ws, !HasDataInQueue());
 }
 
 
@@ -32,7 +32,7 @@ void ExternalSource<GPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<GPUBackend>(0);
   cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
   ForwardCurrentData(output, data_id_, stream_used);
-  SetDepletedOperatorTrace(ws, !(repeats_last_ || HasDataInQueue()));
+  SetDepletedOperatorTrace(ws, !HasDataInQueue());
 }
 
 

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -23,7 +23,7 @@ void ExternalSource<CPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
   auto &thread_pool = ws.GetThreadPool();
   ForwardCurrentData(output, data_id_, thread_pool);
-  SetDepletedOperatorTrace(ws, repeats_last_ || HasDataInQueue());
+  SetDepletedOperatorTrace(ws, !(repeats_last_ || HasDataInQueue()));
 }
 
 
@@ -32,7 +32,7 @@ void ExternalSource<GPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<GPUBackend>(0);
   cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
   ForwardCurrentData(output, data_id_, stream_used);
-  SetDepletedOperatorTrace(ws, repeats_last_ || HasDataInQueue());
+  SetDepletedOperatorTrace(ws, !(repeats_last_ || HasDataInQueue()));
 }
 
 

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -18,11 +18,12 @@
 
 namespace dali {
 
-template <>
+template<>
 void ExternalSource<CPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
   auto &thread_pool = ws.GetThreadPool();
   ForwardCurrentData(output, data_id_, thread_pool);
+  SetDepletedOperatorTrace(ws, repeats_last_ || HasDataInQueue());
 }
 
 
@@ -31,6 +32,7 @@ void ExternalSource<GPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<GPUBackend>(0);
   cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
   ForwardCurrentData(output, data_id_, stream_used);
+  SetDepletedOperatorTrace(ws, repeats_last_ || HasDataInQueue());
 }
 
 

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -23,7 +23,7 @@ void ExternalSource<CPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
   auto &thread_pool = ws.GetThreadPool();
   ForwardCurrentData(output, data_id_, thread_pool);
-  SetDepletedOperatorTrace(ws, !HasDataInQueue());
+  SetDepletedOperatorTrace(ws, !(repeats_last_ || HasDataInQueue()));
 }
 
 
@@ -32,7 +32,7 @@ void ExternalSource<GPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<GPUBackend>(0);
   cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
   ForwardCurrentData(output, data_id_, stream_used);
-  SetDepletedOperatorTrace(ws, !HasDataInQueue());
+  SetDepletedOperatorTrace(ws, !(repeats_last_ || HasDataInQueue()));
 }
 
 

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -38,7 +38,8 @@ class ExternalSource : public InputOperator<Backend> {
       : InputOperator<Backend>(spec),
         previous_dtype_(DALIDataType::DALI_NO_TYPE),
         ndim_(-1),
-        layout_() {
+        layout_(),
+        repeats_last_(spec.GetArgument<bool>("repeat_last")) {
     spec.TryGetArgument(dtype_, "dtype");
     if (spec.TryGetArgument(ndim_, "ndim")) {
       DALI_ENFORCE(ndim_ >= 0, make_string("Incorrect number of dimensions (", ndim_,
@@ -167,6 +168,8 @@ class ExternalSource : public InputOperator<Backend> {
     }
     layout_ = batch.GetLayout();
   }
+
+  const bool repeats_last_;
 
   string output_name_;
 

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -36,10 +36,10 @@ class ExternalSource : public InputOperator<Backend> {
  public:
   explicit ExternalSource(const OpSpec &spec)
       : InputOperator<Backend>(spec),
+        repeats_last_(spec.GetArgument<bool>("repeat_last")),
         previous_dtype_(DALIDataType::DALI_NO_TYPE),
         ndim_(-1),
-        layout_(),
-        repeats_last_(spec.GetArgument<bool>("repeat_last")) {
+        layout_() {
     spec.TryGetArgument(dtype_, "dtype");
     if (spec.TryGetArgument(ndim_, "ndim")) {
       DALI_ENFORCE(ndim_ >= 0, make_string("Incorrect number of dimensions (", ndim_,

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -38,8 +38,7 @@ class ExternalSource : public InputOperator<Backend> {
       : InputOperator<Backend>(spec),
         previous_dtype_(DALIDataType::DALI_NO_TYPE),
         ndim_(-1),
-        layout_(),
-        repeats_last_(spec.GetArgument<bool>("repeat_last")) {
+        layout_() {
     spec.TryGetArgument(dtype_, "dtype");
     if (spec.TryGetArgument(ndim_, "ndim")) {
       DALI_ENFORCE(ndim_ >= 0, make_string("Incorrect number of dimensions (", ndim_,
@@ -168,8 +167,6 @@ class ExternalSource : public InputOperator<Backend> {
     }
     layout_ = batch.GetLayout();
   }
-
-  const bool repeats_last_;
 
   string output_name_;
 

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -38,7 +38,8 @@ class ExternalSource : public InputOperator<Backend> {
       : InputOperator<Backend>(spec),
         previous_dtype_(DALIDataType::DALI_NO_TYPE),
         ndim_(-1),
-        layout_() {
+        layout_(),
+        repeats_last_(spec.GetArgument<bool>("repeat_last")) {
     spec.TryGetArgument(dtype_, "dtype");
     if (spec.TryGetArgument(ndim_, "ndim")) {
       DALI_ENFORCE(ndim_ >= 0, make_string("Incorrect number of dimensions (", ndim_,
@@ -168,6 +169,7 @@ class ExternalSource : public InputOperator<Backend> {
     layout_ = batch.GetLayout();
   }
 
+  const bool repeats_last_;
 
   string output_name_;
 

--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -91,7 +91,7 @@ class ExternalSourceBasicTest : public ::testing::Test {
    * Verify the value of "depleted" trace.
    * @param shall_be_depleted Expected value.
    */
-  void CheckDepletedTraceCorrect(daliPipelineHandle *h, bool shall_be_depleted) {
+  void CheckDepletedTraceValue(daliPipelineHandle *h, bool shall_be_depleted) {
     EXPECT_STREQ(daliGetOperatorTrace(h, input_name_.c_str(), depleted_trace_name_.c_str()),
                  shall_be_depleted ? "true" : "false");
   }
@@ -122,7 +122,7 @@ TYPED_TEST(ExternalSourceBasicTest, DepletedTraceTest) {
   daliRun(&this->handle_);
   daliShareOutput(&this->handle_);
   this->AssertDepletedTraceExist(&this->handle_);
-  this->CheckDepletedTraceCorrect(&this->handle_, true);
+  this->CheckDepletedTraceValue(&this->handle_, true);
   daliOutputRelease(&this->handle_);
 
   this->FeedExternalInput(&this->handle_);
@@ -131,13 +131,13 @@ TYPED_TEST(ExternalSourceBasicTest, DepletedTraceTest) {
   daliRun(&this->handle_);
   daliShareOutput(&this->handle_);
   this->AssertDepletedTraceExist(&this->handle_);
-  this->CheckDepletedTraceCorrect(&this->handle_, false);
+  this->CheckDepletedTraceValue(&this->handle_, false);
   daliOutputRelease(&this->handle_);
 
   daliRun(&this->handle_);
   daliShareOutput(&this->handle_);
   this->AssertDepletedTraceExist(&this->handle_);
-  this->CheckDepletedTraceCorrect(&this->handle_, true);
+  this->CheckDepletedTraceValue(&this->handle_, true);
   daliOutputRelease(&this->handle_);
 
   daliDeletePipeline(&this->handle_);
@@ -156,13 +156,13 @@ TYPED_TEST(ExternalSourceBasicTest, DepletedTraceRepeatLastTest) {
   daliRun(&this->handle_);
   daliShareOutput(&this->handle_);
   this->AssertDepletedTraceExist(&this->handle_);
-  this->CheckDepletedTraceCorrect(&this->handle_, false);
+  this->CheckDepletedTraceValue(&this->handle_, false);
   daliOutputRelease(&this->handle_);
 
   daliRun(&this->handle_);
   daliShareOutput(&this->handle_);
   this->AssertDepletedTraceExist(&this->handle_);
-  this->CheckDepletedTraceCorrect(&this->handle_, false);
+  this->CheckDepletedTraceValue(&this->handle_, false);
   daliOutputRelease(&this->handle_);
 
   this->FeedExternalInput(&this->handle_);
@@ -171,13 +171,13 @@ TYPED_TEST(ExternalSourceBasicTest, DepletedTraceRepeatLastTest) {
   daliRun(&this->handle_);
   daliShareOutput(&this->handle_);
   this->AssertDepletedTraceExist(&this->handle_);
-  this->CheckDepletedTraceCorrect(&this->handle_, false);
+  this->CheckDepletedTraceValue(&this->handle_, false);
   daliOutputRelease(&this->handle_);
 
   daliRun(&this->handle_);
   daliShareOutput(&this->handle_);
   this->AssertDepletedTraceExist(&this->handle_);
-  this->CheckDepletedTraceCorrect(&this->handle_, false);
+  this->CheckDepletedTraceValue(&this->handle_, false);
   daliOutputRelease(&this->handle_);
 
   daliDeletePipeline(&this->handle_);

--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <thrust/host_vector.h>
+#include <thrust/device_vector.h>
 #include <fstream>
 #include <memory>
 #include <tuple>
 #include <utility>
-#include <thrust/host_vector.h>
-#include <thrust/device_vector.h>
 
 #include "dali/test/dali_test_decoder.h"
 #include "dali/pipeline/executor/async_pipelined_executor.h"

--- a/dali/pipeline/operator/builtin/input_operator.h
+++ b/dali/pipeline/operator/builtin/input_operator.h
@@ -328,6 +328,16 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
   }
 
 
+  /**
+   * TODO
+   * @param ws
+   * @param depleted
+   */
+  virtual void SetDepletedOperatorTrace(Workspace& ws, bool depleted) {
+    ws.SetOperatorTrace("depleted", depleted ? "true" : "false");
+  }
+
+
   int device_id_;
   bool blocking_ = true;
   bool no_copy_ = false;

--- a/dali/pipeline/operator/builtin/input_operator.h
+++ b/dali/pipeline/operator/builtin/input_operator.h
@@ -337,7 +337,7 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
    * @param ws Current workspace.
    * @param depleted Value of the trace.
    */
-  virtual void SetDepletedOperatorTrace(Workspace& ws, bool depleted) {
+  void SetDepletedOperatorTrace(Workspace& ws, bool depleted) {
     ws.SetOperatorTrace("depleted", depleted ? "true" : "false");
   }
 

--- a/dali/pipeline/operator/builtin/input_operator.h
+++ b/dali/pipeline/operator/builtin/input_operator.h
@@ -329,8 +329,8 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
 
 
   /**
-   * "depleted" operator trace specifies whether the operator has sufficient recourses to
-   * be run in yet another iteration.
+   * "depleted" operator trace specifies whether the operator has sufficient resources to
+   * run another iteration.
    *
    * If "false", the operator needs to be fed with data to run the next iteration. If "true",
    * the next iteration can be triggered.

--- a/dali/pipeline/operator/builtin/input_operator.h
+++ b/dali/pipeline/operator/builtin/input_operator.h
@@ -329,9 +329,13 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
 
 
   /**
-   * TODO
-   * @param ws
-   * @param depleted
+   * "depleted" operator trace specifies whether the operator has sufficient recourses to
+   * be run in yet another iteration.
+   *
+   * If "false", the operator needs to be fed with data to run the next iteration. If "true",
+   * the next iteration can be triggered.
+   * @param ws Current workspace.
+   * @param depleted Value of the trace.
    */
   virtual void SetDepletedOperatorTrace(Workspace& ws, bool depleted) {
     ws.SetOperatorTrace("depleted", depleted ? "true" : "false");


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** (*non-breaking change which adds functionality*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
After introducing `repeat_last` option in the ExternalSource (#4775), an additional operator trace is needed to properly handle this option in DALI Backend. This PR adds the `"depleted"` trace. This trace is available for every `InputOperator`. By `depleted == "true"` operator informs, that it does not have sufficient resources to be ran again.

When `repeat_last==True` in the external source, it's obvious that it will never deplete, once the data has been provided to the operator.



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [x] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
