### PR TITLE
C++20 Compatibility for dali::Tensor

### DIFF
--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -402,14 +402,14 @@ class Tensor : public Buffer<Backend> {
     return true;
   }
 
-  Tensor<Backend>(const Tensor<Backend>&) = delete;
-  Tensor<Backend>& operator=(const Tensor<Backend>&) = delete;
+  Tensor(const Tensor&) = delete;
+  Tensor& operator=(const Tensor&) = delete;
 
-  Tensor<Backend>(Tensor<Backend> &&t) noexcept {
+  Tensor(Tensor &&t) noexcept {
     *this = std::move(t);
   }
 
-  Tensor<Backend>& operator=(Tensor<Backend> &&t) noexcept {
+  Tensor& operator=(Tensor &&t) noexcept {
     if (&t != this) {
       shape_ = std::exchange(t.shape_, {0});
       meta_ = std::exchange(t.meta_, {});


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** C++20 Compatibility for Custom Plugin Creation. 

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

C++ 20 removes simple templating from ctor's, resulting in a compliation error [here](https://github.com/NVIDIA/DALI/blob/main/dali/pipeline/data/tensor.h#L405) when trying to compile a custom plugin with C++ 20. By removing <Backend> from the rule-of-five defined there, GCC 11 is able to compile a new plugin targeting C++20. This is useful for enabling use of std::span and in future std::mdspan for running over tensor data. There is potentially more to do to compile DALI from source with C++20, but that is out of scope for this PR (and maybe a big project, idk), this is a short and simple fix so I can make my plugins with C++20.

I commit with --signoff but my GPG keys are cooked on this workstation so hasn't signed correctly (doesn't show up as "verified" on gh). This is such a simple fix I'd rather have someone else copy this and submit PR just to get this done. I don't want to mess around with GH sign-off keys for an hour to get it to work correctly (as I have pulled my hair out over this in the past and don't want to do that again).

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

Remove template from rule-of-five of dali::Tensor, no functionality changes.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

The assumtion is that this will only potentially break compilation, hence, the only "test" I ran was to build with docker/build.sh, which finished successfully.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ x ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ x ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
