### PR TITLE
Generalize `__module__` handling and hide private modules from Ops doc

### DIFF
--- a/dali/python/nvidia/dali/fn/__init__.py
+++ b/dali/python/nvidia/dali/fn/__init__.py
@@ -131,5 +131,5 @@ def _wrap_op(op_class, submodule, parent_module, wrapper_doc):
             setattr(parent_module, wrapper_name, wrap_func)
 
 
-external_source.__module__ = __name__
 external_source._schema_name = "ExternalSource"
+_internal._adjust_operator_module(external_source, sys.modules[__name__], [])

--- a/dali/python/nvidia/dali/fn/__init__.py
+++ b/dali/python/nvidia/dali/fn/__init__.py
@@ -122,10 +122,14 @@ def _wrap_op(op_class, submodule, parent_module, wrapper_doc):
     else:
         fn_module = sys.modules[parent_module]
     module = _internal.get_submodule(fn_module, submodule)
+    if not getattr(op_class, "_generated", False):
+        impl_module_override = op_class._impl_module
+    else:
+        impl_module_override = None
     if not hasattr(module, wrapper_name):
         wrap_func = _wrap_op_fn(op_class, wrapper_name, wrapper_doc)
         setattr(module, wrapper_name, wrap_func)
-        _internal._adjust_operator_module(wrap_func, fn_module, submodule)
+        _internal._adjust_operator_module(wrap_func, fn_module, submodule, impl_module_override)
         if make_hidden:
             parent_module = _internal.get_submodule(fn_module, submodule[:-1])
             setattr(parent_module, wrapper_name, wrap_func)

--- a/dali/python/nvidia/dali/fn/__init__.py
+++ b/dali/python/nvidia/dali/fn/__init__.py
@@ -125,8 +125,7 @@ def _wrap_op(op_class, submodule, parent_module, wrapper_doc):
     if not hasattr(module, wrapper_name):
         wrap_func = _wrap_op_fn(op_class, wrapper_name, wrapper_doc)
         setattr(module, wrapper_name, wrap_func)
-        if submodule:
-            wrap_func.__module__ = module.__name__
+        _internal._adjust_operator_module(wrap_func, fn_module, submodule)
         if make_hidden:
             parent_module = _internal.get_submodule(fn_module, submodule[:-1])
             setattr(parent_module, wrapper_name, wrap_func)

--- a/dali/python/nvidia/dali/internal.py
+++ b/dali/python/nvidia/dali/internal.py
@@ -58,7 +58,7 @@ Parameters
     return root
 
 
-def _adjust_operator_module(operator, api_module, submodule):
+def _adjust_operator_module(operator, api_module, submodule, impl_overwrite=None):
     """Adjust the __module__ of `operator` to point into the submodule of `api_module`
     pointed by the list of in `submodule`, for example:
         api_module = <nvidia.dali.ops module>
@@ -66,7 +66,10 @@ def _adjust_operator_module(operator, api_module, submodule):
 
     The original module where the operator code was generated is saved as `_impl_module` to allow
     access to it.
+
+    If the operator has base class defined by hand, but it is generated with an automatic wrapper
+    generator, we can point to the original implementation module via `impl_overwrite`.
     """
     module = get_submodule(api_module, submodule)
-    operator._impl_module = operator.__module__
+    operator._impl_module = operator.__module__ if impl_overwrite is None else impl_overwrite
     operator.__module__ = module.__name__

--- a/dali/python/nvidia/dali/internal.py
+++ b/dali/python/nvidia/dali/internal.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import importlib
 import sys
 import types
@@ -42,3 +56,17 @@ Parameters
                 f"which is not a module, but {m}")
         root = m
     return root
+
+
+def _adjust_operator_module(operator, api_module, submodule):
+    """Adjust the __module__ of `operator` to point into the submodule of `api_module`
+    pointed by the list of in `submodule`, for example:
+        api_module = <nvidia.dali.ops module>
+        submodule = ["experimental", "readers"]
+
+    The original module where the operator code was generated is saved as `_impl_module` to allow
+    access to it.
+    """
+    module = get_submodule(api_module, submodule)
+    operator._impl_module = operator.__module__
+    operator.__module__ = module.__name__

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -586,7 +586,7 @@ def _load_ops():
         module = _internal.get_submodule(ops_module, submodule)
         if not hasattr(module, op_name):
             op_class = python_op_factory(op_name, op_reg_name)
-            op_class.__module__ = module.__name__
+            _internal._adjust_operator_module(op_class, ops_module, submodule)
             setattr(module, op_name, op_class)
 
             if op_name not in ["ExternalSource"]:
@@ -625,7 +625,7 @@ def _load_readers_tfrecord():
         _, submodule, op_name = _process_op_name(op_reg_name)
         module = _internal.get_submodule(ops_module, submodule)
         if not hasattr(module, op_name):
-            op_class.__module__ = module.__name__
+            _internal._adjust_operator_module(op_class, ops_module, submodule)
             setattr(module, op_name, op_class)
             _wrap_op(op_class, submodule)
 
@@ -717,11 +717,16 @@ from nvidia.dali.ops._operators.python_function import (  # noqa: E402, F401
 _wrap_op(PythonFunction)
 _wrap_op(DLTensorPythonFunction)
 
+_internal._adjust_operator_module(PythonFunction, sys.modules[__name__], [])
+_internal._adjust_operator_module(DLTensorPythonFunction, sys.modules[__name__], [])
+
 # Compose is only exposed for ops API, no fn bindings are generated
 from nvidia.dali.ops._operators.compose import Compose  # noqa: E402, F401
 
 _registry.register_cpu_op('Compose')
 _registry.register_gpu_op('Compose')
+
+_internal._adjust_operator_module(Compose, sys.modules[__name__], [])
 
 
 from nvidia.dali.ops._operators.math import (_arithm_op, _group_inputs,  # noqa: E402, F401

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -706,7 +706,7 @@ def _preprocess_inputs(inputs, op_name, device, schema=None):
 # appropriate module.
 from nvidia.dali.external_source import ExternalSource  # noqa: E402
 
-ExternalSource.__module__ = __name__
+_internal._adjust_operator_module(ExternalSource, sys.modules[__name__], [])
 
 # Expose the PythonFunction family of classes and generate the fn bindings for them
 from nvidia.dali.ops._operators.python_function import (  # noqa: E402, F401

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -714,20 +714,19 @@ from nvidia.dali.ops._operators.python_function import (  # noqa: E402, F401
     PythonFunction, DLTensorPythonFunction, _dlpack_to_array,  # noqa: F401
     _dlpack_from_array)  # noqa: F401
 
-_wrap_op(PythonFunction)
-_wrap_op(DLTensorPythonFunction)
-
 _internal._adjust_operator_module(PythonFunction, sys.modules[__name__], [])
 _internal._adjust_operator_module(DLTensorPythonFunction, sys.modules[__name__], [])
+
+_wrap_op(PythonFunction)
+_wrap_op(DLTensorPythonFunction)
 
 # Compose is only exposed for ops API, no fn bindings are generated
 from nvidia.dali.ops._operators.compose import Compose  # noqa: E402, F401
 
-_registry.register_cpu_op('Compose')
-_registry.register_gpu_op('Compose')
-
 _internal._adjust_operator_module(Compose, sys.modules[__name__], [])
 
+_registry.register_cpu_op('Compose')
+_registry.register_gpu_op('Compose')
 
 from nvidia.dali.ops._operators.math import (_arithm_op, _group_inputs,  # noqa: E402, F401
                                              _generate_input_desc)  # noqa: F401

--- a/dali/python/nvidia/dali/plugin/numba/experimental.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental.py
@@ -86,6 +86,7 @@ def _get_shape_view(shapes_ptr, ndims_ptr, num_dims, num_samples):
 
 class NumbaFunction(metaclass=ops._DaliOperatorMeta):
     schema_name = 'NumbaFunction'
+    _impl_module = "nvidia.dali.plugin.numba"
     ops.register_cpu_op('NumbaFunction')
     ops.register_gpu_op('NumbaFunction')
 

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -712,6 +712,7 @@ class DALIRaggedIterator(_DaliBaseIterator):
 
 class TorchPythonFunction(ops.PythonFunctionBase):
     schema_name = "TorchPythonFunction"
+    _impl_module = "nvidia.dali.plugin.pytorch"
     ops.register_cpu_op('TorchPythonFunction')
     ops.register_gpu_op('TorchPythonFunction')
 

--- a/docs/autodoc_submodules.py
+++ b/docs/autodoc_submodules.py
@@ -50,7 +50,6 @@ def get_modules(top_modules):
             if (module.startswith(doc_module) and not module.endswith('hidden')
                     and not _is_private(module)):
                 modules += [module]
-    print(f"{modules=}")
     return sorted(modules)
 
 

--- a/docs/autodoc_submodules.py
+++ b/docs/autodoc_submodules.py
@@ -38,12 +38,19 @@ mod_aditional_doc = {
 }
 
 
+def _is_private(module):
+    submodules = module.split(".")
+    return any([submodule.startswith("_") for submodule in submodules])
+
+
 def get_modules(top_modules):
     modules = []
     for module in sys.modules.keys():
         for doc_module in top_modules:
-            if module.startswith(doc_module) and not module.endswith('hidden'):
+            if (module.startswith(doc_module) and not module.endswith('hidden')
+                    and not _is_private(module)):
                 modules += [module]
+    print(f"{modules=}")
     return sorted(modules)
 
 
@@ -156,4 +163,3 @@ def fn_autodoc(out_filename, generated_path, references):
 
     with open(out_filename, 'w') as f:
         f.write(all_modules_str)
-


### PR DESCRIPTION

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Refactoring**, **Other**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Fix for the documentation rendering / `__module__` visibility.

After refactoring, the documentation for ops API started listing all the internall modules. Modules that start with `_` are no longer visible in Sphinx doc.

Moving the custom operator classes to the dedicated submodules casued the docs to render the path to the implementation module and not the one we want to present in the API - due to the `__module__` change.

As the module with the original implementation is still useful, a generalized way of adjusting the `__module__` was introduced, keeping the original information in the operator under _impl_module`.




## Additional information:

### Affected modules and functionalities:
Doc generation, `__module__` for operator classes: TFRecordReader, Python Functions, compose.



### Key points relevant for the review:
Please check the legacy API documentation rendering.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [x] Other - *doc generation updated, pleas check*
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
