### PR TITLE
Extends guards against intercepting by asan certain functions

### DIFF
--- a/qa/TL0_FW_iterators/test_jax.sh
+++ b/qa/TL0_FW_iterators/test_jax.sh
@@ -13,12 +13,8 @@ test_body() {
     # General tests for iterators
     ${python_invoke_test} -m '(?:^|[\b_\./-])[Tt]est.*jax*' test_fw_iterators.py
 
-    # it takes very long time to run it with sanitizers on and provides little value so turn it off
-    if [ -z "$DALI_ENABLE_SANITIZERS" ]; then
-
-        # More specific JAX tests
-        ${python_new_invoke_test} -s jax test_integration
-    fi
+    # More specific JAX tests
+    ${python_new_invoke_test} -s jax test_integration
 }
 
 pushd ../..

--- a/qa/test_wrapper_pre.c
+++ b/qa/test_wrapper_pre.c
@@ -70,7 +70,7 @@ void free(void *p) {
     trace_init();
   }
 
-  // asume that allocation and free are done at the same level of _Unwind_Backtrace nesting
+  // assume that allocation and free are done at the same level of _Unwind_Backtrace nesting
   // so we don't end up allocating from the nested call and releasing from unnested
   if (use_direct_malloc()) {
     direct_free(p);


### PR DESCRIPTION
- makes sure that __deregister_frame_info_bases doesn't use
  intercepted free/malloc from asan as they call unwind functions
  that try to obtain the same mutex as the __deregister_frame_info_bases
  holds leading to a deadlock
- restores previously excluded JAX tests from asan runs

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- makes sure that __deregister_frame_info_bases doesn't use
  intercepted free/malloc from asan as they call unwind functions
  that try to obtain the same mutex as the __deregister_frame_info_bases
  holds leading to a deadlock
- restores previously excluded JAX tests from asan runs
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- qa/TL0_FW_iterators/test_jax.sh
- qa/test_wrapper_post.c
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - TL0_FW_iterators
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
