### PR TITLE
Remove the direct use of cuda_for_dali auxiliary namespace.

### DIFF
--- a/dali/core/mm/mm_test_utils.h
+++ b/dali/core/mm/mm_test_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -263,7 +263,7 @@ struct test_device_resource
 
 template <typename Kind, bool owning, typename Upstream = async_memory_resource<Kind>>
 using test_stream_resource = test_resource_wrapper<
-    owning, detail::is_host_accessible<Kind>, async_memory_resource<Kind>, Upstream>;
+    owning, is_host_accessible<Kind>, async_memory_resource<Kind>, Upstream>;
 
 
 class test_dev_pool_resource : public test_stream_resource<memory_kind::device, true> {

--- a/dali/kernels/imgproc/resample/resampling_filters.cu
+++ b/dali/kernels/imgproc/resample/resampling_filters.cu
@@ -72,8 +72,7 @@ void InitFilters(ResamplingFilters &filters) {
   const int lanczos_size = (2*lanczos_a*lanczos_resolution + 1);
   const int total_size = triangular_size + gaussian_size + cubic_size + lanczos_size;
 
-  constexpr bool need_staging =
-    !cuda_for_dali::kind_has_property<MemoryKind, cuda_for_dali::memory_access::host>::value;
+  constexpr bool need_staging = !mm::is_host_accessible<MemoryKind>;
 
   using tmp_kind = std::conditional_t<need_staging, mm::memory_kind::host, MemoryKind>;
   filters.filter_data = mm::alloc_raw_unique<float, tmp_kind>(total_size);

--- a/dali/kernels/test/scatter_gather_test.cc
+++ b/dali/kernels/test/scatter_gather_test.cc
@@ -73,7 +73,7 @@ class ScatterGatherTest : public testing::Test {
 
   template <typename MemoryKind>
   void Memcpy(void *dst, const void *src, size_t size, cudaMemcpyKind kind) {
-    if (cuda_for_dali::kind_has_property<MemoryKind, cuda_for_dali::memory_access::host>::value) {
+    if (mm::is_host_accessible<MemoryKind>) {
       memcpy(dst, src, size);
     } else {
       CUDA_CALL(cudaMemcpy(dst, src, size, kind));
@@ -82,7 +82,7 @@ class ScatterGatherTest : public testing::Test {
 
   template <typename MemoryKind>
   void Memset(void *dst, int c, size_t size) {
-    if (cuda_for_dali::kind_has_property<MemoryKind, cuda_for_dali::memory_access::host>::value) {
+    if (mm::is_host_accessible<MemoryKind>) {
       memset(dst, c, size);
     } else {
       CUDA_CALL(cudaMemset(dst, c, size));

--- a/dali/pipeline/data/copy_to_external.h
+++ b/dali/pipeline/data/copy_to_external.h
@@ -138,8 +138,7 @@ template <typename DstKind, typename SrcBackend>
 inline void CopyToExternal(void *dst, const Tensor<SrcBackend> &src, AccessOrder order,
                            bool use_copy_kernel) {
   const bool src_device_access = (std::is_same<SrcBackend, GPUBackend>::value || src.is_pinned());
-  const bool dst_device_access =
-      cuda_for_dali::kind_has_property<DstKind, cuda_for_dali::memory_access::device>::value;
+  const bool dst_device_access = mm::is_device_accessible<DstKind>;
   use_copy_kernel &= dst_device_access && src_device_access;
   using DstBackend = typename detail::kind2backend<DstKind>::type;
   CopyToExternalImpl<DstBackend, SrcBackend>(dst, src, order, use_copy_kernel);
@@ -149,8 +148,7 @@ template <typename DstKind, typename SrcBackend>
 inline void CopyToExternal(void *dst, const TensorList<SrcBackend> &src, AccessOrder order,
                            bool use_copy_kernel) {
   const bool src_device_access = (std::is_same<SrcBackend, GPUBackend>::value || src.is_pinned());
-  const bool dst_device_access =
-      cuda_for_dali::kind_has_property<DstKind, cuda_for_dali::memory_access::device>::value;
+  const bool dst_device_access = mm::is_device_accessible<DstKind>;
   use_copy_kernel &= dst_device_access && src_device_access;
   using DstBackend = typename detail::kind2backend<DstKind>::type;
   CopyToExternalImpl<DstBackend, SrcBackend>(dst, src, order, use_copy_kernel);
@@ -185,8 +183,7 @@ template <typename DstKind, typename SrcBackend>
 inline void CopyToExternal(void** dsts, const TensorList<SrcBackend> &src,
                            AccessOrder order, bool use_copy_kernel) {
   bool src_device_access = (std::is_same<SrcBackend, GPUBackend>::value || src.is_pinned());
-  bool dst_device_access =
-      cuda_for_dali::kind_has_property<DstKind, cuda_for_dali::memory_access::device>::value;
+  bool dst_device_access = mm::is_device_accessible<DstKind>;
   use_copy_kernel &= dst_device_access && src_device_access;
   using DstBackend = typename detail::kind2backend<DstKind>::type;
   CopyToExternalImpl<DstBackend, SrcBackend>(dsts, src, order, use_copy_kernel);

--- a/dali/test/mat2tensor.h
+++ b/dali/test/mat2tensor.h
@@ -72,7 +72,7 @@ template <typename MemoryKind = mm::memory_kind::device, typename T = uint8_t, i
 std::pair<TensorView<kind2storage_t<MemoryKind>, T, ndims>, mm::uptr<T>>
 copy_as_tensor(const cv::Mat &mat) {
   static_assert(
-      cuda_for_dali::kind_has_property<MemoryKind, cuda_for_dali::memory_access::device>::value,
+      mm::is_device_accessible<MemoryKind>,
       "A GPU-accessible memory kind is required.");
   auto tvin = kernels::view_as_tensor<const T, ndims>(mat);
   return copy<MemoryKind>(tvin);

--- a/include/dali/core/backend_tags.h
+++ b/include/dali/core/backend_tags.h
@@ -16,7 +16,7 @@
 #define DALI_CORE_BACKEND_TAGS_H_
 
 #include <type_traits>
-#include "dali/core/mm/cuda_memory_resource.h"
+#include "dali/core/mm/memory_resource.h"
 
 namespace dali {
 
@@ -59,22 +59,22 @@ template <typename MemoryKind>
 struct kind2storage;
 
 template <>
-struct kind2storage<cuda_for_dali::memory_kind::host> {
+struct kind2storage<mm::memory_kind::host> {
   using type = StorageCPU;
 };
 
 template <>
-struct kind2storage<cuda_for_dali::memory_kind::pinned> {
+struct kind2storage<mm::memory_kind::pinned> {
   using type = StorageCPU;
 };
 
 template <>
-struct kind2storage<cuda_for_dali::memory_kind::device> {
+struct kind2storage<mm::memory_kind::device> {
   using type = StorageGPU;
 };
 
 template <>
-struct kind2storage<cuda_for_dali::memory_kind::managed> {
+struct kind2storage<mm::memory_kind::managed> {
   using type = StorageUnified;
 };
 

--- a/include/dali/core/mm/memory_resource.h
+++ b/include/dali/core/mm/memory_resource.h
@@ -37,6 +37,7 @@ namespace dali {
 namespace mm {
 
 namespace memory_kind = cuda_for_dali::memory_kind;
+namespace memory_access = cuda_for_dali::memory_access;
 
 using cuda_for_dali::memory_resource;
 using cuda_for_dali::resource_view;
@@ -45,6 +46,8 @@ using cuda_for_dali::stream_ordered_resource_view;
 using host_memory_resource = memory_resource<memory_kind::host>;
 using pinned_memory_resource = memory_resource<memory_kind::pinned>;
 using cuda_for_dali::stream_view;
+
+using cuda_for_dali::kind_has_property;
 
 template <typename Kind>
 using async_memory_resource = cuda_for_dali::stream_ordered_memory_resource<Kind>;
@@ -57,13 +60,14 @@ struct stream_context {
   stream_view stream;
 };
 
-namespace detail {
-
 template <typename Kind>
 constexpr bool is_host_accessible =
-    cuda_for_dali::kind_has_property<Kind, cuda_for_dali::memory_access::host>::value;
+    mm::kind_has_property<Kind, mm::memory_access::host>::value;
 
-}  // namespace detail
+template <typename Kind>
+constexpr bool is_device_accessible =
+    mm::kind_has_property<Kind, mm::memory_access::device>::value;
+
 
 }  // namespace mm
 }  // namespace dali

--- a/include/dali/core/mm/monotonic_resource.h
+++ b/include/dali/core/mm/monotonic_resource.h
@@ -78,7 +78,7 @@ class monotonic_buffer_resource : public memory_resource<Kind> {
 
 template <typename Kind,
           typename Upstream = mm::memory_resource<Kind>,
-          bool host_impl = detail::is_host_accessible<Kind>>
+          bool host_impl = is_host_accessible<Kind>>
 class monotonic_memory_resource;
 
 /**


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:
Due to conflicts with libcu++, the dependence on a libcu++ fork was removed and the relevant files were copied to DALI and their contents moved to an auxiliary namespace. The direct use of this auxiliary namespace leaks a technical workaround into DALI source base.
This PR imports the relevant symbols into namespace `dali::mm` and the usages of `cuda_for_dali::` are replaced with `mm::`.
Additionally, some memory kind queries are replaced with a helper trait `is_host_accessible`, which was already there (it's been removed from `mm::detail` to `mm`).

## Additional information:

### Affected modules and functionalities:
Memory managment headers and some random files affected by the previous workaround.

### Key points relevant for the review:
N/A

### Tests:
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
