### PR TITLE
Make sure that the relase of python memory from the DALI tensor happens inside GIL

### DIFF
--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -49,6 +49,14 @@ def test_create_tensor():
     assert_array_equal(arr, np.array(tensor))
 
 
+def test_create_tensor_and_make_it_release_memory():
+    arr = np.random.rand(3, 5, 6)
+    tensor = TensorCPU(arr, "NHWC")
+    assert_array_equal(arr, np.array(tensor))
+    arr = None
+    tensor = None
+
+
 def test_create_tensorlist():
     arr = np.random.rand(3, 5, 6)
     tensorlist = TensorListCPU(arr, "NHWC")


### PR DESCRIPTION
- no-copy mode of the DALI tensor constructor keeps an internal reference
  to the python object. When the Tensor is released it needs to happen
  inside GIL as it touches the reference count. This PR makes sure
  that the GIL is acquired.

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- no-copy mode of the DALI tensor constructor keeps an internal reference
  to the python object. When the Tensor is released it needs to happen
  inside GIL as it touches the reference count. This PR makes sure
  that the GIL is acquired.

Relegates to https://github.com/NVIDIA/DALI/pull/5072
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_backend_impl.test_create_tensor_and_make_it_release_memory
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3668
<!--- DALI-XXXX or NA --->
