### PR TITLE
Relax UpdatePropertiesFromSamples check constraints

### DIFF
--- a/dali/pipeline/data/tensor_list.cc
+++ b/dali/pipeline/data/tensor_list.cc
@@ -1118,10 +1118,13 @@ void TensorList<Backend>::UpdatePropertiesFromSamples(bool contiguous) {
   }
   for (int i = 0; i < curr_num_tensors_; i++) {
     if (tensors_[i].nbytes() == 0) {
+      if (is_pinned() != tensors_[i].is_pinned() || order() != tensors_[i].order()) {
+        tensors_[i].reset();
+        tensors_[i].set_pinned(is_pinned());
+        tensors_[i].set_order(order());
+      }
       tensors_[i].set_type(type());
       tensors_[i].SetLayout(GetLayout());
-      tensors_[i].set_pinned(is_pinned());
-      tensors_[i].set_order(order());
       tensors_[i].set_device_id(device_id());
     }
     DALI_ENFORCE(type() == tensors_[i].type(),

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -35,6 +35,11 @@
 
 namespace dali {
 
+// Forward declarations in signature, beware
+namespace test {
+class TensorListVariableBatchSizeTest_UpdatePropertiesFromSamples_Test;
+};  // namespace test
+
 template <typename Backend>
 class DLL_PUBLIC TensorList;
 
@@ -656,6 +661,7 @@ class DLL_PUBLIC TensorList {
   friend void MakeSampleView(class SampleWorkspace &sample, class Workspace &batch,
                              int data_idx, int thread_idx);
   friend void FixBatchPropertiesConsistency(class Workspace &ws, bool contiguous);
+  friend class test::TensorListVariableBatchSizeTest_UpdatePropertiesFromSamples_Test;
 
   auto &tensor_handle(size_t pos) {
     return tensors_[pos];

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -1987,6 +1987,9 @@ TEST_F(TensorListVariableBatchSizeTest, UpdatePropertiesFromSamples) {
   t.set_pinned(true);
   t.Resize(19, DALI_FLOAT);
   tv.UpdatePropertiesFromSamples(false);
+  // check if after calling UpdatePropertiesFromSamples even empty samples in TL have consistent
+  // metadata with the the whole TL
+  tv.SetSample(1, tv.tensor_handle(2));
 }
 
 

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -1980,6 +1980,15 @@ TEST_F(TensorListVariableBatchSizeTest, TlCopyWithResizeDown) {
   EXPECT_PRED_FORMAT2(Compare, test_tl_, tv);
 }
 
+TEST_F(TensorListVariableBatchSizeTest, UpdatePropertiesFromSamples) {
+  TensorList<CPUBackend> tv(3);
+  tv.set_type(DALI_FLOAT);
+  auto &t = tv.tensor_handle(0);
+  t.set_pinned(true);
+  t.Resize(19, DALI_FLOAT);
+  tv.UpdatePropertiesFromSamples(false);
+}
+
 
 }  // namespace test
 }  // namespace dali


### PR DESCRIPTION
- UpdatePropertiesFromSamples checks if all tensors
  in a batch have equal properties. In some cases, when
  the tensor is empty it doesn't make much sense - like the device_id
  or pinnes level. This PR relaxes these constraints

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- UpdatePropertiesFromSamples checks if all tensors
  in a batch have equal properties. In some cases, when
  the tensor is empty it doesn't make much sense - like the device_id
  or pinnes level. This PR relaxes these constraints

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- tensor_list
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- what should be checked for empty tensors
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
    - TensorListVariableBatchSizeTest_UpdatePropertiesFromSamples_Test
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
