### PR TITLE
Remove the avformat_find_stream_info call from the video loader when not needed

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -297,15 +297,8 @@ VideoFile& VideoLoader::get_or_open_file(const std::string &filename) {
     int ret = avformat_open_input(&tmp_raw_fmt_ctx, NULL, NULL, NULL);
     DALI_ENFORCE(ret >= 0, std::string("Could not open file ") + filename +
                  " because of " + av_err2str(ret));
-
     file.fmt_ctx_ = make_unique_av<AVFormatContext>(tmp_raw_fmt_ctx, avformat_close_input);
     LOG_LINE << "File open " << filename << std::endl;
-
-    // is this needed?
-    if (avformat_find_stream_info(file.fmt_ctx_.get(), nullptr) < 0) {
-      DALI_FAIL(std::string("Could not find stream information in ")
-                                + filename);
-    }
 
     LOG_LINE << "File info fetched for " << filename << std::endl;
 
@@ -318,16 +311,34 @@ VideoFile& VideoLoader::get_or_open_file(const std::string &filename) {
 
     file.vid_stream_idx_ = av_find_best_stream(file.fmt_ctx_.get(), AVMEDIA_TYPE_VIDEO,
                                   -1, -1, nullptr, 0);
+    if (file.vid_stream_idx_ < 0) {
+      if (avformat_find_stream_info(file.fmt_ctx_.get(), nullptr) < 0) {
+        DALI_FAIL(std::string("Could not find stream information in ") + filename);
+      }
+      file.vid_stream_idx_ = av_find_best_stream(file.fmt_ctx_.get(), AVMEDIA_TYPE_VIDEO,
+                                  -1, -1, nullptr, 0);
+      DALI_ENFORCE(file.vid_stream_idx_ >= 0,
+                   std::string("Could not find video stream in ") + filename);
+    }
     LOG_LINE << "Best stream " << file.vid_stream_idx_ << " found for "
               << filename << std::endl;
-    if (file.vid_stream_idx_ < 0) {
-      DALI_FAIL(std::string("Could not find video stream in ") + filename);
-    }
 
     auto stream = file.fmt_ctx_->streams[file.vid_stream_idx_];
     int width = codecpar(stream)->width;
     int height = codecpar(stream)->height;
     auto codec_id = codecpar(stream)->codec_id;
+
+    if (width == 0 || height == 0) {
+      if (avformat_find_stream_info(file.fmt_ctx_.get(), nullptr) < 0) {
+        DALI_FAIL(std::string("Could not find stream information in ")
+                                  + filename);
+      }
+
+      width = codecpar(stream)->width;
+      height = codecpar(stream)->height;
+      codec_id = codecpar(stream)->codec_id;
+    }
+
     if (max_width_ == 0) {  // first file to open
       max_width_ = width;
       max_height_ = height;
@@ -513,7 +524,6 @@ void VideoLoader::read_file() {
   auto& file = get_or_open_file(req.filename);
   auto stream = file.fmt_ctx_->streams[file.vid_stream_idx_];
   req.frame_base = file.frame_base_;
-  req.full_range = codecpar(stream)->color_range == AVCOL_RANGE_JPEG;
 
   if (vid_decoder_) {
       vid_decoder_->push_req(req);

--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -197,6 +197,9 @@ int NvDecoder::handle_display(void* user_data, CUVIDPARSERDISPINFO* disp_info) {
 int NvDecoder::handle_sequence_(CUVIDEOFORMAT* format) {
   int ret = kNvcuvid_failure;
   try {
+    // utilize the NVDEC parser to determine if the video is full range
+    recv_queue_.front().full_range =
+        static_cast<bool>(format->video_signal_description.video_full_range_flag);
     ret = decoder_.initialize(format);
   } catch (...) {
     ERROR_LOG << "Unable to decode file " << recv_queue_.peek().filename << '\n';

--- a/dali/util/thread_safe_queue.h
+++ b/dali/util/thread_safe_queue.h
@@ -46,7 +46,11 @@ class ThreadSafeQueue {
   }
 
   const T& peek() {
-    static const auto int_return = T{};
+    return front();
+  }
+
+  T& front() {
+    static auto int_return = T{};
     std::unique_lock<std::mutex> lock{lock_};
     cond_.wait(lock, [&](){return !queue_.empty() || interrupt_;});
     if (interrupt_) {


### PR DESCRIPTION
- video reader calls avformat_find_stream_info to obtain video properties.
  In most formats header provides them and there is no need to call
  mentioned function which attempts to decode a couple of the video
  initial frames.

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- video reader calls avformat_find_stream_info to obtain video properties.
  In most formats header provides them and there is no need to call
  mentioned function which attempts to decode a couple of the video
  initial frames.

Relates to https://github.com/NVIDIA/DALI/issues/5040
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- video loader
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  -  test_video.py
  - test_video_pipeline.py
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
