### PR TITLE
Disable cudaMemPoolReuseAllowOpportunistic in cudaMallocAsync for <r470.60

### DIFF
--- a/dali/core/CMakeLists.txt
+++ b/dali/core/CMakeLists.txt
@@ -91,6 +91,9 @@ set_target_properties(dali_core PROPERTIES
 set(lib_exports "libdali_core.map")
 configure_file("${DALI_ROOT}/cmake/${lib_exports}.in" "${CMAKE_BINARY_DIR}/${lib_exports}")
 target_link_libraries(dali_core PRIVATE -Wl,--version-script=${CMAKE_BINARY_DIR}/${lib_exports})
+if (BUILD_NVML)
+  target_link_libraries(dali_core PRIVATE dynlink_nvml)
+endif(BUILD_NVML)
 
 if (BUILD_TEST)
   adjust_source_file_language_property("${DALI_CORE_TEST_SRCS}")

--- a/dali/core/mm/malloc_resource.cc
+++ b/dali/core/mm/malloc_resource.cc
@@ -97,7 +97,7 @@ cuda_malloc_async_memory_resource::cuda_malloc_async_memory_resource(int device_
     nvml::Init();
     return nvml::GetDriverVersion();
   }();
-  if (driverVersion < 495) {
+  if (driverVersion < 470.60) {
     cudaMemPool_t memPool;
     CUDA_CALL(cudaDeviceGetDefaultMemPool(&memPool, device_id_));
     int val = 0;

--- a/dali/core/mm/malloc_resource.cc
+++ b/dali/core/mm/malloc_resource.cc
@@ -93,8 +93,10 @@ cuda_malloc_async_memory_resource::cuda_malloc_async_memory_resource(int device_
   DeviceGuard dg(device_id_);
   dummy_host_stream_ = CUDAStreamPool::instance().Get(device_id_);
 #if NVML_ENABLED
-  nvml::Init();
-  float driverVersion = nvml::GetDriverVersion();
+  static const float driverVersion = []() {
+    nvml::Init();
+    return nvml::GetDriverVersion();
+  }();
   if (driverVersion < 495) {
     cudaMemPool_t memPool;
     CUDA_CALL(cudaDeviceGetDefaultMemPool(&memPool, device_id_));

--- a/dali/core/mm/malloc_resource.cc
+++ b/dali/core/mm/malloc_resource.cc
@@ -19,6 +19,9 @@
 #include "dali/core/spinlock.h"
 #include "dali/core/mm/malloc_resource.h"
 #include "dali/core/mm/detail/align.h"
+#if NVML_ENABLED
+#include "dali/util/nvml.h"
+#endif  // NVML_ENABLED
 
 namespace dali {
 namespace mm {
@@ -89,6 +92,16 @@ cuda_malloc_async_memory_resource::cuda_malloc_async_memory_resource(int device_
   device_id_ = device_id;
   DeviceGuard dg(device_id_);
   dummy_host_stream_ = CUDAStreamPool::instance().Get(device_id_);
+#if NVML_ENABLED
+  nvml::Init();
+  float driverVersion = nvml::GetDriverVersion();
+  if (driverVersion < 495) {
+    cudaMemPool_t memPool;
+    CUDA_CALL(cudaDeviceGetDefaultMemPool(&memPool, device_id_));
+    int val = 0;
+    CUDA_CALL(cudaMemPoolSetAttribute(memPool, cudaMemPoolReuseAllowOpportunistic, &val));
+  }
+#endif  // NVML_ENABLED
 }
 
 bool cuda_malloc_async_memory_resource::is_supported(int device_id) {


### PR DESCRIPTION
- due to a synchronization problem disable cudaMemPoolReuseAllowOpportunistic
  in cudaMallocAsync for <r470.60 in DALI memory resource

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- due to a synchronization problem disable cudaMemPoolReuseAllowOpportunistic
  in cudaMallocAsync for <r70.60 in DALI memory resource
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- memory resource
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
    - MMAsyncPoolTest
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
