### PR TITLE
Implement checkpointing for random GPU operators

### DIFF
--- a/dali/operators/random/rng_base.h
+++ b/dali/operators/random/rng_base.h
@@ -70,7 +70,7 @@ class RNGBase : public Operator<Backend> {
     } else {
       static_assert(std::is_same_v<Backend, GPUBackend>);
       const auto &states_gpu = cpt.CheckpointState<curand_states>();
-      size_t n = backend_data_.randomizer_.length();
+      size_t n = states_gpu.length();
       std::vector<curandState> states(n);
       cudaMemcpy(states.data(), states_gpu.states(), n * sizeof(curandState),
                  cudaMemcpyDeviceToHost);

--- a/dali/operators/random/rng_base.h
+++ b/dali/operators/random/rng_base.h
@@ -55,8 +55,8 @@ class RNGBase : public Operator<Backend> {
       rng_ = rng;
     } else {
       static_assert(std::is_same_v<Backend, GPUBackend>);
-      const auto &states_cpu = cpt.CheckpointState<std::shared_ptr<curandState>>();
-      backend_data_.randomizer_.set_states(states_cpu.get());
+      const auto &states_gpu = cpt.CheckpointState<std::shared_ptr<curandState>>();
+      backend_data_.randomizer_.set_states(states_gpu.get());
     }
   }
 

--- a/dali/operators/random/rng_base.h
+++ b/dali/operators/random/rng_base.h
@@ -18,6 +18,7 @@
 #include <random>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "dali/core/convert.h"
 #include "dali/pipeline/operator/operator.h"
@@ -71,7 +72,6 @@ class RNGBase : public Operator<Backend> {
       cudaMemcpy(states.data(), ptr_gpu.get(), n * sizeof(curandState), cudaMemcpyDeviceToHost);
       return SnapshotSerializer().Serialize(states);
     }
-
   }
 
   void DeserializeCheckpoint(OpCheckpoint &cpt, const std::string &data) const override {

--- a/dali/operators/util/randomizer.cuh
+++ b/dali/operators/util/randomizer.cuh
@@ -58,7 +58,7 @@ struct curand_states {
     return states;
   }
 
-  DALI_HOST inline void set(const curand_states &other) const {
+  DALI_HOST inline void set(const curand_states &other) {
     cudaMemcpy(states_, other.states_, sizeof(curandState) * len_, cudaMemcpyDeviceToDevice);
   }
 

--- a/dali/operators/util/randomizer.cuh
+++ b/dali/operators/util/randomizer.cuh
@@ -43,14 +43,14 @@ struct curand_states {
   }
 
   DALI_HOST inline std::shared_ptr<curandState> get_states(AccessOrder order) const {
-    auto states_cpu = mm::alloc_raw_shared<curandState, mm::memory_kind::pinned>(len_);
-    cudaMemcpyAsync(states_cpu.get(), states_, sizeof(curandState) * len_,
-                    cudaMemcpyDeviceToHost, order.stream());
-    return states_cpu;
+    auto states = mm::alloc_raw_shared<curandState, mm::memory_kind::device>(len_);
+    cudaMemcpyAsync(states.get(), states_, sizeof(curandState) * len_,
+                    cudaMemcpyDeviceToDevice, order.stream());
+    return states;
   }
 
   DALI_HOST inline void set_states(const curandState *state) const {
-    cudaMemcpy(states_, state, sizeof(curandState) * len_, cudaMemcpyHostToDevice);
+    cudaMemcpy(states_, state, sizeof(curandState) * len_, cudaMemcpyDeviceToDevice);
   }
 
  private:

--- a/dali/pipeline/operator/checkpointing/snapshot_serializer.cc
+++ b/dali/pipeline/operator/checkpointing/snapshot_serializer.cc
@@ -93,7 +93,7 @@ std::string SnapshotSerializer::Serialize(const std::vector<curandState> &snapsh
   return proto_snapshot.SerializeAsString();
 }
 
-template<>
+template<> DLL_PUBLIC
 std::vector<curandState> SnapshotSerializer::Deserialize(const std::string &data) {
   dali_proto::RNGSnapshotGPU proto_snapshot;
   proto_snapshot.ParseFromString(data);

--- a/dali/pipeline/operator/checkpointing/snapshot_serializer.h
+++ b/dali/pipeline/operator/checkpointing/snapshot_serializer.h
@@ -18,6 +18,7 @@
 #include <random>
 #include <string>
 #include <vector>
+#include <curand_kernel.h>  // NOLINT
 
 #include "dali/core/common.h"
 #include "dali/operators/reader/loader/loader.h"
@@ -33,6 +34,8 @@ class DLL_PUBLIC SnapshotSerializer {
   DLL_PUBLIC std::string Serialize(const std::vector<std::mt19937> &snapshot);
 
   DLL_PUBLIC std::string Serialize(const std::vector<std::mt19937_64> &snapshot);
+
+  DLL_PUBLIC std::string Serialize(const std::vector<curandState> &snapshot);
 
   DLL_PUBLIC std::string Serialize(const LoaderStateSnapshot &snapshot);
 

--- a/dali/pipeline/proto/dali.proto
+++ b/dali/pipeline/proto/dali.proto
@@ -91,6 +91,10 @@ message RNGSnapshotCPU {
   repeated string rng = 1;
 }
 
+message RNGSnapshotGPU {
+  repeated string rng = 1;
+}
+
 message ReaderStateSnapshot {
   message LoaderStateSnapshot {
     optional bytes rng = 1;

--- a/dali/pipeline/proto/dali.proto
+++ b/dali/pipeline/proto/dali.proto
@@ -92,7 +92,7 @@ message RNGSnapshotCPU {
 }
 
 message RNGSnapshotGPU {
-  repeated string rng = 1;
+  optional bytes rng = 1;
 }
 
 message ReaderStateSnapshot {

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -291,13 +291,13 @@ def test_multiple_readers(num_iters):
 # note: fn.decoders.image_random_crop is tested by
 # `check_single_input_operator`
 
-@cartesian_params(('cpu',), (None, (1,), (10,)))
+@cartesian_params(('cpu', 'gpu'), (None, (1,), (10,)))
 def test_random_coin_flip(device, shape):
     check_no_input_operator(fn.random.coin_flip, device, shape=shape)
 
 
 @attr('pytorch')
-@cartesian_params(('cpu',), (None, (1,), (10,)))
+@cartesian_params(('cpu', 'gpu'), (None, (1,), (10,)))
 def test_random_coin_flip_pytorch(device, shape):
     check_no_input_operator_pytorch(fn.random.coin_flip, device, shape=shape)
 
@@ -308,20 +308,20 @@ def test_random_normal(device, shape):
 
 
 @attr('pytorch')
-@cartesian_params(('cpu',), (None, (1,), (10,)))
+@cartesian_params(('cpu', 'gpu'), (None, (1,), (10,)))
 def test_random_normal_pytorch(device, shape):
     check_no_input_operator_pytorch(fn.random.normal, device, shape=shape)
 
 
-@cartesian_params(('cpu',), (None, (1,), (10,)))
+@cartesian_params(('cpu', 'gpu'), (None, (1,), (10,)))
 def test_random_uniform(device, shape):
     check_no_input_operator(fn.random.uniform, device, shape=shape)
 
 
 @attr('pytorch')
-@cartesian_params(('cpu',), (None, (1,), (10,)))
+@cartesian_params(('cpu', 'gpu'), (None, (1,), (10,)))
 def test_random_uniform_pytorch(device, shape):
-    check_no_input_operator(fn.random.uniform, device, shape=shape)
+    check_no_input_operator_pytorch(fn.random.uniform, device, shape=shape)
 
 
 # Stateless operators section


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
In this PR I add checkpointing support to `fn.random` operators on the GPU.

## Additional information:

### Affected modules and functionalities:
`curand_states` (from `randomizer.cuh`) now has `get_states` and `set_states` methods, which allow to export internal state or restore it.

`RNGBase` (from `rng_base.h`) can now save/restore states also on the GPU. The checkpoint of GPU random operator is a pointer to states (as returned by `get_states`). An ability to serialize/deserialize such checkpoints was added.

### Key points relevant for the review:

#### Checkpoints are generally kept on the device
Note that the states returned by `get_states` are still on the GPU and `set_states` also expects its input to be on the GPU. `RNGBase`'s Save and Restore also keep the checkpoint as a pointer to the GPU memory. The checkpoint is copied to the host at the very last moment during `Serialize`. This limits the device->host transfers significantly as we only copy the checkpoints that the user intends to save, while the checkpoints which we just trace and then delete never leave the device.

#### Serialization of `curandState`
During serialization, we treat `curandState` as a sequence of bytes, not caring about its structure. I consider it an implementation detail of curand.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3532
<!--- DALI-XXXX or NA --->
