### PR TITLE
Fix lack of crop_pos_z handling for fixed crop window

### DIFF
--- a/dali/operators/image/crop/crop_attr.cc
+++ b/dali/operators/image/crop/crop_attr.cc
@@ -169,7 +169,7 @@ void CropAttr::ProcessArguments(const OpSpec& spec, const ArgumentWorkspace* ws,
 
   crop_x_norm_[data_idx] = spec.GetArgument<float>("crop_pos_x", ws, data_idx);
   crop_y_norm_[data_idx] = spec.GetArgument<float>("crop_pos_y", ws, data_idx);
-  if (spec.ArgumentDefined("crop_d")) {
+  if (spec.ArgumentDefined("crop_d") || crop_depth_[data_idx] != kNoCrop) {
     crop_z_norm_[data_idx] = spec.GetArgument<float>("crop_pos_z", ws, data_idx);
   }
 


### PR DESCRIPTION
- crop_pos_z is disregarded when crop window is defined through
  crop argument and work only with crop_d.

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- crop_pos_z is disregarded when crop window is defined through
  crop argument and work only with crop_d.
- related to https://github.com/NVIDIA/DALI/issues/5117
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- crop operator
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    -  test_crop.test_crop_3d_vs_python_op_crop_fixed_window
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
