### PR TITLE
Refactor ops and fn APIs

### DIFF
--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -795,7 +795,7 @@ Keyword Args
                     kwargs['layout'] = this_layout
 
                 args, arg_inputs = _separate_kwargs(kwargs)
-                op_instance = _OperatorInstance([], args, arg_inputs, self)
+                op_instance = _OperatorInstance([], arg_inputs, args, self)
                 op_instance._callback = callback
                 op_instance._output_index = i
                 op_instance._group = group
@@ -818,7 +818,7 @@ Keyword Args
                 kwargs['layout'] = layout
 
             args, arg_inputs = _separate_kwargs(kwargs)
-            op_instance = _OperatorInstance([], args, arg_inputs, self)
+            op_instance = _OperatorInstance([], arg_inputs, args, self)
             op_instance._callback = callback
             op_instance._output_index = None
             op_instance._group = _ExternalSourceGroup(callback, source_desc, False, [op_instance],

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -617,7 +617,7 @@ Keyword Args
                  prefetch_queue_depth=None, bytes_per_sample_hint=None, batch_info=None,
                  repeat_last=False, **kwargs):
         ""
-        from nvidia.dali.ops import _OperatorInstance
+        from nvidia.dali.ops import _OperatorInstance, _separate_kwargs
         if batch_info is None:
             batch_info = self._batch_info or False
         elif self._batch_info is not None:
@@ -793,7 +793,9 @@ Keyword Args
                     else:
                         this_layout = layout
                     kwargs['layout'] = this_layout
-                op_instance = _OperatorInstance([], self, **kwargs)
+
+                args, arg_inputs = _separate_kwargs(kwargs)
+                op_instance = _OperatorInstance([], args, arg_inputs, self)
                 op_instance._callback = callback
                 op_instance._output_index = i
                 op_instance._group = group
@@ -814,7 +816,9 @@ Keyword Args
                 kwargs['ndim'] = ndim
             if layout is not None:
                 kwargs['layout'] = layout
-            op_instance = _OperatorInstance([], self, **kwargs)
+
+            args, arg_inputs = _separate_kwargs(kwargs)
+            op_instance = _OperatorInstance([], args, arg_inputs, self)
             op_instance._callback = callback
             op_instance._output_index = None
             op_instance._group = _ExternalSourceGroup(callback, source_desc, False, [op_instance],

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -795,7 +795,7 @@ Keyword Args
                     kwargs['layout'] = this_layout
 
                 args, arg_inputs = _separate_kwargs(kwargs)
-                op_instance = _OperatorInstance([], arg_inputs, args, self)
+                op_instance = _OperatorInstance([], arg_inputs, args, {}, self)
                 op_instance._callback = callback
                 op_instance._output_index = i
                 op_instance._group = group

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -800,7 +800,6 @@ Keyword Args
                 op_instance._layout = this_layout
                 op_instance._batch = batch
                 group.append(op_instance)
-                op_instance.generate_outputs()
                 outputs.append(op_instance.unwrapped_outputs)
 
             return outputs
@@ -822,7 +821,6 @@ Keyword Args
                                                       **group_common_kwargs)
             op_instance._layout = layout
             op_instance._batch = batch
-            op_instance.generate_outputs()
 
             return op_instance.unwrapped_outputs
 

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -818,7 +818,7 @@ Keyword Args
                 kwargs['layout'] = layout
 
             args, arg_inputs = _separate_kwargs(kwargs)
-            op_instance = _OperatorInstance([], arg_inputs, args, self)
+            op_instance = _OperatorInstance([], arg_inputs, args, {}, self)
             op_instance._callback = callback
             op_instance._output_index = None
             op_instance._group = _ExternalSourceGroup(callback, source_desc, False, [op_instance],

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -79,14 +79,6 @@ def _wrap_op_fn(op_class, wrapper_name, wrapper_doc):
             init_args["device"] = default_dev
 
         # TODO(klecki): It is now possible to handle creation of _OperatorInstance directly
-
-        # inputs = _preprocess_inputs(inputs, op_class.__name__, device, schema)
-        # input_sets = _build_input_sets(inputs, op_class.__name__)
-        # inst = [nvidia.dali.ops._OperatorInstance(inputs, init_args, call_args, <op>)
-        #         for inputs in input_sets]
-        # # join `inst` instances by the relation id
-        # # repack the outputs
-
         return op_class(**init_args)(*inputs, **call_args)
 
     def fn_wrapper(*inputs, **kwargs):

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -78,6 +78,15 @@ def _wrap_op_fn(op_class, wrapper_name, wrapper_doc):
         if "device" not in init_args:
             init_args["device"] = default_dev
 
+        # TODO(klecki): It is now possible to handle creation of _OperatorInstance directly
+
+        # inputs = _preprocess_inputs(inputs, op_class.__name__, device, schema)
+        # input_sets = _build_input_sets(inputs, op_class.__name__)
+        # inst = [nvidia.dali.ops._OperatorInstance(inputs, init_args, call_args, <op>)
+        #         for inputs in input_sets]
+        # # join `inst` instances by the relation id
+        # # repack the outputs
+
         return op_class(**init_args)(*inputs, **call_args)
 
     def fn_wrapper(*inputs, **kwargs):

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -356,7 +356,6 @@ class _OperatorInstance(object):
     def check_args(self):
         self._op.schema.CheckArgs(self._spec)
 
-
     def _process_instance_name(self, arguments):
         """Extract the name from the arguments or generate the default one.
         The "name" is removed from arguments.
@@ -371,7 +370,6 @@ class _OperatorInstance(object):
             self._name = name
         else:
             self._name = '__' + type(self._op).__name__ + "_" + str(self._counter.id)
-
 
     def _generate_outputs(self):
         pipeline = _Pipeline.current()
@@ -546,7 +544,6 @@ def python_op_factory(name, schema_name=None):
                     f"Operator {type(self).__name__} expects "
                     f"from {self._schema.MinNumInput()} to {self._schema.MaxNumInput()} inputs, "
                     f"but received {len(inputs)}.")
-
 
     Operator.__name__ = str(name)
     Operator.schema_name = schema_name or Operator.__name__

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -285,6 +285,11 @@ def _process_inputs(schema, spec, inputs, operator_name):
     List
         the list of DataNodes representing inputs (there may be conversions)
     """
+    if len(inputs) < schema.MinNumInput() or len(inputs) > schema.MaxNumInput():
+        raise ValueError(
+            f"Operator {operator_name} expects "
+            f"from {schema.MinNumInput()} to {schema.MaxNumInput()} inputs, "
+            f"but received {len(inputs)}.")
     if not inputs:
         return []
     for inp in inputs:
@@ -480,7 +485,6 @@ def python_op_factory(name, schema_name=None):
             # Get the device argument. We will need this to determine
             # the device that our outputs will be stored on
             self._device = device
-            kwargs |= {"device", self._device}
 
             self._init_args, self._call_args = _separate_kwargs(kwargs)
 
@@ -554,14 +558,6 @@ def python_op_factory(name, schema_name=None):
                     outputs.append(op.outputs)
                 result = _repack_output_sets(outputs)
             return result
-
-        # TODO(klecki): Move it to _process_inputs
-        def _check_schema_num_inputs(self, inputs):
-            if len(inputs) < self._schema.MinNumInput() or len(inputs) > self._schema.MaxNumInput():
-                raise ValueError(
-                    f"Operator {type(self).__name__} expects "
-                    f"from {self._schema.MinNumInput()} to {self._schema.MaxNumInput()} inputs, "
-                    f"but received {len(inputs)}.")
 
     Operator.__name__ = str(name)
     Operator.schema_name = schema_name or Operator.__name__

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -482,9 +482,11 @@ def python_op_factory(name, schema_name=None):
             self._spec = _b.OpSpec(schema_name)
             self._schema = _b.GetSchema(schema_name)
 
-            # Get the device argument. We will need this to determine
-            # the device that our outputs will be stored on
+            # Get the device argument. We will need this to determine the device that our outputs
+            # will be stored on. The argument is not listed in schema, so we need to add it
+            # manually to spec. TODO(klecki): Make it more generic.
             self._device = device
+            self._spec.AddArg("device", self._device)
 
             self._init_args, self._call_args = _separate_kwargs(kwargs)
 
@@ -518,8 +520,6 @@ def python_op_factory(name, schema_name=None):
             return self._preserve
 
         def __call__(self, *inputs, **kwargs):
-            self._check_schema_num_inputs(inputs)
-
             inputs = _preprocess_inputs(inputs, self.__class__.__name__, self._device, self._schema)
             input_sets = _build_input_sets(inputs, self.__class__.__name__)
 

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -40,9 +40,9 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
         self._device = device
         self._impl_name = impl_name
 
-        kwargs, self._call_args = ops._separate_kwargs(kwargs)
+        self._init_args, self._call_args = ops._separate_kwargs(kwargs)
 
-        for key, value in kwargs.items():
+        for key, value in self._init_args.items():
             self._spec.AddArg(key, value)
 
         self.function = function
@@ -78,11 +78,12 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
                                 f"Python Operators do not support Multiple Input Sets.")
 
         args, arg_inputs = ops._separate_kwargs(kwargs)
-        op_instance = ops._OperatorInstance(inputs, arg_inputs, args, {}, self)
-        op_instance.spec.AddArg("function_id", id(self.function))
-        op_instance.spec.AddArg("num_outputs", self.num_outputs)
-        op_instance.spec.AddArg("device", self.device)
-
+        args |= {
+            "function_id": id(self.function),
+            "num_outputs": self.num_outputs,
+        }
+        self._spec.AddArg("device", self.device)
+        op_instance = ops._OperatorInstance(inputs, arg_inputs, args, self._init_args, self)
         return op_instance.unwrapped_outputs
 
 

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -83,7 +83,7 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
                                 f"Python Operators do not support Multiple Input Sets.")
 
         args, arg_inputs = ops._separate_kwargs(kwargs)
-        op_instance = ops._OperatorInstance(inputs, args, arg_inputs, self)
+        op_instance = ops._OperatorInstance(inputs, arg_inputs, args, {}, self)
         op_instance.spec.AddArg("function_id", id(self.function))
         op_instance.spec.AddArg("num_outputs", self.num_outputs)
         op_instance.spec.AddArg("device", self.device)
@@ -104,8 +104,6 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
             pipeline.add_sink(t)
             outputs.append(t)
 
-        if _conditionals.conditionals_enabled():
-            _conditionals.register_data_nodes(outputs, inputs, kwargs)
         return outputs[0] if len(outputs) == 1 else outputs
 
 

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -15,7 +15,6 @@
 
 import nvidia.dali.python_function_plugin
 from nvidia.dali import backend as _b
-from nvidia.dali import _conditionals
 from nvidia.dali import ops
 from nvidia.dali.ops import _registry
 from nvidia.dali.data_node import DataNode as _DataNode

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -40,6 +40,7 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
         self._impl_name = impl_name
 
         self._init_args, self._call_args = ops._separate_kwargs(kwargs)
+        self._name = self._init_args.pop("name", None)
 
         for key, value in self._init_args.items():
             self._spec.AddArg(key, value)
@@ -78,6 +79,11 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
 
         args, arg_inputs = ops._separate_kwargs(kwargs)
         args.update({"function_id": id(self.function), "num_outputs": self.num_outputs})
+
+        args = ops._resolve_double_definitions(args, self._init_args, keep_old=False)
+        if self._name is not None:
+            args = ops._resolve_double_definitions(args, {"name": self._name})  # restore the name
+
         op_instance = ops._OperatorInstance(inputs, arg_inputs, args, self._init_args, self)
         op_instance.spec.AddArg("device", self.device)
         return op_instance.unwrapped_outputs

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -87,24 +87,8 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
         op_instance.spec.AddArg("function_id", id(self.function))
         op_instance.spec.AddArg("num_outputs", self.num_outputs)
         op_instance.spec.AddArg("device", self.device)
-        if self.num_outputs == 0:
-            t_name = self._impl_name + "_id_" + str(op_instance.id) + "_sink"
-            t = _DataNode(t_name, self._device, op_instance)
-            pipeline.add_sink(t)
-            return
-        outputs = []
 
-        for i in range(self.num_outputs):
-            t_name = op_instance._name
-            if self.num_outputs > 1:
-                t_name += "[{}]".format(i)
-            t = _DataNode(t_name, self._device, op_instance)
-            op_instance.spec.AddOutput(t.name, t.device)
-            op_instance.append_output(t)
-            pipeline.add_sink(t)
-            outputs.append(t)
-
-        return outputs[0] if len(outputs) == 1 else outputs
+        return op_instance.unwrapped_outputs
 
 
 def _dlpack_to_array(dlpack):

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -71,11 +71,6 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
         if pipeline is None:
             _Pipeline._raise_pipeline_required("PythonFunction operator")
 
-        if (len(inputs) > self._schema.MaxNumInput() or len(inputs) < self._schema.MinNumInput()):
-            raise ValueError(
-                f"Operator {type(self).__name__} expects "
-                f"from {self._schema.MinNumInput()} to {self._schema.MaxNumInput()} inputs, "
-                f"but received {len(inputs)}.")
         for inp in inputs:
             if not isinstance(inp, _DataNode):
                 raise TypeError(f"Expected inputs of type `DataNode`. "

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -77,10 +77,7 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
                                 f"Python Operators do not support Multiple Input Sets.")
 
         args, arg_inputs = ops._separate_kwargs(kwargs)
-        args |= {
-            "function_id": id(self.function),
-            "num_outputs": self.num_outputs,
-        }
+        args.update({"function_id": id(self.function), "num_outputs": self.num_outputs})
         op_instance = ops._OperatorInstance(inputs, arg_inputs, args, self._init_args, self)
         op_instance.spec.AddArg("device", self.device)
         return op_instance.unwrapped_outputs

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -82,8 +82,8 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
             "function_id": id(self.function),
             "num_outputs": self.num_outputs,
         }
-        self._spec.AddArg("device", self.device)
         op_instance = ops._OperatorInstance(inputs, arg_inputs, args, self._init_args, self)
+        op_instance.spec.AddArg("device", self.device)
         return op_instance.unwrapped_outputs
 
 

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -81,7 +81,9 @@ class PythonFunctionBase(metaclass=ops._DaliOperatorMeta):
                 raise TypeError(f"Expected inputs of type `DataNode`. "
                                 f"Received input of type '{type(inp).__name__}'. "
                                 f"Python Operators do not support Multiple Input Sets.")
-        op_instance = ops._OperatorInstance(inputs, self, **kwargs)
+
+        args, arg_inputs = ops._separate_kwargs(kwargs)
+        op_instance = ops._OperatorInstance(inputs, args, arg_inputs, self)
         op_instance.spec.AddArg("function_id", id(self.function))
         op_instance.spec.AddArg("num_outputs", self.num_outputs)
         op_instance.spec.AddArg("device", self.device)

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -77,7 +77,8 @@ class _TFRecordReaderImpl():
                 f"from {self._schema.MinNumInput()} to {self._schema.MaxNumInput()} inputs, "
                 f"but received {len(inputs)}.")
 
-        op_instance = ops._OperatorInstance(inputs, self, **kwargs)
+        args, arg_inputs = ops._separate_kwargs(kwargs)
+        op_instance = ops._OperatorInstance(inputs, args, arg_inputs, self)
         outputs = {}
         feature_names = []
         features = []

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -71,26 +71,13 @@ class _TFRecordReaderImpl():
 
     def __call__(self, *inputs, **kwargs):
         # We do not handle multiple input sets for Reader as they do not have inputs
-        if (len(inputs) > self._schema.MaxNumInput() or len(inputs) < self._schema.MinNumInput()):
-            raise ValueError(
-                f"Operator {type(self).__name__} expects "
-                f"from {self._schema.MinNumInput()} to {self._schema.MaxNumInput()} inputs, "
-                f"but received {len(inputs)}.")
-
         args, arg_inputs = ops._separate_kwargs(kwargs)
         op_instance = ops._OperatorInstance(inputs, args, arg_inputs, {}, self)
         outputs = {}
         feature_names = []
         features = []
-        for i, (feature_name, feature) in enumerate(self._features.items()):
-            t_name = op_instance._name
-            if len(self._features.items()) > 1:
-                t_name += "[{}]".format(i)
-
-            t = _DataNode(t_name, self._device, op_instance)
-            op_instance.spec.AddOutput(t.name, t.device)
-            op_instance.append_output(t)
-            outputs[feature_name] = t
+        for (feature_name, feature), output in zip(self._features.items(), op_instance.outputs):
+            outputs[feature_name] = output
             feature_names.append(feature_name)
             features.append(feature)
 

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 from nvidia.dali import backend as _b
-from nvidia.dali import _conditionals
 from nvidia.dali import ops
-from nvidia.dali.data_node import DataNode as _DataNode
 
 _internal_schemas = ['_TFRecordReader', 'readers___TFRecord']
 
@@ -46,7 +44,6 @@ class _TFRecordReaderImpl():
         self._schema = _b.GetSchema(self._internal_schema_name)
         self._spec = _b.OpSpec(self._internal_schema_name)
         self._device = "cpu"
-
 
         self._init_args, self._call_args = ops._separate_kwargs(kwargs)
         self._init_args |= {

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -78,7 +78,7 @@ class _TFRecordReaderImpl():
                 f"but received {len(inputs)}.")
 
         args, arg_inputs = ops._separate_kwargs(kwargs)
-        op_instance = ops._OperatorInstance(inputs, args, arg_inputs, self)
+        op_instance = ops._OperatorInstance(inputs, args, arg_inputs, {}, self)
         outputs = {}
         feature_names = []
         features = []
@@ -93,10 +93,6 @@ class _TFRecordReaderImpl():
             outputs[feature_name] = t
             feature_names.append(feature_name)
             features.append(feature)
-
-        # We know this reader doesn't have any inputs
-        if _conditionals.conditionals_enabled():
-            _conditionals.register_data_nodes(list(outputs.values()))
 
         op_instance.spec.AddArg("feature_names", feature_names)
         op_instance.spec.AddArg("features", features)

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -93,7 +93,6 @@ class _TFRecordReaderImpl():
 
         op_instance = ops._OperatorInstance(inputs, arg_inputs, args, self._init_args, self)
 
-
         outputs = {}
         for feature_name, output in zip(feature_names, op_instance.outputs):
             outputs[feature_name] = output

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -46,10 +46,7 @@ class _TFRecordReaderImpl():
         self._device = "cpu"
 
         self._init_args, self._call_args = ops._separate_kwargs(kwargs)
-        self._init_args |= {
-            "path": self._path,
-            "index_path": self._index_path
-        }
+        self._init_args.update({"path": self._path, "index_path": self._index_path})
 
         for key, value in self._init_args.items():
             self._spec.AddArg(key, value)

--- a/dali/python/nvidia/dali/plugin/numba/experimental.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental.py
@@ -339,7 +339,9 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
                       ("Expected inputs of type `DataNode`. Received input of type '{}'. " +
                        "Python Operators do not support Multiple Input Sets.")
                       .format(type(inp).__name__))
-        op_instance = ops._OperatorInstance(inputs, self, **kwargs)
+
+        args, arg_inputs = ops._separate_kwargs(kwargs)
+        op_instance = ops._OperatorInstance(inputs, args, arg_inputs, self)
         op_instance.spec.AddArg("run_fn", self.run_fn)
         if self.setup_fn is not None:
             op_instance.spec.AddArg("setup_fn", self.setup_fn)

--- a/dali/python/nvidia/dali/plugin/numba/experimental.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental.py
@@ -341,7 +341,7 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
                       .format(type(inp).__name__))
 
         args, arg_inputs = ops._separate_kwargs(kwargs)
-        op_instance = ops._OperatorInstance(inputs, args, arg_inputs, self)
+        op_instance = ops._OperatorInstance(inputs, arg_inputs, args, {}, self)
         op_instance.spec.AddArg("run_fn", self.run_fn)
         if self.setup_fn is not None:
             op_instance.spec.AddArg("setup_fn", self.setup_fn)

--- a/dali/python/nvidia/dali/plugin/numba/experimental.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental.py
@@ -332,21 +332,21 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
                       .format(type(inp).__name__))
 
         args, arg_inputs = ops._separate_kwargs(kwargs)
-        args |= {
+        args.update({
             "run_fn": self.run_fn,
             "out_types": self.out_types,
             "in_types": self.in_types,
             "outs_ndim": self.outs_ndim,
             "ins_ndim": self.ins_ndim,
             "batch_processing": self.batch_processing,
-        }
+        })
         if self.setup_fn is not None:
-            args |= {"setup_fn": self.setup_fn}
+            args.update({"setup_fn": self.setup_fn})
         if self.device == 'gpu':
-            args |= {
+            args.update({
                 "blocks": self.blocks,
                 "threads_per_block": self.threads_per_block,
-            }
+            })
 
         op_instance = ops._OperatorInstance(inputs, arg_inputs, args, self._init_args, self)
         op_instance.spec.AddArg("device", self.device)

--- a/dali/python/nvidia/dali/plugin/numba/experimental.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental.py
@@ -348,9 +348,8 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
                 "threads_per_block": self.threads_per_block,
             }
 
-        self._spec.AddArg("device", self.device)
-
         op_instance = ops._OperatorInstance(inputs, arg_inputs, args, self._init_args, self)
+        op_instance.spec.AddArg("device", self.device)
 
         return op_instance.unwrapped_outputs
 

--- a/dali/python/nvidia/dali/plugin/numba/experimental.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental.py
@@ -348,6 +348,10 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
                 "threads_per_block": self.threads_per_block,
             })
 
+        args = ops._resolve_double_definitions(args, self._init_args, keep_old=False)
+        if self._name is not None:
+            args = ops._resolve_double_definitions(args, {"name": self._name})  # restore the name
+
         op_instance = ops._OperatorInstance(inputs, arg_inputs, args, self._init_args, self)
         op_instance.spec.AddArg("device", self.device)
 
@@ -408,6 +412,7 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
         self._device = device
 
         self._init_args, self._call_args = ops._separate_kwargs(kwargs)
+        self._name = self._init_args.pop("name", None)
 
         for key, value in self._init_args.items():
             self._spec.AddArg(key, value)

--- a/dali/test/python/conditionals/test_pipeline_conditionals.py
+++ b/dali/test/python/conditionals/test_pipeline_conditionals.py
@@ -1077,10 +1077,9 @@ def test_sanity_enable_conditionals():
     pipe.run()
 
 
-
 def test_multiple_input_source():
 
-    batch_size=16
+    batch_size = 16
 
     @pipeline_def(batch_size=batch_size, device_id=0, num_threads=4, enable_conditionals=True)
     def pipeline():

--- a/dali/test/python/conditionals/test_pipeline_conditionals.py
+++ b/dali/test/python/conditionals/test_pipeline_conditionals.py
@@ -1088,10 +1088,11 @@ def test_multiple_input_source():
 
         const_42 = types.Constant(np.uint8([42]), device="cpu")
         if sample_idx < batch_size / 2:
-            out_42_scoped, out_idx_scoped = fn.copy([const_42 + 0, sample_idx])
+            out_42_scoped, out_idx_scoped = fn.copy(
+                [const_42 + types.Constant(0, dtype=types.UINT8), sample_idx])
         else:
             out_42_scoped = types.Constant(np.uint8([0]), device="cpu")
-            out_idx_scoped = types.Constant(np.uint8([0]), device="cpu")
+            out_idx_scoped = types.Constant(np.int32(0), device="cpu")
 
         return out_42_scoped, out_idx_scoped
 
@@ -1099,5 +1100,5 @@ def test_multiple_input_source():
     pipe.build()
     for _ in range(4):
         out_42, out_idx = pipe.run()
-        check_batch(out_42, [42 if i < (batch_size / 2) else 0 for i in range(batch_size)])
+        check_batch(out_42, [[42] if i < (batch_size / 2) else [0] for i in range(batch_size)])
         check_batch(out_idx, [i if i < (batch_size / 2) else 0 for i in range(batch_size)])


### PR DESCRIPTION
## Category: **Refactoring**  **Bug fix**
<!---
Please pick one from below:
  (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description: 
This part of refactoring moves the most important parts of handling the argument
parsing, deprecation, constant promotion, conditionals, etc to the _OperatorInstance.
In case of ops API, there needs to be a pre-step that merges the state
from `__init__` and `__call__` and is specific that API.
For the `fn` API, apart from promoting constants first (due to the perf reasons),
we can handle the creation of `_OperatorInstance` and filling the `spec` in one go.

`name` is no longer included in argument inputs but considered scalar argument.

It tries to keep most of the implementation in one place, but also allows for detaching
the ops and fn APIs from one another.
The question is, how much of this change we want.

Additionally, some details around the conditionals are streamlined, allowing
to enable them in multiple input sets.

Next steps:
Python function, TFRecord reader and external source implement their Operator class
without inheriting from the one generated in op factory, so they repeat some code.
We probably can refactor it and unify them with the generic code path even more.
Make the special arguments (name, device), less special so they are added to the
spec through generic code-path.

## Additional information:

### Affected modules and functionalities:
fn, ops

### Key points relevant for the review:
Should we do the thing that is put in the fn part as a comment?

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
