### PR TITLE
Fix layout broadcasting arithm ops

### DIFF
--- a/dali/operators/math/expressions/arithmetic.h
+++ b/dali/operators/math/expressions/arithmetic.h
@@ -87,12 +87,12 @@ inline TileCover GetOneTilePerSample(const TensorListShape<> &shape) {
 /**
  * @brief Checks if the child is a (possibly improper) suffix of the parent.
  */
-inline bool EndsWith(const TensorLayout &parent, const TensorLayout &child) {
-  if (parent.size() < child.size()) {
+inline bool EndsWith(const TensorLayout &whole, const TensorLayout &suffix) {
+  if (whole.size() < suffix.size()) {
     return false;
   }
-  for (int i = 0; i < child.size(); i++) {
-    if (parent[parent.size() - 1 - i] != child[child.size() - 1 - i]) {
+  for (int i = 0; i < suffix.size(); i++) {
+    if (whole[whole.size() - 1 - i] != suffix[suffix.size() - 1 - i]) {
       return false;
     }
   }

--- a/dali/operators/math/expressions/arithmetic.h
+++ b/dali/operators/math/expressions/arithmetic.h
@@ -353,7 +353,7 @@ class ArithmeticGenericOp : public Operator<Backend> {
       result_layout_ = GetCommonLayout<Backend>(*expr_, ws);
       // sample_ndim is assumed to be constant between iterations.
       if (result_layout_.size() != result_shape_.sample_dim()) {
-        // If the largest dimentional tensors do not have layout set but some
+        // If the tensors with the most dimensions do not have a layout set but some
         // smaller-dim tensors do, the `GetCommonLayout` returns layout smaller than needed and
         // we cannot use it. For example if `a` has shape (1, 1, 1), layout ""
         // and `b` (3,) and "C", the `a * b` shape is (1, 1, 3)

--- a/dali/operators/math/expressions/arithmetic.h
+++ b/dali/operators/math/expressions/arithmetic.h
@@ -86,10 +86,11 @@ inline TileCover GetOneTilePerSample(const TensorListShape<> &shape) {
 
 /**
  * @brief Checks if the child is a (possibly improper) suffix of the parent.
- * The child must not be longer than the parent.
  */
-inline bool HasSuffix(const TensorLayout &parent, const TensorLayout &child) {
-  assert(parent.size() >= child.size());
+inline bool EndsWith(const TensorLayout &parent, const TensorLayout &child) {
+  if (parent.size() < child.size()) {
+    return false;
+  }
   for (int i = 0; i < child.size(); i++) {
     if (parent[parent.size() - 1 - i] != child[child.size() - 1 - i]) {
       return false;
@@ -118,10 +119,10 @@ DLL_PUBLIC TensorLayout GetCommonLayout(ExprNode &expr, const Workspace &ws) {
   for (int i = 1; i < expr.GetSubexpressionCount(); i++) {
     auto next_layout = GetCommonLayout<Backend>(func[i], ws);
     if (result_layout.size() >= next_layout.size()) {
-      if (HasSuffix(result_layout, next_layout)) {
+      if (EndsWith(result_layout, next_layout)) {
         continue;
       }
-    } else if (HasSuffix(next_layout, result_layout)) {
+    } else if (EndsWith(next_layout, result_layout)) {
       result_layout = next_layout;
       continue;
     }

--- a/dali/operators/math/expressions/arithmetic_test.cc
+++ b/dali/operators/math/expressions/arithmetic_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ TEST(ArithmeticOpsTest, TreePropagationLayoutError) {
     ptr->Resize({{1}, {2}}, DALI_INT32);
   }
   in[0]->SetLayout(TensorLayout());
-  in[1]->SetLayout(TensorLayout("HW"));
+  in[1]->SetLayout(TensorLayout("DH"));
   in[2]->SetLayout(TensorLayout("DHW"));
   ws.AddInput(in[0]);
   ws.AddInput(in[1]);

--- a/dali/test/python/operator_1/test_arithmetic_ops.py
+++ b/dali/test/python/operator_1/test_arithmetic_ops.py
@@ -961,7 +961,10 @@ def test_layout_broadcasting(op_name, args_desc, out_desc, in_devs, in_types, op
 
     p = pipeline()
     p.build()
-    if not isinstance(out_desc, Exception):
+    if isinstance(out_desc, Exception):
+        with assert_raises(Exception, glob="They must be equal or one must be a suffix"):
+            p.run()
+    else:
         o, = p.run()
         expected_shape, expected_layout = out_desc
         expected_layout = expected_layout or ""
@@ -971,9 +974,6 @@ def test_layout_broadcasting(op_name, args_desc, out_desc, in_devs, in_types, op
         for sample_shape in out_shape:
             assert sample_shape == expected_shape, \
                 f"got `{sample_shape}`, expected `{expected_shape}`"
-    else:
-        with assert_raises(Exception, glob="They must be equal or one must be a suffix"):
-            o, = p.run()
 
 
 def test_broadcasting_dimensionality_limits():

--- a/dali/test/python/operator_1/test_arithmetic_ops.py
+++ b/dali/test/python/operator_1/test_arithmetic_ops.py
@@ -21,6 +21,7 @@ from nvidia.dali.tensors import TensorListGPU
 import numpy as np
 from nose.tools import assert_equals
 from nose.plugins.attrib import attr
+from nose2.tools import params
 import itertools
 
 from test_utils import np_type_to_dali
@@ -861,6 +862,108 @@ def test_ternary_ops_broadcasting():
                                               selected_input_arithm_types,
                                               selected_input_arithm_types):
                 yield check_ternary_op, kinds, types_in, op, get_sh, op_desc
+
+
+def generate_layout_broadcasting_cases():
+    rng = np.random.default_rng(4242)
+
+    def get_input_dev(num_inputs):
+        placement = rng.choice(["cpu", "gpu", "non_uniform"])
+        if placement != "non_uniform":
+            return (placement, ) * num_inputs
+        placement = [rng.choice(["cpu", "gpu"]) for _ in range(num_inputs - 1)]
+        placement.append("gpu" if placement[-1] == "cpu" else "cpu")
+        return tuple(placement)
+
+    def get_input_types(num_inputs, integral_only):
+        types = (np.int32, np.uint8)
+        if not integral_only:
+            types += (np.float32, )
+        return tuple(rng.choice(types, size=(num_inputs, )))
+
+    bin_layouts = [
+        ((4, "C"), 4),
+        (("C", 3), 3),
+        (("C", 2), 2),
+        (("C", 1), "C"),
+        ((1, "C"), "C"),
+        ((0, "C"), "C"),
+        (("C", 0), "C"),
+        (("ABCD", 0), "ABCD"),
+        ((0, "ABCD"), "ABCD"),
+        (("ABCD", 3), "ABCD"),
+        ((1, "ABCD"), "ABCD"),
+        (("ABCD", "D"), "ABCD"),
+        (("D", "ABCD"), "ABCD"),
+        (("ABCD", "CD"), "ABCD"),
+        (("ABCD", "BCD"), "ABCD"),
+        (("BCD", "ABCD"), "ABCD"),
+        (("ABCD", "ABCD"), "ABCD"),
+    ]
+
+    ternary_layouts = [
+        (("ABCD", "CD", "D"), "ABCD"),
+        (("ABCD", "D", "CD"), "ABCD"),
+        ((3, "ABCD", "CD"), "ABCD"),
+        ((0, "ABCD", 0), "ABCD"),
+        ((0, "BCD", 4), 4),
+        ((3, 4, "CD"), 4),
+        ((4, "ABCD", 4), "ABCD"),
+    ]
+
+    bin_ops = floaty_operations[:5] + bitwise_operations[:3] + \
+        comparisons_operations[:2] + sane_operations
+
+    def tensor_desc(ndim_or_layout):
+        if isinstance(ndim_or_layout, int):
+            ndim = ndim_or_layout
+            layout = None
+        else:
+            assert isinstance(ndim_or_layout, str)
+            ndim = len(ndim_or_layout)
+            layout = ndim_or_layout
+        max_shape = (5, 7, 11, 13)
+        shape = tuple() if ndim == 0 else max_shape[-ndim:]
+        return shape, layout
+
+    for num_inputs, layouts, op_lists in [
+        (2, bin_layouts, bin_ops),
+        (3, ternary_layouts, ternary_operations),
+    ]:
+        for i, (args_desc, out_desc) in enumerate(layouts):
+            assert (len(args_desc) == num_inputs)
+            op, op_name = op_lists[i % len(op_lists)][:2]
+            op = op if not isinstance(op, tuple) else op[0]
+            input_devs = get_input_dev(num_inputs)
+            in_types = get_input_types(num_inputs, op_name in ("&|^"))
+            args_desc = tuple(tensor_desc(arg) for arg in args_desc)
+            yield op_name, args_desc, tensor_desc(out_desc), input_devs, in_types, op
+
+
+@params(*tuple(generate_layout_broadcasting_cases()))
+def test_layout_broadcasting(op_name, args_desc, out_desc, in_devs, in_types, op):
+    assert len(args_desc) == len(in_devs)
+    assert len(in_types) == len(in_devs)
+    batch_size = 4
+
+    @pipeline_def(batch_size=batch_size, device_id=0, num_threads=4)
+    def pipeline():
+        in_nodes = [
+            types.Constant(np.full(shape, 1, dtype=in_type), device=in_dev, layout=layout)
+            for (shape, layout), in_dev, in_type in zip(args_desc, in_devs, in_types)
+        ]
+        return op(*in_nodes)
+
+    p = pipeline()
+    p.build()
+    o, = p.run()
+    expected_shape, expected_layout = out_desc
+    expected_layout = expected_layout or ""
+    assert o.layout() == expected_layout, f"got `{o.layout()}`, expected `{expected_layout}`"
+    out_shape = o.shape()
+    assert len(out_shape) == batch_size, f"got `{len(out_shape)}`, expected `{batch_size}`"
+    for sample_shape in out_shape:
+        assert sample_shape == expected_shape, f"got `{sample_shape}`, expected `{expected_shape}`"
 
 
 def test_broadcasting_dimensionality_limits():

--- a/dali/test/python/operator_1/test_arithmetic_ops.py
+++ b/dali/test/python/operator_1/test_arithmetic_ops.py
@@ -881,6 +881,10 @@ def generate_layout_broadcasting_cases():
             types += (np.float32, )
         return tuple(rng.choice(types, size=(num_inputs, )))
 
+    # The input layouts and the expected output layout.
+    # A number N denotes an ND tensor without a layout.
+    # `Exception` means that applying an operator with the arguments with
+    # given layouts should raise an error.
     bin_layouts = [
         ((4, "C"), 4),
         (("C", 3), 3),


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Without this change, it is possible to produce tensors whose layout does not match their dimensionality.

The arithm ops layout propagation works by picking just any non-empty layout and making sure that any other operands have either empty or equal layout. This leads to two issues:
* layout of wrong length: if more ndim-ed tensor has no layout and the less ndim-ed tensor does, the output ends up with layout of incorrect lengt. Take `a` of shape (1, 2, 3, 4) and empty layout, and  `b` of shape  (4,) and layout "C". The output ends up to have 4dims and layout "C".
* errors when the layout match but are not equal, for example FHWC and C.

The fix is to 1. check if the picked layout is not too short and if so, discard it, 2. allow for different layouts as long as one if suffix of the other.

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:
It would be nice to follow-up the layout propagation with more involved mechanism that would:
1. not discard partial information, i.e. when bigger dim-ed tensor does not have layout, but the samller dim-ed has, we should retain the information about layout suffix. Possibly with "*" wildcards in the layout (that would have consitently special treatment in equality). 
2. generalize the matching from common suffix to one of the layouts being subsequence of the other.
### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3556
<!--- DALI-XXXX or NA --->
