### PR TITLE
Fix FITS tests with python3.7, reduce memory usage in rand aug tests

### DIFF
--- a/dali/test/python/auto_aug/test_rand_augment.py
+++ b/dali/test/python/auto_aug/test_rand_augment.py
@@ -37,7 +37,7 @@ images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
 def test_run_rand_aug(i, args):
     dev, uniformly_resized, use_shape, fill_value, specify_translation_bounds = args
     batch_sizes = [1, 8, 7, 64, 13, 64, 128]
-    ns = [1, 2, 3, 4]
+    ns = [1, 2, 3]
     ms = [0, 15, 30]
     batch_size = batch_sizes[i % len(batch_sizes)]
     n = ns[i % len(ns)]

--- a/dali/test/python/auto_aug/test_rand_augment.py
+++ b/dali/test/python/auto_aug/test_rand_augment.py
@@ -36,9 +36,10 @@ images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
         itertools.product(("cpu", "gpu"), (True, False), (True, False), (None, 0), (True, False)))))
 def test_run_rand_aug(i, args):
     dev, uniformly_resized, use_shape, fill_value, specify_translation_bounds = args
-    batch_sizes = [1, 8, 7, 64, 13, 64, 128]
+    # Keep batch_sizes ns and ms length co-prime
+    batch_sizes = [1, 8, 7, 13, 31, 64, 128]
     ns = [1, 2, 3]
-    ms = [0, 15, 30]
+    ms = [0, 12, 15, 30]
     batch_size = batch_sizes[i % len(batch_sizes)]
     n = ns[i % len(ns)]
     m = ms[i % len(ms)]

--- a/dali/test/python/reader/test_fits.py
+++ b/dali/test/python/reader/test_fits.py
@@ -60,7 +60,7 @@ def get_astropy_dtypes(compression):
     # The astropy is not actively developed for Python3.6 and the last available
     # version does not support some dtypes
     vi = sys.version_info
-    if vi.major < 3 or (vi.major == 3 and vi.minor <= 6):
+    if vi.major < 3 or (vi.major == 3 and vi.minor <= 7):
         excluded |= {np.int8}
     # Astropy doesn't support writing those types to compressed image
     if compression:


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
-Bumps version of Python for astropy that does not support int8 type to 3.7
-Reduce the memory consumption of rand augment tests to avoid issues with runners with smaller amoutn of avialable mem.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
