### PR TITLE
Add optimized variant of CMN for HWC to CHW case

### DIFF
--- a/dali/kernels/slice/slice_hwc2chw_normalize_gpu.cu
+++ b/dali/kernels/slice/slice_hwc2chw_normalize_gpu.cu
@@ -101,7 +101,7 @@ __global__ void Hwc2ChwNormalize(const Hwc2ChwSampleDesc<Out, In> *samples,
   auto in_start = reinterpret_cast<std::uintptr_t>(sample.in + block.start.x);
   auto aligned_in_start = align_up(in_start, 32 * 4);
   auto bytes_skipped =
-      ::min(aligned_in_start - in_start, static_cast<uint64_t>(block.end.x - block.start.x));
+      ::min(static_cast<int64_t>(aligned_in_start - in_start), block.end.x - block.start.x);
 
   float *aligned_tile = tile + 32 * 4;
   float *prologue_tile = aligned_tile - bytes_skipped;
@@ -235,7 +235,7 @@ __global__ void SliceHwc2ChwNormalize(const Hwc2ChwSampleDesc<Out, In> *samples,
     // align to 4
     auto aligned_in_start = align_up(in_start, 4);
     auto bytes_skipped =
-        ::min(aligned_in_start - in_start, static_cast<uint64_t>(xc_end - xc_start));
+        ::min(static_cast<int32_t>(aligned_in_start - in_start), xc_end - xc_start);
 
     float *prologue_tile = tile_row;
     float *aligned_tile = tile_row + bytes_skipped;

--- a/dali/kernels/slice/slice_hwc2chw_normalize_gpu.cu
+++ b/dali/kernels/slice/slice_hwc2chw_normalize_gpu.cu
@@ -56,11 +56,6 @@ inline __device__ uint32_t FindSampleIdx(const Hwc2ChwSampleDesc<Out, In> *sampl
   return i;
 }
 
-/**
- * @brief
- *
- */
-
 /** @defgroup Hwc2Chw The Slice Hwc2Chw Normalize Mirror-x Pad-channel kernel
  *
  * Kernel that reads a HWC u8 image and outputs a CHW normalized float image, that can be cropped

--- a/dali/kernels/slice/slice_hwc2chw_normalize_gpu.cu
+++ b/dali/kernels/slice/slice_hwc2chw_normalize_gpu.cu
@@ -1,0 +1,512 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <tuple>
+#include <type_traits>
+#include "dali/core/backend_tags.h"
+#include "dali/core/convert.h"
+#include "dali/core/error_handling.h"
+#include "dali/core/permute.h"
+#include "dali/core/static_switch.h"
+#include "dali/kernels/slice/slice_hwc2chw_normalize_gpu.h"
+
+namespace dali {
+namespace kernels {
+
+namespace slice_flip_normalize {
+
+
+template <typename Out, typename In>
+struct Hwc2ChwSampleDesc {
+  Out *__restrict__ out;
+  const In *__restrict__ in;
+  const float *__restrict__ norm_add;
+  const float *__restrict__ norm_mul;
+  const void *__restrict__ fill_values;
+
+  // Dimensions of the output
+  int H, W, C;
+  // Dimensions of the input (relevant to input stride)
+  int input_W, input_C;
+
+  bool flip_x;
+};
+
+/**
+ * @brief
+ *
+ */
+
+/** @defgroup Hwc2Chw The Slice Hwc2Chw Normalize Mirror-x Pad-channel kernel
+ *
+ * Kernel that reads a HWC u8 image and outputs a CHW normalized float image, that can be cropped
+ * in Y, X coordinates, mirrored in X coordinate, and the channels can be padded.
+ *
+ * Overview of the kernel:
+ * The image is processed in flattened coordinates. The Y, X stays the same between the interleaved
+ * input layout and planar output layout. Assuming 3-channel input, we can look at the input as
+ * a sequential stream of values, where we distribute them (sequentially) into 3 output planes.
+ * Use a thread block size, that is divisible both by channel number (for the output loop),
+ * and 4 (for input loop).
+ * The processing steps:
+ * 1. [Input loop] Load the linear chunk of input into shared memory, utilizing 4-byte aligned loads
+ *    and cast it to float.
+ *   a. Unaligned prologue loop - reads the first chunk till we get to address that is aligned with
+ *      32 * 4.
+ *   b. Main loop - do as many aligned 4byte reads as possible
+ *   c. Epilogue loop - read the remaining values that were not possible to read as one 4byte read.
+ * 2. Synchronize
+ * 3. [Output loop] Each thread corresponds to a (Y, X) sequential offset into a plane, computes
+ *    the values for all the channels and writes them.
+ *   a. Optionally, mirroring is performed by inverting the X-coordinate in the output offset.
+ *   b. Padding the output channels is performed by filling additional planes with fill values.
+ *  @{
+ */
+
+/**
+ * @brief Hwc2Chw Normalize Mirror-x Pad-channel kernel
+ * This kernel does not support cropping the x coordinate, so the reads are fully linear.
+ */
+template <typename Out, typename In, bool enable_mirror, bool enable_pad, int kBlockSize,
+          int kStaticChannels>
+__global__ void Hwc2ChwNormalize(const Hwc2ChwSampleDesc<Out, In> *samples,
+                                 const BlockDesc<1> *blocks) {
+  // TODO(klecki): generalize for wider input types
+  static_assert(std::is_same<In, uint8_t>::value, "Only uint8_t supported as input");
+
+  const auto block = blocks[blockIdx.x];
+  const auto sample = samples[block.sample_idx];
+  __shared__ float tile[kBlockSize + 32 * 4];
+
+  // Preload the norm values so they are accessed via registers and not from gmem via pointer.
+  float norm_mul[kStaticChannels], norm_add[kStaticChannels];
+
+  #pragma unroll kStaticChannels
+  for (int c = 0; c < kStaticChannels; c++) {
+    norm_mul[c] = sample.norm_mul[c];
+    norm_add[c] = sample.norm_add[c];
+  }
+
+  auto in_start = reinterpret_cast<std::uintptr_t>(sample.in + block.start.x);
+  auto aligned_in_start = align_up(in_start, 32 * 4);
+  auto bytes_skipped =
+      ::min(aligned_in_start - in_start, static_cast<uint64_t>(block.end.x - block.start.x));
+
+  float *aligned_tile = tile + 32 * 4;
+  float *prologue_tile = aligned_tile - bytes_skipped;
+  const In *prologue_in = sample.in + block.start.x;
+
+  const uchar4 *aligned_in_char4 =
+      reinterpret_cast<const uchar4 *>(sample.in + block.start.x + bytes_skipped);
+
+  // prologue
+  for (int64_t idx = threadIdx.x; idx < bytes_skipped; idx += blockDim.x) {
+    prologue_tile[idx] = prologue_in[idx];
+  }
+  int64_t left_after_prologue = block.end.x - block.start.x - bytes_skipped;
+
+  // aligned load
+  for (int64_t idx = threadIdx.x; idx < left_after_prologue / 4; idx += blockDim.x) {
+    uchar4 in = aligned_in_char4[idx];
+    aligned_tile[idx * 4 + 0] = in.x;
+    aligned_tile[idx * 4 + 1] = in.y;
+    aligned_tile[idx * 4 + 2] = in.z;
+    aligned_tile[idx * 4 + 3] = in.w;
+  }
+  int64_t processed_in_main = (left_after_prologue / 4) * 4;
+  int64_t left_after_main = left_after_prologue - processed_in_main;
+
+  // epilogue
+  float *epilogue_tile = aligned_tile + processed_in_main;
+  const In *epilogue_in = reinterpret_cast<const In *>(aligned_in_char4 + processed_in_main / 4);
+
+  for (int64_t idx = threadIdx.x; idx < left_after_main; idx++) {
+    epilogue_tile[idx] = epilogue_in[idx];
+  }
+
+  __syncthreads();
+  const auto *__restrict__ fill_values = static_cast<const Out *>(sample.fill_values);
+
+  // idx is not divided by the static channels (mostly the block.start.x)
+  for (int64_t idx = threadIdx.x + block.start.x / kStaticChannels, base_x = threadIdx.x;
+       idx < block.end.x / kStaticChannels; idx += blockDim.x, base_x += blockDim.x) {
+    // TODO(klecki): forceinline device function
+    int64_t out_offset;
+    if constexpr (enable_mirror) {
+      if (sample.flip_x) {
+        int y = idx / sample.W;
+        int x = idx - (int64_t)y * sample.W;
+        int target_x = sample.W - 1 - x;
+        out_offset = (int64_t)y * sample.W + target_x;
+      } else {
+        out_offset = idx;
+      }
+    } else {
+      out_offset = idx;
+    }
+
+    #pragma unroll kStaticChannels
+    for (int c = 0; c < kStaticChannels; c++) {
+      // the kStaticChannels == input_C
+      float fpin = prologue_tile[base_x * sample.input_C + c];
+      float fpout = fmaf(fpin, norm_mul[c], norm_add[c]);
+      sample.out[c * sample.H * sample.W + out_offset] = ConvertSat<Out>(fpout);
+    }
+
+    // TODO(klecki): Check if it is better to put another loop
+    if constexpr (enable_pad) {
+      for (int c = kStaticChannels; c < sample.C; c++) {
+        sample.out[c * sample.H * sample.W + out_offset] = fill_values[c];
+      }
+    }
+  }
+}
+
+/**
+ * @brief Slice Hwc2Chw Normalize Mirror-x Pad-channel kernel
+ * This kernel supports cropping in x-coordinate.
+ * It extends the input loop, by utilizing the (unaligned prologue, aligned main loop, epilogue)
+ * pattern in a row-by-row loop.
+ * Indexing is based on the output coordinates, specifically we read rows for coordinate X
+ * between 0 and output H. (The samples are shifted so they always start from 0 in X).
+ */
+template <typename Out, typename In, bool enable_mirror, bool enable_pad, int kBlockSize,
+          int kStaticChannels>
+__global__ void SliceHwc2ChwNormalize(const Hwc2ChwSampleDesc<Out, In> *samples,
+                                      const BlockDesc<1> *blocks) {
+  // TODO(klecki): generalize for wider input types
+  static_assert(std::is_same<In, uint8_t>::value, "Only uint8_t supported as input");
+
+  const auto block = blocks[blockIdx.x];
+  const auto sample = samples[block.sample_idx];
+  __shared__ float tile[kBlockSize + 32 * 4];
+
+  // Preload the norm values so they are accessed via registers and not from gmem via pointer.
+  float norm_mul[kStaticChannels], norm_add[kStaticChannels];
+
+  #pragma unroll kStaticChannels
+  for (int c = 0; c < kStaticChannels; c++) {
+    norm_mul[c] = sample.norm_mul[c];
+    norm_add[c] = sample.norm_add[c];
+  }
+
+  // Strides use the input number of channels without the padding
+  int in_stride = sample.input_W * sample.input_C;
+  int out_stride = sample.W * sample.input_C;
+
+  // The rows we start and end with, we are indexed by output coordinates
+  int y_start = block.start.x / out_stride;
+  int y_end = block.end.x / out_stride + 1;
+
+  float *tile_row = tile;
+
+  for (int y = y_start; y < y_end; y++) {
+    int xc_start, xc_end;
+
+    // The first row doesn't start with 0 due to tiling, the rest do.
+    if (y == y_start) {
+      xc_start = block.start.x - y_start * out_stride;
+
+    } else {
+      xc_start = 0;
+    }
+
+    // Similarly for the end of row for last row
+    if (y == y_end - 1) {
+      xc_end = block.end.x - (y_end - 1) * out_stride;
+    } else {
+      xc_end = out_stride;
+    }
+
+    const In *prologue_in = sample.in + y * in_stride + xc_start;
+
+    auto in_start = reinterpret_cast<std::uintptr_t>(prologue_in);
+    // align to 4
+    auto aligned_in_start = align_up(in_start, 4);
+    auto bytes_skipped =
+        ::min(aligned_in_start - in_start, static_cast<uint64_t>(xc_end - xc_start));
+
+    float *prologue_tile = tile_row;
+    float *aligned_tile = tile_row + bytes_skipped;
+
+    const uchar4 *aligned_in_char4 = reinterpret_cast<const uchar4 *>(prologue_in + bytes_skipped);
+
+    // prologue
+    for (int64_t idx = threadIdx.x; idx < bytes_skipped; idx += blockDim.x) {
+      prologue_tile[idx] = prologue_in[idx];
+    }
+
+    int64_t left_after_prologue = xc_end - xc_start - bytes_skipped;
+
+    // aligned load
+    for (int64_t idx = threadIdx.x; idx < left_after_prologue / 4; idx += blockDim.x) {
+      uchar4 in = aligned_in_char4[idx];
+      aligned_tile[idx * 4 + 0] = in.x;
+      aligned_tile[idx * 4 + 1] = in.y;
+      aligned_tile[idx * 4 + 2] = in.z;
+      aligned_tile[idx * 4 + 3] = in.w;
+    }
+
+    int64_t processed_in_main = (left_after_prologue / 4) * 4;
+    int64_t left_after_main = left_after_prologue - processed_in_main;
+
+    // epilogue
+    float *epilogue_tile = aligned_tile + processed_in_main;
+    const In *epilogue_in = reinterpret_cast<const In *>(aligned_in_char4 + processed_in_main / 4);
+
+    for (int64_t idx = threadIdx.x; idx < left_after_main; idx++) {
+      epilogue_tile[idx] = epilogue_in[idx];
+    }
+    tile_row += (xc_end - xc_start);
+  }
+
+  __syncthreads();
+  const auto *__restrict__ fill_values = static_cast<const Out *>(sample.fill_values);
+
+  for (int64_t idx = threadIdx.x + block.start.x / kStaticChannels, base_x = threadIdx.x;
+       idx < block.end.x / kStaticChannels; idx += blockDim.x, base_x += blockDim.x) {
+    int64_t out_offset;
+    if constexpr (enable_mirror) {
+      if (sample.flip_x) {
+        int y = idx / sample.W;
+        int x = idx - (int64_t)y * sample.W;
+        int target_x = sample.W - 1 - x;
+        out_offset = (int64_t)y * sample.W + target_x;
+      } else {
+        out_offset = idx;
+      }
+    } else {
+      out_offset = idx;
+    }
+
+    #pragma unroll kStaticChannels
+    for (int c = 0; c < kStaticChannels; c++) {
+      // the kStaticChannels == input_C
+      float fpin = tile[base_x * sample.input_C + c];
+      float fpout = fmaf(fpin, norm_mul[c], norm_add[c]);
+      sample.out[c * sample.H * sample.W + out_offset] = ConvertSat<Out>(fpout);
+    }
+
+    // TODO(klecki): Check if it is better to put another loop
+    if constexpr (enable_pad) {
+      for (int c = kStaticChannels; c < sample.C; c++) {
+        sample.out[c * sample.H * sample.W + out_offset] = fill_values[c];
+      }
+    }
+  }
+}
+
+/** @} */  // end of Hwc2Chw
+
+template <typename Out>
+KernelRequirements SliceHwc2ChwNormalizeGPU<Out>::Setup(KernelContext &ctx,
+                                                        const TensorListShape<ndim> &input_shape,
+                                                        span<const SampleArgs> args) {
+  (void)ctx;
+  int num_samples = input_shape.num_samples();
+  DALI_ENFORCE(num_samples == static_cast<int>(args.size()),
+               "Invalid number of samples in kernel args");
+  out_shape_ = TensorListShape<ndim>(num_samples, ndim);
+  collapsed_tiling_shape_ = TensorListShape<1>(num_samples, 1);
+
+  SetupNumChannels(input_shape, args);
+
+  for (int i = 0; i < num_samples; i++) {
+    // N.B. this function produces a HWC shape, that's why we need the permute
+    auto out_sample_shape = ShapeFromRoi(args[i].roi, out_nchannels_);
+    for (int d = 0; d < spatial_dim; d++) {
+      DALI_ENFORCE(out_sample_shape[d] <= input_shape.tensor_shape_span(i)[d],
+                   make_string("Only cropping allowed, got a request for padding in dimension `", d,
+                               "` of sample ", i, "."));
+    }
+    out_sample_shape = permute(out_sample_shape, perm_);
+    out_shape_.set_tensor_shape(i, out_sample_shape);
+    collapsed_tiling_shape_.set_tensor_shape(i, {volume(args[i].roi) * nchannels_});
+  }
+  KernelRequirements req;
+  req.output_shapes = {out_shape_};
+  return req;
+}
+
+template <typename Out>
+std::tuple<float *, float *, Out *> SliceHwc2ChwNormalizeGPU<Out>::SetupParams(
+    KernelContext &ctx, span<const SampleArgs> args) {
+  int num_samples = args.size();
+  float *norm_add_cpu = ctx.scratchpad->AllocatePinned<float>(num_samples * nchannels_);
+  float *norm_mul_cpu = ctx.scratchpad->AllocatePinned<float>(num_samples * nchannels_);
+  Out *fill_values_cpu = ctx.scratchpad->AllocatePinned<Out>(num_samples * out_nchannels_);
+  for (int i = 0; i < num_samples; i++) {
+    const auto &sample_arg = args[i];
+    auto *norm_add_data = norm_add_cpu + i * nchannels_;
+    auto *norm_mul_data = norm_mul_cpu + i * nchannels_;
+    int mean_sz = sample_arg.mean.size();
+    assert(mean_sz == sample_arg.inv_stddev.size());
+    int c = 0;
+    for (; c < mean_sz; c++) {
+      norm_add_data[c] = -sample_arg.mean[c] * sample_arg.inv_stddev[c];
+      norm_mul_data[c] = sample_arg.inv_stddev[c];
+    }
+    for (; c < nchannels_; c++) {
+      norm_add_data[c] = 0.0f;
+      norm_mul_data[c] = 1.0f;
+    }
+    auto *fill_values_data = fill_values_cpu + i * out_nchannels_;
+    int fill_values_sz = sample_arg.fill_values.size();
+    c = 0;
+    for (; c < fill_values_sz; c++)
+      fill_values_data[c] = ConvertSat<Out>(sample_arg.fill_values[c]);
+    for (; c < out_nchannels_; c++)
+      fill_values_data[c] = ConvertSat<Out>(0.0f);
+  }
+
+  return ctx.scratchpad->ToContiguousGPU(ctx.gpu.stream,
+                                         make_span(norm_add_cpu, num_samples * nchannels_),
+                                         make_span(norm_mul_cpu, num_samples * nchannels_),
+                                         make_span(fill_values_cpu, num_samples * out_nchannels_));
+}
+
+template <typename Out>
+auto SliceHwc2ChwNormalizeGPU<Out>::RealignSample(TensorView<StorageGPU, const In, ndim> in_sample,
+                                                  Roi<spatial_dim> roi)
+    -> std::tuple<TensorView<StorageGPU, const In, ndim>, Roi<spatial_dim>> {
+  const auto *data = in_sample.data;
+  auto shape = in_sample.shape;
+  // skip the cropped rows
+  data += roi.lo.y * shape[1] * shape[2];
+  shape[0] = roi.extent().y;
+  // skip the cropped columns
+  data += roi.lo.x * shape[2];
+
+
+  return {TensorView<StorageGPU, const In, ndim>{data, shape},
+          {ivec<spatial_dim>{0}, roi.extent()}};
+}
+
+template <typename Out>
+void SliceHwc2ChwNormalizeGPU<Out>::SetupNumChannels(const TensorListShape<ndim> &input_shape,
+                                                     span<const SampleArgs> args) {
+  if (input_shape.num_samples() == 0) {
+    return;
+  }
+  const auto first_shape = input_shape.tensor_shape_span(0);
+  nchannels_ = first_shape[channel_dim];
+  for (int i = 1; i < input_shape.num_samples(); i++) {
+    int ch = input_shape.tensor_shape_span(i)[channel_dim];
+    DALI_ENFORCE(nchannels_ == ch,
+                 make_string("All samples should have the same number of channels, expected ",
+                             nchannels_, " channels, got ", ch, " channels in sample ", i));
+  }
+  DALI_ENFORCE(
+      input_shape.num_samples() == static_cast<int>(args.size()),
+      "Number of samples in the arguments should match the number of samples in the shape");
+
+  out_nchannels_ = std::max(nchannels_, static_cast<int>(args[0].fill_values.size()));
+  for (int i = 1; i < input_shape.num_samples(); i++) {
+    DALI_ENFORCE(args[i].fill_values.size() == args[0].fill_values.size(),
+                 "All sample arguments should have the same number of fill values");
+  }
+}
+
+
+template <typename Out>
+void SliceHwc2ChwNormalizeGPU<Out>::Run(KernelContext &ctx,
+                                        const TensorListView<StorageGPU, Out, ndim> &out,
+                                        const TensorListView<StorageGPU, const In, ndim> &in,
+                                        span<const SampleArgs> args) {
+  using SampleDesc = Hwc2ChwSampleDesc<Out, In>;
+  using Tile = kernels::BlockDesc<1>;
+  int num_samples = in.num_samples();
+
+  SampleDesc *sample_descs_cpu = ctx.scratchpad->AllocatePinned<SampleDesc>(num_samples);
+  auto [norm_add_gpu, norm_mul_gpu, fill_values_gpu] = SetupParams(ctx, args);
+  bool need_pad = out_nchannels_ != nchannels_;
+  bool need_crop_x = false;
+  bool need_flip_x = false;
+
+  for (int sample_id = 0; sample_id < num_samples; sample_id++) {
+    auto [in_sample, in_roi] = RealignSample(in[sample_id], args[sample_id].roi);
+    // we adjusted the in_roi to start from 0, so roi.extent() == roi.hi
+    if (in_sample.shape[1] != in_roi.hi.x) {
+      need_crop_x = true;
+    }
+
+    auto &sample_desc = sample_descs_cpu[sample_id];
+    sample_desc.in = in_sample.data;
+    sample_desc.out = out.tensor_data(sample_id);
+
+    // The output shape here is after the permutation
+    sample_desc.H = out.tensor_shape(sample_id)[1];
+    sample_desc.W = out.tensor_shape(sample_id)[2];
+    sample_desc.C = out.tensor_shape(sample_id)[0];  // out_nchannels_
+    sample_desc.input_W = in_sample.shape[1];
+    sample_desc.input_C = in_sample.shape[2];  // nchannels_
+
+    sample_desc.norm_add = norm_add_gpu + sample_id * nchannels_;
+    sample_desc.norm_mul = norm_mul_gpu + sample_id * nchannels_;
+    sample_desc.fill_values = fill_values_gpu + sample_id * out_nchannels_;
+    sample_desc.flip_x = args[sample_id].flip_x;
+    if (args[sample_id].flip_x) {
+      need_flip_x = true;
+    }
+  }
+
+  collapsed_block_setup_.SetDefaultBlockSize({kBlockSizeMul * kBlockWidth});
+  collapsed_block_setup_.SetBlockDim(dim3{128, 1, 1});
+
+  // TODO(klecki): hand tiling may give a slightly better results thanks to initial alignment
+  collapsed_block_setup_.SetupBlocks(collapsed_tiling_shape_, true);
+  auto tiles_cpu = collapsed_block_setup_.Blocks();
+  auto grid_dim = collapsed_block_setup_.GridDim();
+  auto block_dim = collapsed_block_setup_.BlockDim();
+
+  auto [sample_descs_gpu, tiles_gpu] = ctx.scratchpad->ToContiguousGPU(
+      ctx.gpu.stream, make_span(sample_descs_cpu, num_samples), tiles_cpu);
+
+  auto dispatch = [samples = sample_descs_cpu, tiles = tiles_gpu, &ctx, need_crop_x, grid_dim,
+                   block_dim](auto pad_v, auto flip_x_v) {
+    if (need_crop_x) {
+      SliceHwc2ChwNormalize<Out, In, flip_x_v.value, pad_v.value, kBlockSizeMul * kBlockWidth,
+                            kStaticChannels>
+          <<<grid_dim, block_dim, 0, ctx.gpu.stream>>>(samples, tiles);
+    } else {
+      Hwc2ChwNormalize<Out, In, flip_x_v.value, pad_v.value, kBlockSizeMul * kBlockWidth,
+                       kStaticChannels><<<grid_dim, block_dim, 0, ctx.gpu.stream>>>(samples, tiles);
+    }
+  };
+
+  auto dispatch_flip = [&](auto pad_v, bool flip_x) {
+    if (flip_x) {
+      dispatch(pad_v, std::true_type{});
+    } else {
+      dispatch(pad_v, std::false_type{});
+    }
+  };
+
+  if (need_pad) {
+    dispatch_flip(std::true_type{}, need_flip_x);
+  } else {
+    dispatch_flip(std::false_type{}, need_flip_x);
+  }
+
+  CUDA_CALL(cudaGetLastError());
+}
+
+
+template class DLL_PUBLIC SliceHwc2ChwNormalizeGPU<float>;
+template class DLL_PUBLIC SliceHwc2ChwNormalizeGPU<float16>;
+
+}  // namespace slice_flip_normalize
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/slice/slice_hwc2chw_normalize_gpu.cu
+++ b/dali/kernels/slice/slice_hwc2chw_normalize_gpu.cu
@@ -425,7 +425,6 @@ void SliceHwc2ChwNormalizeGPU<Out>::Run(KernelContext &ctx,
                                         const TensorListView<StorageGPU, const In, ndim> &in,
                                         span<const SampleArgs> args) {
   using SampleDesc = Hwc2ChwSampleDesc<Out, In>;
-  using Tile = kernels::BlockDesc<1>;
   int num_samples = in.num_samples();
 
   SampleDesc *sample_descs_cpu = ctx.scratchpad->AllocatePinned<SampleDesc>(num_samples);

--- a/dali/kernels/slice/slice_hwc2chw_normalize_gpu.cu
+++ b/dali/kernels/slice/slice_hwc2chw_normalize_gpu.cu
@@ -461,7 +461,7 @@ void SliceHwc2ChwNormalizeGPU<Out>::Run(KernelContext &ctx,
     if (in_sample.shape[1] != in_roi.hi.x) {
       need_crop_x = true;
     }
-    int64_t sample_size = volume(in_sample.shape);
+    int64_t sample_size = collapsed_tiling_shape_[sample_id][0];
 
     if (sample_size == 0) {
       continue;
@@ -493,15 +493,6 @@ void SliceHwc2ChwNormalizeGPU<Out>::Run(KernelContext &ctx,
 
   if (nonempty_samples == 0)
     return;
-
-  // collapsed_block_setup_.SetDefaultBlockSize({kBlockSizeMul * kBlockWidth});
-  // collapsed_block_setup_.SetBlockDim(dim3{128, 1, 1});
-
-  // TODO(klecki): hand tiling may give a slightly better results thanks to initial alignment
-  // collapsed_block_setup_.SetupBlocks(collapsed_tiling_shape_, true);
-  // auto tiles_cpu = collapsed_block_setup_.Blocks();
-  // auto grid_dim = collapsed_block_setup_.GridDim();
-  // auto block_dim = collapsed_block_setup_.BlockDim();
 
   auto [sample_descs_gpu] = ctx.scratchpad->ToContiguousGPU(
       ctx.gpu.stream, make_span(sample_descs_cpu, nonempty_samples));

--- a/dali/kernels/slice/slice_hwc2chw_normalize_gpu.h
+++ b/dali/kernels/slice/slice_hwc2chw_normalize_gpu.h
@@ -102,6 +102,7 @@ class DLL_PUBLIC SliceHwc2ChwNormalizeGPU {
   // This is a multiple of LCM(3, 4) = LCM(Number of Channels, 4) where 4 is from 4-byte reads
   static constexpr int kBlockSizeMul = 24;
   static constexpr int kBlockWidth = 128;
+  static constexpr int kThreadBlockSize = 128;
   // TODO(klecki): Generalize for other static channel values
   static constexpr int kStaticChannels = 3;
 

--- a/dali/kernels/slice/slice_hwc2chw_normalize_gpu.h
+++ b/dali/kernels/slice/slice_hwc2chw_normalize_gpu.h
@@ -60,7 +60,7 @@ class DLL_PUBLIC SliceHwc2ChwNormalizeGPU {
     bool flip_x;                        // wether to mirror in x-axis, EnableFlipX must be true.
   };
 
-  SliceHwc2ChwNormalizeGPU() : collapsed_block_setup_(1) {}
+  SliceHwc2ChwNormalizeGPU() = default;
 
   ~SliceHwc2ChwNormalizeGPU() = default;
 
@@ -116,7 +116,6 @@ class DLL_PUBLIC SliceHwc2ChwNormalizeGPU {
   int out_nchannels_ = -1;
   // HWC -> CHW permutation
   static constexpr std::array<int, ndim> perm_ = {2, 0, 1};
-  BlockSetup<1, -1> collapsed_block_setup_;
 };
 
 }  // namespace slice_flip_normalize

--- a/dali/kernels/slice/slice_hwc2chw_normalize_gpu.h
+++ b/dali/kernels/slice/slice_hwc2chw_normalize_gpu.h
@@ -1,0 +1,128 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_SLICE_SLICE_HWC2CHW_NORMALIZE_GPU_H_
+#define DALI_KERNELS_SLICE_SLICE_HWC2CHW_NORMALIZE_GPU_H_
+
+#include <sys/types.h>
+#include <tuple>
+#include "dali/core/backend_tags.h"
+#include "dali/core/common.h"
+#include "dali/core/geom/vec.h"
+#include "dali/core/small_vector.h"
+#include "dali/core/tensor_shape.h"
+#include "dali/kernels/common/block_setup.h"
+#include "dali/kernels/imgproc/roi.h"
+#include "dali/kernels/kernel.h"
+
+namespace dali {
+namespace kernels {
+
+namespace slice_flip_normalize {
+
+/**
+ * @brief Specialized version of SliceFlipNormalize for HWC->CHW conversion and normalization.
+ *
+ * Optionally allows for cropping the input in y, x (HW) coordinates, flipping in x (W) coordinate
+ * and padding the channels to the multiple of 2.
+ *
+ * The input is assumed to be u8.
+ *
+ * @tparam Out output type
+ *
+ * @details see SliceFlipNormalizeGPU::Args
+ */
+template <typename Out>
+class DLL_PUBLIC SliceHwc2ChwNormalizeGPU {
+ public:
+  static constexpr int spatial_dim = 2;
+  static constexpr int channel_dim = 2;
+  static constexpr int ndim = 3;
+  using In = uint8_t;
+  struct SampleArgs {
+    Roi<spatial_dim> roi;               // input region-of-interest, only proper crop, no padding.
+    SmallVector<float, 4> mean;         // mean (as many values as num. of channels)
+    SmallVector<float, 4> inv_stddev;   // reciprocal of stddev (as many as num. of channels)
+    SmallVector<float, 4> fill_values;  // per-channel fill value (if more values than number
+                                        // channels in the input, the channel dimension is padded
+                                        // on all pixels)
+    bool flip_x;                        // wether to mirror in x-axis, EnableFlipX must be true.
+  };
+
+  SliceHwc2ChwNormalizeGPU() : collapsed_block_setup_(1) {}
+
+  ~SliceHwc2ChwNormalizeGPU() = default;
+
+
+  DLL_PUBLIC KernelRequirements Setup(KernelContext &ctx, const TensorListShape<ndim> &input_shape,
+                                      span<const SampleArgs> args);
+
+  void Run(KernelContext &ctx, const TensorListView<StorageGPU, Out, ndim> &out,
+           const TensorListView<StorageGPU, const In, ndim> &in, span<const SampleArgs> args);
+
+ private:
+  /**
+   * @brief Extract the mean, inv_stddev and fill values from kernel's SampleArgs and transfer
+   *        them to GPU.
+   * @param ctx
+   * @param args The kernel arguments from Setup/Run
+   * @return std::tuple<float *, float *, Out *> pointer to gpu-allocated:
+   *         (mean, inv_stdev, fill_values), first two have nchannels_ values per sample,
+   *         the fill_values has out_nchannels_ values per sample.
+   */
+  std::tuple<float *, float *, Out *> SetupParams(KernelContext &ctx, span<const SampleArgs> args);
+
+  /**
+   * @brief Return the new TensorView and Roi for the input sample, so that the cropped rows
+   *        (in y axis) are completely skipped and the Roi in x-axis starts from 0.
+   *
+   * @param in_sample Original view to the input
+   * @param roi Description of the output Roi (the crop that we need to extract)
+   * @return Adjusted view and roi.
+   */
+  std::tuple<TensorView<StorageGPU, const In, ndim>, Roi<spatial_dim>> RealignSample(
+      TensorView<StorageGPU, const In, ndim> in_sample, Roi<spatial_dim> roi);
+
+  /**
+   * @brief Detect the input and output number of channels and validate if it is uniform.
+   */
+  void SetupNumChannels(const TensorListShape<ndim> &input_shape, span<const SampleArgs> args);
+
+  // This is a multiple of LCM(3, 4) = LCM(Number of Channels, 4) where 4 is from 4-byte reads
+  static constexpr int kBlockSizeMul = 24;
+  static constexpr int kBlockWidth = 128;
+  // TODO(klecki): Generalize for other static channel values
+  static constexpr int kStaticChannels = 3;
+
+  // The shape of the produced outputs in CHW (actual layout)
+  TensorListShape<ndim> out_shape_;
+  // This is a collapsed shape that includes the size of HW output plane (after crop)
+  // and the input number of channels (nchannels_)
+  TensorListShape<1> collapsed_tiling_shape_;
+  // number of channels in the input image
+  int nchannels_ = -1;
+  // number of channels in the output image (in case of padding)
+  int out_nchannels_ = -1;
+  // HWC -> CHW permutation
+  static constexpr std::array<int, ndim> perm_ = {2, 0, 1};
+  BlockSetup<1, -1> collapsed_block_setup_;
+};
+
+}  // namespace slice_flip_normalize
+
+}  // namespace kernels
+}  // namespace dali
+
+
+#endif  // DALI_KERNELS_SLICE_SLICE_HWC2CHW_NORMALIZE_GPU_H_

--- a/dali/operators/image/crop/new_crop_mirror_normalize.cu
+++ b/dali/operators/image/crop/new_crop_mirror_normalize.cu
@@ -100,7 +100,7 @@ class NewCropMirrorNormalizeGPU : public Operator<GPUBackend> {
   bool SetupSliceHwc2ChwNormalize(std::vector<OutputDesc> &output_desc, const Workspace &ws) {
     TYPE_SWITCH(output_type_, type2id, OutputType, (float, float16), (
       return SetupSliceHwc2ChwNormalizeTyped<OutputType>(output_desc, ws);
-    ), DALI_FAIL(make_string("Not supported output type:", output_type_)););  // NOLINT
+    ), DALI_FAIL(make_string("Unsupported output type:", output_type_)););  // NOLINT
   }
 
   template <typename Out>
@@ -141,7 +141,7 @@ class NewCropMirrorNormalizeGPU : public Operator<GPUBackend> {
     // const auto &req = k.Setup(ctx, sh, cargs);
     // // k.test();
     auto cargs = make_cspan(args);
-    auto &req = kmgr_.Setup<Kernel>(0, ctx, sh, make_cspan(args));
+    auto &req = kmgr_.Setup<Kernel>(0, ctx, sh, cargs);
     output_desc[0].type = output_type_;
     output_desc[0].shape = req.output_shapes[0];
     return true;
@@ -154,10 +154,10 @@ class NewCropMirrorNormalizeGPU : public Operator<GPUBackend> {
           VALUE_SWITCH(channel_dim_idx_, ChannelDim, CHANNEL_DIMS, (
             return SetupSfnGpuGenericTyped<OutputType, InputType,
                                            SpatialNdim, ChannelDim>(output_desc, ws);
-          ), DALI_FAIL(make_string("Not supported channel dimension:", channel_dim_idx_)););  // NOLINT
-        ), DALI_FAIL(make_string("Not supported number of spatial dimensions:", spatial_ndim_)););  // NOLINT
-      ), DALI_FAIL(make_string("Not supported output type:", output_type_)););  // NOLINT
-    ), DALI_FAIL(make_string("Not supported input type:", input_type_)););  // NOLINT
+          ), DALI_FAIL(make_string("Unsupported channel dimension:", channel_dim_idx_)););  // NOLINT
+        ), DALI_FAIL(make_string("Unsupported number of spatial dimensions:", spatial_ndim_)););  // NOLINT
+      ), DALI_FAIL(make_string("Unsupported output type:", output_type_)););  // NOLINT
+    ), DALI_FAIL(make_string("Unsupported input type:", input_type_)););  // NOLINT
   }
 
   template <typename Out, typename In, int spatial_ndim, int channel_dim>
@@ -278,7 +278,7 @@ class NewCropMirrorNormalizeGPU : public Operator<GPUBackend> {
       RunSfnKernel<Kernel, float16, uint8_t, 3>(ws, cargs);
       return;
     }
-    DALI_FAIL(make_string("Not supported output type:", output_type_));
+    DALI_FAIL(make_string("Unsupported output type:", output_type_));
   }
 
   void RunSfnGpuGeneric(Workspace &ws) {
@@ -293,10 +293,10 @@ class NewCropMirrorNormalizeGPU : public Operator<GPUBackend> {
 
             auto &args = any_cast<typename Kernel::Args &>(kernel_args_);
             RunSfnKernel<Kernel, OutputType, InputType, ndim>(ws, args);
-          ), DALI_FAIL(make_string("Not supported channel dimension:", channel_dim_idx_)););  // NOLINT
-        ), DALI_FAIL(make_string("Not supported number of spatial dimensions:", spatial_ndim_)););  // NOLINT
-      ), DALI_FAIL(make_string("Not supported output type:", output_type_)););  // NOLINT
-    ), DALI_FAIL(make_string("Not supported input type:", input_type_)););  // NOLINT
+          ), DALI_FAIL(make_string("Unsupported channel dimension:", channel_dim_idx_)););  // NOLINT
+        ), DALI_FAIL(make_string("Unsupported number of spatial dimensions:", spatial_ndim_)););  // NOLINT
+      ), DALI_FAIL(make_string("Unsupported output type:", output_type_)););  // NOLINT
+    ), DALI_FAIL(make_string("Unsupported input type:", input_type_)););  // NOLINT
   }
 
   template <typename Kernel, typename Out, typename In, int ndim, typename Args>

--- a/dali/operators/image/crop/new_crop_mirror_normalize.cu
+++ b/dali/operators/image/crop/new_crop_mirror_normalize.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <utility>
 #include <vector>
 #include "dali/core/any.h"
@@ -19,21 +20,28 @@
 #include "dali/core/error_handling.h"
 #include "dali/core/float16.h"
 #include "dali/core/format.h"
+#include "dali/core/small_vector.h"
+#include "dali/core/span.h"
 #include "dali/core/static_switch.h"
+#include "dali/core/tensor_layout.h"
 #include "dali/core/util.h"
+#include "dali/kernels/imgproc/roi.h"
 #include "dali/kernels/kernel_manager.h"
 #include "dali/kernels/slice/slice_flip_normalize_gpu.h"
 #include "dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h"
+#include "dali/kernels/slice/slice_hwc2chw_normalize_gpu.h"
 #include "dali/operators/generic/slice/out_of_bounds_policy.h"
 #include "dali/operators/image/crop/crop_attr.h"
 #include "dali/operators/image/crop/crop_mirror_normalize.h"  // TODO(janton): remove fallback
+#include "dali/pipeline/data/types.h"
 #include "dali/pipeline/data/views.h"
 #include "dali/pipeline/operator/arg_helper.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/workspace/workspace.h"
 
 #define IN_TYPES (uint8_t, int16_t, uint16_t, int32_t, float, float16)
-#define OUT_TYPES (float , uint8_t, int8_t, float16)
+#define OUT_TYPES (float, uint8_t, int8_t, float16)
 #define SPATIAL_NDIMS (2)
 #define CHANNEL_DIMS (0, 2)
 
@@ -61,91 +69,136 @@ class NewCropMirrorNormalizeGPU : public Operator<GPUBackend> {
   inline ~NewCropMirrorNormalizeGPU() override = default;
 
  protected:
-  template <typename Out, typename In, int spatial_ndim, int channel_dim>
-  bool SetupImplTyped(std::vector<OutputDesc> &output_desc, const Workspace &ws) {
-    static constexpr int ndim = spatial_ndim + 1;
-    auto nsamples = ws.GetInputBatchSize(0);
+  enum class CmnImplKind {
+    SliceFlipNormalizeGpuGeneric,
+    SliceHwc2ChwNormalize,
+    FallbackGeneric
+  };
+
+  /**
+   * @brief Select which implementation to use based on the supported parameters.
+   */
+  CmnImplKind GetImplementationKind(DALIDataType in_type, DALIDataType out_type,
+                                    const TensorLayout &in_layout, const TensorLayout &out_layout,
+                                    int ndim, int spatial_dim, int channel_dim,
+                                    const TensorListShape<> &in_shape, OutOfBoundsPolicy oobp) {
+    if (spatial_dim != 2 || ndim != 3 ||
+        (channel_dim_idx_ != 0 && channel_dim_idx_ != spatial_ndim_)) {
+      return CmnImplKind::FallbackGeneric;
+    }
+    // check for optimized version
+    if (in_type == DALI_UINT8 && (out_type == DALI_FLOAT || out_type == DALI_FLOAT16) &&
+        in_layout == "HWC" && out_layout == "CHW" &&
+        (oobp == OutOfBoundsPolicy::Error || oobp == OutOfBoundsPolicy::TrimToShape)) {
+      // Only 3-channels supported in this version
+      if (in_shape.num_samples() > 0 && in_shape.tensor_shape_span(0)[2] == 3)
+        return CmnImplKind::SliceHwc2ChwNormalize;
+    }
+    return CmnImplKind::SliceFlipNormalizeGpuGeneric;
+  }
+
+  bool SetupSliceHwc2ChwNormalize(std::vector<OutputDesc> &output_desc, const Workspace &ws) {
+    TYPE_SWITCH(output_type_, type2id, OutputType, (float, float16), (
+      return SetupSliceHwc2ChwNormalizeTyped<OutputType>(output_desc, ws);
+    ), DALI_FAIL(make_string("Not supported output type:", output_type_)););  // NOLINT
+  }
+
+  template <typename Out>
+  bool SetupSliceHwc2ChwNormalizeTyped(std::vector<OutputDesc> &output_desc, const Workspace &ws) {
+    using Kernel = kernels::slice_flip_normalize::SliceHwc2ChwNormalizeGPU<Out>;
+    if (!kernel_args_.has_value())
+      kernel_args_ = std::vector<typename Kernel::SampleArgs>{};
+    auto &args = any_cast<std::vector<typename Kernel::SampleArgs> &>(kernel_args_);
+
+    auto num_samples = ws.GetInputBatchSize(0);
     output_desc.resize(1);
 
     const auto &input = ws.Input<GPUBackend>(0);
-    auto in_shape = input.shape();
+    const auto &in_shape = input.shape();
+
+    args.clear();
+    args.reserve(num_samples);
+    for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
+      auto sample_sh = in_shape[sample_idx];
+      int num_channels = sample_sh[2];
+      args.emplace_back();
+      auto &a = args.back();
+
+      a.roi = GetRoi(sample_idx, 0, 1, sample_sh);
+
+      // Horizontal flip
+      a.flip_x = this->spec_.template GetArgument<int>("mirror", &ws, sample_idx);
+
+      GetNormParameters(a.mean, a.inv_stddev, sample_idx, num_channels);
+      GetFillValuesParameters(a.fill_values, sample_idx, num_channels);
+    }
+
+    kmgr_.Resize<Kernel>(1);
+    kernels::KernelContext ctx;
+    ctx.gpu.stream = ws.stream();
+    auto sh = input.shape().to_static<3>();
+    // Kernel &k = kmgr_.Get<Kernel>(0);
+    // const auto &req = k.Setup(ctx, sh, cargs);
+    // // k.test();
+    auto cargs = make_cspan(args);
+    auto &req = kmgr_.Setup<Kernel>(0, ctx, sh, make_cspan(args));
+    output_desc[0].type = output_type_;
+    output_desc[0].shape = req.output_shapes[0];
+    return true;
+  }
+
+  bool SetupSfnGpuGeneric(std::vector<OutputDesc> &output_desc, const Workspace &ws) {
+    TYPE_SWITCH(input_type_, type2id, InputType, IN_TYPES, (
+      TYPE_SWITCH(output_type_, type2id, OutputType, OUT_TYPES, (
+        VALUE_SWITCH(spatial_ndim_, SpatialNdim, SPATIAL_NDIMS, (
+          VALUE_SWITCH(channel_dim_idx_, ChannelDim, CHANNEL_DIMS, (
+            return SetupSfnGpuGenericTyped<OutputType, InputType,
+                                           SpatialNdim, ChannelDim>(output_desc, ws);
+          ), DALI_FAIL(make_string("Not supported channel dimension:", channel_dim_idx_)););  // NOLINT
+        ), DALI_FAIL(make_string("Not supported number of spatial dimensions:", spatial_ndim_)););  // NOLINT
+      ), DALI_FAIL(make_string("Not supported output type:", output_type_)););  // NOLINT
+    ), DALI_FAIL(make_string("Not supported input type:", input_type_)););  // NOLINT
+  }
+
+  template <typename Out, typename In, int spatial_ndim, int channel_dim>
+  bool SetupSfnGpuGenericTyped(std::vector<OutputDesc> &output_desc, const Workspace &ws) {
+    static constexpr int ndim = spatial_ndim + 1;
+    auto num_samples = ws.GetInputBatchSize(0);
+    output_desc.resize(1);
+
+    const auto &input = ws.Input<GPUBackend>(0);
+    const auto &in_shape = input.shape();
 
     using Kernel =
         kernels::slice_flip_normalize::SliceFlipNormalizeGPU<Out, In, spatial_ndim, channel_dim>;
     if (!kernel_args_.has_value())
       kernel_args_ = typename Kernel::Args{};
-    auto &args = any_cast<typename Kernel::Args&>(kernel_args_);
+    auto &args = any_cast<typename Kernel::Args &>(kernel_args_);
 
     int h_dim = input_layout_.find('H');
     assert(h_dim >= 0);
     int w_dim = input_layout_.find('W');
     assert(w_dim >= 0);
 
-    if (output_layout_.empty()) {
-      output_layout_ = input_layout_;
-      std::iota(args.perm.begin(), args.perm.end(), 0);
-    } else {
-      DALI_ENFORCE(output_layout_.is_permutation_of(input_layout_),
-        "The requested output layout is not a permutation of input layout.");
-      auto permuted_dims = GetLayoutMapping<ndim>(input_layout_, output_layout_);
-      for (int d = 0; d < ndim; d++)
-        args.perm[d] = permuted_dims[d];
-    }
+    auto permuted_dims = GetLayoutMapping<ndim>(input_layout_, output_layout_);
+    for (int d = 0; d < ndim; d++)
+      args.perm[d] = permuted_dims[d];
 
     args.sample_args.clear();
-    args.sample_args.reserve(nsamples);
-    for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
+    args.sample_args.reserve(num_samples);
+    for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
       auto sample_sh = in_shape[sample_idx];
+      int num_channels = sample_sh[channel_dim];
       args.sample_args.emplace_back();
       auto &a = args.sample_args.back();
 
-      auto crop_win_gen = crop_attr_.GetCropWindowGenerator(sample_idx);
-      assert(crop_win_gen);
-      CropWindow crop_window = crop_win_gen(sample_sh, input_layout_);
-      ApplySliceBoundsPolicy(out_of_bounds_policy_, sample_sh, crop_window.anchor,
-        crop_window.shape);
-
-      a.roi.lo.x = crop_window.anchor[w_dim];
-      a.roi.hi.x = a.roi.lo.x + crop_window.shape[w_dim];
-      a.roi.lo.y = crop_window.anchor[h_dim];
-      a.roi.hi.y = a.roi.lo.y + crop_window.shape[h_dim];
+      a.roi = GetRoi(sample_idx, h_dim, w_dim, sample_sh);
 
       // Horizontal flip
       a.flip.x = this->spec_.template GetArgument<int>("mirror", &ws, sample_idx);
 
-      span<const float> mean_arg(mean_arg_[sample_idx].data, mean_arg_[sample_idx].num_elements());
-      span<const float> std_arg(std_arg_[sample_idx].data, std_arg_[sample_idx].num_elements());
-      int nchannels = sample_sh[channel_dim];
-      auto nargs = std::max(mean_arg.size(), std_arg.size());
-      DALI_ENFORCE(mean_arg.size() == std_arg.size() || mean_arg.size() == 1 || std_arg.size() == 1,
-                   "``mean`` and ``std`` must either be of the same size, be scalars, or one of "
-                   "them can be a "
-                   "vector and the other a scalar.");
-      a.mean.resize(nchannels);
-      a.inv_stddev.resize(nchannels);
-      for (int c = 0; c < nchannels; c++) {
-        double mean_val = mean_arg[c % mean_arg.size()];
-        double std_val = std_arg[c % std_arg.size()];
-        a.mean[c] = std::fma(-shift_, std_val / scale_, mean_val);
-        a.inv_stddev[c] = scale_ / std_val;
-      }
-
-      if (fill_values_.size() > 0) {
-        a.fill_values.resize(nchannels);
-        DALI_ENFORCE(fill_values_.size() == 1 || static_cast<int>(fill_values_.size()) >= nchannels,
-                     "Should provide either a single fill_value or at least as many as number of "
-                     "channels in the input");
-        for (int c = 0; c < nchannels; c++)
-          a.fill_values[c] = fill_values_[c % fill_values_.size()];
-      }
-
-      if (pad_output_) {
-        int out_nchannels = next_pow2(nchannels);
-        int start_c = a.fill_values.size();
-        for (int c = start_c; c < out_nchannels; c++) {
-          a.fill_values.push_back(0.0f);
-        }
-      }
+      GetNormParameters(a.mean, a.inv_stddev, sample_idx, num_channels);
+      GetFillValuesParameters(a.fill_values, sample_idx, num_channels);
     }
 
     kmgr_.Resize<Kernel>(1);
@@ -164,7 +217,14 @@ class NewCropMirrorNormalizeGPU : public Operator<GPUBackend> {
     input_layout_ = input.GetLayout();
     assert(output_type_ != DALI_NO_TYPE);
 
-    auto nsamples = ws.GetInputBatchSize(0);
+    if (output_layout_.empty()) {
+      output_layout_ = input_layout_;
+    } else {
+      DALI_ENFORCE(output_layout_.is_permutation_of(input_layout_),
+                   "The requested output layout is not a permutation of input layout.");
+    }
+
+    auto num_samples = ws.GetInputBatchSize(0);
     auto in_shape = input.shape();
     int ndim = in_shape.sample_dim();
 
@@ -175,36 +235,72 @@ class NewCropMirrorNormalizeGPU : public Operator<GPUBackend> {
     channel_dim_idx_ = ImageLayoutInfo::ChannelDimIndex(input_layout_);
     assert(channel_dim_idx_ >= 0);
 
-    use_fallback_ = spatial_ndim_ != 2 || ndim != 3 ||
-                    (channel_dim_idx_ != 0 && channel_dim_idx_ != spatial_ndim_);
+    auto impl_kind =
+        GetImplementationKind(input_type_, output_type_, input_layout_, output_layout_, ndim,
+                              spatial_ndim_, channel_dim_idx_, in_shape, out_of_bounds_policy_);
+    if (impl_kind_ != impl_kind) {
+      kernel_args_.reset();
+      kmgr_.Reset();
+      impl_kind_ = impl_kind;
+    }
 
-    if (use_fallback_) {
+
+    if (impl_kind_ == CmnImplKind::FallbackGeneric) {
       DALI_WARN_ONCE("using CropMirrorNormalize legacy implementation");
       return fallback_.Setup(output_desc, ws);
     }
     crop_attr_.ProcessArguments(spec_, ws);
 
     ArgValueFlags flags = ArgValue_EnforceUniform;
-    mean_arg_.Acquire(spec_, ws, nsamples, flags);
-    std_arg_.Acquire(spec_, ws, nsamples, flags);
+    mean_arg_.Acquire(spec_, ws, num_samples, flags);
+    std_arg_.Acquire(spec_, ws, num_samples, flags);
 
+    if (impl_kind_ == CmnImplKind::SliceFlipNormalizeGpuGeneric) {
+      return SetupSfnGpuGeneric(output_desc, ws);
+    }
+
+    return SetupSliceHwc2ChwNormalize(output_desc, ws);
+  }
+
+  void RunSliceHwc2ChwNormalize(Workspace &ws) {
+    if (output_type_ == DALI_FLOAT) {
+      using Kernel = kernels::slice_flip_normalize::SliceHwc2ChwNormalizeGPU<float>;
+
+      auto &args = any_cast<std::vector<typename Kernel::SampleArgs> &>(kernel_args_);
+      auto cargs = make_cspan(args);
+      RunSfnKernel<Kernel, float, uint8_t, 3>(ws, cargs);
+      return;
+    } else if (output_type_ == DALI_FLOAT16) {
+      using Kernel = kernels::slice_flip_normalize::SliceHwc2ChwNormalizeGPU<float16>;
+
+      auto &args = any_cast<std::vector<typename Kernel::SampleArgs> &>(kernel_args_);
+      auto cargs = make_cspan(args);
+      RunSfnKernel<Kernel, float16, uint8_t, 3>(ws, cargs);
+      return;
+    }
+    DALI_FAIL(make_string("Not supported output type:", output_type_));
+  }
+
+  void RunSfnGpuGeneric(Workspace &ws) {
     TYPE_SWITCH(input_type_, type2id, InputType, IN_TYPES, (
       TYPE_SWITCH(output_type_, type2id, OutputType, OUT_TYPES, (
         VALUE_SWITCH(spatial_ndim_, SpatialNdim, SPATIAL_NDIMS, (
           VALUE_SWITCH(channel_dim_idx_, ChannelDim, CHANNEL_DIMS, (
-            return SetupImplTyped<OutputType, InputType, SpatialNdim, ChannelDim>(output_desc, ws);
+            using Kernel =
+                kernels::slice_flip_normalize::SliceFlipNormalizeGPU<OutputType, InputType,
+                                                                     SpatialNdim, ChannelDim>;
+            constexpr int ndim = SpatialNdim + 1;
+
+            auto &args = any_cast<typename Kernel::Args &>(kernel_args_);
+            RunSfnKernel<Kernel, OutputType, InputType, ndim>(ws, args);
           ), DALI_FAIL(make_string("Not supported channel dimension:", channel_dim_idx_)););  // NOLINT
         ), DALI_FAIL(make_string("Not supported number of spatial dimensions:", spatial_ndim_)););  // NOLINT
       ), DALI_FAIL(make_string("Not supported output type:", output_type_)););  // NOLINT
     ), DALI_FAIL(make_string("Not supported input type:", input_type_)););  // NOLINT
   }
 
-  template <typename Out, typename In, int spatial_ndim, int channel_dim>
-  void RunImplTyped(const Workspace &ws) {
-    static constexpr int ndim = spatial_ndim + 1;
-    using Kernel =
-        kernels::slice_flip_normalize::SliceFlipNormalizeGPU<Out, In, spatial_ndim, channel_dim>;
-    auto &args = any_cast<typename Kernel::Args &>(kernel_args_);
+  template <typename Kernel, typename Out, typename In, int ndim, typename Args>
+  void RunSfnKernel(const Workspace &ws, const Args &args) {
     const auto &input = ws.Input<GPUBackend>(0);
     auto &output = ws.Output<GPUBackend>(0);
     output.SetLayout(output_layout_);
@@ -216,24 +312,86 @@ class NewCropMirrorNormalizeGPU : public Operator<GPUBackend> {
   }
 
   void RunImpl(Workspace &ws) override {
-    if (use_fallback_) {
+    if (impl_kind_ == CmnImplKind::FallbackGeneric) {
       fallback_.Run(ws);
       return;
     }
 
-    TYPE_SWITCH(input_type_, type2id, InputType, IN_TYPES, (
-      TYPE_SWITCH(output_type_, type2id, OutputType, OUT_TYPES, (
-        VALUE_SWITCH(spatial_ndim_, SpatialNdim, SPATIAL_NDIMS, (
-          VALUE_SWITCH(channel_dim_idx_, ChannelDim, CHANNEL_DIMS, (
-            RunImplTyped<OutputType, InputType, SpatialNdim, ChannelDim>(ws);
-          ), DALI_FAIL(make_string("Not supported channel dimension:", channel_dim_idx_)););  // NOLINT
-        ), DALI_FAIL(make_string("Not supported number of spatial dimensions:", spatial_ndim_)););  // NOLINT
-      ), DALI_FAIL(make_string("Not supported output type:", output_type_)););  // NOLINT
-    ), DALI_FAIL(make_string("Not supported input type:", input_type_)););  // NOLINT
+    if (impl_kind_ == CmnImplKind::SliceFlipNormalizeGpuGeneric) {
+      RunSfnGpuGeneric(ws);
+      return;
+    }
+
+    RunSliceHwc2ChwNormalize(ws);
   }
 
   bool CanInferOutputs() const override {
     return true;
+  }
+
+
+  /**
+   * @brief Compute the 2D ROI for given sample_idx, crop_attr_ must be update first.
+   *
+   * @param sample_idx Index of the sample
+   * @param h_dim Index of "H" dimension
+   * @param w_dim Index of "W" dimension
+   */
+  kernels::Roi<2> GetRoi(int sample_idx, int h_dim, int w_dim,
+                         const TensorShape<-1> &sample_shape) {
+    auto crop_win_gen = crop_attr_.GetCropWindowGenerator(sample_idx);
+    assert(crop_win_gen);
+    CropWindow crop_window = crop_win_gen(sample_shape, input_layout_);
+    ApplySliceBoundsPolicy(out_of_bounds_policy_, sample_shape, crop_window.anchor,
+                           crop_window.shape);
+
+    kernels::Roi<2> roi;
+
+    roi.lo.x = crop_window.anchor[w_dim];
+    roi.hi.x = roi.lo.x + crop_window.shape[w_dim];
+    roi.lo.y = crop_window.anchor[h_dim];
+    roi.hi.y = roi.lo.y + crop_window.shape[h_dim];
+    return roi;
+  }
+
+  void GetNormParameters(SmallVector<float, 4> &mean, SmallVector<float, 4> &inv_stddev,
+                         int sample_idx, int num_channels) {
+    span<const float> mean_arg(mean_arg_[sample_idx].data, mean_arg_[sample_idx].num_elements());
+    span<const float> std_arg(std_arg_[sample_idx].data, std_arg_[sample_idx].num_elements());
+    auto nargs = std::max(mean_arg.size(), std_arg.size());
+    DALI_ENFORCE(mean_arg.size() == std_arg.size() || mean_arg.size() == 1 || std_arg.size() == 1,
+                 "``mean`` and ``std`` must either be of the same size, be scalars, or one of "
+                 "them can be a "
+                 "vector and the other a scalar.");
+    mean.resize(num_channels);
+    inv_stddev.resize(num_channels);
+    for (int c = 0; c < num_channels; c++) {
+      double mean_val = mean_arg[c % mean_arg.size()];
+      double std_val = std_arg[c % std_arg.size()];
+      mean[c] = std::fma(-shift_, std_val / scale_, mean_val);
+      inv_stddev[c] = scale_ / std_val;
+    }
+  }
+
+  void GetFillValuesParameters(SmallVector<float, 4> &fill_values, int sample_idx,
+                               int num_channels) {
+    if (fill_values_.size() > 0) {
+      fill_values.resize(num_channels);
+      DALI_ENFORCE(
+          fill_values_.size() == 1 || static_cast<int>(fill_values_.size()) >= num_channels,
+          "Should provide either a single fill_value or at least as many as number of "
+          "channels in the input");
+      for (int c = 0; c < num_channels; c++)
+        fill_values[c] = fill_values_[c % fill_values_.size()];
+    }
+
+    if (pad_output_) {
+      int out_num_channels = next_pow2(num_channels);
+      int start_c = fill_values.size();
+      for (int c = start_c; c < out_num_channels; c++) {
+        fill_values.push_back(0.0f);
+      }
+    }
   }
 
   CropMirrorNormalize<GPUBackend> fallback_;
@@ -246,7 +404,7 @@ class NewCropMirrorNormalizeGPU : public Operator<GPUBackend> {
   int channel_dim_idx_;
   int spatial_ndim_;
   bool pad_output_;  // Whether to pad channel dimension to the next power of 2
-  bool use_fallback_ = false;  // whether to use old implementation
+  CmnImplKind impl_kind_ = CmnImplKind::FallbackGeneric;
 
   std::vector<float> fill_values_;
   OutOfBoundsPolicy out_of_bounds_policy_ = OutOfBoundsPolicy::Error;

--- a/dali/test/python/operator_1/test_crop_mirror_normalize.py
+++ b/dali/test/python/operator_1/test_crop_mirror_normalize.py
@@ -22,6 +22,7 @@ from functools import partial
 from nvidia.dali import pipeline_def
 from nvidia.dali.pipeline import Pipeline
 
+from nose2.tools import params
 from nose_utils import assert_raises
 from nose_utils import raises
 from test_slice import check_slice_output, abs_slice_start_and_end
@@ -29,6 +30,9 @@ from test_utils import RandomDataIterator
 from test_utils import as_array
 from test_utils import compare_pipelines, dali_type_to_np
 from test_utils import get_dali_extra_path
+
+
+import itertools
 
 test_data_root = get_dali_extra_path()
 caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
@@ -669,3 +673,39 @@ def test_crop_mirror_normalize_empty_layout():
     batch_size = 3
     for cmn_fn, device in fn_dev_pairs:
         yield check_crop_mirror_normalize_empty_layout, cmn_fn, device, batch_size, in_shape
+
+
+batch_sizes = [1, 16]
+shapes = [(1, 1, 3), (1, 10, 3), (1, 31, 3), (1, 32, 3), (1, 33, 3), (1, 127, 3), (1, 128, 3),
+          (1, 129, 3), (1, 24 * 128 - 1, 3), (1, 24 * 128, 3), (1, 24 * 128 + 1, 3),
+          (8, 24 * 128 - 1, 3), (8, 24 * 128, 3), (8, 24 * 128 + 1, 3), (1024, 1024, 3),
+          (999, 999, 3), (1000, 1000, 3)]
+dtypes = [types.FLOAT, types.FLOAT16]
+pads = [False, True]
+mirrors = [False, True]
+crops = [(1.0, 0.25), (0.25, 0.25), (0.25, 1.0), (0.5, 0.75), (None, None)]
+
+
+@params(*itertools.product(batch_sizes, shapes, dtypes, pads, mirrors, crops))
+def test_cmn_optimized_vs_cpu(batch_size, shape, dtype, pad, mirror, crops):
+
+    @pipeline_def(batch_size=batch_size, device_id=0, num_threads=3)
+    def pipe(device):
+
+        def get_data():
+            out = [
+                np.arange(np.prod(shape), dtype=np.uint8).reshape(shape) for _ in range(batch_size)
+            ]
+            return out
+
+        data = fn.external_source(source=get_data)
+        crop_h, crop_w = crops
+        crop_h_int = int(crop_h * shape[0]) if crop_h else None
+        crop_w_int = int(crop_w * shape[1]) if crop_w else None
+        data = data.gpu() if device == "gpu" else data
+        return fn.crop_mirror_normalize(data, device=device, dtype=dtype, pad_output=pad,
+                                        mirror=mirror, crop_h=crop_h_int, crop_w=crop_w_int)
+
+    pipe_baseline = pipe("cpu")
+    pipe_opt = pipe("gpu")
+    compare_pipelines(pipe_baseline, pipe_opt, batch_size, 3)


### PR DESCRIPTION
## Category: **New feature**, **Refactoring**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Add an optimized version of SliceFlipNormalize kernel for the HWC to CHW layout switch.
The kernel has several variants that allow for:
* cropping (only X-dimension is relevant, as Y-dimension is done via tiling)
* mirroring X coordinate (as required by Crop Mirror Normalize operator)
* padding channel dimension
It assumes uint8_t inputs and allows for float16 and float32 outputs.

The algorithm is described in the docstring.
Additionally, due to the linear tiling, the bin-search for tile index is ported over from the Cast kernel.
Due to time constraints I did some code duplication, it may be worth to generalize this approach
for more kernels in a follow-up PR.

The CropMirrorNormalize operator setup is generalized to support the new and old versions 
of the Slice kernel (most notably their setup).
Selection of appropriate implementation based on the inputs and parameters was added.

Testing is done via Python layer for simplicity.

The pure kernel (disregarding the setups) achieves 2.6 TB/s vs the 1.6 TB/s of the previous variant.

Simple benchmark utilizing DALI pipeline gives 2TB/s for the new one vs 1.5 TB/s for the old one, note that here we are self restricted by the previous iteration, overlapping the compute with training may help further.

## Additional information:

### Affected modules and functionalities:
New slice kernel, CropMirrorNormalize op. 


### Key points relevant for the review:
Kernel impl

### Tests:
Existing operator tests + new Python tests focusing on the parameters used for this kernel variant. 
- [x] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
