### PR TITLE
Use memory pool for large host allocs

### DIFF
--- a/dali/core/mm/binning_resource_test.cc
+++ b/dali/core/mm/binning_resource_test.cc
@@ -1,0 +1,84 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <map>
+#include <memory>
+#include "dali/core/mm/binning_resource.h"
+#include "dali/core/span.h"
+
+namespace dali {
+namespace mm {
+namespace test {
+
+struct DummyResource : public memory_resource<mm::memory_kind::host> {
+  void *do_allocate(size_t bytes, size_t alignment) {
+    (void)alignment;
+    allocs_by_size_[bytes]++;
+    return &allocs_by_size_[bytes];
+  }
+
+  void do_deallocate(void *ptr, size_t bytes, size_t alignment) {
+    ASSERT_EQ(ptr, &allocs_by_size_[bytes]);
+    deallocs_by_size_[bytes]++;
+  }
+
+  std::map<size_t, int> allocs_by_size_;
+  std::map<size_t, int> deallocs_by_size_;
+};
+
+TEST(BinningResourceTest, FindBin) {
+  std::vector<std::shared_ptr<DummyResource>> resources;
+  for (int i = 0; i < 4; i++)
+    resources.push_back(std::make_shared<DummyResource>());
+
+  size_t bin_split_points[] =  { 32, 1024, 1<<20 };
+  binning_resource binning(
+    make_cspan(bin_split_points),
+    make_cspan(resources));
+
+  void *p0 = binning.allocate(1);
+  binning.deallocate(p0, 1);
+  void *p1 = binning.allocate(32);
+  binning.deallocate(p1, 32);
+  void *p2 = binning.allocate(256);
+  binning.deallocate(p2, 256);
+  void *p3 = binning.allocate(1024);
+  binning.deallocate(p3, 1024);
+  void *p4 = binning.allocate(65536);
+  binning.deallocate(p4, 65536);
+  void *p5 = binning.allocate(1<<20);
+  binning.deallocate(p5, 1<<20);
+  void *p6 = binning.allocate(10<<20);
+  binning.deallocate(p6, 10<<20);
+  EXPECT_EQ(resources[0]->allocs_by_size_[1], 1);
+  EXPECT_EQ(resources[0]->deallocs_by_size_[1], 1);
+  EXPECT_EQ(resources[0]->allocs_by_size_[32], 1);
+  EXPECT_EQ(resources[0]->deallocs_by_size_[32], 1);
+  EXPECT_EQ(resources[1]->allocs_by_size_[256], 1);
+  EXPECT_EQ(resources[1]->deallocs_by_size_[256], 1);
+  EXPECT_EQ(resources[1]->allocs_by_size_[1024], 1);
+  EXPECT_EQ(resources[1]->deallocs_by_size_[1024], 1);
+  EXPECT_EQ(resources[2]->allocs_by_size_[65536], 1);
+  EXPECT_EQ(resources[2]->deallocs_by_size_[65536], 1);
+  EXPECT_EQ(resources[2]->allocs_by_size_[1<<20], 1);
+  EXPECT_EQ(resources[2]->deallocs_by_size_[1<<20], 1);
+  EXPECT_EQ(resources[3]->allocs_by_size_[10<<20], 1);
+  EXPECT_EQ(resources[3]->deallocs_by_size_[10<<20], 1);
+}
+
+}  // namespace test
+}  // namespace mm
+}  // namespace dali
+

--- a/dali/core/mm/default_resources.cc
+++ b/dali/core/mm/default_resources.cc
@@ -18,6 +18,7 @@
 #include "dali/core/error_handling.h"
 #include "dali/core/format.h"
 #include "dali/core/mm/malloc_resource.h"
+#include "dali/core/mm/binning_resource.h"
 #include "dali/core/device_guard.h"
 #include "dali/core/mm/async_pool.h"
 #include "dali/core/mm/composite_resource.h"
@@ -126,11 +127,6 @@ struct DefaultResources {
 
 #define g_resources (DefaultResources::instance())
 
-inline std::shared_ptr<host_memory_resource> CreateDefaultHostResource() {
-  static auto rsrc = std::make_shared<malloc_memory_resource>();
-  return rsrc;
-}
-
 struct CUDARTLoader {
   CUDARTLoader() {
     int device_id = 0;
@@ -161,6 +157,50 @@ bool UseVMM() {
     return !env || atoi(env);
   }();
   return value;
+}
+
+size_t MallocThreshold() {
+  char *env = getenv("DALI_MALLOC_POOL_THRESHOLD");
+  int len = 0;
+  if (env && (len = strlen(env))) {
+    for (int i = 0; i < len; i++) {
+      bool valid = std::isdigit(env[i]) || (i == len - 1 && (env[i] == 'k' || env[i] == 'M'));
+      if (!valid) {
+        DALI_FAIL(make_string(
+          "DALI_MALLOC_POOL_THRESHOLD must be a number, optionally followed by 'k' or 'M', got: ",
+          env));
+      }
+    }
+    size_t s = atoll(env);
+    if (env[len-1] == 'k')
+      s <<= 10;
+    else if (env[len-1] == 'M')
+      s <<= 20;
+    return s;
+  } else {
+    char *mmap = getenv("MALLOC_MMAP_MAX_");
+    if (mmap && !atoi(mmap))
+      return 0;
+    char *thresh = getenv("MALLOC_MMAP_THRESHOLD_");
+    if (thresh)
+      return atoll(thresh);
+    return (32 << 20);  // max for 64-bit Linux systems
+  }
+}
+
+inline std::shared_ptr<host_memory_resource> CreateDefaultHostResource() {
+  static auto rsrc = std::make_shared<malloc_memory_resource>();
+  size_t threshold = MallocThreshold();
+  if (threshold > 0) {
+    using pool_t = pool_resource<mm::memory_kind::host, mm::coalescing_free_tree, spinlock>;
+    static auto pool = std::make_shared<pool_t>(rsrc.get());
+    size_t thresholds[] = { threshold };
+    std::shared_ptr<host_memory_resource> resources[2] = { rsrc, pool };
+    using binning_t = decltype(binning_resource(thresholds, resources));
+    auto binning_rsrc = std::make_shared<binning_t>(thresholds, resources);
+    return binning_rsrc;
+  }
+  return rsrc;
 }
 
 inline std::shared_ptr<device_async_resource> CreateDefaultDeviceResource() {

--- a/docs/advanced_topics_performance_tuning.rst
+++ b/docs/advanced_topics_performance_tuning.rst
@@ -83,6 +83,37 @@ For convenience, the DALI_BUFFER_GROWTH_FACTOR environment variable and the
 `nvidia.dali.backend.SetBufferGrowthFactor` Python function can be used to set the same
 growth factor for the host and the GPU buffers.
 
+
+Allocator Configuration
+-----------------------
+
+DALI uses several types of memory resources for various kinds of memory.
+
+For regular host memory, DALI uses (aligned) ``malloc`` for small allocations and a custom memory
+pool for large allocations (to prevent costly calls to ``mmap`` by ``malloc``).
+The maximum size of a host allocation that is allocated directly with ``malloc`` can be customized
+by setting ``DALI_MALLOC_POOL_THRESHOLD`` environment variable. If not specified, the value is
+either derived from environment variables controlling ``malloc`` or, if not found, a default value
+of 32M is used.
+
+For host pinned memory, DALI uses a stream-aware memory pool on top of ``cudaMallocHost``.
+Direct usage of ``cudaMallocHost``, while discouraged, can be forced by specifying
+``DALI_USE_PINNED_MEM_POOL=0`` in the environment.
+
+For device memory, DALI uses a stream-aware memory pool built on top of CUDA VMM resource
+(if the platform supports VMM) or plain ``cudaMalloc`` otherwise. The pool can be disabled by
+setting ``DALI_USE_DEVICE_MEM_POOL=0``. Use ``DALI_USE_VMM=0`` to switch from CUDA VMM to
+``cudaMalloc``.
+
+.. warning::
+    Disabling memory pools will result in a dramatic drop in performance. This option is provided
+    only for debugging purposes.
+
+    Disabling CUDA VMM can further degrade performance due to pessimistic synchronization in
+    ``cudaFree``, and it can cause out-of-memory errors due to fragmentation affecting
+    ``cudaMalloc``.
+
+
 Memory Pool Preallocation
 -------------------------
 

--- a/include/dali/core/mm/binning_resource.h
+++ b/include/dali/core/mm/binning_resource.h
@@ -61,7 +61,7 @@ class   binning_resource : public Interface {
    *                                by applying operators &* in succession
    *
    * @param split_points            a collection of split points; it must have one fewer element
-   *                                than split_points
+   *                                than resources
    * @param resources               a collection of memory resource pointers or smart poitners or
    *                                iterators
    * @param extr                    extra payload

--- a/include/dali/core/mm/binning_resource.h
+++ b/include/dali/core/mm/binning_resource.h
@@ -1,0 +1,162 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_MM_BINNING_RESOURCE_H_
+#define DALI_CORE_MM_BINNING_RESOURCE_H_
+
+#include <algorithm>
+#include <cassert>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include "dali/core/traits.h"
+#include "dali/core/util.h"
+#include "dali/core/mm/memory_resource.h"
+
+namespace dali {
+namespace mm {
+
+/** @brief A memory resource that distributes allocation requests to several other resources
+ *         based on the allocation size.
+ *
+ * This meta-resource aggregates multiple resources of the same kind and directs alllocation
+ * and deallocation requests to these resources based on the allocation size. The proper resource
+ * is selected by running a binary search on a sorted array of split points.
+ * The split point is an inclusive upper bound - e.g. split points of 16 and 64k would result
+ * in allocation up to 16 bytes going to resource 0, 17..64k to resource 1 and 64k+1 and up to
+ * resource 2.
+ *
+ */
+template <typename Kind,
+          int nstatic_bins = -1,
+          typename ExtraArgs = std::tuple<>,
+          typename Interface = mm::memory_resource<Kind>>
+class binning_resource : public Interface {
+ public:
+  using memory_kind = Kind;
+  static constexpr int static_num_bins = nstatic_bins;
+  static_assert(static_num_bins != 0);
+
+  /** @brief Constructs a binning resource from an array of split points, resources and extra data
+   *
+   * This constructor servers is used in a type deduction guide.
+   *
+   * @tparam SplitPointCollection   a collection of split points; it must have element type
+   *                                convertible to size_t and support iterationa and obtaining size
+   *                                with std::size
+   *
+   * @tparam ResourceCollection     a collection of pointers or iterators to memory_resource<Kind>
+   *                                objects; the elements must be convertible to a plain pointer
+   *                                by applying operators &* in succession
+   *
+   * @param split_points            a collection of split points; it must have one fewer element
+   *                                than split_points
+   * @param resources               a collection of memory resource pointers or smart poitners or
+   *                                iterators
+   * @param extr                    extra payload
+   */
+  template <typename SplitPointCollection, typename ResourceCollection, typename Extra>
+  binning_resource(const SplitPointCollection &split_points,
+                   const ResourceCollection &resources,
+                   Extra &&extra)
+  : extra_args_(std::forward<ExtraArgs>(extra)) {
+    if constexpr (static_num_bins > 0) {
+      assert(split_points.size() == static_num_bins - 1);
+      assert(resources.size() == static_num_bins);
+    }
+
+    assert(dali::size(split_points) + 1 == dali::size(resources));
+    resize_if_possible(bin_split_points_, dali::size(split_points));
+    resize_if_possible(resources_, dali::size(resources));
+
+    int i = 0;
+    for (auto split_point : split_points) {
+      bin_split_points_[i] = split_point;
+      if (i && split_point <= bin_split_points_[i-1])
+        throw std::invalid_argument("Bin split points must be strictly increasing.");
+      i++;
+    }
+    assert(i == num_bins() - 1);
+
+    i = 0;
+    for (auto &&ptr : resources)
+      resources_[i++] = &*ptr;
+
+    assert(i == num_bins());
+  }
+
+  template <typename SplitPointCollection, typename ResourceCollection>
+  binning_resource(const SplitPointCollection &split_points,
+                   const ResourceCollection &resources)
+  : binning_resource(split_points, resources, ExtraArgs()) {}
+
+  int num_bins() const {
+    return resources_.size();
+  }
+
+  size_t split_point(int after_bin) const {
+    assert(after_bin >= 0 && after_bin < num_bins() - 1);
+    return bin_split_points_[after_bin];
+  }
+
+  auto resource(int bin) const {
+    assert(bin >= 0 && bin < num_bins());
+    return resources_[bin];
+  }
+
+ private:
+  void *do_allocate(size_t bytes, size_t alignment) override {
+    int bin = find_bin(bytes);
+    return resource(bin)->allocate(bytes, alignment);
+  }
+
+  void do_deallocate(void *ptr, size_t bytes, size_t alignment) override {
+    int bin = find_bin(bytes);
+    resource(bin)->deallocate(ptr, bytes, alignment);
+  }
+
+  int find_bin(size_t size) const {
+    auto bin_it = std::lower_bound(bin_split_points_.begin(), bin_split_points_.end(), size);
+    return bin_it - bin_split_points_.begin();
+  }
+
+  ExtraArgs extra_args_;
+  template <typename T, int n>
+  using store_t = std::conditional_t<(static_num_bins < 0),
+    std::vector<T>, std::array<T, (n < 0 ? 0 : n)>>;
+
+  store_t<size_t, static_num_bins - 1> bin_split_points_;
+  store_t<mm::memory_resource<Kind> *, static_num_bins> resources_;
+};
+
+template <typename SplitPointCollection,
+          typename ResourceCollection,
+          typename Extra>
+binning_resource(const SplitPointCollection &split, const ResourceCollection &res, Extra &&extra) ->
+binning_resource<
+  typename std::remove_reference_t<decltype(*res[0])>::memory_kind,
+  -1,
+  Extra>;
+
+template <typename SplitPointCollection,
+          typename ResourceCollection>
+binning_resource(const SplitPointCollection &split, const ResourceCollection &res) ->
+binning_resource<
+  typename std::remove_reference_t<decltype(*res[0])>::memory_kind,
+  -1>;
+
+}  // namespace mm
+}  // namespace dali
+
+#endif  // DALI_CORE_MM_BINNING_RESOURCE_H_

--- a/include/dali/core/mm/binning_resource.h
+++ b/include/dali/core/mm/binning_resource.h
@@ -42,7 +42,7 @@ template <typename Kind,
           int nstatic_bins = -1,
           typename ExtraArgs = std::tuple<>,
           typename Interface = mm::memory_resource<Kind>>
-class binning_resource : public Interface {
+class   binning_resource : public Interface {
  public:
   using memory_kind = Kind;
   static constexpr int static_num_bins = nstatic_bins;


### PR DESCRIPTION
## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:
DALI uses dynamic allocation rather aggressively. Large allocations with `malloc` are handled with `mmap`, which causes slowdowns. This PR adds a binning resource and redirects large allocations to a host memory pool (as opposed to passing them directly to malloc). It also introduces an internal knob `DALI_MALLOC_POOL_THRESHOLD` allowing the user to set the maximum size of allocations that go to malloc.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
