### PR TITLE
Store original alignment in `async_pool::padded_`.

### DIFF
--- a/include/dali/core/mm/async_pool.h
+++ b/include/dali/core/mm/async_pool.h
@@ -377,6 +377,7 @@ class async_pool_resource : public async_memory_resource<Kind>,
         char *block_end = base + block_size;
         char *remainder = detail::align_ptr(aligned + bytes, remainder_alignment);
         bool split = supports_splitting && remainder + min_split_remainder < block_end;
+        size_t orig_alignment = f->alignment;
         size_t split_size = block_size;
         if (split) {
           // Adjust the pending free `f` so that it contains only what remains after
@@ -391,10 +392,10 @@ class async_pool_resource : public async_memory_resource<Kind>,
         } else {
           remove_pending_free(from, f, false);
         }
-        if (split_size != bytes) {
+        if (split_size != bytes || alignment != orig_alignment) {
           padded_[aligned] = { split_size,
                                static_cast<int>(front_padding),
-                               static_cast<int>(alignment) };
+                               static_cast<int>(orig_alignment) };
         }
         return aligned;
       }


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
When using dealloc_async/alloc_async, the original alignment information could be lost, possibly leading to inconsistencies in upstream resource.

## Additional information:

### Affected modules and functionalities:
async_pool + tests



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] ~New tests added~ Test updated
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
