### PR TITLE
Replace GPU dltensor per-sample copying kernel with a batched one

### DIFF
--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -148,7 +148,7 @@ void CopyOutputData(TensorList<CPUBackend> &output, std::vector<DLMTensorPtr> &d
   auto out_shape = output.shape();
   for (int i = 0; i < batch_size; ++i) {
     thread_pool.AddWork([&, i](int) {
-      CopyDlTensor<CPUBackend>(output.raw_mutable_tensor(i), dl_tensors[i]);
+      CopyDlTensorCpu(output.raw_mutable_tensor(i), dl_tensors[i]);
     }, out_shape.tensor_size(i));
   }
   thread_pool.RunAll();
@@ -157,9 +157,7 @@ void CopyOutputData(TensorList<CPUBackend> &output, std::vector<DLMTensorPtr> &d
 template <>
 void CopyOutputData(TensorList<GPUBackend>& output, std::vector<DLMTensorPtr> &dl_tensors,
                     int batch_size, Workspace &workspace) {
-  for (int i = 0; i < batch_size; ++i) {
-    CopyDlTensor<GPUBackend>(output.raw_mutable_tensor(i), dl_tensors[i], workspace.stream());
-  }
+  CopyDlTensorBatchGpu(output, dl_tensors, batch_size, workspace.stream());
 }
 
 }  // namespace detail

--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -144,9 +144,10 @@ TensorListShape<> GetDLTensorListShape(const std::vector<DLMTensorPtr>& dl_tenso
 template <>
 void CopyOutputData(TensorList<CPUBackend> &output, std::vector<DLMTensorPtr> &dl_tensors,
                     Workspace &workspace) {
+  int batch_size = dl_tensors.size();
   auto &thread_pool = workspace.GetThreadPool();
   auto out_shape = output.shape();
-  for (int i = 0; i < dl_tensors.size(); ++i) {
+  for (int i = 0; i < batch_size; ++i) {
     thread_pool.AddWork([&, i](int) {
       CopyDlTensorCpu(output.raw_mutable_tensor(i), dl_tensors[i]);
     }, out_shape.tensor_size(i));

--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -143,10 +143,10 @@ TensorListShape<> GetDLTensorListShape(const std::vector<DLMTensorPtr>& dl_tenso
 
 template <>
 void CopyOutputData(TensorList<CPUBackend> &output, std::vector<DLMTensorPtr> &dl_tensors,
-                    int batch_size, Workspace &workspace) {
+                    Workspace &workspace) {
   auto &thread_pool = workspace.GetThreadPool();
   auto out_shape = output.shape();
-  for (int i = 0; i < batch_size; ++i) {
+  for (int i = 0; i < dl_tensors.size(); ++i) {
     thread_pool.AddWork([&, i](int) {
       CopyDlTensorCpu(output.raw_mutable_tensor(i), dl_tensors[i]);
     }, out_shape.tensor_size(i));
@@ -156,8 +156,8 @@ void CopyOutputData(TensorList<CPUBackend> &output, std::vector<DLMTensorPtr> &d
 
 template <>
 void CopyOutputData(TensorList<GPUBackend>& output, std::vector<DLMTensorPtr> &dl_tensors,
-                    int batch_size, Workspace &workspace) {
-  CopyDlTensorBatchGpu(output, dl_tensors, batch_size, workspace.stream());
+                    Workspace &workspace) {
+  CopyDlTensorBatchGpu(output, dl_tensors, workspace.stream());
 }
 
 }  // namespace detail

--- a/dali/operators/python_function/dltensor_function.h
+++ b/dali/operators/python_function/dltensor_function.h
@@ -17,9 +17,9 @@
 #include <dali/util/pybind.h>
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
-#include <vector>
-#include <utility>
 #include <string>
+#include <utility>
+#include <vector>
 #include "dali/pipeline/operator/operator.h"
 #include "dali/pipeline/util/copy_with_stride.h"
 
@@ -75,21 +75,6 @@ std::vector<DLMTensorPtr> CastToDLTensorList(py::list &list, Index exp_size, Ind
 }
 
 TensorListShape<> GetDLTensorListShape(const std::vector<DLMTensorPtr> &dl_tensors);
-
-template <typename Backend>
-void CopyDlTensor(void *out_data, DLMTensorPtr &dlm_tensor_ptr, cudaStream_t stream = 0) {
-  auto &dl_tensor = dlm_tensor_ptr->dl_tensor;
-  auto item_size = dl_tensor.dtype.bits / 8;
-  if (dl_tensor.strides) {
-    std::vector<Index> strides(dl_tensor.ndim);
-    for (Index i = 0; i < dl_tensor.ndim; ++i) strides[i] = dl_tensor.strides[i] * item_size;
-    CopyWithStride<Backend>(out_data, dl_tensor.data, strides.data(),
-                            dl_tensor.shape, dl_tensor.ndim, item_size, stream);
-  } else {
-    CopyWithStride<Backend>(out_data, dl_tensor.data, nullptr,
-                            dl_tensor.shape, dl_tensor.ndim, item_size, stream);
-  }
-}
 
 template <typename Backend>
 py::list PrepareDLTensorInputs(Workspace &ws);

--- a/dali/operators/python_function/dltensor_function.h
+++ b/dali/operators/python_function/dltensor_function.h
@@ -84,7 +84,7 @@ py::list PrepareDLTensorInputsPerSample(Workspace &ws);
 
 template <typename Workspace, typename Output>
 void CopyOutputData(Output& output, std::vector<DLMTensorPtr> &dl_tensors,
-                    int batch_size, Workspace &workspace);
+                    Workspace &workspace);
 
 template <typename Backend>
 void PrepareOutputs(Workspace &ws, const py::object &output_o, int batch_size) {
@@ -95,7 +95,7 @@ void PrepareOutputs(Workspace &ws, const py::object &output_o, int batch_size) {
     if (dl_tensors.empty()) continue;
     auto &tlist = ws.Output<Backend>(idx);
     tlist.Resize(GetDLTensorListShape(dl_tensors), DLToDALIType(dl_tensors[0]->dl_tensor.dtype));
-    CopyOutputData(tlist, dl_tensors, batch_size, ws);
+    CopyOutputData(tlist, dl_tensors, ws);
   }
 }
 

--- a/dali/pipeline/data/dltensor.cc
+++ b/dali/pipeline/data/dltensor.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ inline std::string to_string(const DLDataType &dl_type) {
 
 DALIDataType DLToDALIType(const DLDataType &dl_type) {
   DALI_ENFORCE(dl_type.lanes == 1,
-               "DALI Tensors do no not support types with the number of lanes other than 1");
+               "DALI Tensors do not support types with the number of lanes other than 1");
   switch (dl_type.code) {
     case kDLUInt: {
       switch (dl_type.bits) {

--- a/dali/pipeline/util/copy_with_stride.cc
+++ b/dali/pipeline/util/copy_with_stride.cc
@@ -111,7 +111,8 @@ void CopyDlTensorCpu(void *out_data, DLMTensorPtr &dlm_tensor_ptr) {
     CopyWithStrideCpu(out_data, dl_tensor.data, strides.data(), dl_tensor.shape, dl_tensor.ndim,
                       item_size);
   } else {
-    CopyWithStrideCpu(out_data, dl_tensor.data, nullptr, dl_tensor.shape, dl_tensor.ndim, item_size);
+    CopyWithStrideCpu(out_data, dl_tensor.data, nullptr, dl_tensor.shape, dl_tensor.ndim,
+                      item_size);
   }
 }
 

--- a/dali/pipeline/util/copy_with_stride.cc
+++ b/dali/pipeline/util/copy_with_stride.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -84,13 +84,8 @@ inline Index DeepestContiguous(const Index *in_strides,
   return 0;
 }
 
-template <>
-void CopyWithStride<CPUBackend>(void *output, const void *input,
-                    const Index *in_strides,
-                    const Index *shape,
-                    int ndim,
-                    size_t item_size,
-                    cudaStream_t) {
+void CopyWithStrideCpu(void *output, const void *input, const Index *in_strides, const Index *shape,
+                       int ndim, size_t item_size) {
   assert(ndim >= 0);
   if (!in_strides) {
     std::memcpy(output, input, item_size * volume(shape, shape + ndim));
@@ -104,6 +99,20 @@ void CopyWithStride<CPUBackend>(void *output, const void *input,
   auto deepest_contiguous = DeepestContiguous(in_strides, shape, ndim, item_size);
   CopyWithStrideHelper(output, input, in_strides, out_strides.data(),
                        shape, ndim, 0, deepest_contiguous);
+}
+
+void CopyDlTensorCpu(void *out_data, DLMTensorPtr &dlm_tensor_ptr) {
+  auto &dl_tensor = dlm_tensor_ptr->dl_tensor;
+  auto item_size = dl_tensor.dtype.bits / 8;
+  if (dl_tensor.strides) {
+    std::vector<Index> strides(dl_tensor.ndim);
+    for (Index i = 0; i < dl_tensor.ndim; ++i)
+      strides[i] = dl_tensor.strides[i] * item_size;
+    CopyWithStrideCpu(out_data, dl_tensor.data, strides.data(), dl_tensor.shape, dl_tensor.ndim,
+                      item_size);
+  } else {
+    CopyWithStrideCpu(out_data, dl_tensor.data, nullptr, dl_tensor.shape, dl_tensor.ndim, item_size);
+  }
 }
 
 }  // namespace dali

--- a/dali/pipeline/util/copy_with_stride.cu
+++ b/dali/pipeline/util/copy_with_stride.cu
@@ -149,7 +149,6 @@ template <typename ElementTypeDesc, typename MismatchedNdimT>
 DALI_DEVICE DALI_FORCEINLINE void UnalignedCopy(const StridedCopyDesc &sample,
                                                 MismatchedNdimT mismatched_ndim) {
   using T = typename ElementTypeDesc::type;
-  using VecT = typename ElementTypeDesc::vec_type;
   constexpr int vec_len = ElementTypeDesc::vec_len;
   int skip_left = sample.aligned.skip_left;
   int skip_right = sample.aligned.skip_right;
@@ -232,13 +231,13 @@ void FillSampleAlignmentInfo(StridedCopyDesc &sample) {
   auto output_base_addr = reinterpret_cast<std::uintptr_t>(sample.output);
   auto aligned_output_addr = align_up(output_base_addr, sizeof(T) * vec_len);
   sample.aligned.skip_left = (aligned_output_addr - output_base_addr) / sizeof(T);
-  assert(0 <= sample.aligned.skip_left && sample.aligned.skip_left < ElementTypeDesc::vec_len);
+  assert(0 <= sample.aligned.skip_left && sample.aligned.skip_left < vec_len);
   sample.aligned.skip_left = std::min<int64_t>(sample.size, sample.aligned.skip_left);
   int64_t remaining_size = sample.size - sample.aligned.skip_left;
   assert(0 <= remaining_size && remaining_size < sample.size);
-  sample.aligned.size = align_down(remaining_size, ElementTypeDesc::vec_len);
+  sample.aligned.size = align_down(remaining_size, vec_len);
   sample.aligned.skip_right = remaining_size - sample.aligned.size;
-  assert(0 <= sample.aligned.skip_right && sample.aligned.skip_right < ElementTypeDesc::vec_len);
+  assert(0 <= sample.aligned.skip_right && sample.aligned.skip_right < vec_len);
   assert(sample.aligned.skip_left + sample.aligned.skip_right + sample.aligned.size == sample.size);
 }
 

--- a/dali/pipeline/util/copy_with_stride.cu
+++ b/dali/pipeline/util/copy_with_stride.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,58 +12,387 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/pipeline/util/copy_with_stride.h"
+#include <algorithm>
+
 #include <cuda_runtime.h>
-#include <dali/core/util.h>
 #include <dali/core/dev_array.h>
+#include <dali/core/geom/vec.h>
+#include <dali/core/util.h>
+#include "dali/pipeline/util/copy_with_stride.h"
 
 namespace dali {
 
+namespace strided_copy {
+
 constexpr int MAX_DIMS = 15;
 
-__global__ void CopyWithStrideKernel(uint8_t *output, const uint8_t *input, Index size,
-                                     DeviceArray<Index, MAX_DIMS> out_strides,
-                                     DeviceArray<Index, MAX_DIMS> in_strides,
-                                     int ndim) {
-  auto out_idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (out_idx >= size)
-    return;
-  Index in_idx = 0;
-  Index elem_offset = out_idx;
-  for (int dim = 0; dim < ndim; ++dim) {
+struct StridedCopyDesc {
+  void *output;
+  const void *input;
+  int64_t in_strides[MAX_DIMS];
+  int64_t out_strides[MAX_DIMS];
+  int64_t size;
+};
+
+template <typename T, size_t num_elements, size_t alignment>
+struct alignas(alignment) Vectorized {
+  T payload[num_elements];  // NOLINT(runtime/arrays)
+
+  DALI_DEVICE DALI_FORCEINLINE T &operator[](int idx) {
+    return payload[idx];
+  }
+};
+
+template <int NumBytes>
+struct ElementTypeOfSize {};
+
+template <>
+struct ElementTypeOfSize<1> {
+  using type = uint8_t;
+};
+
+template <>
+struct ElementTypeOfSize<2> {
+  using type = uint16_t;
+};
+
+template <>
+struct ElementTypeOfSize<4> {
+  using type = uint32_t;
+};
+
+template <>
+struct ElementTypeOfSize<8> {
+  using type = uint64_t;
+};
+
+template <int NumBytes, int VecLen = 4>
+struct ElementType {
+  static constexpr int vec_len = VecLen;
+  using type = typename ElementTypeOfSize<NumBytes>::type;
+  using vec_type = Vectorized<type, vec_len, vec_len * sizeof(type)>;
+};
+
+
+template <int MaxNDim_>
+struct MismatchedNdim {
+  DALI_DEVICE DALI_FORCEINLINE constexpr int operator()() {
+    return MaxNDim_;
+  }
+};
+
+template <>
+struct MismatchedNdim<-1> {
+  MismatchedNdim(int max_ndim) : max_ndim_{max_ndim} {}
+  DALI_DEVICE DALI_FORCEINLINE int operator()() {
+    return max_ndim_;
+  }
+
+ private:
+  int max_ndim_;
+};
+
+/**
+ * @brief Takes a flat output index, recomputes the output coordiantes based on the out_strides
+ * and returns flat input index based on input strides.
+ *
+ */
+template <typename MismatchedNdimT>
+DALI_DEVICE DALI_FORCEINLINE int64_t GetInputIdx(MismatchedNdimT mismatched_ndim, int64_t out_idx,
+                                                 const int64_t *in_strides,
+                                                 const int64_t *out_strides) {
+  int64_t in_idx = 0;
+  int64_t elem_offset = out_idx;
+#pragma unroll
+  for (int dim = 0; dim < mismatched_ndim(); ++dim) {
     auto n = elem_offset / out_strides[dim];
     in_idx += n * in_strides[dim];
     elem_offset -= n * out_strides[dim];
   }
-  output[out_idx] = input[in_idx + elem_offset];
+  return in_idx + elem_offset;
 }
 
-template <>
-void CopyWithStride<GPUBackend>(void *output, const void *input,
-                                const Index *in_strides,
-                                const Index *shape,
-                                int ndim,
-                                size_t item_size,
-                                cudaStream_t stream) {
-  if (!in_strides) {
-    CUDA_CALL(
-      cudaMemcpyAsync(output, input, volume(shape, shape + ndim) * item_size,
-                      cudaMemcpyDeviceToDevice, stream));
+/**
+ * @brief Copies element by element (in contrast to vector of elements) `num_padded_elements`
+ * elements from the start and the `num_cropped_elements` elements from the end of the sample.
+ *
+ * Assumes that there is very few padded and cropped elements
+ * (less than the ElementTypeDesc's vector type elements, typically 4).
+ * In particular, only a single block will be active.
+ */
+template <typename ElementTypeDesc, typename MismatchedNdimT>
+DALI_DEVICE DALI_FORCEINLINE void UnalignedCopy(const StridedCopyDesc &sample,
+                                                MismatchedNdimT mismatched_ndim,
+                                                const int num_padded_elements,
+                                                const int num_cropped_elements) {
+  using T = typename ElementTypeDesc::type;
+  using VecT = typename ElementTypeDesc::vec_type;
+  constexpr int vec_len = ElementTypeDesc::vec_len;
+  if (blockIdx.x == 0 && (num_padded_elements > 0 || num_cropped_elements > 0)) {
+    assert(2 * vec_len <= blockDim.x);
+    assert(num_padded_elements < vec_len);
+    assert(num_cropped_elements < vec_len);
+    const T *__restrict__ input = static_cast<const T *>(sample.input);
+    T *__restrict__ output = static_cast<T *>(sample.output);
+    int padded_idx = threadIdx.x;
+    int cropped_idx = threadIdx.x - vec_len;
+    if (padded_idx < num_padded_elements) {
+      auto in_idx =
+          GetInputIdx(mismatched_ndim, threadIdx.x, sample.in_strides, sample.out_strides);
+      output[threadIdx.x] = input[in_idx];
+    } else if (0 <= cropped_idx && cropped_idx < num_cropped_elements) {
+      int64_t idx = sample.size - num_cropped_elements + cropped_idx;
+      auto in_idx = GetInputIdx(mismatched_ndim, idx, sample.in_strides, sample.out_strides);
+      output[idx] = input[in_idx];
+    }
+  }
+}
+
+template <typename ElementTypeDesc>
+DALI_HOST_DEV DALI_FORCEINLINE void SampleAlignmentInfo(int &num_padded_elements,
+                                                        int &num_cropped_elements,
+                                                        int64_t &aligned_down_size,
+                                                        const StridedCopyDesc &sample) {
+  using T = typename ElementTypeDesc::type;
+  using VecT = typename ElementTypeDesc::vec_type;
+  auto output_base_addr = reinterpret_cast<std::uintptr_t>(sample.output);
+  auto aligned_output_addr = align_up(output_base_addr, alignof(VecT));
+  num_padded_elements = (aligned_output_addr - output_base_addr) / sizeof(T);
+  int64_t remaining_size = sample.size - num_padded_elements;
+  aligned_down_size = align_down(remaining_size, ElementTypeDesc::vec_len);
+  num_cropped_elements = remaining_size - aligned_down_size;
+}
+
+template <typename ElementTypeDesc>
+bool IsAligned(const StridedCopyDesc &sample) {
+  int num_padded_elements, num_cropped_elements;
+  int64_t aligned_down_size;
+  SampleAlignmentInfo<ElementTypeDesc>(num_padded_elements, num_cropped_elements, aligned_down_size,
+                                       sample);
+  return num_padded_elements == 0 && num_cropped_elements == 0;
+}
+
+/**
+ * @brief Performs aligned copy.
+ *
+ * The input is read element-by-element but the output is stored in a vectorized type and
+ * written into global memory with wider, vectorized writes.
+ * This benefits performance by 1. vectorized writes and 2. utilization of
+ * cache in the reads if the input happens to be mostly compact
+ * (for example the strides are due to row-major image with padded rows).
+ *
+ * Note, the output address must be aligned to meet the vectorized writes requirements.
+ * If it is not, the first `num_padded_elements` elements are skipped and the
+ * (T*)(output) + num_padded_elements is assumed to be aligned.
+ */
+template <typename ElementTypeDesc, typename MismatchedNdimT>
+DALI_DEVICE DALI_FORCEINLINE void AlignedCopy(const StridedCopyDesc &sample,
+                                              MismatchedNdimT mismatched_ndim,
+                                              const int num_padded_elements,
+                                              const int64_t aligned_down_size) {
+  using T = typename ElementTypeDesc::type;
+  using VecT = typename ElementTypeDesc::vec_type;
+  constexpr int vec_len = ElementTypeDesc::vec_len;
+  const T *__restrict__ input = static_cast<const T *>(sample.input);
+  VecT *__restrict__ output =
+      reinterpret_cast<VecT *>(static_cast<T *>(sample.output) + num_padded_elements);
+  for (int64_t flat_idx = vec_len * (blockIdx.x * blockDim.x + threadIdx.x);
+       flat_idx < aligned_down_size; flat_idx += vec_len * blockDim.x * gridDim.x) {
+    VecT out_vec;
+#pragma unroll
+    for (int i = 0; i < vec_len; i++) {
+      auto in_idx = GetInputIdx(mismatched_ndim, flat_idx + num_padded_elements + i,
+                                sample.in_strides, sample.out_strides);
+      out_vec[i] = input[in_idx];
+    }
+    output[flat_idx / vec_len] = out_vec;
+  }
+}
+
+/**
+ * @brief Performs partially vectorized copy.
+ *
+ * The input is read element-by-element but the output is stored in a vectorized type and
+ * written into global memory with wider, vectorized writes.
+ * This benefits performance by 1. vectorized writes and 2. utilization of
+ * cache in the reads if the input happens to be mostly compact
+ * (for example the strides are due to row-major image with padded rows).
+ *
+ * If the output base address or size is not aligned with the vectorized type, the
+ * begining and end of the sample is handled separately.
+ */
+template <typename ElementTypeDesc, bool IsOutputAligned = false, typename MismatchedNdimT>
+__global__ void BatchedCopy(const StridedCopyDesc *sample_descs, MismatchedNdimT mismatched_ndim) {
+  using T = typename ElementTypeDesc::type;
+  using VecT = typename ElementTypeDesc::vec_type;
+  static_assert(sizeof(VecT) == sizeof(T) * ElementTypeDesc::vec_len);
+  const auto sample = sample_descs[blockIdx.y];
+  int num_padded_elements, num_cropped_elements;
+  int64_t aligned_down_size;
+  if constexpr (!IsOutputAligned) {
+    SampleAlignmentInfo<ElementTypeDesc>(num_padded_elements, num_cropped_elements,
+                                         aligned_down_size, sample);
+  } else {
+    num_padded_elements = 0;
+    num_cropped_elements = 0;
+    aligned_down_size = sample.size;
+  }
+  UnalignedCopy<ElementTypeDesc>(sample, mismatched_ndim, num_padded_elements,
+                                 num_cropped_elements);
+  AlignedCopy<ElementTypeDesc>(sample, mismatched_ndim, num_padded_elements, aligned_down_size);
+}
+
+template <int ElementSize, typename MismatchedNdimT>
+void CopyBatch(span<const StridedCopyDesc> sample_descs, MismatchedNdimT mismatched_ndim,
+               cudaStream_t stream) {
+  kernels::DynamicScratchpad scratchpad({}, stream);
+  using T = ElementType<ElementSize>;
+  constexpr unsigned int kMaxBlockSize = 1024u;
+  static constexpr int kBlockSize = 128;
+  const StridedCopyDesc *sample_descs_gpu;
+  std::tie(sample_descs_gpu) = scratchpad.ToContiguousGPU(stream, sample_descs);
+  int64_t max_vol = 0;
+  bool has_aligned_output = true;
+  for (auto &sample_desc : sample_descs) {
+    max_vol = std::max(max_vol, sample_desc.size);
+    has_aligned_output &= IsAligned<T>(sample_desc);
+  }
+  unsigned int blocks_num = div_ceil(max_vol, T::vec_len * kBlockSize);
+  blocks_num = std::min(blocks_num, kMaxBlockSize);
+  unsigned int num_samples = sample_descs.size();
+  dim3 grid = {blocks_num, num_samples, 1};
+  BOOL_SWITCH(has_aligned_output, HasAlignedOutput,
+              (BatchedCopy<T, HasAlignedOutput>
+               <<<grid, kBlockSize, 0, stream>>>(sample_descs_gpu, mismatched_ndim);));
+}
+
+
+void CopyBatch(span<const StridedCopyDesc> sample_descs, int max_mismatched_ndim, int element_size,
+               cudaStream_t stream) {
+  VALUE_SWITCH(element_size, ElementSize, (1, 2, 4, 8), (
+    VALUE_SWITCH(max_mismatched_ndim, NDim, (0, 1, 2, 3, 4, 5), (
+      CopyBatch<ElementSize>(sample_descs, MismatchedNdim<NDim>{}, stream);
+    ), (
+      CopyBatch<ElementSize>(sample_descs, MismatchedNdim<-1>(max_mismatched_ndim), stream);
+    ));
+  ), DALI_FAIL(make_string("Unsupported element size: ", element_size)););  // NOLINT
+}
+
+}  // namespace strided_copy
+
+void ValidateBatch(int &element_size, int &ndim, std::vector<DLMTensorPtr> &dl_tensors,
+                   int batch_size) {
+  int num_bits;
+  for (int i = 0; i < batch_size; i++) {
+    auto &dlm_tensor_ptr = dl_tensors[i];
+    auto &dl_tensor = dlm_tensor_ptr->dl_tensor;
+    int lanes = dl_tensor.dtype.lanes;
+    DALI_ENFORCE(lanes == 1, make_string("DALI Tensors do not support types with the number of "
+                                         "lanes other than 1, got tensor with `",
+                                         lanes, "` lanes."));
+    if (i == 0) {
+      num_bits = dl_tensor.dtype.bits;
+      ndim = dl_tensor.ndim;
+    } else {
+      DALI_ENFORCE(num_bits == dl_tensor.dtype.bits,
+                   "All tensors in the DALI batch must have the same type.");
+      int cur_ndim = dl_tensor.ndim;
+      DALI_ENFORCE(
+          ndim == cur_ndim,
+          make_string("All tensors in the DALI batch must have the same number of extents. Got "
+                      "tensors with `",
+                      ndim, "` and `", cur_ndim, "` dims."));
+    }
+  }
+  // Limitation based on DLToDALIType
+  DALI_ENFORCE(num_bits == 8 || num_bits == 16 || num_bits == 32 || num_bits == 64,
+               "Unsupported data type width. Currently DALI tensors support only types of 8, 16, "
+               "32 or 64 bits");
+  DALI_ENFORCE(0 <= ndim && ndim <= strided_copy::MAX_DIMS,
+               make_string("DALI tensor must have between 0 and ", strided_copy::MAX_DIMS,
+                           " dimensions, got tensor with `", ndim, "` dimensions."));
+  element_size = num_bits / 8;
+}
+
+
+/**
+ * @brief Copies batch of DlTensors (which may be strided) into a batch of DALI tensors (which are
+ * dense/compact).
+ *
+ * For the input DlTensors that are not strided, we simply run the cudaMemcpyAsync. Otherwise, a
+ * copy kernel is used. The copy kernel will go over the output DALI tensors linearly (the tensor is
+ * compact/dese) and translate the flat output indicies into input indicies.
+ *
+ * The input batch is validated against some of DALI batch requirements, such as uniform data
+ * type and dimensionality.
+ *
+ * @param output
+ * @param dl_tensors
+ * @param batch_size
+ * @param stream
+ */
+void CopyDlTensorBatchGpu(TensorList<GPUBackend> &output, std::vector<DLMTensorPtr> &dl_tensors,
+                          int batch_size, cudaStream_t stream) {
+  if (batch_size <= 0) {
     return;
   }
-  DeviceArray<Index, MAX_DIMS> out_strides{};
-  out_strides[ndim - 1] = item_size;
-  for (int i = ndim - 2; i >= 0; --i) {
-    out_strides[i] = out_strides[i + 1] * shape[i + 1];
+  int element_size, ndim;
+  ValidateBatch(element_size, ndim, dl_tensors, batch_size);
+  SmallVector<strided_copy::StridedCopyDesc, 128> sample_descs;
+  const auto cuda_mem_copy = [&output, element_size, stream](int sample_idx,
+                                                             const auto &dl_tensor) {
+    void *out_data = output.raw_mutable_tensor(sample_idx);
+    auto size = volume(dl_tensor.shape, dl_tensor.shape + dl_tensor.ndim) * element_size;
+    CUDA_CALL(cudaMemcpyAsync(out_data, dl_tensor.data, size, cudaMemcpyDeviceToDevice, stream));
+  };
+  // If some innermost (the smallest in DALI tensor) strides match the strides of the incoming
+  // DlPack tensor, we can stop the translation from output index to input index early. For that,
+  // we need to keep track of how many outermost dimensions actually mismatch.
+  int max_mismatched_ndim = 0;
+  for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
+    auto &dlm_tensor_ptr = dl_tensors[sample_idx];
+    auto &dl_tensor = dlm_tensor_ptr->dl_tensor;
+    if (!dl_tensor.strides) {
+      cuda_mem_copy(sample_idx, dl_tensor);
+      continue;
+    }
+    strided_copy::StridedCopyDesc sample_desc;
+    // compute input and the compact output strides first, if they match
+    for (int d = 0; d < dl_tensor.ndim; d++) {
+      sample_desc.in_strides[d] = dl_tensor.strides[d];
+    }
+    if (ndim > 0) {
+      sample_desc.out_strides[ndim - 1] = 1;
+      for (int d = ndim - 2; d >= 0; --d) {
+        sample_desc.out_strides[d] = sample_desc.out_strides[d + 1] * dl_tensor.shape[d + 1];
+      }
+    }
+    // if the strides match (and given that the out strides are compact/dense),
+    // we can just go with cudamemcpy
+    {
+      int mismatched_ndim = ndim;
+      for (int d = ndim - 1; d >= 0; d--) {
+        if (sample_desc.in_strides[d] != sample_desc.out_strides[d]) {
+          break;
+        }
+        mismatched_ndim--;
+      }
+      if (mismatched_ndim == 0) {
+        cuda_mem_copy(sample_idx, dl_tensor);
+        continue;
+      }
+      max_mismatched_ndim = std::max(max_mismatched_ndim, mismatched_ndim);
+    }
+    // otherwise, when the strides do not match, fill the rest of sample_desc
+    // and add it to the vector with samples for the kernel
+    sample_desc.output = output.raw_mutable_tensor(sample_idx);
+    sample_desc.input = dl_tensor.data;
+    sample_desc.size = volume(dl_tensor.shape, dl_tensor.shape + ndim);
+    sample_descs.push_back(sample_desc);
   }
-  DeviceArray<Index, MAX_DIMS> in_strides_arr{};
-  std::copy(in_strides, in_strides + ndim, in_strides_arr.data());
-  Index size = volume(shape, shape + ndim) * item_size;
-  auto blocks_num = (size + 1023) / 1024;
-  auto block_size = (size < 1024) ? size : 1024;
-  CopyWithStrideKernel<<<blocks_num, block_size, 0, stream>>>
-      (static_cast<uint8_t*>(output), static_cast<const uint8_t*>(input),
-       size, out_strides, in_strides_arr, ndim);
+  if (sample_descs.size() > 0) {
+    strided_copy::CopyBatch(make_cspan(sample_descs), max_mismatched_ndim, element_size, stream);
+  }
 }
 
 }  // namespace dali

--- a/dali/pipeline/util/copy_with_stride.cu
+++ b/dali/pipeline/util/copy_with_stride.cu
@@ -345,7 +345,8 @@ void ValidateBatch(int &element_size, int &ndim, std::vector<DLMTensorPtr> &dl_t
  * @param stream
  */
 void CopyDlTensorBatchGpu(TensorList<GPUBackend> &output, std::vector<DLMTensorPtr> &dl_tensors,
-                          int batch_size, cudaStream_t stream) {
+                          cudaStream_t stream) {
+  int batch_size = dl_tensors.size();
   if (batch_size <= 0) {
     return;
   }

--- a/dali/pipeline/util/copy_with_stride.h
+++ b/dali/pipeline/util/copy_with_stride.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,17 +17,19 @@
 
 #include <vector>
 #include "dali/core/common.h"
+#include "dali/core/span.h"
+#include "dali/core/util.h"
+#include "dali/kernels/dynamic_scratchpad.h"
 #include "dali/pipeline/data/backend.h"
+#include "dali/pipeline/data/dltensor.h"
 
 namespace dali {
 
-template <typename Backend>
-DLL_PUBLIC void CopyWithStride(void *output, const void *input,
-                               const Index *in_strides,
-                               const Index *shape,
-                               int ndim,
-                               size_t item_size,
-                               cudaStream_t stream = 0);
+DLL_PUBLIC void CopyDlTensorCpu(void *out_data, DLMTensorPtr &dlm_tensor_ptr);
+
+DLL_PUBLIC void CopyDlTensorBatchGpu(TensorList<GPUBackend> &output,
+                                     std::vector<DLMTensorPtr> &dl_tensors, int batch_size,
+                                     cudaStream_t stream);
 
 }  // namespace dali
 

--- a/dali/pipeline/util/copy_with_stride.h
+++ b/dali/pipeline/util/copy_with_stride.h
@@ -28,7 +28,7 @@ namespace dali {
 DLL_PUBLIC void CopyDlTensorCpu(void *out_data, DLMTensorPtr &dlm_tensor_ptr);
 
 DLL_PUBLIC void CopyDlTensorBatchGpu(TensorList<GPUBackend> &output,
-                                     std::vector<DLMTensorPtr> &dl_tensors, int batch_size,
+                                     std::vector<DLMTensorPtr> &dl_tensors,
                                      cudaStream_t stream);
 
 }  // namespace dali

--- a/dali/pipeline/util/copy_with_stride_test.cc
+++ b/dali/pipeline/util/copy_with_stride_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,101 +12,242 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "dali/pipeline/util/copy_with_stride.h"
 #include <gtest/gtest.h>
 #include <memory>
-#include "dali/pipeline/util/copy_with_stride.h"
+#include <utility>
 #include "dali/core/dev_buffer.h"
+#include "dali/pipeline/data/dltensor.h"
 
 namespace dali {
 
 TEST(CopyWithStrideTest, OneDim) {
-  float data[] = {1, 2, 3, 4, 5, 6};
-  std::array<float, 3> out;
-  Index stride = 2 * sizeof(float);
-  Index shape = 3;
-  CopyWithStride<CPUBackend>(out.data(), data, &stride, &shape, 1, sizeof(float));
-  ASSERT_TRUE((out == std::array<float, 3>{1, 3, 5}));
+  const auto dtype = DALI_FLOAT;
+  using T = float;
+  T data[] = {1, 2, 3, 4, 5, 6};
+  TensorShape<1> stride{2};
+  TensorShape<1> shape{3};
+  constexpr int vol = 3;
+  ASSERT_EQ(vol, volume(shape));
+  std::array<T, vol> out;
+  DLTensorResource resource(shape);
+  resource.strides = stride;
+  auto dl_tensor =
+      MakeDLTensor(data, dtype, false, -1, std::make_unique<DLTensorResource>(resource));
+  CopyDlTensorCpu(out.data(), dl_tensor);
+  ASSERT_TRUE((out == std::array<T, vol>{1, 3, 5}));
 }
 
 TEST(CopyWithStrideTest, TwoDims)  {
-  size_t data[] = {11, 12, 13, 14,
-                   21, 22, 23, 24,
-                   31, 32, 33, 34,
-                   41, 42, 43, 44};
-  std::array<size_t, 8> out;
-  Index stride[] = {8 * sizeof(size_t), sizeof(size_t)};
-  Index shape[] = {2, 4};
-  CopyWithStride<CPUBackend>(out.data(), data, stride, shape, 2, sizeof(size_t));
-  ASSERT_TRUE((out == std::array<size_t, 8>{11, 12, 13, 14,
-                                            31, 32, 33, 34}));
+  const auto dtype = DALI_INT64;
+  using T = int64_t;
+  T data[] = {11, 12, 13, 14,
+              21, 22, 23, 24,
+              31, 32, 33, 34,
+              41, 42, 43, 44};
+  TensorShape<2> stride{8, 1};
+  TensorShape<2> shape{2, 4};
+  constexpr int vol = 8;
+  ASSERT_EQ(vol, volume(shape));
+  std::array<T, vol> out;
+  DLTensorResource resource(shape);
+  resource.strides = stride;
+  auto dl_tensor =
+      MakeDLTensor(data, dtype, false, -1, std::make_unique<DLTensorResource>(resource));
+  CopyDlTensorCpu(out.data(), dl_tensor);
+  ASSERT_TRUE((out == std::array<T, vol>{11, 12, 13, 14,
+                                         31, 32, 33, 34}));
 }
 
 TEST(CopyWithStrideTest, SimpleCopy) {
-  uint8 data[] = {1, 2,
-                  3, 4,
+  const auto dtype = DALI_UINT8;
+  using T = uint8_t;
+  T data[] = {1, 2,
+              3, 4,
 
-                  5, 6,
-                  7, 8};
-  std::array<uint8, 8> out;
-  Index stride[] = {4, 2, 1};
-  Index shape[] = {2, 2, 2};
-  CopyWithStride<CPUBackend>(out.data(), data, stride, shape, 3, 1);
-  ASSERT_TRUE((out == std::array<uint8, 8>{1, 2,
-                                           3, 4,
+              5, 6,
+              7, 8};
+  TensorShape<3>  stride{4, 2, 1};
+  TensorShape<3> shape{2, 2, 2};
+  constexpr int vol = 8;
+  ASSERT_EQ(vol, volume(shape));
+  std::array<T, vol> out;
+  DLTensorResource resource(shape);
+  resource.strides = stride;
+  auto dl_tensor =
+      MakeDLTensor(data, dtype, false, -1, std::make_unique<DLTensorResource>(resource));
+  CopyDlTensorCpu(out.data(), dl_tensor);
+  ASSERT_TRUE((out == std::array<T, vol>{1, 2,
+                                         3, 4,
 
-                                           5, 6,
-                                           7, 8}));
+                                         5, 6,
+                                         7, 8}));
+}
+
+DLMTensorPtr AsDlTensor(void* data, DALIDataType dtype, TensorShape<> shape, TensorShape<> stride) {
+  DLTensorResource resource(shape);
+  resource.strides = stride;
+  return MakeDLTensor(data, dtype, true, 0, std::make_unique<DLTensorResource>(resource));
+}
+
+std::vector<DLMTensorPtr> DlTensorSingletonBatch(DLMTensorPtr dl_tensor) {
+  std::vector<DLMTensorPtr> dl_tensors;
+  dl_tensors.push_back(std::move(dl_tensor));
+  return dl_tensors;
+}
+
+TensorList<GPUBackend> SingletonTL(TensorShape<> shape, DALIDataType dtype) {
+  TensorList<GPUBackend> output;
+  TensorListShape tls(1, shape.sample_dim());
+  tls.set_tensor_shape(0, shape);
+  output.Resize(tls, dtype);
+  return output;
 }
 
 TEST(CopyWithStrideTest, OneDimGPU) {
-  float h_data[] = {1, 2, 3, 4, 5, 6};
-  Index stride = 2 * sizeof(float);
-  Index shape = 3;
-  DeviceBuffer<float> data, out;
+  const auto dtype = DALI_FLOAT;
+  using T = float;
+  T h_data[] = {1, 2, 3, 4, 5, 6};
+  DeviceBuffer<T> data;
   data.from_host(h_data);
-  out.resize(data.size());
-  CopyWithStride<GPUBackend>(out, data, &stride, &shape, 1, sizeof(float));
-  std::array<float, 3> h_out;
-  CUDA_CALL(cudaMemcpy(h_out.data(), out, 3 * sizeof(float), cudaMemcpyDeviceToHost));
-  ASSERT_TRUE((h_out == std::array<float, 3>{1, 3, 5}));
+  TensorShape<1> stride{2};
+  TensorShape<1> shape{3};
+  constexpr int vol = 3;
+  ASSERT_EQ(vol, volume(shape));
+  auto dl_tensors = DlTensorSingletonBatch(AsDlTensor(data, dtype, shape, stride));
+  auto output_tl = SingletonTL(shape, dtype);
+  CopyDlTensorBatchGpu(output_tl, dl_tensors, 0);
+  std::array<T, vol> h_out;
+  CUDA_CALL(cudaMemcpy(h_out.data(), output_tl.raw_mutable_tensor(0), vol * sizeof(T),
+                       cudaMemcpyDeviceToHost));
+  ASSERT_TRUE((h_out == std::array<T, vol>{1, 3, 5}));
 }
 
 TEST(CopyWithStrideTest, TwoDimsGPU) {
-  size_t h_data[] = {11, 12, 13, 14,
-                     21, 22, 23, 24,
-                     31, 32, 33, 34,
-                     41, 42, 43, 44};
-  Index stride[] = {8 * sizeof(size_t), sizeof(size_t)};
-  Index shape[] = {2, 4};
-  DeviceBuffer<size_t> data, out;
+  const auto dtype = DALI_INT64;
+  using T = int64_t;
+  T h_data[] = {11, 12, 13, 14,
+                21, 22, 23, 24,
+                31, 32, 33, 34,
+                41, 42, 43, 44};
+  TensorShape<2> stride{8, 1};
+  TensorShape<2> shape{2, 4};
+  constexpr int vol = 8;
+  ASSERT_EQ(vol, volume(shape));
+  DeviceBuffer<int64> data;
   data.from_host(h_data);
-  out.resize(data.size());
-  CopyWithStride<GPUBackend>(out, data, stride, shape, 2, sizeof(size_t));
-  std::array<size_t , 8> h_out;
-  CUDA_CALL(cudaMemcpy(h_out.data(), out, 8 * sizeof(size_t), cudaMemcpyDeviceToHost));
-  ASSERT_TRUE((h_out == std::array<size_t, 8>{11, 12, 13, 14,
-                                              31, 32, 33, 34}));
+  auto dl_tensors = DlTensorSingletonBatch(AsDlTensor(data, dtype, shape, stride));
+  auto output_tl = SingletonTL(shape, dtype);
+  CopyDlTensorBatchGpu(output_tl, dl_tensors, 0);
+  std::array<T, vol> h_out;
+  CUDA_CALL(cudaMemcpy(h_out.data(), output_tl.raw_mutable_tensor(0), vol * sizeof(T),
+                       cudaMemcpyDeviceToHost));
+  ASSERT_TRUE((h_out == std::array<T, vol>{11, 12, 13, 14, 31, 32, 33, 34}));
+}
+
+TEST(CopyWithStrideTest, TwoDimsGPUOdd) {
+  const auto dtype = DALI_UINT8;
+  using T = uint8_t;
+  T h_data[] = {1,  2,  3,  4,  5,
+                6,  7,  8,  9,  10,
+                11, 12, 13, 14, 15,
+                16, 17, 18, 19, 20,
+                21, 22, 23, 24, 25,
+                26, 27, 28, 29, 30};
+  TensorShape<2> stride{15, 1};
+  TensorShape<2> shape{2, 4};
+  constexpr int vol = 8;
+  ASSERT_EQ(vol, volume(shape));
+  DeviceBuffer<T> data;
+  data.from_host(h_data);
+  auto dl_tensors = DlTensorSingletonBatch(AsDlTensor(data, dtype, shape, stride));
+  auto output_tl = SingletonTL(shape, dtype);
+  CopyDlTensorBatchGpu(output_tl, dl_tensors, 0);
+  std::array<T, vol> h_out;
+  CUDA_CALL(cudaMemcpy(h_out.data(), output_tl.raw_mutable_tensor(0), vol * sizeof(T),
+                       cudaMemcpyDeviceToHost));
+  ASSERT_TRUE((h_out == std::array<T, vol>{1, 2, 3, 4, 16, 17, 18, 19}));
+}
+
+TEST(CopyWithStrideTest, TwoDimsInnerStride) {
+  const auto dtype = DALI_UINT8;
+  using T = uint8_t;
+  T h_data[] = {1,  2,  3,  4,  5,
+                6,  7,  8,  9,  10,
+                11, 12, 13, 14, 15,
+                16, 17, 18, 19, 20,
+                21, 22, 23, 24, 25,
+                26, 27, 28, 29, 30};
+  TensorShape<2> stride{15, 5};
+  TensorShape<2> shape{2, 3};
+  constexpr int vol = 6;
+  ASSERT_EQ(vol, volume(shape));
+  DeviceBuffer<T> data;
+  data.from_host(h_data);
+  auto dl_tensors = DlTensorSingletonBatch(AsDlTensor(data, dtype, shape, stride));
+  auto output_tl = SingletonTL(shape, dtype);
+  CopyDlTensorBatchGpu(output_tl, dl_tensors, 0);
+  std::array<T, vol> h_out;
+  CUDA_CALL(cudaMemcpy(h_out.data(), output_tl.raw_mutable_tensor(0), vol * sizeof(T),
+                       cudaMemcpyDeviceToHost));
+  ASSERT_TRUE((h_out == std::array<T, vol>{1, 6, 11, 16, 21, 26}));
+}
+
+TEST(CopyWithStrideTest, TwoDimsTransposed) {
+  const auto dtype = DALI_UINT16;
+  using T = uint16_t;
+  T h_data[] = {1,  2,  3,  4,  5,
+                6,  7,  8,  9,  10,
+                11, 12, 13, 14, 15,
+                16, 17, 18, 19, 20,
+                21, 22, 23, 24, 25,
+                26, 27, 28, 29, 30};
+  TensorShape<2> stride{1, 5};
+  TensorShape<2> shape{5, 6};
+  constexpr int vol = 30;
+  ASSERT_EQ(vol, volume(shape));
+  DeviceBuffer<T> data;
+  data.from_host(h_data);
+  auto dl_tensors = DlTensorSingletonBatch(AsDlTensor(data, dtype, shape, stride));
+  auto output_tl = SingletonTL(shape, dtype);
+  CopyDlTensorBatchGpu(output_tl, dl_tensors, 0);
+  std::array<T, vol> h_out;
+  CUDA_CALL(cudaMemcpy(h_out.data(), output_tl.raw_mutable_tensor(0), vol * sizeof(T),
+                       cudaMemcpyDeviceToHost));
+  std::array<T, vol> ref = {
+    1,  6, 11, 16, 21, 26,
+    2,  7, 12, 17, 22, 27,
+    3,  8, 13, 18, 23, 28,
+    4,  9, 14, 19, 24, 29,
+    5, 10, 15, 20, 25, 30};
+  ASSERT_TRUE(h_out == ref);
 }
 
 TEST(CopyWithStrideTest, SimpleCopyGPU) {
-  uint8 h_data[] = {1, 2,
-                    3, 4,
+  const auto dtype = DALI_FLOAT;
+  using T = float;
+  T h_data[] = {1,  2,  3,
+                4,  5,  6,
 
-                    5, 6,
-                    7, 8};
-  Index stride[] = {4, 2, 1};
-  Index shape[] = {2, 2, 2};
-  DeviceBuffer<uint8> data, out;
+                7,  8,  9,
+                10, 11, 12};
+  TensorShape<3> stride{6, 3, 1};
+  TensorShape<3> shape{2, 2, 3};
+  constexpr int vol = 12;
+  ASSERT_EQ(vol, volume(shape));
+  DeviceBuffer<T> data;
   data.from_host(h_data);
-  out.resize(data.size());
-  CopyWithStride<GPUBackend>(out, data, stride, shape, 3, sizeof(uint8));
-  std::array<uint8 , 8> h_out;
-  CUDA_CALL(cudaMemcpy(h_out.data(), out, 8 * sizeof(uint8), cudaMemcpyDeviceToHost));
-  ASSERT_TRUE((h_out == std::array<uint8, 8>{1, 2,
-                                             3, 4,
+  auto dl_tensors = DlTensorSingletonBatch(AsDlTensor(data, dtype, shape, stride));
+  auto output_tl = SingletonTL(shape, dtype);
+  CopyDlTensorBatchGpu(output_tl, dl_tensors, 0);
+  std::array<T, vol> h_out;
+  CUDA_CALL(cudaMemcpy(h_out.data(), output_tl.raw_mutable_tensor(0), vol * sizeof(T),
+                       cudaMemcpyDeviceToHost));
+  ASSERT_TRUE((h_out == std::array<T, vol>{1,  2,  3,
+                                           4,  5,  6,
 
-                                             5, 6,
-                                             7, 8}));
+                                           7,  8,  9,
+                                           10, 11, 12}));
 }
 
 }  // namespace dali

--- a/dali/test/python/test_dltensor_operator.py
+++ b/dali/test/python/test_dltensor_operator.py
@@ -19,6 +19,8 @@ import os
 import random
 from functools import partial
 from nvidia.dali.pipeline import Pipeline
+from nvidia.dali import fn, pipeline_def
+from nvidia.dali.python_function_plugin import current_dali_stream
 
 test_data_root = os.environ['DALI_EXTRA_PATH']
 images_dir = os.path.join(test_data_root, 'db', 'single', 'jpeg')
@@ -188,6 +190,9 @@ def test_pytorch():
         for device in ['cpu', 'gpu']:
             yield pytorch_case, testcase, device
 
+    yield from _gpu_sliced_torch_suite()
+    yield from _gpu_permuted_extents_torch_suite()
+
 
 def mxnet_adapter(fun, in1, in2):
     tin1 = [mxnd.from_dlpack(dltensor) for dltensor in in1]
@@ -331,3 +336,286 @@ def test_cupy():
 def test_cupy_kernel_gray_scale():
     setup_cupy()
     cupy_case(cupy_kernel_gray_scale, synchronize=False)
+
+
+# ---------------- test strided copy kernel with strided tensors -----------------
+
+
+def get_random_torch_batch(g, shapes, dtype):
+    is_fp = torch.is_floating_point(torch.tensor([], dtype=dtype))
+    if is_fp:
+        return [torch.rand((shape), generator=g, dtype=dtype) for shape in shapes]
+    else:
+        iinfo = torch.iinfo(dtype)
+        dtype_min, dtype_max = iinfo.min, iinfo.max
+        return [
+            torch.randint(dtype_min, dtype_max, shape, generator=g, dtype=dtype) for shape in shapes
+        ]
+
+
+def get_sliced_torch_case(case_name):
+    # [(extents of the original shape), (slice of the corresponding extent)]
+    # the original extents and slice shapes are purposely all prime numbers
+    # to test handling of unaligned tensors
+    prime_images = [
+        ((107, 181, 3), (slice(1, 102), slice(179), slice(None))),
+        ((1097, 227, 5), (slice(None), slice(None), slice(1, 4))),
+        ((107, 167, 1), (slice(1, 14), slice(None), slice(None))),
+        ((107, 23, 3), (slice(103), slice(None), slice(None))),
+        ((173, 23, 5), (slice(None), slice(None), slice(1, 1))),
+        ((401, 167, 5), (slice(4, 167), slice(None), slice(0, 3))),
+        ((181, 401, 5), (slice(2, None), slice(397), slice(None))),
+        ((181, 107, 1), (slice(179), slice(103), slice(1))),
+        ((373, 181, 5), (slice(None), slice(None), slice(None, None, 2))),
+        ((199, 401, 3), (slice(None), slice(None), slice(None))),
+        ((167, 1097, 1), (slice(8, None, 7), slice(24, None, 23), slice(None))),
+        ((181, 61, 1), (slice(179), slice(58, None), slice(None))),
+        ((401, 61, 1), (slice(397), slice(None), slice(None))),
+        ((373, 173, 1), (slice(None), slice(167), slice(None))),
+        ((173, 199, 3), (slice(None), slice(None), slice(2, 3))),
+        ((181, 1097, 1), (slice(2, None, None), slice(1093), slice(None))),
+    ]
+
+    prime_grey_images = [((199, 23), (slice(None, 173, None), slice(None, 19, None))),
+                         ((373, 373), (slice(None, 331, None), slice(42, None, None))),
+                         ((1097, 181), (slice(114, None, None), slice(None, 157, None))),
+                         ((61, 227), (slice(None, 53, None), slice(28, None, None))),
+                         ((1097, 61), (slice(114, None, None), slice(None, 53, None))),
+                         ((181, 199), (slice(None, 157, None), slice(None, 173, None))),
+                         ((1097, 1097), (slice(114, None, None), slice(None, 983, None))),
+                         ((373, 227), (slice(42, None, None), slice(None, 199, None))),
+                         ((227, 173), (slice(None, 199, None), slice(None, 151, None))),
+                         ((227, 173), (slice(None, 199, None), slice(22, None, None))),
+                         ((401, 173), (slice(42, None, None), slice(None, 151, None))),
+                         ((107, 23), (slice(18, None, None), slice(None, 19, None))),
+                         ((23, 199), (slice(4, None, None), slice(26, None, None))),
+                         ((199, 23), (slice(26, None, None), slice(4, None, None))),
+                         ((227, 23), (slice(None, 199, None), slice(None, 19, None))),
+                         ((23, 23), (slice(4, None, None), slice(4, None, None))),
+                         ((167, 181), (slice(18, None, None), slice(24, None, None))),
+                         ((167, 181), (slice(18, None, None), slice(24, None, None))),
+                         ((181, 227), (slice(None, 157, None), slice(None, 199, None))),
+                         ((401, 199), (slice(None, 359, None), slice(None, 173, None))),
+                         ((107, 181), (slice(None, 89, None), slice(None, 157, None))),
+                         ((173, 61), (slice(None, 151, None), slice(8, None, None))),
+                         ((227, 167), (slice(None, 199, None), slice(18, None, None))),
+                         ((173, 401), (slice(22, None, None), slice(None, 359, None))),
+                         ((23, 227), (slice(4, None, None), slice(28, None, None))),
+                         ((227, 23), (slice(28, None, None), slice(4, None, None))),
+                         ((373, 373), (slice(42, None, None), slice(None, 331, None))),
+                         ((61, 107), (slice(None, 53, None), slice(18, None, None))),
+                         ((181, 61), (slice(24, None, None), slice(None, 53, None))),
+                         ((107, 181), (slice(None, 89, None), slice(24, None, None))),
+                         ((401, 23), (slice(42, None, None), slice(4, None, None))),
+                         ((373, 401), (slice(None, 331, None), slice(42, None, None)))]
+
+    vid = [((17, ) + shape, (slice(None), ) + sl) for shape, sl in prime_images]
+
+    ndim_11 = [(tuple(3 if i == j else 1 for j in range(11)) + shape, ((slice(None), ) * 11) + sl)
+               for i, (shape, sl) in enumerate(prime_images)]
+
+    cases = {
+        "slice_images": prime_images,
+        "slice_grey_images": prime_grey_images,
+        "slice_vid": vid,
+        "slice_ndim_11": ndim_11
+    }
+    shape_slices = cases[case_name]
+    shapes, slices = tuple(zip(*shape_slices))
+    assert len(shapes) == len(slices) == len(shape_slices)
+    return shapes, slices
+
+
+def _gpu_sliced_torch_case(case_name, dtype, g):
+
+    shapes, slices = get_sliced_torch_case(case_name)
+    input_batch = get_random_torch_batch(g, shapes, dtype)
+    assert len(input_batch) == len(shapes)
+
+    # returns sliced view of the input tensors
+    def sliced_tensor(batch):
+        stream = current_dali_stream()
+        torch_stream = torch.cuda.ExternalStream(stream)
+        with torch.cuda.stream(torch_stream):
+            tensors = [torch_dlpack.from_dlpack(t) for t in batch]
+            assert len(tensors) == len(slices)
+            tensor_views = [t[sl] for t, sl in zip(tensors, slices)]
+            out = [torch_dlpack.to_dlpack(t) for t in tensor_views]
+            return out
+
+    @pipeline_def(batch_size=len(input_batch), num_threads=4, device_id=0)
+    def pipeline():
+        data = fn.external_source(lambda: input_batch)
+        data = fn.dl_tensor_python_function(data.gpu(), batch_processing=True,
+                                            function=sliced_tensor, synchronize_stream=False)
+        return data
+
+    p = pipeline()
+    p.build()
+    out, = p.run()
+
+    out = [numpy.array(sample) for sample in out.as_cpu()]
+    ref = [numpy.array(sample)[sl] for sample, sl in zip(input_batch, slices)]
+
+    numpy.testing.assert_equal(out, ref)
+
+
+def _gpu_sliced_torch_suite():
+
+    g = torch.Generator()
+    g.manual_seed(42)
+
+    for case_name in ("slice_images", "slice_grey_images", "slice_vid", "slice_ndim_11"):
+        for dtype in (torch.uint8, torch.int16, torch.float32, torch.float64):
+            yield _gpu_sliced_torch_case, case_name, dtype, g
+
+
+def get_permute_extents_case(case_name):
+    rng = random.Random(44)
+
+    def permuted(it):
+        copy = list(it)
+        rng.shuffle(copy)
+        return tuple(copy)
+
+    def permuted_extents(ndim):
+        extents = list(range(ndim))
+        rng.shuffle(extents)
+        return tuple(extents)
+
+    # the original extents are purposely all prime numbers
+    # to test handling of unaligned tensors
+    prime_images = [
+        (199, 181, 3),
+        (1097, 61, 5),
+        (373, 373, 1),
+        (107, 23, 3),
+        (173, 23, 5),
+        (401, 167, 5),
+        (181, 401, 5),
+        (181, 107, 1),
+        (373, 181, 5),
+        (199, 401, 3),
+        (1097, 1097, 1),
+        (181, 61, 1),
+        (401, 61, 1),
+        (373, 173, 1),
+        (227, 199, 3),
+        (181, 1097, 1),
+    ]
+
+    if case_name == "transpose_channels_image":
+        prime_images_transposed_channel = list(zip(prime_images, [(2, 0, 1)] * len(prime_images)))
+        assert len(prime_images_transposed_channel) == len(prime_images)
+        return prime_images_transposed_channel
+
+    if case_name == "transpose_hw_image":
+        prime_images_transposed_hw = list(zip(prime_images, [(1, 0, 2)] * len(prime_images)))
+        assert len(prime_images_transposed_hw) == len(prime_images)
+        return prime_images_transposed_hw
+
+    if case_name == "image_random_permutation":
+        prime_images_rnd_permuted = list(
+            zip(prime_images, [permuted_extents(3) for _ in range(len(prime_images))]))
+        assert len(prime_images_rnd_permuted) == len(prime_images)
+        return prime_images_rnd_permuted
+
+    if case_name == "transpose_channels_video":
+        prime_vid_like = [
+            (13, 199, 181, 3),
+            (3, 1097, 61, 5),
+            (17, 373, 373, 1),
+            (5, 107, 23, 3),
+            (11, 173, 23, 5),
+            (11, 401, 167, 5),
+            (7, 181, 401, 5),
+            (5, 181, 107, 1),
+            (3, 373, 181, 5),
+            (23, 199, 401, 3),
+            (3, 1097, 1097, 1),
+            (31, 181, 61, 1),
+            (17, 401, 61, 1),
+            (5, 373, 173, 1),
+            (3, 227, 199, 3),
+            (7, 181, 1097, 1),
+        ]
+
+        prime_vid_like_transposed_channel = list(
+            zip(prime_vid_like, [(3, 0, 1, 2)] * len(prime_vid_like)))
+        assert len(prime_vid_like_transposed_channel) == len(prime_vid_like)
+        return prime_vid_like_transposed_channel
+
+    if case_name == "ndim_6_permute_outermost_3":
+        # optimization to early stop translation of flat output index to flat input index
+        # should kick in, test if that's fine
+        ndim_6_transpose_outermost = [(permuted([3, 5, 7, 11, 13, 17]), permuted_extents(3) +
+                                       (3, 4, 5)) for _ in range(5)]
+        assert len(ndim_6_transpose_outermost) == 5
+        return ndim_6_transpose_outermost
+
+    if case_name == "ndim_6_permute_all":
+        ndim_6_rnd_permuted = [(permuted([3, 5, 7, 11, 13, 17]), permuted_extents(6))
+                               for _ in range(32)]
+        assert len(ndim_6_rnd_permuted) == 32
+        return ndim_6_rnd_permuted
+
+    if case_name == "ndim_15_permute_all":
+        # max ndim supported
+        ndim_15_rnd_permuted = [(permuted([3, 5, 7, 11, 13, 17, 1, 1, 1, 1, 1, 1, 1, 1,
+                                           1]), permuted_extents(15)) for _ in range(32)]
+        assert len(ndim_15_rnd_permuted) == 32
+        return ndim_15_rnd_permuted
+
+
+def _gpu_permuted_extents_torch_case(case_name, dtype, g):
+
+    shapes_perms = get_permute_extents_case(case_name)
+    shapes, perms = tuple(zip(*shapes_perms))
+    assert len(shapes) == len(perms) == len(shapes_perms)
+    input_batch = get_random_torch_batch(g, shapes, dtype)
+    assert len(input_batch) == len(shapes)
+
+    # returns permuted view of the input tensors
+    def permuted_tensors(batch):
+        stream = current_dali_stream()
+        torch_stream = torch.cuda.ExternalStream(stream)
+        with torch.cuda.stream(torch_stream):
+            tensors = [torch_dlpack.from_dlpack(t) for t in batch]
+            assert len(tensors) == len(perms)
+            tensor_views = [t.permute(perm) for t, perm in zip(tensors, perms)]
+            out = [torch_dlpack.to_dlpack(t) for t in tensor_views]
+            return out
+
+    @pipeline_def(batch_size=len(input_batch), num_threads=4, device_id=0)
+    def pipeline():
+        data = fn.external_source(lambda: input_batch)
+        data = fn.dl_tensor_python_function(data.gpu(), batch_processing=True,
+                                            function=permuted_tensors, synchronize_stream=False)
+        return data
+
+    p = pipeline()
+    p.build()
+    out, = p.run()
+
+    out = [numpy.array(sample) for sample in out.as_cpu()]
+    ref = [numpy.array(sample).transpose(perm) for sample, perm in zip(input_batch, perms)]
+
+    numpy.testing.assert_equal(out, ref)
+
+
+def _gpu_permuted_extents_torch_suite():
+
+    g = torch.Generator()
+    g.manual_seed(44)
+
+    for case_name in (
+            "transpose_channels_image",
+            "transpose_hw_image",
+            "image_random_permutation",
+            "transpose_channels_video",
+            "ndim_6_permute_outermost_3",
+            "ndim_6_permute_all",
+            "ndim_15_permute_all",
+    ):
+        for dtype in (torch.uint8, torch.int16, torch.int32, torch.float64):
+            yield _gpu_permuted_extents_torch_case, case_name, dtype, g


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Replace per-sample copying kernel for GPU DL Tensors with a batched one for better performance.

This is done in copy_with_stride - the backend templated `CopyWithStride` that copied a single sample is replaced with the `CopyDlTensorCpu` which just keeps the old implementation and the `CopyDlTensorBatchGpu` that handles gpu tensors in batches.

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

The current approach is to copy each tensor separately: either with cudaMemCopyAsync if the tensor does not provide `.strides` (according to dlpack it must be compact then) or run a kernel that addresses each byte separately: from flat output (compact, as that is DALI tensor) index to coordinates and then to input flat index. The latter case was a major bottleneck - in case of CV-CUDA ColorTwist called in `fn.dl_tensor_python_function` vs the native `fn.color_twist`, the e2e throughput drops 4 times.

This PR 
1. keeps per-sample cudaMemCopyAsync copy path for tensors with no strides and extends it to tensors that do have strides but they are compact (i.e. match output DALI tensors strides).
2. the remaining tensors from the input are grouped into a batch and a batched copy-kernel is launched.

The copy-kernel aims to speed-up the copy:
1. instead of always using byte as input and output type, the underlaying element type is used (so that tensors of types bigger than byte do faster reads and writes).
2. relying on the fact that the output tensor is compact, the writes are vectorized - each thread reads four items seprately but stores them in the vectorized type and writes in a singe go. If the input tensor happens to be close to compact, the caches should help here as well. This is the case for CV-CUDA outputs, as they striding boils down to padding row size. Note, this requires separate handling of the possibly unaligned start and end of the output tensor.
3. The translation of output_index to input_index stops early if the inner most strides match. In case of CV-CUDA images it means we need to do the div, mod arithmetic only for the first stride, which speeds up the copy significantly.
4. The common number of dimensions for tensor (0-5) are handled statically for smaller register pressure.

In total, a generic use case should benefit from a single kernel launch and vectorized writes, while the cases akin to CV-CUDA row padded tensors should see major boost. If needed, one could optimize other cases in the future, such as transposed views.


### Affected modules and functionalities:
The `copy_with_stride` utility was used only in the family of python_functions.
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3609
<!--- DALI-XXXX or NA --->
