### PR TITLE
Add checkpointing benchmarks

### DIFF
--- a/dali/benchmark/CMakeLists.txt
+++ b/dali/benchmark/CMakeLists.txt
@@ -42,6 +42,8 @@ if (BUILD_BENCHMARK)
     "${CMAKE_CURRENT_SOURCE_DIR}/cast_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/coin_flip_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/transpose_bench.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/file_reader_fast_forward_bench.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/checkpointing_bench.cc"
   )
 
   if (BUILD_LMDB)

--- a/dali/benchmark/checkpointing_bench.cc
+++ b/dali/benchmark/checkpointing_bench.cc
@@ -1,0 +1,161 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+
+#include "dali/benchmark/dali_bench.h"
+#include "dali/pipeline/pipeline.h"
+#include "dali/util/image.h"
+#include "dali/test/dali_test_config.h"
+
+namespace dali {
+
+enum class CheckpointingPolicy {Disabled, Enabled, SaveEveryIter, SerializeEveryIter};
+
+class CheckpointingOverhead : public DALIBenchmark {
+ public:
+  void run(benchmark::State& st,
+           const OpSpec &op_spec,
+           const vector<std::pair<string, string>> &outputs) {
+    auto policy = static_cast<CheckpointingPolicy>(st.range(0));
+    bool checkpointing = (policy != CheckpointingPolicy::Disabled);
+
+    auto pipe = createPipeline(op_spec);
+    if (checkpointing) {
+      pipe->EnableCheckpointing();
+    }
+    pipe->Build(outputs);
+
+    Workspace ws;
+
+    // Warmup
+    pipe->RunCPU();
+    pipe->RunGPU();
+    pipe->Outputs(&ws);
+
+    while (st.KeepRunning()) {
+      pipe->RunCPU();
+      pipe->RunGPU();
+      pipe->Outputs(&ws);
+      if (policy == CheckpointingPolicy::SaveEveryIter) {
+        volatile auto cpt = pipe->GetCheckpoint();
+      } else if (policy == CheckpointingPolicy::SerializeEveryIter) {
+        volatile auto cpt = pipe->SerializedCheckpoint();
+      }
+    }
+
+    if (policy == CheckpointingPolicy::Disabled) {
+      st.SetLabel("disabled");
+    } else if (policy == CheckpointingPolicy::Enabled) {
+      st.SetLabel("enabled");
+    } else if (policy == CheckpointingPolicy::SaveEveryIter) {
+      st.SetLabel("save");
+    } else if (policy == CheckpointingPolicy::SerializeEveryIter) {
+      st.SetLabel("serialize");
+    }
+  }
+
+ protected:
+  std::unique_ptr<Pipeline> createPipeline(const OpSpec &op_spec) {
+    const int batch_size = 256;
+    const int num_thread = 4;
+    const bool pipelined = true;
+    const int prefetch_queue_depth = 2;
+    const bool async = true;
+
+    auto pipe = std::make_unique<Pipeline>(batch_size, num_thread, 0, -1, pipelined,
+                                           prefetch_queue_depth, async);
+    pipe->AddOperator(op_spec);
+    return pipe;
+  }
+};
+
+static void Args(benchmark::internal::Benchmark *b) {
+  const std::vector<CheckpointingPolicy> policies = {
+    CheckpointingPolicy::Disabled,
+    CheckpointingPolicy::Enabled,
+    CheckpointingPolicy::SaveEveryIter,
+    CheckpointingPolicy::SerializeEveryIter,
+  };
+  for (auto p : policies) {
+    b->Args({static_cast<int>(p)});
+  }
+}
+
+BENCHMARK_DEFINE_F(CheckpointingOverhead, StatelessCpu)(benchmark::State& st) {
+  auto op = OpSpec("Constant")
+        .AddArg("device", "cpu")
+        .AddArg("idata", std::vector<int>(1, 1))
+        .AddArg("shape", std::vector<int>(2, 100))  // 100x100
+        .AddOutput("output", "cpu");
+  this->run(st, op, {{"output", "cpu"}});
+}
+
+BENCHMARK_REGISTER_F(CheckpointingOverhead, StatelessCpu)->Iterations(100)
+->Unit(benchmark::kMillisecond)
+->Apply(Args);
+
+BENCHMARK_DEFINE_F(CheckpointingOverhead, StatelessGpu)(benchmark::State& st) {
+  auto op = OpSpec("Constant")
+        .AddArg("device", "gpu")
+        .AddArg("idata", std::vector<int>(1, 1))
+        .AddArg("shape", std::vector<int>(2, 100))  // 100x100
+        .AddOutput("output", "gpu");
+  this->run(st, op, {{"output", "gpu"}});
+}
+
+BENCHMARK_REGISTER_F(CheckpointingOverhead, StatelessGpu)->Iterations(100)
+->Unit(benchmark::kMillisecond)
+->Apply(Args);
+
+BENCHMARK_DEFINE_F(CheckpointingOverhead, RandomCpu)(benchmark::State& st) {
+  auto op = OpSpec("CoinFlip")
+        .AddArg("device", "cpu")
+        .AddArg("shape", std::vector<int>(2, 100))  // 100x100
+        .AddOutput("output", "cpu");
+  this->run(st, op, {{"output", "cpu"}});
+}
+
+BENCHMARK_REGISTER_F(CheckpointingOverhead, RandomCpu)->Iterations(100)
+->Unit(benchmark::kMillisecond)
+->Apply(Args);
+
+BENCHMARK_DEFINE_F(CheckpointingOverhead, RandomGpu)(benchmark::State& st) {
+  auto op = OpSpec("CoinFlip")
+        .AddArg("device", "gpu")
+        .AddArg("shape", std::vector<int>(2, 100))  // 100x100
+        .AddOutput("output", "gpu");
+  this->run(st, op, {{"output", "gpu"}});
+}
+
+BENCHMARK_REGISTER_F(CheckpointingOverhead, RandomGpu)->Iterations(100)
+->Unit(benchmark::kMillisecond)
+->Apply(Args);
+
+BENCHMARK_DEFINE_F(CheckpointingOverhead, Reader)(benchmark::State& st) {
+  auto op = OpSpec("FileReader")
+        .AddArg("device", "cpu")
+        .AddArg("files", jpeg_names_)
+        .AddArg("initial_fill", 1024)
+        .AddArg("random_shuffle", true)
+        .AddOutput("output", "cpu")
+        .AddOutput("labels", "cpu");
+  this->run(st, op, {{"output", "cpu"}});
+}
+
+BENCHMARK_REGISTER_F(CheckpointingOverhead, Reader)->Iterations(100)
+->Unit(benchmark::kMillisecond)
+->Apply(Args);
+
+}  // namespace dali

--- a/dali/benchmark/file_reader_fast_forward_bench.cc
+++ b/dali/benchmark/file_reader_fast_forward_bench.cc
@@ -1,0 +1,112 @@
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+
+#include "dali/benchmark/dali_bench.h"
+#include "dali/pipeline/pipeline.h"
+#include "dali/util/image.h"
+#include "dali/test/dali_test_config.h"
+
+namespace dali {
+
+class FileReaderFastForward : public DALIBenchmark {
+ public:
+  // Returns a vector of n (possibly repeating) paths to test images
+  std::vector<std::string> get_paths(size_t n) {
+    static std::vector<std::string> pool;
+    auto jpegs = jpeg_names_;
+    DALI_ENFORCE(!jpeg_names_.empty(), "No images!");
+    while (pool.size() < n) {
+      pool.insert(pool.end(), jpegs.begin(), jpegs.end());
+    }
+    return {pool.begin(), pool.begin() + n};
+  }
+
+  std::unique_ptr<Pipeline> create_reader_pipeline(size_t dataset_size, int initial_buffer_fill) {
+    const int batch_size = 1;
+    const int num_thread = 4;
+    const bool pipelined = true;
+    const int prefetch_queue_depth = 2;
+    const bool async = true;
+    bool random_shuffle = (initial_buffer_fill > 1);
+    auto pipe = std::make_unique<Pipeline>(batch_size, num_thread, 0, -1, pipelined,
+                                           prefetch_queue_depth, async);
+
+    pipe->AddOperator(
+        OpSpec("FileReader")
+        .AddArg("device", "cpu")
+        .AddArg("files", get_paths(dataset_size))
+        .AddArg("initial_fill", initial_buffer_fill)
+        .AddArg("random_shuffle", random_shuffle)
+        .AddOutput("jpegs", "cpu")
+        .AddOutput("labels", "cpu"));
+
+    pipe->EnableCheckpointing();
+
+    return pipe;
+  }
+};
+
+BENCHMARK_DEFINE_F(FileReaderFastForward, FastForward)(benchmark::State& st) { // NOLINT
+  int dataset_size = st.range(0) + 1;
+  int snapshot_at = st.range(1);
+  int initial_buffer_fill = st.range(2);
+  auto pipe = create_reader_pipeline(dataset_size, initial_buffer_fill);
+
+  vector<std::pair<string, string>> outputs = {{"jpegs", "cpu"}};
+  pipe->Build(outputs);
+
+  Workspace ws;
+  for (int i = 0; i < snapshot_at; i++) {
+    pipe->RunCPU();
+    pipe->RunGPU();
+    pipe->Outputs(&ws);
+  }
+
+  auto cpt = pipe->GetCheckpoint();
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+    auto pipe2 = create_reader_pipeline(dataset_size, initial_buffer_fill);
+    pipe2->Build(outputs);
+    st.ResumeTiming();
+
+    pipe2->RestoreFromCheckpoint(cpt);
+
+    st.PauseTiming();
+    pipe2->RunCPU();
+    pipe2->RunGPU();
+    pipe2->Outputs(&ws);
+    st.ResumeTiming();
+  }
+}
+
+static void Args(benchmark::internal::Benchmark *b) {
+  for (int dataset_size = 100; dataset_size <= 1000000; dataset_size *= 100) {
+    for (int frac = 0; frac <= 10; frac++) {
+      // Without random shuffle
+      b->Args({dataset_size, dataset_size * frac / 10, 1});
+
+      // With random shuffle, initial_fill=1024
+      b->Args({dataset_size, dataset_size * frac / 10, 1024});
+    }
+  }
+}
+
+BENCHMARK_REGISTER_F(FileReaderFastForward, FastForward)->Iterations(1)
+->Unit(benchmark::kMillisecond)
+->UseRealTime()
+->Apply(Args);
+
+}  // namespace dali


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->

## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

**Other** - benchmarks

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

In this PR I add benchmarks measuring 

1. Checkpointing overhead for particular operators
2. Performance of file loader fast-forwarding

## Additional information:

### Checkpointing overhead benchmarks
`CheckpointingOverhead` benchmark class is intended to be used to estimate checkpointing overhead for particular operators. Its `run` method allows to run an operator in one of 4 configurations, described by `enum CheckpointingPolicy`:
- `Disabled`: no checkpointing at all
- `Enabled`: executor traces the states, but doesn't save them
- `SaveEveryIter`: The pipeline is queried for checkpoint after every iteration, but the checkpoint returned is not serialized.
- `SerializeEveryIter`: The pipeline is queried for checkpoint after every iteration and the checkpoint is serialized.

This allows us to estimate the following types of overhead:

- `Enabled - Disabled` is the overhead of state tracing itself. It should be (and is!) zero: we don't want enabling checkpointing to hurt the performance
- `SaveEveryIter - Disabled` is the overhead of copying the checkpoints. It should be low too.
- `SerializeEveryIter - SaveEveryIter` is the overhead of checkpoint serialization to protobuf.

This benchmark is run for the following types of operators:
- Stateless on CPU and GPU: checkpointing should have no impact on those, they serve as a baseline
- FileReader
- Random on CPU and GPU

### Fast-forwarding benchmarks
As you might remember from #5113 , actual checkpoint of the reader is saved every epoch. Mid-epoch checkpoint is just the state at the beginning of the epoch and its _age_. When restoring such mid-epoch checkpoint, loader first restores the state from the beginning of the epoch and then fast-forwards it. This fast-forwarding is done in linear time and the `FileReaderFastForward` benchmark measures its performance for different number of steps.

It is run with both shuffling enabled and disabled for datasets of size 10^2, 10^4 and 10^6 with checkpoints at 0%, 10%, 20%, ..., 100% of the epoch. The results are, as expected, linear. 

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [x] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3688
<!--- DALI-XXXX or NA --->

### Benchmark results
#### Fast-forwarding
<img width="269" alt="image" src="https://github.com/NVIDIA/DALI/assets/34919255/3353a8ae-376a-4c58-8cf3-acab92ada6c5">

#### Overhead
```
----------------------------------------------------------------------------------------------
Benchmark                                                    Time             CPU   Iterations
----------------------------------------------------------------------------------------------
CheckpointingOverhead/StatelessCpu/0/iterations:100      0.979 ms        0.010 ms          100 disabled
CheckpointingOverhead/StatelessCpu/1/iterations:100      0.921 ms        0.010 ms          100 enabled
CheckpointingOverhead/StatelessCpu/2/iterations:100      0.928 ms        0.011 ms          100 save
CheckpointingOverhead/StatelessCpu/3/iterations:100      0.914 ms        0.012 ms          100 serialize

CheckpointingOverhead/StatelessGpu/0/iterations:100      0.179 ms        0.030 ms          100 disabled
CheckpointingOverhead/StatelessGpu/1/iterations:100      0.174 ms        0.030 ms          100 enabled
CheckpointingOverhead/StatelessGpu/2/iterations:100      0.177 ms        0.030 ms          100 save
CheckpointingOverhead/StatelessGpu/3/iterations:100      0.170 ms        0.031 ms          100 serialize

CheckpointingOverhead/RandomCpu/0/iterations:100          9.22 ms        0.013 ms          100 disabled
CheckpointingOverhead/RandomCpu/1/iterations:100          9.49 ms        0.015 ms          100 enabled
CheckpointingOverhead/RandomCpu/2/iterations:100          9.42 ms        0.090 ms          100 save
CheckpointingOverhead/RandomCpu/3/iterations:100          15.4 ms         6.08 ms          100 serialize

CheckpointingOverhead/RandomGpu/0/iterations:100         0.129 ms        0.024 ms          100 disabled
CheckpointingOverhead/RandomGpu/1/iterations:100         0.174 ms        0.058 ms          100 enabled
CheckpointingOverhead/RandomGpu/2/iterations:100         0.167 ms        0.059 ms          100 save
CheckpointingOverhead/RandomGpu/3/iterations:100          19.4 ms         19.2 ms          100 serialize

CheckpointingOverhead/Reader/0/iterations:100            0.804 ms        0.009 ms          100 disabled
CheckpointingOverhead/Reader/1/iterations:100            0.795 ms        0.009 ms          100 enabled
CheckpointingOverhead/Reader/2/iterations:100            0.807 ms        0.010 ms          100 save
CheckpointingOverhead/Reader/3/iterations:100            0.801 ms        0.012 ms          100 serialize
```
