### PR TITLE
Set layout from argument in external source

### DIFF
--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -23,6 +23,7 @@ void ExternalSource<CPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
   auto &thread_pool = ws.GetThreadPool();
   ForwardCurrentData(output, data_id_, thread_pool);
+  output.SetLayout(layout_);
   SetDepletedOperatorTrace(ws, !(repeats_last_ || HasDataInQueue()));
 }
 
@@ -32,6 +33,7 @@ void ExternalSource<GPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<GPUBackend>(0);
   cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
   ForwardCurrentData(output, data_id_, stream_used);
+  output.SetLayout(layout_);
   SetDepletedOperatorTrace(ws, !(repeats_last_ || HasDataInQueue()));
 }
 

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -157,16 +157,23 @@ class ExternalSource : public InputOperator<Backend> {
     ndim_ = input_ndim;
 
     if (spec_.HasArgument("layout")) {
-      DALI_ENFORCE(layout_ == batch.GetLayout(),
-                   make_string("Expected data with layout: \"", layout_,
+      if (batch.GetLayout().empty()) {
+        layout_ = spec_.template GetArgument<TensorLayout>("layout");
+      } else {
+        DALI_ENFORCE(layout_ == batch.GetLayout(),
+                     make_string("Expected data with layout: \"", layout_,
                      "\" and got: \"", batch.GetLayout(), "\"."));
-    } else if (!layout_.empty()) {
-      DALI_ENFORCE(layout_ == batch.GetLayout(),
-                   make_string("Layout of the data fed to the external source has changed "
-                     "from previous iteration. Layout in the previous iteration was \"", layout_,
-                     "\" and the current is \"", batch.GetLayout(), "\"."));
+      }
+    } else {
+        if (layout_.empty()) {
+          layout_ = batch.GetLayout();
+        } else  {
+          DALI_ENFORCE(layout_ == batch.GetLayout(),
+                        make_string("Layout of the data fed to the external source has changed "
+                          "from previous iteration. Layout in the previous iteration was \"",
+                          layout_, "\" and the current is \"", batch.GetLayout(), "\"."));
+        }
     }
-    layout_ = batch.GetLayout();
   }
 
   const bool repeats_last_;

--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -418,6 +418,15 @@ def test_layout_changing():
     src_pipe.run()
 
 
+def test_layout_set_as_arg():
+    src_pipe = Pipeline(1, 1, 0, prefetch_queue_depth=1)
+    src_pipe.set_outputs(fn.external_source(name="input", layout="H"))
+    src_pipe.build()
+    src_pipe.feed_input("input", [np.zeros((1))])
+    out, = src_pipe.run()
+    assert out.layout() == "H"
+
+
 def _test_partially_utilized_external_source_warning(usage_mask, source_type):
     np_rng = np.random.default_rng(12345)
     max_batch_size = 8


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

**Bug fix**

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

Previously, when the layout was specified in the ES argument and a user called feed_input without providing layout, the operator complained about the mismatch. Now, in such case, the layout for the output will be set from the provided operator argument.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

eternal_source

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
