### PR TITLE
Add O_DIRECT support to the TFRecord reader

### DIFF
--- a/dali/operators/reader/parser/tfrecord_parser.h
+++ b/dali/operators/reader/parser/tfrecord_parser.h
@@ -60,7 +60,7 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
     raw_data = raw_data + sizeof(length) + sizeof(crc);
     DALI_ENFORCE(example.ParseFromArray(raw_data, length),
       make_string("Error while parsing TFRecord file: ", data.GetSourceInfo(),
-                  " (raw data length: ", length, "bytes)."));
+                  " (raw data length: ", length, " bytes)."));
 
     for (size_t i = 0; i < features_.size(); ++i) {
       auto& output = ws->Output<CPUBackend>(i);

--- a/dali/operators/reader/tfrecord_reader_op.cc
+++ b/dali/operators/reader/tfrecord_reader_op.cc
@@ -45,7 +45,13 @@ DALI_SCHEMA(readers___TFRecordBase)
 
 The index files can be obtained from TFRecord files by using the ``tfrecord2idx`` script
 that is distributed with DALI.)code",
-      DALI_STRING_VEC);
+      DALI_STRING_VEC)
+  .AddOptionalArg("use_o_direct",
+      R"code(If set to True, the data will be read directly from the storage bypassing system
+cache.
+
+Mutually exclusive with ``dont_use_mmap=False``.)code",
+      false);
 
 // Internal readers._tfrecord schema.
 DALI_SCHEMA(readers___TFRecord)

--- a/dali/operators/reader/tfrecord_reader_op.cc
+++ b/dali/operators/reader/tfrecord_reader_op.cc
@@ -48,7 +48,7 @@ The index files can be obtained from TFRecord files by using the ``tfrecord2idx`
 that is distributed with DALI.)code",
       DALI_STRING_VEC)
   .AddOptionalArg("use_o_direct",
-      R"code(If set to True, the data will be read directly from the storage bypassing system
+      R"code(If set to True, the data will be read directly from the storage bypassing the system
 cache.
 
 Mutually exclusive with ``dont_use_mmap=False``.)code",


### PR DESCRIPTION
- adds the `use_o_direct` option to the TFRecord reader. In effect
  the reader reads to the internal buffer which chunks are shared
  with samples. When the buffer runs out of content new one
  is allocated and the old lives as long as any sample still
  uses a piece of it

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- adds the `use_o_direct` option to the TFRecord reader. In effect
  the reader reads to the internal buffer which chunks are shared
  with samples. When the buffer runs out of content new one
  is allocated and the old lives as long as any sample still
  uses a piece of it
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- dali/operators/reader/loader/indexed_file_loader.h
- dali/operators/reader/parser/tfrecord_parser.h
- dali/operators/reader/tfrecord_reader_op.cc
- dali/test/python/reader/test_index.py
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_index.test_tfrecord_pad_last_batch
    - test_index.test_tfrecord_odirect
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3404
<!--- DALI-XXXX or NA --->
