### PR TITLE
Fix exit sequence.

### DIFF
--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -29,6 +29,7 @@
 #include "dali/pipeline/operator/argument.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/core/device_guard.h"
+#include "dali/core/mm/default_resources.h"
 #include "dali/pipeline/dali.pb.h"
 
 namespace dali {
@@ -87,15 +88,34 @@ void DeserializeOpSpec(const dali_proto::OpDef &def, OpSpec *spec) {
   }
 }
 
+void InitializeMemoryResources(int device_id) {
+  (void)mm::GetDefaultResource<mm::memory_kind::host>();
+  if (device_id != CPU_ONLY_DEVICE_ID) {
+    DeviceGuard dg(device_id);
+    (void)mm::GetDefaultResource<mm::memory_kind::pinned>();
+    (void)mm::GetDefaultDeviceResource(device_id);
+  }
+}
 
 }  // namespace
 
+Pipeline::Pipeline(int max_batch_size, int num_threads, int device_id, int64_t seed,
+                   bool pipelined_execution, int prefetch_queue_depth,
+                   bool async_execution, size_t bytes_per_sample_hint,
+                   bool set_affinity, int max_num_stream, int default_cuda_stream_priority)
+    : built_(false), separated_execution_{false} {
+  InitializeMemoryResources(device_id);
+  Init(max_batch_size, num_threads, device_id, seed, pipelined_execution, separated_execution_,
+       async_execution, bytes_per_sample_hint, set_affinity, max_num_stream,
+       default_cuda_stream_priority, QueueSizes{prefetch_queue_depth});
+}
 
 Pipeline::Pipeline(const string &serialized_pipe, int batch_size, int num_threads, int device_id,
                    bool pipelined_execution, int prefetch_queue_depth, bool async_execution,
                    size_t bytes_per_sample_hint, bool set_affinity, int max_num_stream,
                    int default_cuda_stream_priority, int64_t seed)
     : built_(false), separated_execution_(false) {
+  InitializeMemoryResources(device_id);
   dali_proto::PipelineDef def;
   DALI_ENFORCE(DeserializePipeline(serialized_pipe, def), "Error parsing serialized pipeline.");
 
@@ -152,6 +172,8 @@ Pipeline::Pipeline(const string &serialized_pipe, int batch_size, int num_thread
 Pipeline::~Pipeline() {
   Shutdown();
   graph_ = {};
+  executor_ = {};
+  repeat_last_ = {};
 }
 
 void Pipeline::Init(int max_batch_size, int num_threads, int device_id, int64_t seed,

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -88,13 +88,8 @@ void DeserializeOpSpec(const dali_proto::OpDef &def, OpSpec *spec) {
   }
 }
 
-void InitializeMemoryResources(int device_id) {
+void InitializeMemoryResources() {
   (void)mm::GetDefaultResource<mm::memory_kind::host>();
-  if (device_id != CPU_ONLY_DEVICE_ID) {
-    DeviceGuard dg(device_id);
-    (void)mm::GetDefaultResource<mm::memory_kind::pinned>();
-    (void)mm::GetDefaultDeviceResource(device_id);
-  }
 }
 
 }  // namespace
@@ -104,7 +99,7 @@ Pipeline::Pipeline(int max_batch_size, int num_threads, int device_id, int64_t s
                    bool async_execution, size_t bytes_per_sample_hint,
                    bool set_affinity, int max_num_stream, int default_cuda_stream_priority)
     : built_(false), separated_execution_{false} {
-  InitializeMemoryResources(device_id);
+  InitializeMemoryResources();
   Init(max_batch_size, num_threads, device_id, seed, pipelined_execution, separated_execution_,
        async_execution, bytes_per_sample_hint, set_affinity, max_num_stream,
        default_cuda_stream_priority, QueueSizes{prefetch_queue_depth});
@@ -115,7 +110,7 @@ Pipeline::Pipeline(const string &serialized_pipe, int batch_size, int num_thread
                    size_t bytes_per_sample_hint, bool set_affinity, int max_num_stream,
                    int default_cuda_stream_priority, int64_t seed)
     : built_(false), separated_execution_(false) {
-  InitializeMemoryResources(device_id);
+  InitializeMemoryResources();
   dali_proto::PipelineDef def;
   DALI_ENFORCE(DeserializePipeline(serialized_pipe, def), "Error parsing serialized pipeline.");
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -89,16 +89,11 @@ class DLL_PUBLIC Pipeline {
    * @param default_cuda_stream_priority  CUDA stream priority used by DALI.
    * See `cudaStreamCreateWithPriority` in CUDA documentation
    */
-  DLL_PUBLIC inline Pipeline(int max_batch_size, int num_threads, int device_id, int64_t seed = -1,
+  DLL_PUBLIC Pipeline(int max_batch_size, int num_threads, int device_id, int64_t seed = -1,
                              bool pipelined_execution = true, int prefetch_queue_depth = 2,
                              bool async_execution = true, size_t bytes_per_sample_hint = 0,
                              bool set_affinity = false, int max_num_stream = -1,
-                             int default_cuda_stream_priority = 0)
-      : built_(false), separated_execution_{false} {
-    Init(max_batch_size, num_threads, device_id, seed, pipelined_execution, separated_execution_,
-         async_execution, bytes_per_sample_hint, set_affinity, max_num_stream,
-         default_cuda_stream_priority, QueueSizes{prefetch_queue_depth});
-  }
+                             int default_cuda_stream_priority = 0);
 
   DLL_PUBLIC Pipeline(const string &serialized_pipe, int max_batch_size = -1, int num_threads = -1,
                       int device_id = -1, bool pipelined_execution = true,

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -90,10 +90,10 @@ class DLL_PUBLIC Pipeline {
    * See `cudaStreamCreateWithPriority` in CUDA documentation
    */
   DLL_PUBLIC Pipeline(int max_batch_size, int num_threads, int device_id, int64_t seed = -1,
-                             bool pipelined_execution = true, int prefetch_queue_depth = 2,
-                             bool async_execution = true, size_t bytes_per_sample_hint = 0,
-                             bool set_affinity = false, int max_num_stream = -1,
-                             int default_cuda_stream_priority = 0);
+                      bool pipelined_execution = true, int prefetch_queue_depth = 2,
+                      bool async_execution = true, size_t bytes_per_sample_hint = 0,
+                      bool set_affinity = false, int max_num_stream = -1,
+                      int default_cuda_stream_priority = 0);
 
   DLL_PUBLIC Pipeline(const string &serialized_pipe, int max_batch_size = -1, int num_threads = -1,
                       int device_id = -1, bool pipelined_execution = true,

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1854,6 +1854,7 @@ PYBIND11_MODULE(backend_impl, m) {
              p->Build(build_args);
          })
     .def("Build", [](Pipeline *p) { p->Build(); })
+    .def("Shutdown", &Pipeline::Shutdown)
     .def("SetExecutionTypes",
         [](Pipeline *p, bool exec_pipelined, bool exec_separated, bool exec_async) {
           p->SetExecutionTypes(exec_pipelined, exec_separated, exec_async);

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1854,7 +1854,7 @@ PYBIND11_MODULE(backend_impl, m) {
              p->Build(build_args);
          })
     .def("Build", [](Pipeline *p) { p->Build(); })
-    .def("Shutdown", &Pipeline::Shutdown)
+    .def("Shutdown", &Pipeline::Shutdown, py::call_guard<py::gil_scoped_release>())
     .def("SetExecutionTypes",
         [](Pipeline *p, bool exec_pipelined, bool exec_separated, bool exec_async) {
           p->SetExecutionTypes(exec_pipelined, exec_separated, exec_async);

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -335,7 +335,7 @@ Parameters
 
     def _shutdown(self):
         if self._pipe:
-            del self._pipe      # delete the backend pipeline, shutting it down
+            self._pipe.Shutdown()
             self._pipe = None
             Pipeline._pipes.remove(self)
 

--- a/dali/test/python/operator_2/test_python_function_cleanup.py
+++ b/dali/test/python/operator_2/test_python_function_cleanup.py
@@ -1,0 +1,27 @@
+import nvidia.dali.fn as fn
+import nvidia.dali.types as types
+from nvidia.dali.pipeline import pipeline_def
+import numpy as np
+
+
+def f(x):
+    return x
+
+
+@pipeline_def(batch_size=256, num_threads=1, seed=0)
+def pipeline():
+    x = types.Constant(np.full((1,), 0))
+    x = fn.python_function(x, function=f, num_outputs=1)
+    y = types.Constant(np.full((1024, 720), 0))
+
+    return x + y
+
+
+p = None
+
+
+def test_shutdown():
+    global p
+    p = pipeline(device_id=None)
+    p.build()
+    p.run()

--- a/dali/test/python/operator_2/test_python_function_cleanup.py
+++ b/dali/test/python/operator_2/test_python_function_cleanup.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 from nvidia.dali.pipeline import pipeline_def

--- a/dali/test/python/test_python_function_cleanup.py
+++ b/dali/test/python/test_python_function_cleanup.py
@@ -30,6 +30,7 @@ def pipeline():
 
     return x + y
 
+
 p = pipeline(device_id=None)
 p.build()
 p.run()

--- a/dali/test/python/test_python_function_cleanup.py
+++ b/dali/test/python/test_python_function_cleanup.py
@@ -30,12 +30,6 @@ def pipeline():
 
     return x + y
 
-
-p = None
-
-
-def test_shutdown():
-    global p
-    p = pipeline(device_id=None)
-    p.build()
-    p.run()
+p = pipeline(device_id=None)
+p.build()
+p.run()

--- a/qa/TL0_python-self-test-core/test_body.sh
+++ b/qa/TL0_python-self-test-core/test_body.sh
@@ -18,6 +18,7 @@ test_py_with_framework() {
 }
 
 test_py() {
+    python test_python_function_cleanup.py
     python test_detection_pipeline.py -i 300
     python test_RN50_data_pipeline.py -s -i 10
     python test_coco_tfrecord.py -i 64


### PR DESCRIPTION
Register a python atexit handler that shuts down the pipelines.
Fix host resource cleanup.
Improve Pipeline shutdown sequence; ensure that memory resources are ready when the pipeline is created

## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
The bug: when using PythonFunction operator, the shutdown sequence was somehow broken and the pipeline was still running when the interpreter was already torn down and some libraries were unloaded.

The fix:
Register a python atexit handler that shuts down the pipelines.
Fix host resource cleanup.
Improve Pipeline shutdown sequence; ensure that memory resources are ready when the pipeline is created
Additionally (I don't know how necessary this is, after all) - got rid of static variables when creating host default resource.

## Additional information:

### Affected modules and functionalities:
Pipeline (C++ and Python)
Default resources.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3673
<!--- DALI-XXXX or NA --->
