### PR TITLE
Fix constructing tensors from `__cuda_array_interface__` v3.

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -255,6 +255,13 @@ void FillTensorFromCudaArray(const py::object object, TensorType *batch, int dev
     CUDA_CALL(cudaGetDevice(&device_id));
   }
 
+  batch->Reset();
+
+  if (cu_a_interface.contains("stream")) {
+     auto order = AccessOrder(cudaStream_t(PyLong_AsVoidPtr(cu_a_interface["stream"].ptr())));
+     batch->set_order(order);
+  }
+
   // Keep a copy of the input object ref in the deleter, so its refcount is increased
   // while this shared_ptr is alive (and the data should be kept alive)
   batch->ShareData(shared_ptr<void>(ptr, [obj_ref = object](void *) {}),


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
When constructing tensors from `__cuda_array_interface__` we assumed that the data is ready. This doesn't need to be the case.
When the `__cuda_array_interface__` contains a stream field, we should instead synchronize with that stream or set it as the current "order" for the new tensor (I chose the latter approach).

The bug manifested itself in debug mode tests with CuPy.

## Additional information:

### Affected modules and functionalities:
Creating DALI tensors from `__cuda_array_interface__` in backend_impl.



### Key points relevant for the review:
?

### Tests:
`test_pipeline_debug_mode:test_injection_cupy`
- [X] Existing tests apply
- [ ] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
