### PR TITLE
Fix processing cost calculator: the order of filter support

### DIFF
--- a/dali/kernels/imgproc/resample/resampling_setup.cc
+++ b/dali/kernels/imgproc/resample/resampling_setup.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -284,8 +284,8 @@ void SeparableResamplingSetup<spatial_ndim>::SetupSample(
   ROI roi = ComputeScaleAndROI(desc, params);
 
   ivec<spatial_ndim> filter_support;
-  for (int i = 0, d = spatial_ndim - 1; i < spatial_ndim; i++, d--) {
-    int support = desc.filter[d].support();
+  for (int i = 0; i < spatial_ndim; i++) {
+    int support = desc.filter[i].support();
     // NN filter has support -1, so we need the max() below
     filter_support[i] = std::max(1, support);
   }


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
In the setup, the resize operator estimates the cost of running the resize with different orders of the resampled axes. It uses output, input sizes and the size of filters used along particular axes. However, it seems that the filters support size is unnecesarily reversed when passed to the best order calculator, which may result in sub-optimal performance in some cases.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
The performance of the dali resize operator, esp. for downsampling with antialias on and filters with big radious.
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
While the shapes and arguments come in a (D)HW (limited to spatial dims) layout, the SampleDesc keeps the extents in the WH(D) order. The filters are setup in the `SetFilters` method called a few lines above the fix. They are kept in the SampleDesc in the WH(D) order, same as the computed input (roi) and output shapes here. 
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
