### PR TITLE
Refactor ops into a submodule

### DIFF
--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # pylint: disable=no-member
-import ast
 import sys
 import threading
 import warnings
@@ -25,18 +24,18 @@ from nvidia.dali import fn as _functional
 from nvidia.dali import internal as _internal
 from nvidia.dali.data_node import DataNode as _DataNode
 from nvidia.dali.pipeline import Pipeline as _Pipeline
-from nvidia.dali.types import (_type_name_convert_to_string, _type_convert_value,
-                               _default_converter, _vector_element_type, _bool_types,
+from nvidia.dali.types import (_type_name_convert_to_string, _type_convert_value,  # noqa: F401
+                               _default_converter, _vector_element_type, _bool_types,  # noqa: F401
                                _int_like_types, _float_types, DALIDataType, CUDAStream as
                                _CUDAStream, ScalarConstant as _ScalarConstant, Constant as
-                               _Constant)
+                               _Constant)  # noqa: F401
 from nvidia.dali import _conditionals
 
-from nvidia.dali.ops import (_registry, _names, _docs)
+from nvidia.dali.ops import (_registry, _names, _docs)  # noqa: F401
 
 # reexpose what was previously visible:
-from nvidia.dali.ops._registry import (cpu_ops, mixed_ops, gpu_ops, register_cpu_op,
-                                       register_gpu_op)
+from nvidia.dali.ops._registry import (cpu_ops, mixed_ops, gpu_ops, register_cpu_op,  # noqa: F401
+                                       register_gpu_op)  # noqa: F401
 from nvidia.dali.ops._names import (_op_name, _process_op_name, _schema_name)
 
 cupy = None
@@ -481,7 +480,6 @@ def python_op_factory(name, schema_name=None):
     Operator.schema_name = schema_name or Operator.__name__
     Operator.__call__.__doc__ = _docs._docstring_generator_call(Operator.schema_name)
     return Operator
-
 
 
 def _wrap_op(op_class, submodule=[], parent_module=None):

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -515,6 +515,10 @@ def _load_ops():
                 setattr(parent_module, op_name, op_class)
 
 
+def Reload():
+    _load_ops()
+
+
 class _TFRecordReaderImpl():
     """ custom wrappers around ops """
 

--- a/dali/python/nvidia/dali/ops/_docs.py
+++ b/dali/python/nvidia/dali/ops/_docs.py
@@ -1,0 +1,314 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+
+from nvidia.dali import backend as _b
+from nvidia.dali.types import _default_converter, _type_name_convert_to_string
+
+from nvidia.dali.ops import _registry, _names
+
+
+def _numpydoc_formatter(name, type, doc, optional=False):
+    """
+    Format the documentation for single argument, `name`, `type` and `doc` are expected to be
+    strings.
+
+    The formatting is:
+    <name> : <type>[, optional]
+        <doc>
+    """
+    indent = "\n" + " " * 4
+    if optional:
+        type += ", optional"
+    return "`{}` : {}{}{}".format(name, type, indent, doc.replace("\n", indent))
+
+
+def _get_inputs_doc(schema):
+    """
+    Generate numpydoc-formatted docstring section for operator inputs (positional arguments)
+    based on the schema.
+
+    The inputs are represented in `Args` section using `_numpydoc_formatter`.
+
+    If schema provides names and docstrings for inputs, they are used, otherwise placeholder
+    text is used indicating the supported number of inputs.
+
+    Note: The type of input is indicated as TensorList with supported layouts listed.
+
+    schema : OpSchema
+       Schema of the operator to be documented
+    """
+    # Inputs section
+    if schema.MaxNumInput() == 0:
+        return ""
+    ret = """
+Args
+----
+"""
+    if schema.HasInputDox():
+        for i in range(schema.MaxNumInput()):
+            optional = i >= schema.MinNumInput()
+            input_type_str = schema.GetInputType(i) + _supported_layouts_str(
+                schema.GetSupportedLayouts(i))
+            dox = schema.GetInputDox(i)
+            input_name = schema.GetInputName(i)
+            ret += _numpydoc_formatter(input_name, input_type_str, dox, optional) + "\n"
+    else:
+        for i in range(schema.MinNumInput()):
+            input_type_str = "TensorList" + _supported_layouts_str(schema.GetSupportedLayouts(i))
+            dox = "Input to the operator."
+            input_name = f"input{i}" if schema.MaxNumInput() > 1 else "input"
+            ret += _numpydoc_formatter(input_name, input_type_str, dox, False) + "\n"
+
+        extra_opt_args = schema.MaxNumInput() - schema.MinNumInput()
+        if extra_opt_args == 1:
+            i = schema.MinNumInput()
+            input_type_str = "TensorList" + _supported_layouts_str(schema.GetSupportedLayouts(i))
+            dox = "Input to the operator."
+            input_name = f"input{i}" if schema.MaxNumInput() > 1 else "input"
+            ret += _numpydoc_formatter(input_name, input_type_str, dox, True) + "\n"
+        elif extra_opt_args > 1:
+            input_type_str = "TensorList"
+            input_name = f"input[{schema.MinNumInput()}..{schema.MaxNumInput()-1}]"
+            dox = f"This function accepts up to {extra_opt_args} optional positional inputs"
+            ret += _numpydoc_formatter(input_name, input_type_str, dox, True) + "\n"
+
+    ret += "\n"
+    return ret
+
+
+def _get_kwargs(schema):
+    """
+    Get the numpydoc-formatted docstring section for keywords arguments.
+
+
+    schema : OpSchema
+       Schema of the operator to be documented
+    """
+    ret = ""
+    for arg in schema.GetArgumentNames():
+        skip_full_doc = False
+        type_name = ""
+        dtype = None
+        doc = ""
+        deprecation_warning = None
+        if schema.IsDeprecatedArg(arg):
+            meta = schema.DeprecatedArgMeta(arg)
+            msg = meta['msg']
+            assert msg is not None
+            deprecation_warning = ".. warning::\n\n    " + msg.replace("\n", "\n    ")
+            renamed_arg = meta['renamed_to']
+            # Renamed and removed arguments won't show full documentation (only warning box)
+            skip_full_doc = renamed_arg or meta['removed']
+            # Renamed aliases are not fully registered to the schema, that's why we query for the
+            # info on the renamed_arg name.
+            if renamed_arg:
+                dtype = schema.GetArgumentType(renamed_arg)
+                type_name = _type_name_convert_to_string(
+                    dtype, allow_tensors=schema.IsTensorArgument(renamed_arg))
+        # Try to get dtype only if not set already
+        # (renamed args go through a different path, see above)
+        if not dtype:
+            dtype = schema.GetArgumentType(arg)
+            type_name = _type_name_convert_to_string(dtype,
+                                                     allow_tensors=schema.IsTensorArgument(arg))
+        # Add argument documentation if necessary
+        if not skip_full_doc:
+            if schema.IsArgumentOptional(arg):
+                type_name += ", optional"
+                if schema.HasArgumentDefaultValue(arg):
+                    default_value_string = schema.GetArgumentDefaultValueString(arg)
+                    default_value = ast.literal_eval(default_value_string)
+                    type_name += ", default = `{}`".format(_default_converter(dtype, default_value))
+            doc += schema.GetArgumentDox(arg).rstrip("\n")
+            if schema.ArgSupportsPerFrameInput(arg):
+                doc += "\n\nSupports :func:`per-frame<nvidia.dali.fn.per_frame>` inputs."
+            if deprecation_warning:
+                doc += "\n\n" + deprecation_warning
+        elif deprecation_warning:
+            doc += deprecation_warning
+        ret += _numpydoc_formatter(arg, type_name, doc)
+        ret += '\n'
+    return ret
+
+
+def _docstring_generator_main(cls, api):
+    """
+        Generate docstring for the class obtaining it from schema based on cls.__name__
+        This lists all the Keyword args that can be used when creating operator
+    """
+    op_name = _names._schema_name(cls)
+    schema = _b.GetSchema(op_name)
+    ret = '\n'
+
+    if schema.IsDeprecated():
+        use_instead = _names._op_name(schema.DeprecatedInFavorOf(), api)
+        ret += ".. warning::\n\n   This operator is now deprecated"
+        if use_instead:
+            ret += ". Use :meth:`" + use_instead + "` instead."
+        explanation = schema.DeprecationMessage()
+        if explanation:
+            indent = "\n" + " " * 3
+            ret += indent
+            ret += indent
+            explanation = explanation.replace("\n", indent)
+            ret += explanation
+        ret += "\n\n"
+
+    ret += schema.Dox()
+    ret += '\n'
+
+    if schema.IsDocPartiallyHidden():
+        return ret
+
+    supported_statements = []
+    if schema.IsSequenceOperator():
+        supported_statements.append("expects sequence inputs")
+    elif schema.AllowsSequences():
+        supported_statements.append("allows sequence inputs")
+
+    if schema.SupportsVolumetric():
+        supported_statements.append("supports volumetric data")
+
+    if len(supported_statements) > 0:
+        ret += "\nThis operator "
+        ret += supported_statements[0]
+        if len(supported_statements) > 1:
+            ret += " and " + supported_statements[1]
+        ret += ".\n"
+
+    if schema.IsNoPrune():
+        ret += "\nThis operator will **not** be optimized out of the graph.\n"
+
+    op_dev = []
+    if op_name in _registry.cpu_ops():
+        op_dev.append("'cpu'")
+    if op_name in _registry.gpu_ops():
+        op_dev.append("'gpu'")
+    if op_name in _registry.mixed_ops():
+        op_dev.append("'mixed'")
+    ret += """
+Supported backends
+"""
+    for dev in op_dev:
+        ret += " * " + dev + "\n"
+    ret += "\n"
+    return ret
+
+
+def _docstring_generator(cls):
+    op_name = _names._schema_name(cls)
+    schema = _b.GetSchema(op_name)
+    ret = _docstring_generator_main(cls, "ops")
+    if schema.IsDocPartiallyHidden():
+        return ret
+    ret += """
+Keyword args
+------------
+"""
+    ret += _get_kwargs(schema)
+    return ret
+
+
+def _supported_layouts_str(supported_layouts):
+    if len(supported_layouts) == 0:
+        return ""
+    return " (" + ", ".join(["\'" + str(layout) + "\'" for layout in supported_layouts]) + ")"
+
+
+def _docstring_prefix_from_inputs(op_name):
+    """
+        Generate start of the docstring for `__call__` of Operator `op_name`
+        assuming the docstrings were provided for all inputs separately
+
+        Returns the signature of `__call__` and list of `Args` in appropriate section
+    """
+    schema = _b.GetSchema(op_name)
+    # Signature
+    ret = "__call__(" + schema.GetCallSignatureInputs() + ", **kwargs)\n"
+    # __call__ docstring
+    ret += "\nOperator call to be used in graph definition.\n"
+    # Args section
+    ret += _get_inputs_doc(schema)
+    return ret
+
+
+def _docstring_prefix_auto(op_name):
+    """
+        Generate start of the docstring for `__call__` of Operator `op_name`
+        with default values. Assumes there will be 0 or 1 inputs
+    """
+    schema = _b.GetSchema(op_name)
+    if schema.MaxNumInput() == 0:
+        return """__call__(**kwargs)
+
+Operator call to be used in graph definition. This operator doesn't have any inputs.
+"""
+    elif schema.MaxNumInput() == 1:
+        ret = """__call__(data, **kwargs)
+
+Operator call to be used in graph definition.
+
+Args
+----
+"""
+        dox = "Input to the operator.\n"
+        fmt = "TensorList" + _supported_layouts_str(schema.GetSupportedLayouts(0))
+        ret += _numpydoc_formatter("data", fmt, dox, optional=False)
+        return ret
+    return ""
+
+
+def _docstring_generator_call(op_name):
+    """
+        Generate full docstring for `__call__` of Operator `op_name`.
+    """
+    schema = _b.GetSchema(op_name)
+    if schema.IsDocPartiallyHidden():
+        return ""
+    if schema.HasCallDox():
+        ret = schema.GetCallDox()
+    elif schema.HasInputDox():
+        ret = _docstring_prefix_from_inputs(op_name)
+    elif schema.CanUseAutoInputDox():
+        ret = _docstring_prefix_auto(op_name)
+    else:
+        op_full_name, _, _ = _names._process_op_name(op_name)
+        ret = "See :meth:`nvidia.dali.ops." + op_full_name + "` class for complete information.\n"
+    if schema.AppendKwargsSection():
+        # Kwargs section
+        tensor_kwargs = _get_kwargs(schema)
+        if tensor_kwargs:
+            ret += """
+Keyword Args
+------------
+"""
+            ret += tensor_kwargs
+    return ret
+
+
+def _docstring_generator_fn(cls):
+    op_name = _names._schema_name(cls)
+    schema = _b.GetSchema(op_name)
+    ret = _docstring_generator_main(cls, "fn")
+    if schema.IsDocPartiallyHidden():
+        return ret
+    ret += _get_inputs_doc(schema)
+    ret += """
+Keyword args
+------------
+"""
+    ret += _get_kwargs(schema)
+    return ret

--- a/dali/python/nvidia/dali/ops/_names.py
+++ b/dali/python/nvidia/dali/ops/_names.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali import fn as _functional
+
+
+def _schema_name(cls):
+    """Extract the name of the schema from Operator class."""
+    return getattr(cls, 'schema_name', cls.__name__)
+
+
+def _process_op_name(op_schema_name, make_hidden=False):
+    """Based on the schema name (for example "Resize" or "experimental__readers__Video")
+    transform it into Python-compatible module & operator name information.
+
+    Parameters
+    ----------
+    op_schema_name : str
+        The name of the schema
+    make_hidden : bool, optional
+        Should a .hidden module be added to the module path to indicate an internal operator,
+        that it's later reimported but not directly discoverable, by default False
+
+    Returns
+    -------
+    (str, list, str)
+        (Full name with all submodules, submodule path to the operator, name of the operator),
+        for example:
+            ("Resize", [], "Resize") or
+            ("experimental.readers.Video", ["experimental", "readers"], "Video")
+    """
+    # Two underscores (reasoning: we might want to have single underscores in the namespace itself)
+    namespace_delim = "__"
+    op_full_name = op_schema_name.replace(namespace_delim, '.')
+    *submodule, op_name = op_full_name.split('.')
+    if make_hidden:
+        submodule = [*submodule, 'hidden']
+    return op_full_name, submodule, op_name
+
+
+def _op_name(op_schema_name, api="fn"):
+    """Extract the name of the operator from the schema and return it transformed for given API:
+    CamelCase for "ops" API, and snake_case for "fn" API. The name contains full module path,
+    for example:
+        _op_name("experimental__readers__VideoResize", "fn") -> "experimental.readers.video_resize"
+
+    Parameters
+    ----------
+    op_schema_name : str
+        The name of the schema
+    api : str, optional
+        API type, "ops" or "fn", by default "fn"
+
+    Returns
+    -------
+    str
+        The fully qualified name in given API
+    """
+    full_name, submodule, op_name = _process_op_name(op_schema_name)
+    if api == "fn":
+        return ".".join([*submodule, _functional._to_snake_case(op_name)])
+    elif api == "ops":
+        return full_name
+    else:
+        raise ValueError(f'{api} is not a valid DALI api name, try one of {"fn", "ops"}')

--- a/dali/python/nvidia/dali/ops/_registry.py
+++ b/dali/python/nvidia/dali/ops/_registry.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali import backend as _b
+
+# Registry of operators names for given backends
+_cpu_ops = set({})
+_gpu_ops = set({})
+_mixed_ops = set({})
+
+
+def cpu_ops():
+    """Get the set of the names of all registered CPU operators"""
+    return _cpu_ops
+
+
+def gpu_ops():
+    """Get the set of the names of all registered GPU operators"""
+    return _gpu_ops
+
+
+def mixed_ops():
+    """Get the set of the names of all registered Mixed operators"""
+    return _mixed_ops
+
+
+def _all_registered_ops():
+    """Return the set of the names of all registered operators"""
+    return _cpu_ops.union(_gpu_ops).union(_mixed_ops)
+
+
+def register_cpu_op(name):
+    """Add new CPU op name to the registry."""
+    global _cpu_ops
+    _cpu_ops = _cpu_ops.union({name})
+
+
+def register_gpu_op(name):
+    """Add new GPU op name to the registry"""
+    global _gpu_ops
+    _gpu_ops = _gpu_ops.union({name})
+
+
+def _discover_ops():
+    """Query the backend for all registered operator names, update the Python-side registry of
+    operator names."""
+    global _cpu_ops
+    global _gpu_ops
+    global _mixed_ops
+    _cpu_ops = _cpu_ops.union(set(_b.RegisteredCPUOps()))
+    _gpu_ops = _gpu_ops.union(set(_b.RegisteredGPUOps()))
+    _mixed_ops = _mixed_ops.union(set(_b.RegisteredMixedOps()))


### PR DESCRIPTION

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Refactoring**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
 (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
This is first part of refactoring, with the following steps:
* ops.py was moved into ops/__init__.py
* Utilities related to keeping the names of registered operators were moved to a dedicated _registry.py file.
* Utilities for parsing and reporting name based on schema name were moved to a dedicated _names.py file.
* Docstring generation was moved to dedicated _docs.py file.
* Some docstrings were added.

The visibility of the symbols placed in the new files was kept the same as in the original code to not cause cascading changes in DALI.

The next steps will involve:
* Extending the registration of the custom operator to allow moving the code into separate files (like PythonOp or TFRecordReader).
* Adjusting the processing of inputs and arguments, and filling the OpSpec, so the code can better maintained between the two APIs.

## Additional information:

### Affected modules and functionalities:
nvidia/dali/ops.py -> nvidia/dali/ops/...


### Key points relevant for the review:
Did we miss any symbols?
Can the adjusted imports cause any problems? - probably a question for CI.
Check if the utilities that rely on the internals, like generation of the sphinx docs, still work as intended.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
This changes a placement of the ops module code, but everything should work the same, so all current tests apply, documentation should be generated in the same way as well.
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
