### PR TITLE
Add implicit scope to batch_permutation

### DIFF
--- a/dali/operators/random/batch_permutation.cc
+++ b/dali/operators/random/batch_permutation.cc
@@ -29,10 +29,7 @@ indexing samples in the batch.)")
       R"(If true, the output can contain repetitions and omissions.)", false)
   .AddOptionalArg("no_fixed_points", R"(If true, the the output permutation cannot contain fixed
 points, that is ``out[i] != i``. This argument is ignored when batch size is 1.)", false)
-  .AddOptionalArg<int>("_scope", R"code(Any CPU batch to infer the current batch size from.
-
-If the operator has no other tensor inputs, this argument can serve as a source of a current
-batch size.)code", 0, true);
+  .AddParent("ImplicitScopeAttr");
 
 void BatchPermutation::RunImpl(Workspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);

--- a/dali/operators/random/batch_permutation.cc
+++ b/dali/operators/random/batch_permutation.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,11 @@ indexing samples in the batch.)")
   .AddOptionalArg("allow_repetitions",
       R"(If true, the output can contain repetitions and omissions.)", false)
   .AddOptionalArg("no_fixed_points", R"(If true, the the output permutation cannot contain fixed
-points, that is ``out[i] != i``. This argument is ignored when batch size is 1.)", false);
+points, that is ``out[i] != i``. This argument is ignored when batch size is 1.)", false)
+  .AddOptionalArg<int>("_scope", R"code(Any CPU batch to infer the current batch size from.
+
+If the operator has no other tensor inputs, this argument can serve as a source of a current
+batch size.)code", 0, true);
 
 void BatchPermutation::RunImpl(Workspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);

--- a/dali/pipeline/operator/builtin/conditional/scope_argument.cc
+++ b/dali/pipeline/operator/builtin/conditional/scope_argument.cc
@@ -1,0 +1,21 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/operator/operator.h"
+
+DALI_SCHEMA(ImplicitScopeAttr)
+    .AddOptionalArg<int>("_scope", R"code(Any batch to infer the current batch size from.
+
+If the operator has no other tensor inputs, this argument can serve as a source of a current
+batch size.)code", 0, true);

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -331,7 +331,7 @@ OpSchema &OpSchema::AddOptionalArg(const std::string &s, const std::string &doc,
                                    std::nullptr_t, bool enable_tensor_input,
                                    bool support_per_frame_input) {
   CheckArgument(s);
-  optional_arguments_[s] = {doc, dtype, nullptr, HideArgument(s)};
+  optional_arguments_[s] = {doc, dtype, nullptr, ShouldHideArgument(s)};
   if (enable_tensor_input) {
     tensor_arguments_[s] = {support_per_frame_input};
   }
@@ -343,7 +343,7 @@ OpSchema &OpSchema::AddOptionalTypeArg(const std::string &s, const std::string &
                                        DALIDataType default_value) {
   CheckArgument(s);
   auto to_store = Value::construct(default_value);
-  optional_arguments_[s] = {doc, DALI_DATA_TYPE, to_store.get(), HideArgument(s)};
+  optional_arguments_[s] = {doc, DALI_DATA_TYPE, to_store.get(), ShouldHideArgument(s)};
   optional_arguments_unq_.push_back(std::move(to_store));
   return *this;
 }

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -331,7 +331,7 @@ OpSchema &OpSchema::AddOptionalArg(const std::string &s, const std::string &doc,
                                    std::nullptr_t, bool enable_tensor_input,
                                    bool support_per_frame_input) {
   CheckArgument(s);
-  optional_arguments_[s] = {doc, dtype, nullptr};
+  optional_arguments_[s] = {doc, dtype, nullptr, HideArgument(s)};
   if (enable_tensor_input) {
     tensor_arguments_[s] = {support_per_frame_input};
   }
@@ -343,7 +343,7 @@ OpSchema &OpSchema::AddOptionalTypeArg(const std::string &s, const std::string &
                                        DALIDataType default_value) {
   CheckArgument(s);
   auto to_store = Value::construct(default_value);
-  optional_arguments_[s] = {doc, DALI_DATA_TYPE, to_store.get()};
+  optional_arguments_[s] = {doc, DALI_DATA_TYPE, to_store.get(), HideArgument(s)};
   optional_arguments_unq_.push_back(std::move(to_store));
   return *this;
 }
@@ -807,7 +807,9 @@ std::vector<std::string> OpSchema::GetArgumentNames() const {
     ret.push_back(arg_pair.first);
   }
   for (auto &arg_pair : optional) {
-    ret.push_back(arg_pair.first);
+    if (!arg_pair.second.hidden) {
+      ret.push_back(arg_pair.first);
+    }
   }
   for (auto &arg_pair : deprecated) {
     // Deprecated aliases only appear in `deprecated` but regular

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -68,10 +68,6 @@ enum class InputDevice : uint8_t {
   GPU = 2,
 };
 
-inline bool HideArgument(const std::string &name) {
-  return name.size() && name[0] == '_';
-}
-
 class DLL_PUBLIC OpSchema {
  public:
   typedef std::function<int(const OpSpec &spec)> SpecFunc;
@@ -351,7 +347,7 @@ class DLL_PUBLIC OpSchema {
 used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc, nullptr)`)");
     CheckArgument(s);
     auto to_store = Value::construct(default_value);
-    optional_arguments_[s] = {doc, type2id<T>::value, to_store.get(), HideArgument(s)};
+    optional_arguments_[s] = {doc, type2id<T>::value, to_store.get(), ShouldHideArgument(s)};
     optional_arguments_unq_.push_back(std::move(to_store));
     if (enable_tensor_input) {
       tensor_arguments_[s] = {support_per_frame_input};
@@ -393,7 +389,7 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
     CheckArgument(s);
     using S = argument_storage_t<T>;
     auto to_store = Value::construct(detail::convert_vector<S>(default_value));
-    bool hide_argument = HideArgument(s);
+    bool hide_argument = ShouldHideArgument(s);
     optional_arguments_[s] = {doc, type2id<std::vector<T>>::value, to_store.get(), hide_argument};
     optional_arguments_unq_.push_back(std::move(to_store));
     if (enable_tensor_input) {
@@ -714,6 +710,10 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   DLL_PUBLIC bool ArgSupportsPerFrameInput(const std::string &arg_name) const;
 
  private:
+  static inline bool ShouldHideArgument(const std::string &name) {
+    return name.size() && name[0] == '_';
+  }
+
   const TensorArgDesc *FindTensorArgument(const std::string &name) const;
 
   void CheckArgument(const std::string &s);

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -453,8 +453,8 @@ void ExposeTensor(py::module &m) {
       R"code(
       Exposes tensor data as DLPack compatible capsule.
 
-      Note: 
-        This function does not implement full DLPack contract and 
+      Note:
+        This function does not implement full DLPack contract and
       should not be used to export DALI CPU tensors to DLPack compatible
       endpoints.
 
@@ -641,8 +641,8 @@ void ExposeTensor(py::module &m) {
       R"code(
       Exposes tensor data as DLPack compatible capsule.
 
-      Note: 
-        This function does not implement full DLPack contract and 
+      Note:
+        This function does not implement full DLPack contract and
       should not be used to export DALI GPU tensors to DLPack compatible
       endpoints.
 
@@ -2131,7 +2131,11 @@ PYBIND11_MODULE(backend_impl, m) {
           auto meta = schema->DeprecatedArgMeta(arg_name);
           return DeprecatedArgMetaToDict(meta);
         })
-    .def("GetSupportedLayouts", &OpSchema::GetSupportedLayouts);
+    .def("GetSupportedLayouts", &OpSchema::GetSupportedLayouts)
+    .def("HasArgument",
+        [](OpSchema *schema, const std::string &arg_name) {
+          return schema->HasArgument(arg_name);
+        });
 
   ExposeTensorLayout(types_m);
   ExposeTensor(m);


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** /**New feature** (*non-breaking change which adds functionality*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:

The PR makes the following code work.
```
batch =  fn.decoders.image(batch, device="mixed")
if fn.random.coin_flip():
        permuted_batch = fn.permute_batch(batch, indices=fn.batch_permutation())
```
Without it, the `fn.permute_batch` will fail due `indicies` exceeding the valid indicies for the `batch` in the inner scope.

Even though we call `fn.batch_permutation()` inside the if body, the operator will run as if it was called in the outer scope - that is it will produce a permutation for a full batch size. Then, that permutation will be split according to the `fn.random.coin_flip()` predicate.

Unfortunately, randomly splitting permutation in two smaller lists usually does not produce a valid permutations for smaller lists, i.e. while `[3, 0, 2, 1]` is a valid permutation of four elements, splitting it in two `[3, 0]`, `[2, 1]` does not produce valid permutations of two elements.

The hoisting of `fn.batch_permutation` into an outer scope happens becuase the fn.batch_permutation does not accept any tensor arguments - those args serve as a source of the "local scope" batch size. This PR fixes the problem by introducing an implicit "_scope" argument that is automatically injected with a dummy batch whose size matches the local batch size.

## Additional information:

### Affected modules and functionalities:

* OpSchema - by introduction of HiddenOptional arguments.
* fn.batch_permutation - it now has new parent schema with the `_scope` arg.
* ops.py - code that automatically injects a referential scope to those operators that have the `_scope` argument.

A possible follow-up would be to use the same mechanism for any operator that can potentially have no other tensor arugments. For example random generators - in their case, hositing to global scope and then splitting the output does not impact the correctness, but may incur some performence penalty.



### Key points relevant for the review:
Is it tested properly? Is the hidden `_scope` arg hidden in the docs? Anywhere else where you'd rather not see a *hidden* argument that I should check?
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3495
<!--- DALI-XXXX or NA --->
