### PR TITLE
Add Fast-Forward to Loader base

### DIFF
--- a/dali/operators/reader/loader/cufile_loader.h
+++ b/dali/operators/reader/loader/cufile_loader.h
@@ -51,7 +51,7 @@ class CUFileLoader : public FileLoader<GPUBackend, Target, CUFileStream> {
      * cuFileDeregister functions, so instead of letting them to be cleared by Loader class when
      * cuFile is no longer accesible we need to do that here.
      */
-    this->last_sample_ptr_tmp.reset();
+    this->last_sample_ptr_tmp.ptr.reset();
     this->sample_buffer_.clear();
     this->empty_tensors_.clear();
   }

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -329,17 +329,9 @@ class Loader {
 
   /**
    * @brief Advances loader position in the data source by skipping n samples.
-   * @param n Number of samples to skip.
+   * @warning This generic implementation is very inefficient and should be overriden.
   */
-  void Advance(uint64_t n) {
-    AdvanceImpl(n);
-  }
-
-  /**
-   * @brief Advances loader position in the data source by skipping n samples.
-   * @warning This generic implementation is inefficient and should be overriden.
-  */
-  virtual void AdvanceImpl(uint64_t n) {
+  virtual void Skip(uint64_t n) {
     LoadTargetUniquePtr tensor_ptr;
     {
       std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
@@ -485,7 +477,7 @@ class Loader {
         continue;
       }
 
-      Advance(target->idx - at);
+      Skip(target->idx - at);
       at = target->idx;
 
       LoadTargetSharedPtr tensor_ptr = {new LoadTarget,
@@ -501,7 +493,7 @@ class Loader {
     }
 
     Reset(true);
-    Advance(read_sample_counter_);
+    Skip(read_sample_counter_);
   }
 
   std::vector<IndexedLoadTargetSharedPtr> sample_buffer_;

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -231,11 +231,12 @@ class Loader {
       for (int i = 0; i < initial_buffer_fill_; ++i) {
         LoadTargetSharedPtr tensor_ptr = nullptr;
         if (!dry_run) {
-          tensor_ptr = LoadTargetSharedPtr(new LoadTarget,
-                           [this](LoadTarget* sample){
-                                      LoadTargetUniquePtr recycle_ptr(sample);
-                                      RecycleTensor(std::move(recycle_ptr));
-                                  });
+          tensor_ptr = LoadTargetSharedPtr(
+            new LoadTarget,
+            [this](LoadTarget* sample){
+              LoadTargetUniquePtr recycle_ptr(sample);
+              RecycleTensor(std::move(recycle_ptr));
+            });
           PrepareEmpty(*tensor_ptr);
           ReadSample(*tensor_ptr);
         }
@@ -287,12 +288,15 @@ class Loader {
       // being called by multiple consumer threads
       {
         std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
-        DALI_ENFORCE(empty_tensors_.size() > 0, "No empty tensors - did you forget to return them?");
-        tensor_ptr = {empty_tensors_.back().release(),
-                      [this](LoadTarget* sample){
-                        LoadTargetUniquePtr recycle_ptr(sample);
-                        RecycleTensor(std::move(recycle_ptr));
-                      }};
+        DALI_ENFORCE(empty_tensors_.size() > 0,
+                     "No empty tensors - did you forget to return them?");
+        tensor_ptr = {
+          empty_tensors_.back().release(),
+          [this](LoadTarget* sample){
+            LoadTargetUniquePtr recycle_ptr(sample);
+            RecycleTensor(std::move(recycle_ptr));
+          }
+        };
         empty_tensors_.pop_back();
       }
       ReadSample(*tensor_ptr);
@@ -352,7 +356,7 @@ class Loader {
   */
   virtual void Rewind(bool wrap_to_shard) {
     DALI_FAIL("Loader doesn't support rewinding, restoring from checkpoint is impossible");
-  };
+  }
 
   void PrepareMetadata() {
     if (!loading_flag_) {
@@ -489,11 +493,13 @@ class Loader {
       Skip(target->idx - at);
       at = target->idx;
 
-      LoadTargetSharedPtr tensor_ptr = {new LoadTarget,
-                           [this](LoadTarget* sample){
-                                      LoadTargetUniquePtr recycle_ptr(sample);
-                                      RecycleTensor(std::move(recycle_ptr));
-                            }};
+      LoadTargetSharedPtr tensor_ptr = {
+        new LoadTarget,
+        [this](LoadTarget* sample){
+          LoadTargetUniquePtr recycle_ptr(sample);
+          RecycleTensor(std::move(recycle_ptr));
+        }
+      };
       PrepareEmpty(*tensor_ptr);
       ReadSample(*tensor_ptr);
       last = tensor_ptr;

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -65,6 +65,12 @@ class Loader {
  public:
   using LoadTargetUniquePtr = std::unique_ptr<LoadTarget>;
   using LoadTargetSharedPtr = std::shared_ptr<LoadTarget>;
+
+  struct IndexedLoadTargetSharedPtr {
+    Index idx;
+    LoadTargetSharedPtr ptr;
+  };
+
   explicit Loader(const OpSpec& options)
     : shuffle_(options.GetArgument<bool>("random_shuffle")),
       initial_buffer_fill_(shuffle_ ? options.GetArgument<int>("initial_fill") : 1),
@@ -199,8 +205,19 @@ class Loader {
             pad_last_batch_;
   }
 
+  /**
+   * @brief Fast-forwards a loader by skipping n samples.
+  */
+  void FastForward(Index n) {
+    for (Index i = 0; i < n; i++) {
+      ReadOne(false, false, true);
+    }
+    ReadMissingSamples();
+  }
+
+
   // Get a random read sample
-  LoadTargetSharedPtr ReadOne(bool is_new_batch, bool is_end_of_batch) {
+  LoadTargetSharedPtr ReadOne(bool is_new_batch, bool is_end_of_batch, bool dry_run = false) {
     PrepareMetadata();
     DomainTimeRange tr("[DALI][Loader] ReadOne", DomainTimeRange::kGreen1);
     // perform an initial buffer fill if it hasn't already happened
@@ -211,11 +228,18 @@ class Loader {
       // Read an initial number of samples to fill our
       // sample buffer
       for (int i = 0; i < initial_buffer_fill_; ++i) {
-        auto tensor_ptr = LoadTargetUniquePtr(new LoadTarget());
-        PrepareEmpty(*tensor_ptr);
-        ReadSample(*tensor_ptr);
+        LoadTargetSharedPtr tensor_ptr = nullptr;
+        if (!dry_run) {
+          tensor_ptr = LoadTargetSharedPtr(new LoadTarget,
+                           [this](LoadTarget* sample){
+                                      LoadTargetUniquePtr recycle_ptr(sample);
+                                      RecycleTensor(std::move(recycle_ptr));
+                                  });
+          PrepareEmpty(*tensor_ptr);
+          ReadSample(*tensor_ptr);
+        }
+        sample_buffer_.push_back({read_sample_counter_, std::move(tensor_ptr)});
         IncreaseReadSampleCounter();
-        sample_buffer_.push_back(std::move(tensor_ptr));
         ++shards_.back().end;
       }
 
@@ -239,7 +263,7 @@ class Loader {
           // batch will contain samples from the next epoch - increment the epoch number.
           consumer_epoch_++;
         }
-        return last_sample_ptr_tmp;
+        return last_sample_ptr_tmp.ptr;
       }
 
       // remove shard that was fully consumed
@@ -253,27 +277,30 @@ class Loader {
 
     int offset = shuffle_ ? dis(e_) : 0;
     Index idx = (shards_.front().start + offset) % sample_buffer_.size();
-    LoadTargetSharedPtr sample_ptr(sample_buffer_[idx].release(),
-      [this](LoadTarget* sample) {
-        LoadTargetUniquePtr recycle_ptr(sample);
-        RecycleTensor(std::move(recycle_ptr));
-    });
+
     std::swap(sample_buffer_[idx], sample_buffer_[shards_.front().start % sample_buffer_.size()]);
-    // now grab an empty tensor, fill it and add to filled buffers
-    // empty_tensors_ needs to be thread-safe w.r.t. RecycleTensor()
-    // being called by multiple consumer threads
-    LoadTargetUniquePtr tensor_ptr;
-    {
-      std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
-      DALI_ENFORCE(empty_tensors_.size() > 0, "No empty tensors - did you forget to return them?");
-      tensor_ptr = std::move(empty_tensors_.back());
-      empty_tensors_.pop_back();
+    LoadTargetSharedPtr tensor_ptr = nullptr;
+    if (!dry_run) {
+      // now grab an empty tensor, fill it and add to filled buffers
+      // empty_tensors_ needs to be thread-safe w.r.t. RecycleTensor()
+      // being called by multiple consumer threads
+      {
+        std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
+        DALI_ENFORCE(empty_tensors_.size() > 0, "No empty tensors - did you forget to return them?");
+        tensor_ptr = {empty_tensors_.back().release(),
+                      [this](LoadTarget* sample){
+                        LoadTargetUniquePtr recycle_ptr(sample);
+                        RecycleTensor(std::move(recycle_ptr));
+                      }};
+        empty_tensors_.pop_back();
+      }
+      ReadSample(*tensor_ptr);
     }
-    ReadSample(*tensor_ptr);
+    IndexedLoadTargetSharedPtr sample = {read_sample_counter_, tensor_ptr};
     IncreaseReadSampleCounter();
-    std::swap(sample_buffer_[shards_.back().end % sample_buffer_.size()], tensor_ptr);
+    std::swap(sample_buffer_[shards_.back().end % sample_buffer_.size()], sample);
     ++shards_.back().end;
-    last_sample_ptr_tmp = sample_ptr;
+    last_sample_ptr_tmp = sample;
 
     shards_.front().start++;
     returned_sample_counter_++;
@@ -284,7 +311,7 @@ class Loader {
       consumer_epoch_++;
     }
 
-    return sample_ptr;
+    return sample.ptr;
   }
 
   // return a tensor to the empty pile
@@ -298,6 +325,32 @@ class Loader {
   // used to populate the sample buffer for "shuffled"
   // reads.
   virtual void ReadSample(LoadTarget& tensor) = 0;
+
+  /**
+   * @brief Advances loader position in the data source by skipping n samples.
+   * @param n Number of samples to skip.
+  */
+  void Advance(uint64_t n) {
+    AdvanceImpl(n);
+  }
+
+  /**
+   * @brief Advances loader position in the data source by skipping n samples.
+   * @warning This generic implementation is inefficient and should be overriden.
+  */
+  virtual void AdvanceImpl(uint64_t n) {
+    LoadTargetUniquePtr tensor_ptr;
+    {
+      std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
+      DALI_ENFORCE(empty_tensors_.size() > 0, "No empty tensors");
+      tensor_ptr = std::move(empty_tensors_.back());
+      empty_tensors_.pop_back();
+    }
+    for (uint64_t i = 0; i < n; i++) {
+      ReadSample(*tensor_ptr);
+    }
+    RecycleTensor(std::move(tensor_ptr));
+  }
 
   void PrepareMetadata() {
     if (!loading_flag_) {
@@ -404,7 +457,52 @@ class Loader {
     return cache_ && cache_->IsCached(key);
   }
 
-  std::vector<LoadTargetUniquePtr> sample_buffer_;
+
+  void ReadMissingSamples() {
+    if (!initial_buffer_filled_) return;
+
+    std::vector<IndexedLoadTargetSharedPtr*> to_read;
+    if (!last_sample_ptr_tmp.ptr) {
+      to_read.push_back(&last_sample_ptr_tmp);
+    }
+    for (auto &sample : sample_buffer_) {
+      if (!sample.ptr) {
+        to_read.push_back(&sample);
+      }
+    }
+
+    // We can't move backwards, so samples have to be read in order
+    std::sort(to_read.begin(), to_read.end(), [](auto a, auto b){ return a->idx < b->idx; });
+
+    Reset(true);
+
+    Index at = 0;
+    LoadTargetSharedPtr last = nullptr;
+    for (auto target : to_read) {
+      if (target->idx < at) {
+        target->ptr = last;
+        continue;
+      }
+
+      Advance(target->idx - at);
+      at = target->idx;
+
+      LoadTargetSharedPtr tensor_ptr = {new LoadTarget,
+                           [this](LoadTarget* sample){
+                                      LoadTargetUniquePtr recycle_ptr(sample);
+                                      RecycleTensor(std::move(recycle_ptr));
+                            }};
+      PrepareEmpty(*tensor_ptr);
+      ReadSample(*tensor_ptr);
+      last = tensor_ptr;
+      target->ptr = std::move(tensor_ptr);
+      at++;
+    }
+
+    Advance(read_sample_counter_ - at);
+  }
+
+  std::vector<IndexedLoadTargetSharedPtr> sample_buffer_;
 
   std::vector<LoadTargetUniquePtr> empty_tensors_;
 
@@ -472,7 +570,7 @@ class Loader {
   // Number of data shards that were actually read by the reader
   int virtual_shard_id_;
   // Keeps pointer to the last returned sample just in case it needs to be cloned
-  LoadTargetSharedPtr last_sample_ptr_tmp;
+  IndexedLoadTargetSharedPtr last_sample_ptr_tmp;
 
   struct ShardBoundaries {
     Index start;

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -87,13 +87,10 @@ class Loader {
       skip_cached_images_(options.GetArgument<bool>("skip_cached_images")),
       lazy_init_(options.GetArgument<bool>("lazy_init")),
       loading_flag_(false),
-      returned_sample_counter_(0),
       pad_last_batch_(options.GetArgument<bool>("pad_last_batch")),
       dont_use_mmap_(options.GetArgument<bool>("dont_use_mmap")),
       checkpointing_(options.GetArgument<bool>("checkpointing")),
-      consumer_epoch_(0),
-      max_batch_size_(options.GetArgument<int>("max_batch_size")),
-      read_sample_counter_(0) {
+      max_batch_size_(options.GetArgument<int>("max_batch_size")) {
     DALI_ENFORCE(initial_empty_size_ > 0, "Batch size needs to be greater than 0");
     DALI_ENFORCE(num_shards_ > shard_id_, "num_shards needs to be greater than shard_id");
     // initialize a random distribution -- this will be
@@ -558,7 +555,7 @@ class Loader {
   std::shared_ptr<ImageCache> cache_;
 
   // Counts how many samples the reader have read returned in the current epoch (including padding)
-  Index returned_sample_counter_;
+  Index returned_sample_counter_ = 0;
   // If true, the last batch will be padded with the last sample so that the number
   // of samples matches batch size
   bool pad_last_batch_;
@@ -572,7 +569,7 @@ class Loader {
   bool checkpointing_;
   // The epoch number the next returned sample belongs to,
   // tracked only if checkpointing is enabled
-  int consumer_epoch_;
+  int consumer_epoch_ = 0;
   // Batch size
   int max_batch_size_;
   // Number of data shards that were actually read by the reader
@@ -591,7 +588,7 @@ class Loader {
  private:
   bool initial_buffer_filled_ = false;
   // Counts how many samples the reader have read already from this epoch
-  Index read_sample_counter_;
+  Index read_sample_counter_ = 0;
 };
 
 template<typename T, typename... Args>

--- a/dali/operators/reader/loader/loader_test.cc
+++ b/dali/operators/reader/loader/loader_test.cc
@@ -209,7 +209,7 @@ class DummyCountingLoader : public Loader<CPUBackend, Tensor<CPUBackend>, true> 
   std::vector<uint64_t> ReadInts(size_t n) {
     std::vector<uint64_t> result(n);
     for (size_t i = 0; i < n; i++) {
-      result[i] = ReadInt(false, false);
+      result[i] = ReadInt(i % max_batch_size_ == 0, (i + 1) % max_batch_size_ == 0);
     }
     return result;
   }

--- a/dali/operators/reader/loader/loader_test.cc
+++ b/dali/operators/reader/loader/loader_test.cc
@@ -198,8 +198,16 @@ class DummyCountingLoader : public Loader<CPUBackend, Tensor<CPUBackend>, true> 
     return size_;
   }
 
-  void Reset(bool wrap_to_shard) override {
+  void Skip(uint64_t n) override {
+    counter_ += n;
+  }
+
+  void Rewind(bool wrap_to_shard) override {
     counter_ = 0;
+  }
+
+  void Reset(bool wrap_to_shard) override {
+    Rewind(wrap_to_shard);
   }
 
   uint64_t ReadInt(bool is_new_batch, bool is_end_of_batch) {

--- a/dali/operators/reader/loader/loader_test.cc
+++ b/dali/operators/reader/loader/loader_test.cc
@@ -180,4 +180,77 @@ TYPED_TEST(DataLoadStoreTest, CachedLMDBTest) {
 }
 #endif
 
+
+class DummyCountingLoader : public Loader<CPUBackend, Tensor<CPUBackend>, true> {
+ public:
+  explicit DummyCountingLoader(const OpSpec& spec, uint64_t size) :
+    Loader<CPUBackend, Tensor<CPUBackend>, true>(spec),
+    size_(size), counter_(0) {}
+
+  void ReadSample(Tensor<CPUBackend> &t) override {
+    t.Resize({1}, DALI_UINT64);
+    *t.mutable_data<uint64_t>() = counter_++;
+  }
+
+  void PrepareMetadataImpl() override {}
+
+  Index SizeImpl() override {
+    return size_;
+  }
+
+  void Reset(bool wrap_to_shard) override {
+    counter_ = 0;
+  }
+
+  uint64_t ReadInt(bool is_new_batch, bool is_end_of_batch) {
+    return *ReadOne(is_new_batch, is_end_of_batch)->data<uint64_t>();
+  }
+
+  std::vector<uint64_t> ReadInts(size_t n) {
+    std::vector<uint64_t> result(n);
+    for (size_t i = 0; i < n; i++) {
+      result[i] = ReadInt(false, false);
+    }
+    return result;
+  }
+
+ private:
+  uint64_t size_;
+  uint64_t counter_;
+};
+
+void testFastForward(const OpSpec &spec, uint64_t data_size, int steps) {
+  auto reference = InitLoader<DummyCountingLoader>(spec, data_size)->ReadInts(steps);
+  auto loader = InitLoader<DummyCountingLoader>(spec, data_size);
+
+  int pos = 0;
+  int fast_forward_distance = 0;
+  while (pos + 3 < steps) {
+    for (int i = 0; i < 3; i++) {
+      EXPECT_EQ(loader->ReadInt(false, false), reference[pos]);
+      pos++;
+    }
+    loader->FastForward(fast_forward_distance);
+    pos += fast_forward_distance;
+    fast_forward_distance++;
+  }
+}
+
+TEST(LoaderCheckpointingTest, TestFastForwardNoShuffle) {
+  auto spec = OpSpec("FileReader")
+                .AddArg("device_id", 0)
+                .AddArg("max_batch_size", 256);
+  testFastForward(spec, 200, 50);
+}
+
+TEST(LoaderCheckpointingTest, TestFastForwardShuffled) {
+  auto spec = OpSpec("FileReader")
+                .AddArg("device_id", 0)
+                .AddArg("max_batch_size", 256)
+                .AddArg("initial_fill", 10)
+                .AddArg("random_shuffle", true)
+                .AddArg("seed", 123);
+  testFastForward(spec, 200, 50);
+}
+
 };  // namespace dali


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

This PR gives `Loader` a capability to fast-forward by _n_ steps, i.e. change its internal state to a state looking as if the `Loader` has returned _n_ more samples. This functionality will be later used for restoring mid-epoch checkpoints.

From the high level, fast-forwarding is done in two steps:

- _(Step 1)_ Simulate the `Loader` state for _n_ steps, but without touching the data: keep track of samples present in the buffer, but don't load them.

- _(Step 2)_ Check which samples need to be loaded and read them using `ReadSample`.

As _(Step 1)_ doesn't touch the data it should be relatively cheap. Cost of _(Step 2)_ depends on how fast the particular loader can load samples from given indices (i.e. how fast can it seek).

To implement _(Step 1)_ the following changes were made:

- **`IndexedLoadTargetSharedPtr`**, which is a pair of a sample index and tensor pointer, was introduced. Both `sample_buffer_` and `last_sample_ptr_tmp_` were changed to contain those instead of just pointers. This way we can keep track of samples
- `ReadOne` was extended with **_dry run_ mode**, controlled by `dry_run` argument. In a _dry_ mode `ReadOne` doesn't call `ReadSample` to read the sample, but instead just puts `nullptr` as the data pointer. This means that after running `ReadOne` in _dry_ mode for a few times the state of the loader is almost the same as it would be in normal mode, except for some samples having `nullptr` as their pointer. Those are the ones to be loaded in _(Step 2)_.

To implement _(Step 2)_ the following changes were made:
- `Loader` base class was extended with **`Skip(n)` method**, which skips reading _n_ samples. Efficient implementation of that method is trivial for some loaders (for example for file loader this just means adding _n_ to the pointer to current file) and harder for others (WDS, video).
- An inefficient **generic implementation of `Skip`** is provided by the baseclass: it simply reads samples and discards them instantly. It should be overriden by all loaders, but I put it here to provide some working implementation for all loaders.
- **`ReadMissingSamples` method** was added, which scans for samples having null pointer and reads them. As we only have `Skip` and thus are unable to seek backward freely, this method first lists all samples to be read and then reads them in a single forward pass through the data.
- To support fast-forward, loaders are required to provide **`Rewind` method**, which will reset the reader to the first sample. That's what `Reset` was probably originally meant to do, but now multiple loaders are also doing things like `current_epoch++` in their `Reset`s. `Rewind` is expected not to have any such side effects. Together with `Skip`, `Rewind` allows to move between samples to be read.

The following minor technical changes were made:
- Originally, the samples in the buffer were kept as `unique_ptr`s and transformed to `shared_ptr`s prior to returning. Now `ReadMissingSamples` might need to load the same sample into the buffer multiple times, so I decided to **keep samples in the buffer as shared pointers** as well, so now the `unique_ptr -> shared_ptr` transformation happens earlier.
- `ReadMissingSamples` uses `Reset`, `Skip` and `ReadSample` to make the loader read samples other that indicated by its current state (`read_sample_counter_` in particular). By design, `ReadSample` shouldn't depend on reading state of the loader, but just return the next sample, because the sample buffer is rather an implementation detail of the Loader. To make sure `ReadSample` won't depend on it, I **make `read_sample_counter_` and `initial_buffer_filled_` private**. 
- Also, **`virtual_shard_id_` should be made private**, but it's used in one place, in `Reset` of `FileLabelLoader` and it was recently introduced there (https://github.com/NVIDIA/DALI/issues/4954). I hope to eliminate this use when implementing mid-epoch checkpointing there. I added a _todo_ to make `virtual_shard_id_` private as well.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

Loader baseclass

### Key points relevant for the review:

The only change that could potentially break existing stuff is keeping shared pointers instead of unique pointers in the sample buffer. It is also possible that after fast-forward a few samples in the sample buffer will be pointers to the same tensor. Is there some problem with it that I don't see?

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3652
<!--- DALI-XXXX or NA --->
