### PR TITLE
Support checkpointing in `tfrecord` and `mxnet` readers

### DIFF
--- a/dali/operators/reader/loader/indexed_file_loader.h
+++ b/dali/operators/reader/loader/indexed_file_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
 
 namespace dali {
 
-class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
+class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>, true> {
  public:
   explicit IndexedFileLoader(const OpSpec& spec)
     : Loader(spec),
@@ -172,6 +172,10 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     return;
   }
 
+  void Skip() override {
+    MoveToNextShard(current_index_++);
+  }
+
   ~IndexedFileLoader() override {
     current_file_.reset();
   }
@@ -213,7 +217,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     int64 seek_pos, size;
     size_t file_index;
     if (wrap_to_shard) {
-      current_index_ = start_index(shard_id_, num_shards_, SizeImpl());
+      current_index_ = start_index(virtual_shard_id_, num_shards_, SizeImpl());
     } else {
       current_index_ = 0;
     }

--- a/dali/operators/reader/mxnet_reader_op.h
+++ b/dali/operators/reader/mxnet_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2018, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,12 +20,13 @@
 #include "dali/operators/reader/parser/recordio_parser.h"
 
 namespace dali {
-class MXNetReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
+class MXNetReader : public DataReader<CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true> {
  public:
   explicit MXNetReader(const OpSpec& spec)
-  : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
+  : DataReader<CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true>(spec) {
     loader_ = InitLoader<RecordIOLoader>(spec);
     parser_.reset(new RecordIOParser(spec));
+    this->SetInitialSnapshot();
   }
 
   void RunImpl(SampleWorkspace &ws) override {
@@ -34,7 +35,7 @@ class MXNetReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   }
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true);
 };
 }  // namespace dali
 

--- a/dali/operators/reader/tfrecord_reader_op.cc
+++ b/dali/operators/reader/tfrecord_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2018, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ void TFRecordReader::Prefetch() {
   // We actually prepare the next batch
   DomainTimeRange tr("[DALI][TFRecordReader] Prefetch #" + to_string(curr_batch_producer_),
                      DomainTimeRange::kRed);
-  DataReader<CPUBackend, Tensor<CPUBackend>>::Prefetch();
+  DataReader<CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true>::Prefetch();
 
   auto idx_loader = dynamic_cast<IndexedFileLoader*>(loader_.get());
   while (idx_loader->AnyWorkLeft()) {

--- a/dali/operators/reader/tfrecord_reader_op.h
+++ b/dali/operators/reader/tfrecord_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2018, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,10 +23,11 @@
 
 namespace dali {
 
-class TFRecordReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
+class TFRecordReader
+    : public DataReader<CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true> {
  public:
   explicit TFRecordReader(const OpSpec& spec)
-  : DataReader<CPUBackend, Tensor<CPUBackend>>(spec),
+  : DataReader<CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true>(spec),
     dont_use_mmap_(spec.GetArgument<bool>("dont_use_mmap")),
     use_o_direct_(spec.GetArgument<bool>("use_o_direct")),
     thread_pool_(num_threads_, spec.GetArgument<int>("device_id"), false, "TFRecordReader") {
@@ -36,6 +37,7 @@ class TFRecordReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
     parser_.reset(new TFRecordParser(spec));
     DALI_ENFORCE(!skip_cached_images_,
       "TFRecordReader doesn't support `skip_cached_images` option");
+    this->SetInitialSnapshot();
   }
 
   void RunImpl(SampleWorkspace &ws) override {
@@ -52,7 +54,7 @@ class TFRecordReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   void Prefetch() override;
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true);
   bool dont_use_mmap_ = false;
   bool use_o_direct_ = false;
   size_t o_direct_chunk_size_ = 0;

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -20,6 +20,7 @@ from test_utils import get_dali_extra_path, compare_pipelines
 from nose2.tools import params, cartesian_params
 from nose.plugins.attrib import attr
 from dataclasses import dataclass
+from nvidia.dali import tfrecord as tfrec
 
 data_root = get_dali_extra_path()
 images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
@@ -137,7 +138,11 @@ def check_reader_checkpointing(reader, num_epochs, batch_size, iters_into_epoch,
     @pipeline_def(batch_size=batch_size, device_id=0,
                   num_threads=4, enable_checkpointing=True)
     def pipeline():
-        return tuple(reader(name="Reader", **kwargs))
+        result = reader(name="Reader", **kwargs)
+        if isinstance(result, list):
+            return tuple(result)
+        else:
+            return result
 
     p = pipeline()
     p.build()
@@ -236,6 +241,73 @@ def test_coco_reader(
         initial_fill=initial_fill,
         polygon_masks=True,
         image_ids=True)
+
+
+@params(
+        (0, 1, 0, 1, True, True, True, None),
+        (0, 3, 0, 2, True, True, False, 1),
+        (4, 5, 1, 3, True, False, True, 2),
+        (1, 7, 2, 4, True, False, False, None),
+        (11, 2, 2, 10, False, True, True, 1),
+        (2, 4, 1, 6, False, True, False, 2),
+        (5, 6, 2, 3, False, False, True, None),
+        (3, 8, 4, 5, False, False, False, 1),
+)
+def test_mxnet_reader(
+        num_epochs, batch_size, shard_id, num_shards,
+        random_shuffle, stick_to_shard, pad_last_batch,
+        iters_into_epoch=None):
+
+    recordio_dir = os.path.join(data_root, 'db', 'recordio')
+    recordio_rec = os.path.join(recordio_dir, 'train.rec')
+    recordio_idx = os.path.join(recordio_dir, 'train.idx')
+
+    check_reader_checkpointing(
+        fn.readers.mxnet, num_epochs, batch_size, iters_into_epoch,
+        path=recordio_rec,
+        index_path=recordio_idx,
+        pad_last_batch=pad_last_batch,
+        random_shuffle=random_shuffle,
+        shard_id=shard_id,
+        num_shards=num_shards,
+        stick_to_shard=stick_to_shard)
+
+
+@params(
+        (0, 1, 0, 1, True, True, True, None),
+        (0, 2, 0, 2, True, True, False, 1),
+        (6, 3, 1, 3, True, False, True, 2),
+        (3, 4, 2, 4, True, False, False, None),
+        (10, 5, 2, 10, False, True, True, 1),
+        (4, 6, 1, 6, False, True, False, 2),
+        (10, 7, 2, 3, False, False, True, None),
+        (2, 8, 4, 5, False, False, False, 1),
+)
+def test_tfrecord_reader(
+        num_epochs, batch_size, shard_id, num_shards,
+        random_shuffle, stick_to_shard, pad_last_batch,
+        iters_into_epoch=None):
+
+    tfrecord_dir = os.path.join(data_root, 'db', 'tfrecord')
+    tfrecord = os.path.join(tfrecord_dir, 'train')
+    tfrecord_idx = os.path.join(tfrecord_dir, 'train.idx')
+
+    def tfrecord_wrapper(*args, **kwargs):
+        return fn.readers.tfrecord(*args, **kwargs)["image/encoded"]
+
+    check_reader_checkpointing(
+        tfrecord_wrapper, num_epochs, batch_size, iters_into_epoch,
+        path=tfrecord,
+        index_path=tfrecord_idx,
+        features={
+            "image/encoded": tfrec.FixedLenFeature((), tfrec.string, ""),
+            "image/class/label": tfrec.FixedLenFeature([1], tfrec.int64, -1)
+        },
+        pad_last_batch=pad_last_batch,
+        random_shuffle=random_shuffle,
+        shard_id=shard_id,
+        num_shards=num_shards,
+        stick_to_shard=stick_to_shard)
 
 
 @attr('pytorch')


### PR DESCRIPTION
## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:

This PR adds checkpointing support to `mxnet` and `tfrecord` readers.

They are both based on `IndexedFileLoader` (`TFRecordReader` uses it directly, `MXNetReader` uses `RecordIOLoader` which is a subclass of it).

## Additional information:

Adding checkpointing support is a simple task, similar for every loader and reader.

The following changes were required to enable checkpointing in `IndexedFileLoader`:
- Make it inherit from `Loader<..., supports_checkpointing=true>`
- Implement `Skip()` method. `Skip` should behave like `ReadSample` in terms of side effects, but should skip a sample instead of reading it. This method is used to implement fast-forwarding in `Loader` baseclass.
- Change `Reset` to use `virtual_shard_id_` (which is the shard currently processed)
  instead of `shard_id_` (which is the initial shard requested by the user). See [2] for more details.

The following changes were required to enable checkpointing in the readers:
- Make it inherit from `DataReader<..., supports_checkpointing=true>`. See [1] for more details.
- Store the very first snapshot in the constructor with `this->SetInitialSnapshot()`.
  Subsequent snapshots are saved by `DataReader` baseclass.

#### [1] Changing `DataReader` template parameters
Inheriting from `DataReader<..., supports_checkpointing=true>` might look strange in the diff, because the `DataReader` is defined as:
```cpp
template <typename Backend, typename LoadTarget,
          typename ParseTarget = LoadTarget, bool supports_checkpointing = false>
```
and is used mostly as:
```cpp
DataReader<Backend, Target>
```
so to enable checkpointing one needs to add two parameters:
```cpp
DataReader<Backend, Target, Target, true>
```

#### [2] `virtual_shard_id_`
`virtual_shard_id_` and `shard_id_`  might differ when `stick_to_shard=False`.

This change doesn't impact existing code, because `Reset` is normally called after each full pass over the data, so then those two are equal. It might happen that a checkpoint is saved when the reader was is processing a different shard that `shard_id_`,  so to restore from such checkpoint we need to be able to reset to the current shard (`virtual_shard_id_`).

The same change was made in `FileReader` in #4954.


### Affected modules and functionalities:
- `IndexedFileLoader` and `RecordIOLoader`
- `TFRecordReader` and `MXNetReader`

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.
If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->

A minor change in the `check_reader_checkpointing` helper was required to support single-output readers.

- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3691
<!--- DALI-XXXX or NA --->
