### PR TITLE
Improve symbol visibility when importing

### DIFF
--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -16,7 +16,11 @@
 from enum import Enum, unique
 import re
 
-from nvidia.dali._backend_enums import DALIDataType, DALIImageType, DALIInterpType
+from nvidia.dali._backend_enums import (
+    DALIDataType as DALIDataType,
+    DALIImageType as DALIImageType,
+    DALIInterpType as DALIInterpType,
+)
 
 # TODO: Handle forwarding imports from backend_impl
 from nvidia.dali.backend_impl.types import *        # noqa: F401, F403


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: Bug fix?
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
The PEP describing stub files: https://peps.python.org/pep-0484/#stub-files
mandates using `from A import X as X` syntax in stub files to mark symbols as
reexported. The same syntax is used inside the regular module, making the
VSCode intellisense pick up the adjusted symbols better.

In case of `import nvidia.dali.types as t`, we had:
```
t.DALIDat<space> # not working
t.DALIDataType.<space> # list the enum members correctly
```
now, the intellisense lists the enum types correctly:
![obraz](https://github.com/NVIDIA/DALI/assets/8121971/a5d075b1-000f-4500-ac8d-e8774334fe22)


## Additional information:

### Affected modules and functionalities:
nvidia.dali.types symbol visibility in some code completion engines.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
