### PR TITLE
Change Loader to make checkpoints at the end of an epoch

### DIFF
--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -196,8 +196,20 @@ class Loader {
     PushStateSnapshot();
   }
 
+    bool ShouldPadBatch(bool is_new_batch) {
+      // If the reader has depleted samples from the given shard, but shards are not equal
+      // and we need to pad samples inside batch (even create a whole new dummy batch) using padding
+      // just to return in each shard the same number of samples and batches within the epoch.
+      // It happened only when pad_last_batch_ is set
+      // First part of this condition makes sure that the same number of batches is returned in each
+      // shard. Second makes sure that padding is done up to the full batch. For the first sample in
+      // the batch is_new_batch is set so it means that padding may be no longer needed
+      return (returned_sample_counter_  < num_samples(num_shards_, Size()) || !is_new_batch) &&
+              pad_last_batch_;
+  }
+
   // Get a random read sample
-  LoadTargetSharedPtr ReadOne(bool is_new_batch) {
+  LoadTargetSharedPtr ReadOne(bool is_new_batch, bool is_end_of_batch) {
     PrepareMetadata();
     DomainTimeRange tr("[DALI][Loader] ReadOne", DomainTimeRange::kGreen1);
     // perform an initial buffer fill if it hasn't already happened
@@ -229,26 +241,17 @@ class Loader {
     }
 
     if (shards_.front().start == shards_.front().end) {
-      // If the reader has depleted samples from the given shard, but shards are not equal
-      // and we need to pad samples inside batch (even create a whole new dummy batch) using padding
-      // just to return in each shard the same number of samples and batches within the epoch.
-      // It happened only when pad_last_batch_ is set
-      // First part of this condition makes sure that the same number of batches is returned in each
-      // shard. Second makes sure that padding is done up to the full batch. For the first sample in
-      // the batch is_new_batch is set so it means that padding may be no longer needed
-      if ((returned_sample_counter_  < num_samples(num_shards_, Size()) || !is_new_batch) &&
-        pad_last_batch_) {
+      if (ShouldPadBatch(is_new_batch)) {
         ++returned_sample_counter_;
+        // If this is the last sample of the epoch, a checkpoint is created.
+        if (checkpointing_ && !ShouldPadBatch(is_end_of_batch))
+          PushStateSnapshot();
         return last_sample_ptr_tmp;
       }
+
       // remove shard that was fully consumed
       shards_.pop_front();
       returned_sample_counter_ = 0;
-
-      if (checkpointing_) {
-        // Create a checkpoint before processing the new shard
-        PushStateSnapshot();
-      }
     }
 
     // choose the random index
@@ -281,6 +284,13 @@ class Loader {
 
     shards_.front().start++;
     returned_sample_counter_++;
+
+    // If this is the last sample of the epoch, a checkpoint is created.
+    if (checkpointing_ && shards_.front().start == shards_.front().end &&
+        !ShouldPadBatch(is_end_of_batch)) {
+      PushStateSnapshot();
+    }
+
     return sample_ptr;
   }
 

--- a/dali/operators/reader/loader/loader_test.cc
+++ b/dali/operators/reader/loader/loader_test.cc
@@ -59,7 +59,7 @@ TYPED_TEST(DataLoadStoreTest, LMDBTest) {
     // grab an entry from the reader
     // tensor should be returned automatically when
     // shared_ptr to sample is destroyed
-    auto sample = reader->ReadOne(false);
+    auto sample = reader->ReadOne(false, false);
   }
 }
 #endif
@@ -75,7 +75,7 @@ TYPED_TEST(DataLoadStoreTest, FileLabelLoaderMmmap) {
             .AddArg("dont_use_mmap", dont_use_mmap)));
 
     reader->PrepareMetadata();
-    auto sample = reader->ReadOne(false);
+    auto sample = reader->ReadOne(false, false);
     EXPECT_EQ(sample->image.shares_data(), !dont_use_mmap);
   }
 }
@@ -94,7 +94,7 @@ TYPED_TEST(DataLoadStoreTest, RecordIOLoaderMmmap) {
             .AddArg("dont_use_mmap", dont_use_mmap)));
 
     reader->PrepareMetadata();
-    auto sample = reader->ReadOne(false);
+    auto sample = reader->ReadOne(false, false);
     EXPECT_EQ(sample->shares_data(), !dont_use_mmap);
   }
 }
@@ -113,7 +113,7 @@ TYPED_TEST(DataLoadStoreTest, TFRecordLoaderMmmap) {
             .AddArg("dont_use_mmap", dont_use_mmap)));
 
     reader->PrepareMetadata();
-    auto sample = reader->ReadOne(false);
+    auto sample = reader->ReadOne(false, false);
     EXPECT_EQ(sample->shares_data(), !dont_use_mmap);
   }
 }
@@ -130,7 +130,7 @@ TYPED_TEST(DataLoadStoreTest, CocoLoaderMmmap) {
                       .AddArg("dont_use_mmap", dont_use_mmap);
     shared_ptr<dali::CocoLoader> reader(new CocoLoader(coco_spec));
     reader->PrepareMetadata();
-    auto sample = reader->ReadOne(false);
+    auto sample = reader->ReadOne(false, false);
     EXPECT_EQ(sample->image.shares_data(), !dont_use_mmap);
   }
 }
@@ -149,7 +149,7 @@ TYPED_TEST(DataLoadStoreTest, LoaderTest) {
     // grab an entry from the reader
     // tensor should be returned automatically when
     // shared_ptr to sample is destroyed
-    auto sample = reader->ReadOne(false);
+    auto sample = reader->ReadOne(false, false);
   }
 }
 
@@ -173,7 +173,7 @@ TYPED_TEST(DataLoadStoreTest, CachedLMDBTest) {
 
   for (int i = 0; i < 10500; ++i) {
     // grab an entry from the reader
-    auto sample = reader->ReadOne(false);
+    auto sample = reader->ReadOne(false, false);
   }
 
   return;

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -89,7 +89,7 @@ class DataReader : public Operator<Backend> {
     curr_batch.clear();
     curr_batch.reserve(max_batch_size_);
     for (int i = 0; i < max_batch_size_; ++i) {
-      curr_batch.push_back(loader_->ReadOne(i == 0));
+      curr_batch.push_back(loader_->ReadOne(i == 0, i == max_batch_size_ - 1));
     }
   }
 

--- a/dali/operators/reader/reader_op_test.cc
+++ b/dali/operators/reader/reader_op_test.cc
@@ -80,7 +80,7 @@ class DummyDataReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   bool Prefetch() override {
     for (int i = 0; i < Operator::batch_size_; ++i) {
       printf("new tensor %d\n", i);
-      auto *t = loader_->ReadOne(false);
+      auto *t = loader_->ReadOne(false, false);
       prefetched_batch_.push_back(t);
     }
     return true;
@@ -537,10 +537,9 @@ class FileReaderTest : public DALITest {
                                                            bool stick_to_shard = false) {
     auto node = pipe.GetOperatorNode("file_reader");
     OpCheckpoint cpt(node->spec);
-    auto ret = RunEpoch(pipe, batch_size, num_shards, stick_to_shard);
     node->op->SaveState(cpt, std::nullopt);
     EXPECT_EQ(cpt.CheckpointState<LoaderStateSnapshot>().current_epoch, epoch_nr);
-    return {ret, cpt};
+    return {RunEpoch(pipe, batch_size, num_shards, stick_to_shard), cpt};
   }
 
   void RestoreCheckpointedState(Pipeline &pipe, const OpCheckpoint &cpt) {


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

While working on https://github.com/NVIDIA/DALI/pull/5008, I have noticed, that in the DataReader, checkpoint is created at the start of an epoch, whereas in the other operators, a checkpoint must be calculated at the end of an epoch.

To fix this issue, this PR changes the way Loader creates inner state snapshots. Instead of checking if a new epoch started now, it is checked if a new epoch starts in the next iteration.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
