### PR TITLE
Generate overloads for Multiple Input Sets in Python interface files

### DIFF
--- a/dali/python/nvidia/dali/ops/_signatures.py
+++ b/dali/python/nvidia/dali/ops/_signatures.py
@@ -75,7 +75,6 @@ _enum_mapping = {
     types.DALIInterpType: _DALIInterpType
 }
 
-
 _MAX_INPUT_SPELLED_OUT = 10
 
 
@@ -140,7 +139,6 @@ def _get_annotation_input_regular(schema):
     return _DataNode
 
 
-
 def _get_annotation_return_regular(schema):
     """Produce the return annotation for DALI operator suitable for primary, non-MIS overload.
     Note the flattening, single output is not packed in Sequence.
@@ -202,7 +200,6 @@ def _get_annotation_return_mis(schema):
     return return_annotation
 
 
-
 def _get_positional_input_params(schema, input_annotation_gen=lambda x, y: _DataNode):
     """Get the list of positional only inputs to the operator.
 
@@ -214,10 +211,12 @@ def _get_positional_input_params(schema, input_annotation_gen=lambda x, y: _Data
     """
     param_list = []
     if not schema.HasInputDox() and schema.MaxNumInput() > _MAX_INPUT_SPELLED_OUT:
-        param_list.append(Parameter("input", Parameter.VAR_POSITIONAL, annotation=input_annotation_gen(schema)))
+        param_list.append(
+            Parameter("input", Parameter.VAR_POSITIONAL, annotation=input_annotation_gen(schema)))
     else:
         for i in range(schema.MaxNumInput()):
-            param_list.append(_get_positional_input_param(schema, i, annotation=input_annotation_gen(schema)))
+            param_list.append(
+                _get_positional_input_param(schema, i, annotation=input_annotation_gen(schema)))
     return param_list
 
 
@@ -314,7 +313,8 @@ def _call_signature(schema, include_inputs=True, include_kwargs=True, include_se
         param_list.append(Parameter("self", kind=Parameter.POSITIONAL_ONLY))
 
     if include_inputs:
-        param_list.extend(_get_positional_input_params(schema, input_annotation_gen=input_annotation_gen))
+        param_list.extend(
+            _get_positional_input_params(schema, input_annotation_gen=input_annotation_gen))
 
     if include_kwargs:
         param_list.extend(_get_keyword_params(schema, all_args_optional=all_args_optional))

--- a/dali/python/nvidia/dali/ops/_signatures.py
+++ b/dali/python/nvidia/dali/ops/_signatures.py
@@ -350,6 +350,11 @@ def _gen_fn_signature(schema, schema_name, fn_name):
     Multiple Input Sets), we will match the second overload that is more general.
     The secondary overload has less constrained return type annotation but we have to accept it
     to not have exponential number of overloads.
+    There is a special case, where the secondary overload with exactly one input accepts only
+    List[DataNode] (see the `_get_annotation_input_mis`). Passing a variable recognized as
+    Union[DataNode, List[DataNode]] to such overload set still resolves correctly under mypy and
+    pylance, resulting again in the Union[DataNode, List[DataNode]] return type (for single output),
+    keeping us in the MIS realm in the simple case.
     """
     return inspect_repr_fixups(f"""
 @overload

--- a/dali/test/python/type_annotations/test_typing_pipelines.py
+++ b/dali/test/python/type_annotations/test_typing_pipelines.py
@@ -69,7 +69,7 @@ def test_rn50_pipe():
 def test_rn50_pipe_mis():
 
     @pipeline_def(batch_size=10, device_id=0, num_threads=4)
-    def rn50_pipe() -> Any:
+    def rn50_pipe():
         enc_0, label_0 = fn.readers.file(
             files=[str(_test_root / "db/single/jpeg/113/snail-4291306_1280.jpg")],
             name="FileReader_0")
@@ -108,7 +108,6 @@ def test_rn50_pipe_mis():
         assert isinstance(imgs, tensors.TensorListGPU)
         assert imgs.dtype == types.DALIDataType.FLOAT16  # noqa: E721
     assert isinstance(labels, tensors.TensorListGPU)
-
 
 
 def test_rn50_ops_pipe():

--- a/dali/test/python/type_annotations/test_typing_pipelines.py
+++ b/dali/test/python/type_annotations/test_typing_pipelines.py
@@ -69,7 +69,7 @@ def test_rn50_pipe():
 def test_rn50_pipe_mis():
 
     @pipeline_def(batch_size=10, device_id=0, num_threads=4)
-    def rn50_pipe():
+    def rn50_pipe() -> Any:
         enc_0, label_0 = fn.readers.file(
             files=[str(_test_root / "db/single/jpeg/113/snail-4291306_1280.jpg")],
             name="FileReader_0")
@@ -85,6 +85,9 @@ def test_rn50_pipe_mis():
         rng = fn.random.coin_flip(probability=0.5)
 
         resized = fn.random_resized_crop(imgs, size=[224, 224])
+        # note that mypy type-checks when we pass resized, which is of type
+        # DataNode | List[DataNode] into the 1-input CMN, that expects either a DataNode in primary
+        # overload, or List[DataNode] in the secondary one.
         normalized = fn.crop_mirror_normalize(resized, mirror=rng, dtype=types.DALIDataType.FLOAT16,
                                               output_layout="HWC", crop=(224, 224),
                                               mean=[0.485 * 255, 0.456 * 255, 0.406 * 255],


### PR DESCRIPTION
![obraz](https://github.com/NVIDIA/DALI/assets/8121971/006ba73f-f38e-4032-aaa5-297bc1771e8f)

## Category: **New feature**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Expand the API coverage by providing two overloads for each API function.
* Primary one accepts only `DataNodes` and has as constrained type as possible (`DataNode` for 1 output - `Union` return types are much less useful in IDE and with mypy)
* Secondary that allows to pass a `List[DataNode]` for inputs, indicating Multiple Input Sets handling. Such lists can be passed as one of several input, and the other inputs that are `DataNodes` will be bcast to match that.

Python overload resolution appears to be sequential - first matching function is selected, so when using regular `DataNode` inputs, we pick the overload with nicer return types.
Anything indicating MIS will fall into the other overload. 

Next step is to include TensorLike/SampleLike constants in the signatures.

## Additional information:

### Affected modules and functionalities:
Signature generation



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
