### PR TITLE
Fix static variable destruction order in Resampling Filters

### DIFF
--- a/dali/kernels/imgproc/resample/resampling_filters.cu
+++ b/dali/kernels/imgproc/resample/resampling_filters.cu
@@ -169,10 +169,10 @@ std::shared_ptr<ResamplingFilters> GetResamplingFilters() {
 
 
 std::shared_ptr<ResamplingFilters> GetResamplingFiltersCPU() {
+  (void)mm::GetDefaultResource<mm::memory_kind::host>();
   static std::once_flag once;
   static std::shared_ptr<ResamplingFilters> cpu_filters;
   std::call_once(once, []() {
-    (void)mm::GetDefaultResource<mm::memory_kind::host>();
     cpu_filters = std::make_shared<ResamplingFilters>();
     InitFilters<mm::memory_kind::host>(*cpu_filters);
   });


### PR DESCRIPTION
Make sure that the CPU default resource is _created_ before ResamplingFiltersCPU singleton is _declared_.

## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
Before the fix the static `shared_ptr` was declared (and thus created) before touching default host memory resource.
While the actual contents of the pointer were initialized after, it is the declaration of the pointer variable, not its initialization, that determines the destruction order. In rare circumstances, it was possible that there was no prior usage of host memory resource, which resulted in a hard fault at process teardown.

See #5131 

## Additional information:
N/A

### Affected modules and functionalities:
N/A

### Key points relevant for the review:
N/A

### Tests:
Fixes the repro in #5131

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
