### PR TITLE
Fix abs diff computation in check_batch test utility

### DIFF
--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -131,7 +131,7 @@ def get_gpu_num():
 
 def _get_absdiff(left, right):
 
-    def make_signed(dtype):
+    def make_unsigned(dtype):
         if not np.issubdtype(dtype, np.signedinteger):
             return dtype
         return {
@@ -144,11 +144,15 @@ def _get_absdiff(left, right):
     # np.abs of diff doesn't handle overflow for unsigned types
     absdiff = np.maximum(left, right) - np.minimum(left, right)
     # max - min can overflow for signed types, wrap them up
-    absdiff = absdiff.astype(make_signed(absdiff.dtype))
+    absdiff = absdiff.astype(make_unsigned(absdiff.dtype))
     return absdiff
 
 
 def _check_absdiff():
+    """
+    In principle, overflow on signed int is UB (that we relied on so far anyway).
+    The following one-time check aims to verify the overflow wraps as expected.
+    """
     for i in range(-128, 127):
         for j in range(-128, 127):
             left = np.array([i, i], dtype=np.int8)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
The `check_batch` utility reports wrong abs differences for unsigned types if the actual difference is bigger than the half of the range of the type. (Take uint8 and 1 vs 254 - the abs diff is 253 while the chekc_batch would report 3).
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
