### PR TITLE
Fix the check for dynamically generated number of outputs

### DIFF
--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -593,7 +593,7 @@ DLL_PUBLIC const DeprecatedArgDef &OpSchema::DeprecatedArgMeta(const std::string
 
 
 bool OpSchema::HasOutputFn() const {
-  return static_cast<bool>(output_fn_);
+  return static_cast<bool>(output_fn_) || static_cast<bool>(additional_outputs_fn_);
 }
 
 

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -599,6 +599,7 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
 
   /**
    * @brief Check whether this operator calculates number of outputs statically
+   * @return false if static, true if dynamic
    */
   DLL_PUBLIC bool HasOutputFn() const;
 


### PR DESCRIPTION


<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Bug fix** 
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
The documentation for HasOutputFunction suggests that it allows to check if operator calculates the number of outputs dynamically or if it is set statically.

We have two entities:
OutputFn - calculates the number of outputs dynamically based on OpSpec AdditionalOutputsFn - calculates dynamically based on OpSpec additional outputs.

If any of those is present, number of outputs is not know statically.

HasOutputFn allowed to detect only the first case, now it will detect any of the two.
This check is only used in Python when generating signatures.

This additionally fixes incorrect return type annotation for some operators that indicate dynamic number of outputs using AdditionalOutputsFn.

It appears that it could return negative number of additional outputs, so I can't use the NumOutputs as a lower bound.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A
I inspected the the signatures of operators that have the AdditionalOutputsFn, now the annotation
suggests dynamic number of outputs.

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Generated signatures
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
