### PR TITLE
Add mid-epoch checkpointing to Loader

### DIFF
--- a/dali/operators/reader/loader/file_label_loader.h
+++ b/dali/operators/reader/loader/file_label_loader.h
@@ -196,13 +196,16 @@ class DLL_PUBLIC FileLabelLoaderBase : public Loader<CPUBackend, ImageLabelWrapp
     Reset(true);
   }
 
-  void Reset(bool wrap_to_shard) override {
+  void Rewind(bool wrap_to_shard) override {
     if (wrap_to_shard) {
       current_index_ = start_index(virtual_shard_id_, num_shards_, SizeImpl());
     } else {
       current_index_ = 0;
     }
+  }
 
+  void Reset(bool wrap_to_shard) override {
+    Rewind(wrap_to_shard);
     current_epoch_++;
 
     if (shuffle_after_epoch_) {

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -189,7 +189,7 @@ class Loader {
 
     // Re-run reset
     Reset(true);
-    
+
     SaveStateSnapshot(current_snapshot_);
 
     FastForward(state.age);

--- a/dali/operators/reader/loader/loader_test.cc
+++ b/dali/operators/reader/loader/loader_test.cc
@@ -342,7 +342,7 @@ TEST(LoaderCheckpointingTest, TestCheckpointShortEpoch) {
 
   TestLoaderCheckpointing(InitLoader<DummyCountingLoader>(
     spec,
-    8   /* epoch size, that's 3 epochs in a sample buffer! */, 
+    8   /* epoch size, that's 3 epochs in a sample buffer! */,
     100 /* add 100*current_epoch to each output to differentiate samples */),
   32);
 }

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -125,24 +125,8 @@ class DataReader : public Operator<Backend> {
                    "Cannot restore the checkpoint, because "
                    "checkpointing was not enabled.");
       auto &snapshot = cpt.CheckpointState<LoaderStateSnapshot>();
-
-      StopPrefetchThread();
-      for (auto &batch : prefetched_batch_queue_) {
-        batch.clear();
-      }
-
       loader_->RestoreStateFromSnapshot(snapshot);
-      curr_batch_consumer_ = 0;
-      curr_batch_producer_ = 0;
-      consumer_cycle_ = false;
-      producer_cycle_ = false;
-      snapshot_consumer_ = 0;
-      snapshot_producer_ = 0;
-
       SetInitialSnapshot();
-
-      StartPrefetchThread();
-      ConsumerWait();
     }
   }
 
@@ -177,7 +161,6 @@ class DataReader : public Operator<Backend> {
     std::lock_guard<std::mutex> lock(prefetch_access_mutex_);
     // if thread hasn't been started yet, start it
     if (prefetch_thread_.joinable()) return;
-    finished_ = false;
     prefetch_thread_ = std::thread(&DataReader::PrefetchWorker, this);
   }
 

--- a/dali/pipeline/operator/checkpointing/snapshot_serializer.cc
+++ b/dali/pipeline/operator/checkpointing/snapshot_serializer.cc
@@ -90,6 +90,7 @@ std::string SnapshotSerializer::Serialize(const LoaderStateSnapshot &snapshot) {
   dali_proto::ReaderStateSnapshot proto_snapshot;
   proto_snapshot.mutable_loader_state()->set_rng(SerializeToString(snapshot.rng));
   proto_snapshot.mutable_loader_state()->set_current_epoch(snapshot.current_epoch);
+  proto_snapshot.mutable_loader_state()->set_age(snapshot.age);
   return proto_snapshot.SerializeAsString();
 }
 
@@ -100,6 +101,7 @@ LoaderStateSnapshot SnapshotSerializer::Deserialize(const std::string &data) {
   return LoaderStateSnapshot {
     DeserializeFromString<std::default_random_engine>(proto_snapshot.loader_state().rng()),
     proto_snapshot.loader_state().current_epoch(),
+    proto_snapshot.loader_state().age(),
   };
 }
 

--- a/dali/pipeline/operator/checkpointing/snapshot_serializer_test.cc
+++ b/dali/pipeline/operator/checkpointing/snapshot_serializer_test.cc
@@ -51,7 +51,8 @@ TEST_F(SnapshotSerializerTest, VectorMt19937_64) {
 TEST_F(SnapshotSerializerTest, LoaderStateSnapshot) {
   LoaderStateSnapshot snapshot = {
     std::default_random_engine(123),
-    321
+    321,
+    567
   };
 
   std::string serialized = SnapshotSerializer().Serialize(snapshot);
@@ -59,6 +60,7 @@ TEST_F(SnapshotSerializerTest, LoaderStateSnapshot) {
 
   EXPECT_EQ(snapshot.rng, deserialized.rng);
   EXPECT_EQ(snapshot.current_epoch, deserialized.current_epoch);
+  EXPECT_EQ(snapshot.age, deserialized.age);
 }
 
 }  // namespace dali

--- a/dali/pipeline/proto/dali.proto
+++ b/dali/pipeline/proto/dali.proto
@@ -95,6 +95,7 @@ message ReaderStateSnapshot {
   message LoaderStateSnapshot {
     optional bytes rng = 1;
     optional int32 current_epoch = 2;
+    optional int32 age = 3;
   }
   optional LoaderStateSnapshot loader_state = 1;
 }


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** (*non-breaking change which adds functionality*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

This PR allows `Loader` to checkpoint at any time (including mid-epoch).

If checkpointing is enabled, loader takes a snapshot of its state at the beginning of every epoch. This snapshot is kept in `current_snapshot_` together with its `age`, indicating how many samples were returned since the snapshot was taken.

When restoring a checkpoint, first the state from the snapshot is restored and then the loader is fast-forwarded (https://github.com/NVIDIA/DALI/pull/5088) by `age` steps.

## Additional information:

### Affected modules and functionalities:
Checkpointing in loader `Loader` baseclass was modified to allow mid-epoch checkpointing. 

In addition to that, the following additional changes were made:
- Sample indices (stored together with actual buffered samples to allow reading them lazily in `ReadMissingSamples`, see https://github.com/NVIDIA/DALI/pull/5088) were changed from being sample's index _in the epoch_ (`read_sample_counter`) to being absolute sample's index (`total_read_sample_counter`). That's because it's possible that there are samples from multiple epochs in the buffer and `ReadMissingSamples` must know which epoch is each sample from, because samples may be shuffled between epochs.
- ~In `reader_op.h`, when restoring the checkpoint, we now stop the prefetch thread to prevent races and clear prefetch queue to return tensors to the loader. This worked before because of the assumption that `restore` will be called only on freshly-created pipeline. I'd like to lift this assumption soon.~ This can wait until the follow-up PR when I deal with this completely. Undone in https://github.com/NVIDIA/DALI/pull/5103/commits/0a1a24b3b6b03d599173ce8aa0b284fd57bc113c
- The changes in `FileLabelLoader` are just implementing `Rewind` to keep existing code working.

### Follow-ups
- `FileReader` will get mid-epoch checkpointing support in a separate PR, coming soon
- To optimize checkpoint restore, I'd like to store snapshots every _n_ samples and not just every epoch.
- This solution should allow us to lift `pad_last_batch=True` requirement from `FileReader`.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Several fixes were made in `DummyCountingLoader ` to make it epoch-aware. Also, to simulate possible differences between epochs, an optional parameter `mark_epoch` (default `0`) was added to  `DummyCountingLoader `, which adds `mark_epoch * current_epoch` to each sample.

<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3652
<!--- DALI-XXXX or NA --->
