### PR TITLE
Disable NUMBA CPU test for runs with memory sanitizer

### DIFF
--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -396,6 +396,7 @@ def test_random_object_bbox_cpu():
                        cycle="quiet", input_layout="")
 
 
+@attr('numba')
 def test_numba_func_cpu():
     def set_all_values_to_255_batch(out0, in0):
         out0[0][:] = 255

--- a/qa/TL0_cpu_only/test_nofw.sh
+++ b/qa/TL0_cpu_only/test_nofw.sh
@@ -33,8 +33,11 @@ test_body() {
 
     "$FULLPATH" --gtest_filter="*CpuOnly*:*CApi*/0.*-*0.UseCopyKernel:*ForceNoCopyFail:*daliOutputCopySamples"
   done
-
-  ${python_invoke_test} --attr '!pytorch' test_dali_cpu_only.py
+  if [ -z "$DALI_ENABLE_SANITIZERS" ]; then
+    ${python_invoke_test} --attr '!pytorch' test_dali_cpu_only.py
+  else
+    ${python_invoke_test} --attr '!pytorch,!numba' test_dali_cpu_only.py
+  fi
 }
 
 pushd ../..


### PR DESCRIPTION
- the 0.57 NUMVA version causes stackoverflow when
  the memory sanitizer is on. This PR turns off that
  particular test

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- the 0.57 NUMVA version causes stackoverflow when
  the memory sanitizer is on. This PR turns off that
  particular test

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- dali/test/python/test_dali_cpu_only.py
- qa/TL0_cpu_only/test_nofw.sh 
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_dali_cpu_only.test_numba_func_cpu
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
