### PR TITLE
Fix CUDA block sizes in Numba GPU tests.

### DIFF
--- a/dali/test/python/operator_1/test_numba_func.py
+++ b/dali/test/python/operator_1/test_numba_func.py
@@ -227,7 +227,7 @@ def test_numba_func_gpu():
 
     device = "gpu"
     blocks = [32, 32, 1]
-    threads_per_block = [32, 32, 1]
+    threads_per_block = [32, 16, 1]
     for shape, dtype, run_fn, out_types, in_types, outs_ndim, ins_ndim, \
             setup_fn, batch_processing, expected_out in args:
         yield _testimpl_numba_func, \
@@ -345,7 +345,7 @@ def test_numba_func_image_gpu():
     ]
     device = "gpu"
     blocks = [32, 32, 1]
-    threads_per_block = [16, 1, 1]
+    threads_per_block = [32, 8, 1]
     for run_fn, out_types, in_types, outs_ndim, ins_ndim, \
             setup_fn, batch_processing, transform in args:
         yield _testimpl_numba_func_image, \
@@ -421,7 +421,7 @@ def test_split_images_col():
 
 def test_split_images_col_gpu():
     blocks = [32, 32, 1]
-    threads_per_block = [16, 1, 1]
+    threads_per_block = [32, 8, 1]
     pipe = numba_func_split_image_pipe(
         batch_size=8, num_threads=1, device_id=0,
         run_fn=split_images_col_sample_gpu, setup_fn=setup_split_images_col,
@@ -504,7 +504,7 @@ def test_multiple_ins():
 
 def test_multiple_ins_gpu():
     blocks = [32, 32, 1]
-    threads_per_block = [16, 1, 1]
+    threads_per_block = [32, 8, 1]
     pipe = numba_multiple_ins_pipe(
         shapes=[(10, 10)], dtype=np.uint8, batch_size=8, num_threads=1, device_id=0,
         run_fn=multiple_ins_run_gpu,


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
- The block size of 32x32 caused an error due to insufficient resources on supported GPUs (V100).
- The block size below a single warp (16x1x1) didn't make sense

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
This change is tests only.

- [X] Existing tests apply
- [ ] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
