### PR TITLE
Move the loader snapshot queue to the reader

### DIFF
--- a/dali/operators/reader/file_reader_op.cc
+++ b/dali/operators/reader/file_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,18 +16,8 @@
 
 #include "dali/operators/reader/file_reader_op.h"
 #include "dali/operators/reader/loader/utils.h"
-#include "dali/pipeline/operator/checkpointing/snapshot_serializer.h"
 
 namespace dali {
-
-std::string FileReader::SerializeCheckpoint(const OpCheckpoint &cpt) const {
-  const auto &state = cpt.CheckpointState<LoaderStateSnapshot>();
-  return SnapshotSerializer().Serialize(state);
-}
-
-void FileReader::DeserializeCheckpoint(OpCheckpoint &cpt, const std::string &data) const {
-  cpt.MutableCheckpointState() = SnapshotSerializer().Deserialize<LoaderStateSnapshot>(data);
-}
 
 DALI_REGISTER_OPERATOR(readers__File, FileReader, CPU);
 

--- a/dali/operators/reader/file_reader_op.h
+++ b/dali/operators/reader/file_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ class FileReader : public DataReader<CPUBackend, ImageLabelWrapper, ImageLabelWr
     : DataReader<CPUBackend, ImageLabelWrapper, ImageLabelWrapper, true>(spec) {
     bool shuffle_after_epoch = spec.GetArgument<bool>("shuffle_after_epoch");
     loader_ = InitLoader<FileLabelLoader>(spec, shuffle_after_epoch);
+    this->SetInitialSnapshot();
   }
 
   void RunImpl(SampleWorkspace &ws) override {
@@ -53,18 +54,6 @@ class FileReader : public DataReader<CPUBackend, ImageLabelWrapper, ImageLabelWr
 
     label_output.mutable_data<int>()[0] = image_label.label;
   }
-
-  void SaveState(OpCheckpoint &cpt, AccessOrder order) override {
-    cpt.MutableCheckpointState() = loader_->PopStateSnapshot();
-  }
-
-  void RestoreState(const OpCheckpoint &cpt) override {
-    loader_->RestoreStateFromSnapshot(cpt.CheckpointState<LoaderStateSnapshot>());
-  }
-
-  std::string SerializeCheckpoint(const OpCheckpoint &cpt) const override;
-
-  void DeserializeCheckpoint(OpCheckpoint &cpt, const std::string &data) const override;
 
  protected:
   USE_READER_OPERATOR_MEMBERS(CPUBackend, ImageLabelWrapper, ImageLabelWrapper, true);

--- a/dali/operators/reader/loader/file_label_loader.h
+++ b/dali/operators/reader/loader/file_label_loader.h
@@ -186,7 +186,7 @@ class DLL_PUBLIC FileLabelLoaderBase : public Loader<CPUBackend, ImageLabelWrapp
       std::shuffle(image_label_pairs_.begin(), image_label_pairs_.end(), g);
     }
 
-    if (checkpointing_ && shuffle_after_epoch_) {
+    if (IsCheckpointingEnabled() && shuffle_after_epoch_) {
       // save initial order
       // DO not call std::move on image_label_pairs_, even though it is restored in Reset
       // it may be needed if SizeImpl is called!
@@ -206,7 +206,7 @@ class DLL_PUBLIC FileLabelLoaderBase : public Loader<CPUBackend, ImageLabelWrapp
     current_epoch_++;
 
     if (shuffle_after_epoch_) {
-      if (checkpointing_) {
+      if (IsCheckpointingEnabled()) {
         // With checkpointing enabled, dataset order must be easy to restore.
         // The shuffling is run with different seed every epoch, so this doesn't impact
         // the random distribution.
@@ -230,7 +230,7 @@ class DLL_PUBLIC FileLabelLoaderBase : public Loader<CPUBackend, ImageLabelWrapp
   using Base::initial_buffer_fill_;
   using Base::copy_read_data_;
   using Base::read_ahead_;
-  using Base::checkpointing_;
+  using Base::IsCheckpointingEnabled;
   using Base::PrepareEmptyTensor;
   using Base::MoveToNextShard;
   using Base::ShouldSkipImage;

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <utility>
@@ -27,6 +28,7 @@
 #include "dali/core/nvtx.h"
 #include "dali/operators/reader/loader/loader.h"
 #include "dali/operators/reader/parser/parser.h"
+#include "dali/pipeline/operator/checkpointing/snapshot_serializer.h"
 #include "dali/pipeline/operator/operator.h"
 
 namespace dali {
@@ -64,6 +66,10 @@ class DataReader : public Operator<Backend> {
         curr_batch_producer_(0),
         consumer_cycle_(false),
         producer_cycle_(false),
+        checkpointing_(spec.GetArgument<bool>("checkpointing")),
+        loader_snapshot_queue_(SnapshotQueueDepth()),
+        snapshot_consumer_(0),
+        snapshot_producer_(0),
         device_id_(-1),
         samples_processed_(0) {
           if (std::is_same<Backend, GPUBackend>::value) {
@@ -91,6 +97,44 @@ class DataReader : public Operator<Backend> {
     for (int i = 0; i < max_batch_size_; ++i) {
       curr_batch.push_back(loader_->ReadOne(i == 0, i == max_batch_size_ - 1));
     }
+    SaveLoaderSnapshot();
+  }
+
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override {
+    if constexpr (!supports_checkpointing) {
+      DALI_FAIL(make_string("The reader ", spec_.name(), " does not support checkpointing."));
+    } else {
+      DALI_ENFORCE(checkpointing_,
+                   "Cannot save the checkpoint, because "
+                   "checkpointing was not enabled.");
+      auto &snapshot = loader_snapshot_queue_[snapshot_consumer_];
+      DALI_ENFORCE(snapshot,
+                   make_string("Cannot save the checkpoint. Currently, the reader `", spec_.name(),
+                               "` supports checkpointing only between epochs."));
+      cpt.MutableCheckpointState() = *snapshot;
+    }
+  }
+
+  void RestoreState(const OpCheckpoint &cpt) override {
+    if constexpr (!supports_checkpointing) {
+      DALI_FAIL(make_string("The reader ", spec_.name(), " does not support checkpointing."));
+    } else {
+      DALI_ENFORCE(checkpointing_,
+                   "Cannot restore the checkpoint, because "
+                   "checkpointing was not enabled.");
+      auto &snapshot = cpt.CheckpointState<LoaderStateSnapshot>();
+      loader_->RestoreStateFromSnapshot(snapshot);
+      SetInitialSnapshot();
+    }
+  }
+
+  std::string SerializeCheckpoint(const OpCheckpoint &cpt) const override {
+    const auto &state = cpt.CheckpointState<LoaderStateSnapshot>();
+    return SnapshotSerializer().Serialize(state);
+  }
+
+  void DeserializeCheckpoint(OpCheckpoint &cpt, const std::string &data) const override {
+    cpt.MutableCheckpointState() = SnapshotSerializer().Deserialize<LoaderStateSnapshot>(data);
   }
 
   // Main prefetch work loop
@@ -225,6 +269,51 @@ class DataReader : public Operator<Backend> {
   }
 
  protected:
+  int SnapshotQueueDepth() {
+    // we keep the snapshots of loader state after producing each of `prefetch_queue_depth_`
+    // batches + 1 snapshot before that.
+    return supports_checkpointing && checkpointing_ ? prefetch_queue_depth_ + 1 : 0;
+  }
+
+  bool IsCheckpointingEnabled() {
+    return supports_checkpointing && checkpointing_;
+  }
+
+  void AdvanceSnapshotProducer() {
+    if (IsCheckpointingEnabled()) {
+      snapshot_producer_ = (snapshot_producer_ + 1) % SnapshotQueueDepth();
+    }
+  }
+
+  void AdvanceSnapshotConsumer() {
+    if (IsCheckpointingEnabled()) {
+      snapshot_consumer_ = (snapshot_consumer_ + 1) % SnapshotQueueDepth();
+    }
+  }
+
+  void SetInitialSnapshot() {
+    if (IsCheckpointingEnabled()) {
+      DALI_ENFORCE(!prefetch_thread_.joinable(),
+                  "Reader's checkpointing must be initialized before reading any samples");
+      snapshot_producer_ = 0;
+      snapshot_consumer_ = 0;
+      SaveLoaderSnapshot();
+      AdvanceSnapshotProducer();
+    }
+  }
+
+  void SaveLoaderSnapshot() {
+    if (IsCheckpointingEnabled()) {
+      if (!loader_->IsEpochDepleted()) {
+        // TODO(ktokarski) Currently, the loader cannot save its state in the middle
+        // of the epoch, so we put None in the queue instead.
+        loader_snapshot_queue_[snapshot_producer_] = {};
+      } else {
+        loader_snapshot_queue_[snapshot_producer_] = loader_->GetStateSnapshot();
+      }
+    }
+  }
+
   void ParseIfNeeded(const Tensor<CPUBackend>& tensor, SampleWorkspace* ws) {
     using OutputCache = std::unordered_map<std::string, std::vector<Tensor<CPUBackend>>>;
     static OutputCache output_cache;
@@ -290,6 +379,7 @@ class DataReader : public Operator<Backend> {
     {
       std::lock_guard<std::mutex> lock(prefetch_access_mutex_);
       AdvanceIndex(curr_batch_producer_, producer_cycle_);
+      AdvanceSnapshotProducer();
     }
     consumer_.notify_all();
   }
@@ -311,6 +401,7 @@ class DataReader : public Operator<Backend> {
     {
       std::lock_guard<std::mutex> lock(prefetch_access_mutex_);
       AdvanceIndex(curr_batch_consumer_, consumer_cycle_);
+      AdvanceSnapshotConsumer();
     }
     producer_.notify_one();
   }
@@ -350,6 +441,10 @@ class DataReader : public Operator<Backend> {
   int curr_batch_producer_;
   bool consumer_cycle_;
   bool producer_cycle_;
+  bool checkpointing_;
+  std::vector<std::optional<LoaderStateSnapshot>> loader_snapshot_queue_;
+  int snapshot_consumer_;
+  int snapshot_producer_;
   int device_id_;
 
   // keep track of how many samples have been processed over all threads.


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
This PR moves the snapshot queue from the loader to the reader. 
Reader already is resposible for prefetching batches, so it makes sense for it to make sure to keep loader's state snapshot after each produced batch. This should simplify loaders code and remove the need for extra mutex to access loaders snapshot queue. The snapshot queue is now advanced alongside the batch prefetch queue, which makes accessing snapshots (reader's by the executor and loader's by the reader) to have no side effects.  

The snapshots are put in the queue by the prefetching thread. If the loader cannot be checkpointed at the given moment, the reader simply puts None in the queue and the relevant error is raised on the attempt to access the snapshot. This could be extended to the executor as well (so that it does not have to compute epoch sizes in advance).

In the future, the snapshot queue could be extracted from the reader and provided to it as a dependency similar to loader. This way, we could provide different checkpointing mechanisms to different readers and loaders.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3653
<!--- DALI-XXXX or NA --->
