### PR TITLE
Extend Numba compatibility checks. Skip Numba GPU tests on incompatibe systems.

### DIFF
--- a/dali/python/nvidia/dali/plugin/numba/experimental.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental.py
@@ -447,27 +447,38 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
         self.threads_per_block = threads_per_block
 
     @staticmethod
-    def _check_minimal_numba_version():
+    def _check_minimal_numba_version(throw: bool = True):
         current_version = LooseVersion(nb.__version__)
         toolkit_version = cuda.runtime.get_version()
         if toolkit_version[0] not in minimal_numba_version:
-            raise RuntimeError(f'Unsupported CUDA toolkit version: {toolkit_version}')
+            if throw:
+                raise RuntimeError(f'Unsupported CUDA toolkit version: {toolkit_version}')
+            else:
+                return False
         min_ver = minimal_numba_version[toolkit_version[0]]
         if current_version < min_ver:
-            raise RuntimeError("Insufficient Numba version. Numba GPU operator "
-                               f"requires Numba {str(min_ver)} or higher. "
-                               f"Detected version: {str(LooseVersion(nb.__version__))}.")
+            if throw:
+                raise RuntimeError(f"Insufficient Numba version. Numba GPU operator "
+                                   f"requires Numba {str(min_ver)} or higher. "
+                                   f"Detected version: {str(LooseVersion(nb.__version__))}.")
+            else:
+                return False
+        return True
 
     @staticmethod
-    def _check_cuda_compatibility():
+    def _check_cuda_compatibility(throw: bool = True):
         toolkit_version = cuda.runtime.get_version()
         driver_version = cuda.driver.driver.get_version()
 
         if toolkit_version > driver_version:
-            raise RuntimeError("Environment is not compatible with Numba GPU operator. "
-                               f"Driver version is {driver_version} and CUDA Toolkit "
-                               f"version is {toolkit_version}. "
-                               "Driver cannot be older than the CUDA Toolkit")
+            if throw:
+                raise RuntimeError(f"Environment is not compatible with Numba GPU operator. "
+                                   f"Driver version is {driver_version} and CUDA Toolkit "
+                                   f"version is {toolkit_version}. "
+                                   "Driver cannot be older than the CUDA Toolkit")
+            else:
+                return False
+        return True
 
 
 ops._wrap_op(NumbaFunction, "fn.experimental", "nvidia.dali.plugin.numba")

--- a/dali/python/nvidia/dali/plugin/numba/experimental.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental.py
@@ -446,6 +446,7 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
         self.blocks = blocks
         self.threads_per_block = threads_per_block
 
+    @staticmethod
     def _check_minimal_numba_version():
         current_version = LooseVersion(nb.__version__)
         toolkit_version = cuda.runtime.get_version()
@@ -457,6 +458,7 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
                                f"requires Numba {str(min_ver)} or higher. "
                                f"Detected version: {str(LooseVersion(nb.__version__))}.")
 
+    @staticmethod
     def _check_cuda_compatibility():
         toolkit_version = cuda.runtime.get_version()
         driver_version = cuda.driver.driver.get_version()

--- a/dali/python/nvidia/dali/plugin/numba/experimental.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,7 +55,10 @@ _to_numba = {
 
 
 # Minimal version of Numba that is required for Numba GPU operator to work
-minimal_numba_version = LooseVersion('0.55.2')
+minimal_numba_version = {
+    11: LooseVersion('0.55.2'),
+    12: LooseVersion('0.57.0'),
+}
 
 
 @nb.extending.intrinsic
@@ -378,8 +381,8 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
                  threads_per_block=None,
                  **kwargs):
         if device == 'gpu':
-            self._check_minimal_numba_version()
-            self._check_cuda_compatibility()
+            NumbaFunction._check_minimal_numba_version()
+            NumbaFunction._check_cuda_compatibility()
 
         assert len(in_types) == len(ins_ndim), ("Number of input types "
                                                 "and input dimensions should match.")
@@ -443,14 +446,18 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
         self.blocks = blocks
         self.threads_per_block = threads_per_block
 
-    def _check_minimal_numba_version(self):
+    def _check_minimal_numba_version():
         current_version = LooseVersion(nb.__version__)
-        if current_version < minimal_numba_version:
+        toolkit_version = cuda.runtime.get_version()
+        if toolkit_version[0] not in minimal_numba_version:
+            raise RuntimeError(f'Unsupported CUDA toolkit version: {toolkit_version}')
+        min_ver = minimal_numba_version[toolkit_version[0]]
+        if current_version < min_ver:
             raise RuntimeError("Insufficient Numba version. Numba GPU operator "
-                               f"requires Numba {minimal_numba_version} or higher. "
-                               f"Detected version: {LooseVersion(nb.__version__)}.")
+                               f"requires Numba {str(min_ver)} or higher. "
+                               f"Detected version: {str(LooseVersion(nb.__version__))}.")
 
-    def _check_cuda_compatibility(self):
+    def _check_cuda_compatibility():
         toolkit_version = cuda.runtime.get_version()
         driver_version = cuda.driver.driver.get_version()
 

--- a/dali/test/python/operator_1/test_numba_func.py
+++ b/dali/test/python/operator_1/test_numba_func.py
@@ -46,9 +46,8 @@ def check_env_compatibility_cpu():
 
 def check_env_compatibility_gpu():
     import nvidia.dali.plugin.numba.experimental as ex
-    try:
-        ex.NumbaFunction._check_minimal_numba_version()
-    except RuntimeError:
+    if (not ex.NumbaFunction._check_minimal_numba_version(False)
+            or not ex.NumbaFunction._check_cuda_compatibility(False)):
         raise SkipTest()
 
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
There's no version of Numba that suports both Python 3.7 and CUDA 12. As a result, running Numba operator GPU tests on a system with Python 3.7 cannot succeed.
This PR adds an additional check in the operator's construction, with proper error message and also invokes this check as a prerequisite for Numba operator GPU tests.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
`operator_1/test_numba_func.py`

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
