### PR TITLE
Add alignment to cuda_malloc_async_memory_resource.

### DIFF
--- a/dali/core/mm/async_pool_test.cu
+++ b/dali/core/mm/async_pool_test.cu
@@ -159,6 +159,7 @@ void AsyncPoolTest(Pool &pool, std::vector<block> &blocks, Mutex &mtx, CUDAStrea
       if (hogs++ > max_hogs) {
         CUDA_CALL(cudaStreamSynchronize(stream));
         max_hogs = sync_dist(rng);
+        hogs = 0;
       }
       hog.run(stream);
     }
@@ -171,6 +172,7 @@ void AsyncPoolTest(Pool &pool, std::vector<block> &blocks, Mutex &mtx, CUDAStrea
       alignment = 1 << align_log_dist(rng);
       void *ptr = stream ? pool.allocate_async(size, alignment, sv)
                          : pool.allocate(size, alignment);
+      ASSERT_TRUE(mm::detail::is_aligned(ptr, alignment));
       CUDA_CALL(cudaMemsetAsync(ptr, fill, size, stream));
       {
         std::lock_guard<Mutex> guard(mtx);

--- a/dali/core/mm/malloc_resource.cc
+++ b/dali/core/mm/malloc_resource.cc
@@ -1,0 +1,155 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mutex>
+#include <unordered_map>
+#include "dali/core/cuda_stream_pool.h"
+#include "dali/core/device_guard.h"
+#include "dali/core/spinlock.h"
+#include "dali/core/mm/malloc_resource.h"
+#include "dali/core/mm/detail/align.h"
+
+namespace dali {
+namespace mm {
+
+#if CUDA_VERSION >= 11020
+
+namespace {
+
+class aligned_alloc_helper {
+ public:
+  static constexpr size_t kCudaMallocAlignment = 256;
+
+  void *alloc(size_t size, size_t alignment, cudaStream_t stream) {
+    void *ptr;
+    if (alignment > kCudaMallocAlignment) {
+      CUDA_CALL(cudaMallocAsync(&ptr, size + alignment - kCudaMallocAlignment, stream));
+      if (detail::is_aligned(ptr, alignment))
+        return ptr;
+
+      void *aligned = detail::align_ptr(ptr, alignment);
+      std::lock_guard guard(mtx_);
+      orig_ptrs_[aligned] = ptr;
+      return aligned;
+    } else {
+      CUDA_CALL(cudaMallocAsync(&ptr, size, stream));
+    }
+    return ptr;
+  }
+
+  void free(void *ptr, size_t size, size_t alignment, cudaStream_t stream) {
+    (void)size;
+    if (alignment > kCudaMallocAlignment) {
+      std::lock_guard guard(mtx_);
+      auto it = orig_ptrs_.find(ptr);
+      if (it != orig_ptrs_.end()) {
+        ptr = it->second;
+        orig_ptrs_.erase(it);
+      }
+    }
+    CUDA_DTOR_CALL(cudaFreeAsync(ptr, stream));
+  }
+
+  static aligned_alloc_helper &instance() {
+    static aligned_alloc_helper inst;
+    return inst;
+  }
+
+ private:
+  spinlock mtx_;
+  std::unordered_map<void *, void*> orig_ptrs_;
+};
+
+}  // namespace
+
+cuda_malloc_async_memory_resource::cuda_malloc_async_memory_resource(int device_id) {
+  // Construct the helper.
+  // The `instance` construction is finished before that of the first instance of
+  // `cuda_malloc_async_memory_resource` - a natural destruction order would be for
+  // all instances of `cuda_malloc_async_memory_resource` to be destroyed before
+  // the helper is destroyed.
+  (void)aligned_alloc_helper::instance();
+
+  if (device_id < 0) {
+    CUDA_CALL(cudaGetDevice(&device_id));
+  }
+
+  device_id_ = device_id;
+  DeviceGuard dg(device_id_);
+  dummy_host_stream_ = CUDAStreamPool::instance().Get(device_id_);
+}
+
+bool cuda_malloc_async_memory_resource::is_supported(int device_id) {
+  static const int num_devices = []() {
+    int ndev;
+    CUDA_CALL(cudaGetDeviceCount(&ndev));
+    return ndev;
+  }();
+  enum Support {
+    unintialized = 0,
+    unsupported = -1,
+    supported = 1
+  };
+  static vector<Support> support(num_devices);
+  if (device_id < 0)
+    CUDA_CALL(cudaGetDevice(&device_id));
+
+  if (!support[device_id]) {
+    auto stream = CUDAStreamPool::instance().Get(device_id);
+    try {
+    void *ptr;
+      CUDA_CALL(cudaMallocAsync(&ptr, 16, stream));
+      CUDA_CALL(cudaFreeAsync(ptr, stream));
+      support[device_id] = supported;
+    } catch (const CUDAError &e) {
+      if (e.rt_error() == cudaErrorNotSupported)
+        support[device_id] = unsupported;
+      else
+        throw;
+    }
+  }
+  return support[device_id] == supported;
+}
+
+void *cuda_malloc_async_memory_resource::do_allocate(size_t size, size_t alignment) {
+  DeviceGuard dg(device_id_);
+  void *ptr = aligned_alloc_helper::instance().alloc(size, alignment, dummy_host_stream_);
+  CUDA_CALL(cudaStreamSynchronize(dummy_host_stream_));
+  return ptr;
+}
+
+void cuda_malloc_async_memory_resource::do_deallocate(void *ptr, size_t size, size_t alignment) {
+  DeviceGuard dg(device_id_);
+  aligned_alloc_helper::instance().free(ptr, size, alignment, dummy_host_stream_);
+}
+
+void *cuda_malloc_async_memory_resource::do_allocate_async(size_t size,
+                                                           size_t alignment,
+                                                           stream_view stream)  {
+  DeviceGuard dg(device_id_);
+  return aligned_alloc_helper::instance().alloc(size, alignment, stream.get());
+}
+
+void cuda_malloc_async_memory_resource::do_deallocate_async(void *ptr,
+                                                            size_t size,
+                                                            size_t alignment,
+                                                            stream_view stream) {
+  DeviceGuard dg(device_id_);
+  aligned_alloc_helper::instance().free(ptr, size, alignment, stream.get());
+}
+
+#endif
+
+}  // namespace mm
+}  // namespace dali

--- a/dali/core/mm/malloc_resource.cc
+++ b/dali/core/mm/malloc_resource.cc
@@ -75,10 +75,11 @@ class aligned_alloc_helper {
 
 cuda_malloc_async_memory_resource::cuda_malloc_async_memory_resource(int device_id) {
   // Construct the helper.
-  // The `instance` construction is finished before that of the first instance of
-  // `cuda_malloc_async_memory_resource` - a natural destruction order would be for
-  // all instances of `cuda_malloc_async_memory_resource` to be destroyed before
-  // the helper is destroyed.
+  // Calling this in the constructor guarantees that the construction of the object returned by
+  // `aligned_alloc_helper::instance` is complete before the construction of the first instance
+  // of `cuda_malloc_async_memory_resource` - a natural destruction order would be for all
+  // instances of `cuda_malloc_async_memory_resource` to be destroyed before the helper
+  // is destroyed.
   (void)aligned_alloc_helper::instance();
 
   if (device_id < 0) {

--- a/include/dali/core/mm/malloc_resource.h
+++ b/include/dali/core/mm/malloc_resource.h
@@ -17,10 +17,8 @@
 
 #include <stdlib.h>
 #include <malloc.h>
-#include <vector>
 #include "dali/core/mm/memory_resource.h"
 #include "dali/core/cuda_error.h"
-#include "dali/core/cuda_stream.h"
 #include "dali/core/cuda_stream_pool.h"
 #include "dali/core/mm/detail/align.h"
 #include "dali/core/device_guard.h"
@@ -206,78 +204,25 @@ class managed_malloc_memory_resource : public managed_async_resource {
 
 #if CUDA_VERSION >= 11020
 
-class cuda_malloc_async_memory_resource
+class DLL_PUBLIC cuda_malloc_async_memory_resource
 : public mm::async_memory_resource<mm::memory_kind::device> {
  public:
   cuda_malloc_async_memory_resource() : cuda_malloc_async_memory_resource(-1) {}
 
-  explicit cuda_malloc_async_memory_resource(int device_id) {
-    if (device_id < 0) {
-      CUDA_CALL(cudaGetDevice(&device_id));
-    }
+  explicit cuda_malloc_async_memory_resource(int device_id);
 
-    device_id_ = device_id;
-    DeviceGuard dg(device_id_);
-    dummy_host_stream_ = CUDAStreamPool::instance().Get(device_id_);
-  }
+  static bool is_supported(int device_id = -1);
 
-  static bool is_supported(int device_id = -1) {
-    static const int num_devices = []() {
-      int ndev;
-      CUDA_CALL(cudaGetDeviceCount(&ndev));
-      return ndev;
-    }();
-    enum Support {
-      unintialized = 0,
-      unsupported = -1,
-      supported = 1
-    };
-    static vector<Support> support(num_devices);
-    if (device_id < 0)
-      CUDA_CALL(cudaGetDevice(&device_id));
-
-    if (!support[device_id]) {
-      auto stream = CUDAStreamPool::instance().Get(device_id);
-      try {
-      void *ptr;
-        CUDA_CALL(cudaMallocAsync(&ptr, 16, stream));
-        CUDA_CALL(cudaFreeAsync(ptr, stream));
-        support[device_id] = supported;
-      } catch (const CUDAError &e) {
-        if (e.rt_error() == cudaErrorNotSupported)
-          support[device_id] = unsupported;
-        else
-          throw;
-      }
-    }
-    return support[device_id] == supported;
-  }
+  int device_id() const noexcept { return device_id_; }
 
  private:
-  void *do_allocate(size_t size, size_t alignment) override {
-    DeviceGuard dg(device_id_);
-    void *ptr;
-    CUDA_CALL(cudaMallocAsync(&ptr, size, dummy_host_stream_));
-    CUDA_CALL(cudaStreamSynchronize(dummy_host_stream_));
-    return ptr;
-  }
+  void *do_allocate(size_t size, size_t alignment) override;
 
-  void do_deallocate(void *ptr, size_t size, size_t alignment) override  {
-    DeviceGuard dg(device_id_);
-    CUDA_DTOR_CALL(cudaFreeAsync(ptr, dummy_host_stream_));
-  }
+  void do_deallocate(void *ptr, size_t size, size_t alignment) override;
 
-  void *do_allocate_async(size_t size, size_t alignment, stream_view stream) override  {
-    DeviceGuard dg(device_id_);
-    void *ptr;
-    CUDA_CALL(cudaMallocAsync(&ptr, size, stream.get()));
-    return ptr;
-  }
+  void *do_allocate_async(size_t size, size_t alignment, stream_view stream) override;
 
-  void do_deallocate_async(void *ptr, size_t size, size_t alignment, stream_view stream) override {
-    DeviceGuard dg(device_id_);
-    CUDA_DTOR_CALL(cudaFreeAsync(ptr, stream.get()));
-  }
+  void do_deallocate_async(void *ptr, size_t size, size_t alignment, stream_view stream) override;
 
   int device_id_;
   CUDAStreamLease dummy_host_stream_;


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix**
**New feature**


## Description:
`cudaMallocAsync` allocates memory aligned to a multiple of 256 bytes, however, DALI's memory_resource interface can be used to request overaligned memory. Before this PR, DALI would neither return properly aligned memory nor raise an error, should cudaMallocAsync return insufficiently aligned pointer.
This PR adds overalignment support by requesting larger blocks for allocations with alignment >256B and aligning the pointer accoringly. The mapping aligned->original pointer is kept (in a global state) and upon deletion, the pointer being deleted is looked up in the map and, if found, replaced with the original pointer.

Additionally, a tiny performance bug is fixed in AsyncPool tests.

## Additional information:

### Affected modules and functionalities:
`cuda_malloc_async_memory_resource`
AsyncPool tests.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] ~New tests added~ Test adjusted
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
