### PR TITLE
Adding handling of non-uniform tensors in DALI Pytorch plugin

### DIFF
--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -644,7 +644,7 @@ class DALIGluonIterator(_DaliBaseIterator):
                         else:
                             feed_ndarray(single_tensor, pyt_tensors[category][j])
                     
-                    values = torch.hstack(pyt_tensors["data"])
+                    values = torch.hstack(pyt_tensors[category])
                     
                     indices = [[(i, j) for j in range(shape[0])] for i, shape in enumerate(category_shapes[category])]
                     indices = [indice for el_indices in indices for indice in el_indices]

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -413,6 +413,287 @@ class DALIClassificationIterator(DALIGenericIterator):
                                                          last_batch_policy=last_batch_policy,
                                                          prepare_first_batch=prepare_first_batch)
 
+###############################################
+###############################################
+# Gluon API
+###############################################
+###############################################
+
+
+class DALIGluonIterator(_DaliBaseIterator):
+    """
+    General DALI iterator for PyTorch with Gluon API. It can return any number of
+    outputs from the DALI pipeline in the form of per GPU tuples. These tuples consisting of
+    NDArrays (for outputs marked as DALIGluonIterator.DENSE_TAG) and list of NDArrays (for
+    output marked as DALIGluonIterator.SPARSE_TAG).
+
+    Parameters
+    ----------
+    pipelines : list of nvidia.dali.Pipeline
+                List of pipelines to use
+    size : int, default = -1
+                Number of samples in the shard for the wrapped pipeline (if there is more than
+                one it is a sum)
+                Providing -1 means that the iterator will work until StopIteration is raised
+                from the inside of iter_setup(). The options `last_batch_policy` and
+                `last_batch_padded` don't work in such case. It works with only one pipeline inside
+                the iterator.
+                Mutually exclusive with `reader_name` argument
+    reader_name : str, default = None
+                Name of the reader which will be queried to the shard size, number of shards and
+                all other properties necessary to count properly the number of relevant and padded
+                samples that iterator needs to deal with. It automatically sets `last_batch_policy`
+                to PARTIAL when the FILL is used, and `last_batch_padded` accordingly to match
+                the reader's configuration
+    output_types : list of str, optional, default = None
+                List of tags indicating whether the pipeline(s) output batch is
+                uniform (all the samples have the same size) or not. Batch output marked
+                as the former will be returned as a single NDArray, the latter
+                will be returned as a list of NDArray.
+                Must be either DALIGluonIterator.DENSE_TAG
+                or DALIGluonIterator.SPARSE_TAG.
+                Length of output_types must match the number of output of the pipeline(s).
+                If not set, all outputs are considered to be marked with
+                DALIGluonIterator.DENSE_TAG.
+    auto_reset : string or bool, optional, default = False
+                Whether the iterator resets itself for the next epoch or it requires reset() to be
+                called explicitly.
+
+                It can be one of the following values:
+
+                * ``"no"``, ``False`` or ``None`` - at the end of epoch StopIteration is raised
+                  and reset() needs to be called
+                * ``"yes"`` or ``"True"``- at the end of epoch StopIteration is raised but reset()
+                  is called internally automatically
+
+    fill_last_batch : bool, optional, default = None
+                **Deprecated** Please use ``last_batch_policy`` instead
+
+                Whether to fill the last batch with data up to 'self.batch_size'.
+                The iterator would return the first integer multiple
+                of self._num_gpus * self.batch_size entries which exceeds 'size'.
+                Setting this flag to False will cause the iterator to return
+                exactly 'size' entries.
+    last_batch_policy: optional, default = LastBatchPolicy.FILL
+                What to do with the last batch when there are not enough samples in the epoch
+                to fully fill it. See :meth:`nvidia.dali.plugin.base_iterator.LastBatchPolicy`
+    last_batch_padded : bool, optional, default = False
+                Whether the last batch provided by DALI is padded with the last sample
+                or it just wraps up. In the conjunction with ``last_batch_policy`` it tells
+                if the iterator returning last batch with data only partially filled with
+                data from the current epoch is dropping padding samples or samples from
+                the next epoch (it doesn't literally drop but sets ``pad`` field of ndarray
+                so the following code could use it to drop the data). If set to ``False`` next
+                epoch will end sooner as data from it was consumed but dropped. If set to
+                True next epoch would be the same length as the first one. For this to happen,
+                the option `pad_last_batch` in the reader needs to be set to True as well.
+                It is overwritten when `reader_name` argument is provided
+    prepare_first_batch : bool, optional, default = True
+                Whether DALI should buffer the first batch right after the creation of the iterator,
+                so one batch is already prepared when the iterator is prompted for the data
+
+    Example
+    -------
+    With the data set ``[1,2,3,4,5,6,7]`` and the batch size 2:
+
+    last_batch_policy = LastBatchPolicy.PARTIAL, last_batch_padded = True  ->
+    last batch = ``[7]``, next iteration will return ``[1, 2]``
+
+    last_batch_policy = LastBatchPolicy.PARTIAL, last_batch_padded = False ->
+    last batch = ``[7]``, next iteration will return ``[2, 3]``
+
+    last_batch_policy = LastBatchPolicy.FILL, last_batch_padded = True   ->
+    last batch = ``[7, 7]``, next iteration will return ``[1, 2]``
+
+    last_batch_policy = LastBatchPolicy.FILL, last_batch_padded = False  ->
+    last batch = ``[7, 1]``, next iteration will return ``[2, 3]``
+
+    last_batch_policy = LastBatchPolicy.DROP, last_batch_padded = True   ->
+    last batch = ``[5, 6]``, next iteration will return ``[1, 2]``
+
+    last_batch_policy = LastBatchPolicy.DROP, last_batch_padded = False  ->
+    last batch = ``[5, 6]``, next iteration will return ``[2, 3]``
+    """
+
+    def __init__(self,
+                 pipelines,
+                 output_map,
+                 size=-1,
+                 reader_name=None,
+                 output_types=None,
+                 auto_reset=False,
+                 fill_last_batch=None,
+                 dynamic_shape=False,
+                 last_batch_padded=False,
+                 last_batch_policy=LastBatchPolicy.FILL,
+                 prepare_first_batch=True):
+
+        # check the assert first as _DaliBaseIterator would run the prefetch
+        self._output_tags = {DALIGluonIterator.DENSE_TAG, DALIGluonIterator.SPARSE_TAG}
+
+        assert len(set(output_map)) == len(output_map), "output_map names should be distinct"
+        assert output_types is None or set(output_types) <= self._output_tags, \
+            "Only DENSE_TAG and SPARSE_TAG are allowed"
+
+        self.output_map = output_map
+        self._outputs_types = output_types
+
+        super(DALIGluonIterator, self).__init__(
+            pipelines,
+            size,
+            reader_name,
+            auto_reset,
+            fill_last_batch,
+            last_batch_padded,
+            last_batch_policy,
+            prepare_first_batch
+        )
+
+        self._first_batch = None
+        if self._prepare_first_batch:
+            try:
+                self._first_batch = self._first_batch = DALIGluonIterator.__next__(self)
+                # call to `next` sets _ever_consumed to True but if we are just calling it from
+                # here we should set if to False again
+                self._ever_consumed = False
+            except StopIteration:
+                assert False, "It seems that there is no data in the pipeline. This may happen " \
+                       "if `last_batch_policy` is set to PARTIAL and the requested batch size is " \
+                       "greater than the shard size."
+
+    def __next__(self):
+        self._ever_consumed = True
+        if self._first_batch is not None:
+            batch = self._first_batch
+            self._first_batch = None
+            return batch
+
+        # Gather outputs
+        dali_outputs = self._get_outputs()
+
+        data_batches = [None for i in range(self._num_gpus)]
+        for i in range(self._num_gpus):
+            dev_id = self._pipes[i].device_id
+            # initialize dict for all output categories
+            category_outputs = dict()
+            # segregate outputs into categories
+            for j, out in enumerate(dali_outputs[i]):
+                category_outputs[self.output_map[j]] = out
+            
+            # Change DALI TensorLists into Tensors
+            category_tensors = dict()
+            category_shapes = dict()
+            category_torch_type = dict()
+            category_device = dict()
+            torch_gpu_device = None
+            torch_cpu_device = torch.device('cpu')
+
+            for j, (category, out) in enumerate(category_outputs.items()):
+                if self._outputs_types is None or \
+                   self._outputs_types[j] == DALIGluonIterator.DENSE_TAG:
+                    category_tensors[category] = out.as_tensor()
+                    category_shapes[category] = category_tensors[category].shape()
+                else:
+                    category_tensors[category] = [x for x in out]
+                    category_shapes[category] = [x.shape() for x in out]
+                
+                # check dtype
+                category_torch_type[category] = to_torch_type[out.dtype]
+
+                # check device
+                if type(out) is TensorListGPU:
+                    if not torch_gpu_device:
+                        torch_gpu_device = torch.device('cuda', dev_id)
+                    category_device[category] = torch_gpu_device
+                else:
+                    category_device[category] = torch_cpu_device
+
+            pyt_tensors = dict()
+            for j, category in enumerate(self.output_map):
+                if self._outputs_types is None or \
+                   self._outputs_types[j] == DALIGluonIterator.DENSE_TAG:
+                    pyt_tensors[category] = torch.empty(category_shapes[category],
+                                                        dtype=category_torch_type[category],
+                                                        device=category_device[category])
+                else:
+                    pyt_tensors[category] = [
+                       torch.empty(shape,
+                                   dtype=category_torch_type[category],
+                                   device=category_device[category]) 
+                       for shape in category_shapes[category]
+                    ]
+
+            data_batches[i] = pyt_tensors
+
+            # Copy data from DALI Tensors to torch tensors
+            for j, (category, tensor) in enumerate(category_tensors.items()):
+                if self._outputs_types is None or \
+                   self._outputs_types[j] == DALIGluonIterator.DENSE_TAG:
+                    if isinstance(tensor, (TensorGPU, TensorListGPU)):
+                        # Using same cuda_stream used by torch.zeros to set the memory
+                        stream = torch.cuda.current_stream(device=pyt_tensors[category].device)
+                        feed_ndarray(tensor, pyt_tensors[category], cuda_stream=stream)
+                    else:
+                        feed_ndarray(tensor, pyt_tensors[category])
+                else:
+                    for j, single_tensor in enumerate(tensor):
+                        if isinstance(tensor, (TensorGPU, TensorListGPU)):
+                            # Using same cuda_stream used by torch.zeros to set the memory
+                            stream = torch.cuda.current_stream(device=pyt_tensors[category][j].device)
+                            feed_ndarray(single_tensor, pyt_tensors[category][j], cuda_stream=stream)
+                        else:
+                            feed_ndarray(single_tensor, pyt_tensors[category][j])
+                    
+                    values = torch.hstack(pyt_tensors["data"])
+                    
+                    indices = [[(i, j) for j in range(shape[0])] for i, shape in enumerate(category_shapes[category])]
+                    indices = [indice for el_indices in indices for indice in el_indices]
+                    indices = torch.LongTensor(indices, device=values.device)
+
+                    pyt_tensors[category] = torch.sparse_coo_tensor(indices.T, values)
+
+        self._schedule_runs()
+
+        self._advance_and_check_drop_last()
+
+        if self._reader_name:
+            if_drop, left = self._remove_padded()
+            if np.any(if_drop):
+                output = []
+                for batch, to_copy in zip(data_batches, left):
+                    batch = batch.copy()
+                    for category in self.output_map:
+                        batch[category] = batch[category][0:to_copy]
+                    output.append(batch)
+                return output
+
+        else:
+            if self._last_batch_policy == LastBatchPolicy.PARTIAL and (
+                                          self._counter > self._size) and self._size > 0:
+                # First calculate how much data is required to return exactly self._size entries.
+                diff = self._num_gpus * self.batch_size - (self._counter - self._size)
+                # Figure out how many GPUs to grab from.
+                numGPUs_tograb = int(np.ceil(diff / self.batch_size))
+                # Figure out how many results to grab from the last GPU
+                # (as a fractional GPU batch may be required to bring us
+                # right up to self._size).
+                mod_diff = diff % self.batch_size
+                data_fromlastGPU = mod_diff if mod_diff else self.batch_size
+
+                # Grab the relevant data.
+                # 1) Grab everything from the relevant GPUs.
+                # 2) Grab the right data from the last GPU.
+                # 3) Append data together correctly and return.
+                output = data_batches[0:numGPUs_tograb]
+                output[-1] = output[-1].copy()
+                for category in self._output_categories:
+                    output[-1][category] = output[-1][category][0:data_fromlastGPU]
+                return output
+
+        return data_batches
+
+    DENSE_TAG = "dense"
+    SPARSE_TAG = "sparse"
 
 class TorchPythonFunction(ops.PythonFunctionBase):
     schema_name = "TorchPythonFunction"

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -872,6 +872,7 @@ def test_pytorch_iterator_feed_ndarray_types():
     for data_type in types:
         yield check_pytorch_iterator_feed_ndarray_types, data_type
 
+
 def test_ragged_iterator_sparse_coo_batch():
     from nvidia.dali.plugin.pytorch import DALIRaggedIterator as RaggedIterator
     num_gpus = 1
@@ -879,26 +880,27 @@ def test_ragged_iterator_sparse_coo_batch():
 
     pipes, _ = create_pipeline(
         lambda gpu: create_coco_pipeline(batch_size=batch_size, num_threads=4, shard_id=gpu,
-                                            num_gpus=num_gpus, data_paths=data_sets[0],
-                                            random_shuffle=True, stick_to_shard=False,
-                                            shuffle_after_epoch=False, pad_last_batch=True,
-                                            return_labels=True),
+                                         num_gpus=num_gpus, data_paths=data_sets[0],
+                                         random_shuffle=True, stick_to_shard=False,
+                                         shuffle_after_epoch=False, pad_last_batch=True,
+                                         return_labels=True),
         batch_size, num_gpus
     )
 
     dali_train_iter = RaggedIterator(pipes, output_map=["labels", "ids"],
-                                    size=pipes[0].epoch_size("Reader"),
-                                    output_types=[RaggedIterator.SPARSE_COO_TAG,
-                                                    RaggedIterator.DENSE_TAG],
-                                    last_batch_policy=LastBatchPolicy.FILL)
+                                     size=pipes[0].epoch_size("Reader"),
+                                     output_types=[RaggedIterator.SPARSE_COO_TAG,
+                                                   RaggedIterator.DENSE_TAG],
+                                     last_batch_policy=LastBatchPolicy.FILL)
 
     for it in dali_train_iter:
         labels, ids = it[0]["labels"], it[0]["ids"]  # gpu 0
         # labels should be a sparse coo batch: a sparse coo tensor
         # ids should be a dense batch: a single dense tensor
         assert len(labels) == batch_size
-        assert labels.is_sparse == True
-        assert ids.is_sparse == False
+        assert labels.is_sparse is True
+        assert ids.is_sparse is False
+
 
 def test_ragged_iterator_sparse_list_batch():
     from nvidia.dali.plugin.pytorch import DALIRaggedIterator as RaggedIterator
@@ -907,27 +909,26 @@ def test_ragged_iterator_sparse_list_batch():
 
     pipes, _ = create_pipeline(
         lambda gpu: create_coco_pipeline(batch_size=batch_size, num_threads=4, shard_id=gpu,
-                                            num_gpus=num_gpus, data_paths=data_sets[0],
-                                            random_shuffle=True, stick_to_shard=False,
-                                            shuffle_after_epoch=False, pad_last_batch=True,
-                                            return_labels=True),
+                                         num_gpus=num_gpus, data_paths=data_sets[0],
+                                         random_shuffle=True, stick_to_shard=False,
+                                         shuffle_after_epoch=False, pad_last_batch=True,
+                                         return_labels=True),
         batch_size, num_gpus
     )
 
     dali_train_iter = RaggedIterator(pipes, output_map=["labels", "ids"],
-                                    size=pipes[0].epoch_size("Reader"),
-                                    output_types=[RaggedIterator.SPARSE_LIST_TAG,
-                                                    RaggedIterator.DENSE_TAG],
-                                    last_batch_policy=LastBatchPolicy.FILL)
+                                     size=pipes[0].epoch_size("Reader"),
+                                     output_types=[RaggedIterator.SPARSE_LIST_TAG,
+                                                   RaggedIterator.DENSE_TAG],
+                                     last_batch_policy=LastBatchPolicy.FILL)
 
     for it in dali_train_iter:
         labels, ids = it[0]["labels"], it[0]["ids"]  # gpu 0
         # labels should be a sparse list batch: a list of dense tensor
         # ids should be a dense batch: a single dense tensor
         assert len(labels) == batch_size
-        assert isinstance(labels, list) == True
-        assert ids.is_sparse == False
-
+        assert isinstance(labels, list) is True
+        assert ids.is_sparse is False
 
 
 def test_mxnet_iterator_feed_ndarray():

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -872,8 +872,8 @@ def test_pytorch_iterator_feed_ndarray_types():
     for data_type in types:
         yield check_pytorch_iterator_feed_ndarray_types, data_type
 
-def test_gluon_iterator_sparse_batch():
-    from nvidia.dali.plugin.pytorch import DALIGluonIterator as GluonIterator
+def test_ragged_iterator_sparse_coo_batch():
+    from nvidia.dali.plugin.pytorch import DALIRaggedIterator as RaggedIterator
     num_gpus = 1
     batch_size = 16
 
@@ -886,18 +886,46 @@ def test_gluon_iterator_sparse_batch():
         batch_size, num_gpus
     )
 
-    dali_train_iter = GluonIterator(pipes, output_map=["labels", "ids"],
+    dali_train_iter = RaggedIterator(pipes, output_map=["labels", "ids"],
                                     size=pipes[0].epoch_size("Reader"),
-                                    output_types=[GluonIterator.SPARSE_TAG,
-                                                    GluonIterator.DENSE_TAG],
+                                    output_types=[RaggedIterator.SPARSE_COO_TAG,
+                                                    RaggedIterator.DENSE_TAG],
                                     last_batch_policy=LastBatchPolicy.FILL)
 
     for it in dali_train_iter:
         labels, ids = it[0]["labels"], it[0]["ids"]  # gpu 0
-        # labels should be a sparse batch: a sparse tensor
+        # labels should be a sparse coo batch: a sparse coo tensor
         # ids should be a dense batch: a single dense tensor
         assert len(labels) == batch_size
         assert labels.is_sparse == True
+        assert ids.is_sparse == False
+
+def test_ragged_iterator_sparse_list_batch():
+    from nvidia.dali.plugin.pytorch import DALIRaggedIterator as RaggedIterator
+    num_gpus = 1
+    batch_size = 16
+
+    pipes, _ = create_pipeline(
+        lambda gpu: create_coco_pipeline(batch_size=batch_size, num_threads=4, shard_id=gpu,
+                                            num_gpus=num_gpus, data_paths=data_sets[0],
+                                            random_shuffle=True, stick_to_shard=False,
+                                            shuffle_after_epoch=False, pad_last_batch=True,
+                                            return_labels=True),
+        batch_size, num_gpus
+    )
+
+    dali_train_iter = RaggedIterator(pipes, output_map=["labels", "ids"],
+                                    size=pipes[0].epoch_size("Reader"),
+                                    output_types=[RaggedIterator.SPARSE_LIST_TAG,
+                                                    RaggedIterator.DENSE_TAG],
+                                    last_batch_policy=LastBatchPolicy.FILL)
+
+    for it in dali_train_iter:
+        labels, ids = it[0]["labels"], it[0]["ids"]  # gpu 0
+        # labels should be a sparse list batch: a list of dense tensor
+        # ids should be a dense batch: a single dense tensor
+        assert len(labels) == batch_size
+        assert isinstance(labels, list) == True
         assert ids.is_sparse == False
 
 


### PR DESCRIPTION
## Category: **New feature**

## Description:
In this PR we (together with @Qabrix) address ticket #2365, and add handling of non-uniform tensors in the DALI PyTroch plugin via the addition of a new class iterator based on [GluonIterator](https://github.com/NVIDIA/DALI/blob/b7e0dc1236715f1c31ee5ae75ed1f6dd47f1ef54/dali/python/nvidia/dali/plugin/mxnet.py#L593) as suggested in the ticket. @JanuszL please take a look.

## Additional information:

### Affected modules and functionalities:
PyTorch plugin

### Key points relevant for the review:
Whether the suggested implementation is sufficient for DALI use cases, namely data pipelines. Right now the provided iterator supports tensor lists containing 2D tensors (as in [COCO test example](https://github.com/NVIDIA/DALI/blob/b7e0dc1236715f1c31ee5ae75ed1f6dd47f1ef54/dali/test/python/test_fw_iterators.py#LL527C1-L527C1)), and output sparse tensors support only 2D indices (first dimension - batch id, second dimension - element id). 

### Tests:
For now, we only implemented sparse batch tests on COCO. Let us know what cases should we cover (whether the same as MXNet GluonIterator). 
## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
