### PR TITLE
Replace optional stream in SaveState with AccessOrder 

### DIFF
--- a/dali/operators/decoder/host/fused/host_decoder_random_crop.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_random_crop.cc
@@ -24,7 +24,7 @@
 
 namespace dali {
 
-void HostDecoderRandomCrop::SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) {
+void HostDecoderRandomCrop::SaveState(OpCheckpoint &cpt, AccessOrder order) {
   cpt.MutableCheckpointState() = RNGSnapshot();
 }
 

--- a/dali/operators/decoder/host/fused/host_decoder_random_crop.h
+++ b/dali/operators/decoder/host/fused/host_decoder_random_crop.h
@@ -36,7 +36,7 @@ class HostDecoderRandomCrop : public HostDecoder, public RandomCropAttr {
   inline ~HostDecoderRandomCrop() override = default;
   DISABLE_COPY_MOVE_ASSIGN(HostDecoderRandomCrop);
 
-  void SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) override;
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override;
 
   void RestoreState(const OpCheckpoint &cpt) override;
 

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.cc
@@ -20,7 +20,7 @@
 
 namespace dali {
 
-void nvJPEGDecoderRandomCrop::SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) {
+void nvJPEGDecoderRandomCrop::SaveState(OpCheckpoint &cpt, AccessOrder order) {
   cpt.MutableCheckpointState() = RNGSnapshot();
 }
 

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.h
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.h
@@ -32,7 +32,7 @@ class nvJPEGDecoderRandomCrop : public nvJPEGDecoder, public RandomCropAttr {
 
   DISABLE_COPY_MOVE_ASSIGN(nvJPEGDecoderRandomCrop);
 
-  void SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) override;
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override;
 
   void RestoreState(const OpCheckpoint &cpt) override;
 

--- a/dali/operators/random/rng_base.h
+++ b/dali/operators/random/rng_base.h
@@ -35,7 +35,7 @@ struct RNGBaseFields;
 template <typename Backend, typename Impl, bool IsNoiseGen>
 class RNGBase : public Operator<Backend> {
  public:
-  void SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) override {
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override {
     if constexpr (std::is_same_v<Backend, CPUBackend>) {
       cpt.MutableCheckpointState() = rng_;
     } else {

--- a/dali/operators/random/rng_base_cpu_test.cc
+++ b/dali/operators/random/rng_base_cpu_test.cc
@@ -63,7 +63,7 @@ class RNGCheckpointingTest : public ::testing::Test {
     // save and restore the pipeline
     auto node = original_pipe.GetOperatorNode("rng_op");
     OpCheckpoint cpt(node->spec);
-    node->op->SaveState(cpt, std::nullopt);
+    node->op->SaveState(cpt, {});
     restored_pipe.GetOperatorNode("rng_op")->op->RestoreState(cpt);
 
     // make sure the restored pipeline has the same internal state

--- a/dali/operators/reader/file_reader_op.h
+++ b/dali/operators/reader/file_reader_op.h
@@ -54,7 +54,7 @@ class FileReader : public DataReader<CPUBackend, ImageLabelWrapper, ImageLabelWr
     label_output.mutable_data<int>()[0] = image_label.label;
   }
 
-  void SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) override {
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override {
     cpt.MutableCheckpointState() = loader_->PopStateSnapshot();
   }
 

--- a/dali/operators/reader/reader_op_test.cc
+++ b/dali/operators/reader/reader_op_test.cc
@@ -537,7 +537,7 @@ class FileReaderTest : public DALITest {
                                                            bool stick_to_shard = false) {
     auto node = pipe.GetOperatorNode("file_reader");
     OpCheckpoint cpt(node->spec);
-    node->op->SaveState(cpt, std::nullopt);
+    node->op->SaveState(cpt, {});
     EXPECT_EQ(cpt.CheckpointState<LoaderStateSnapshot>().current_epoch, epoch_nr);
     return {RunEpoch(pipe, batch_size, num_shards, stick_to_shard), cpt};
   }

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -390,7 +390,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunHelper(OpNode &op_node, Workspac
     auto &cpt = GetCurrentIterationData(iter).checkpoint;
     auto &op_cpt = cpt.GetOpCheckpoint(op_node.id);
     cpt.SetIterationId(iter);
-    op_node.op->SaveState(op_cpt, ws.has_stream() ? std::optional{ws.stream()} : std::nullopt);
+    op_node.op->SaveState(op_cpt, ws.output_order());
   };
 
   // If it is the first iteration, create initial checkpoint.

--- a/dali/pipeline/operator/checkpointing/checkpoint_test.cc
+++ b/dali/pipeline/operator/checkpointing/checkpoint_test.cc
@@ -184,7 +184,7 @@ class CheckpointTest : public DALITest {
     for (OpNodeId i = 0; i < nodes_cnt; i++) {
       ASSERT_EQ(original_graph.Node(i).spec.name(),
                 checkpoint.GetOpCheckpoint(i).OperatorName());
-      original_graph.Node(i).op->SaveState(checkpoint.GetOpCheckpoint(i), 
+      original_graph.Node(i).op->SaveState(checkpoint.GetOpCheckpoint(i),
                                            AccessOrder(this->stream_.get()));
     }
 

--- a/dali/pipeline/operator/checkpointing/stateless_operator.h
+++ b/dali/pipeline/operator/checkpointing/stateless_operator.h
@@ -31,7 +31,7 @@ class StatelessOperator : public Operator<Backend> {
 
   inline ~StatelessOperator() override {}
 
-  void SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) override {}
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override {}
 
   void RestoreState(const OpCheckpoint &cpt) override {}
 

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -159,7 +159,7 @@ class DLL_PUBLIC OperatorBase {
    *
    * Is called exactly once per epoch.
   */
-  virtual void SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) {
+  virtual void SaveState(OpCheckpoint &cpt, AccessOrder order) {
     DALI_FAIL("Checkpointing is not implemented for this operator.");
   }
 

--- a/dali/test/dali_test_checkpointing.h
+++ b/dali/test/dali_test_checkpointing.h
@@ -66,7 +66,7 @@ class PipelineWrapper {
       OpCheckpoint cpt(spec);
       // TODO(mstaniewski): provide a stream, so operators with state kept
       // in device memory can be tested.
-      GetOperator(id)->SaveState(cpt, std::nullopt);
+      GetOperator(id)->SaveState(cpt, {});
       clone.GetOperator(id)->RestoreState(cpt);
     }
 

--- a/dali/test/operators/dummy_op.cc
+++ b/dali/test/operators/dummy_op.cc
@@ -23,7 +23,7 @@ TestStatefulSource::TestStatefulSource(const OpSpec &spec)
     : Operator<CPUBackend>(spec),
       epoch_size_(spec.GetArgument<int>("epoch_size")) {}
 
-void TestStatefulSource::SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) {
+void TestStatefulSource::SaveState(OpCheckpoint &cpt, AccessOrder order) {
   DALI_ENFORCE(checkpoints_to_collect_ > 0,
                "Attempting to collect a checkpoint from an empty queue. ");
   checkpoints_to_collect_--;  /* simulate removing checkpoint from queue */
@@ -68,7 +68,7 @@ void TestStatefulSource::RunImpl(Workspace &ws) {
 TestStatefulOpCPU::TestStatefulOpCPU(const OpSpec &spec)
     : Operator<CPUBackend>(spec) {}
 
-void TestStatefulOpCPU::SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) {
+void TestStatefulOpCPU::SaveState(OpCheckpoint &cpt, AccessOrder order) {
   cpt.MutableCheckpointState() = state_;
 }
 

--- a/dali/test/operators/dummy_op.h
+++ b/dali/test/operators/dummy_op.h
@@ -50,7 +50,7 @@ class TestStatefulSource : public Operator<CPUBackend> {
 
   DISABLE_COPY_MOVE_ASSIGN(TestStatefulSource);
 
-  void SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) override;
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override;
 
   void RestoreState(const OpCheckpoint &cpt) override;
 
@@ -78,7 +78,7 @@ class TestStatefulOpCPU : public Operator<CPUBackend> {
 
   DISABLE_COPY_MOVE_ASSIGN(TestStatefulOpCPU);
 
-  void SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) override;
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override;
 
   void RestoreState(const OpCheckpoint &cpt) override;
 
@@ -104,7 +104,7 @@ class TestStatefulOpMixed : public Operator<MixedBackend> {
 
   DISABLE_COPY_MOVE_ASSIGN(TestStatefulOpMixed);
 
-  void SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) override;
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override;
 
   void RestoreState(const OpCheckpoint &cpt) override;
 
@@ -128,7 +128,7 @@ class TestStatefulOpGPU : public Operator<GPUBackend> {
 
   DISABLE_COPY_MOVE_ASSIGN(TestStatefulOpGPU);
 
-  void SaveState(OpCheckpoint &cpt, std::optional<cudaStream_t> stream) override;
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override;
 
   void RestoreState(const OpCheckpoint &cpt) override;
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
This PR replaces `std::optional<cudaStream_t>` in operator's method `SaveState`, with an `AccessOrder`, to make it more unified with the rest of the library's code.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
