### PR TITLE
Fix sharding in Caffe reader

### DIFF
--- a/dali/operators/reader/loader/lmdb.h
+++ b/dali/operators/reader/loader/lmdb.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,6 +60,8 @@ class IndexedLMDB {
     mdb_size_ = stat.ms_entries;
     LOG_LINE << "lmdb " << num_ << " " << db_path_
              << " has " << mdb_size_ << " entries" << std::endl;
+    MDB_val tmp_key, tmp_value;
+    mdb_cursor_get(mdb_cursor_, &tmp_key, &tmp_value, MDB_FIRST);
     mdb_index_ = 0;
   }
   size_t GetSize() const { return mdb_size_; }

--- a/dali/operators/reader/loader/lmdb.h
+++ b/dali/operators/reader/loader/lmdb.h
@@ -60,8 +60,11 @@ class IndexedLMDB {
     mdb_size_ = stat.ms_entries;
     LOG_LINE << "lmdb " << num_ << " " << db_path_
              << " has " << mdb_size_ << " entries" << std::endl;
+
+    // We must reset the cursor to the first entry, because mdb_cursor_open doesn't place it there.
     MDB_val tmp_key, tmp_value;
     mdb_cursor_get(mdb_cursor_, &tmp_key, &tmp_value, MDB_FIRST);
+
     mdb_index_ = 0;
   }
   size_t GetSize() const { return mdb_size_; }

--- a/dali/test/python/reader/test_caffe.py
+++ b/dali/test/python/reader/test_caffe.py
@@ -121,7 +121,7 @@ def test_caffe_sharding():
         def sample_id(sample):
             return sample.as_array().sum()
 
-        return {sample_id(p.run()[0]) for _ in range(size * num_shards)}
+        return {sample_id(p.run()[0]) for _ in range(size)}
 
     dataset = get_data(0, 1, False)
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->

## Category:
<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

### The problem
This PR fixes a problem with sharding in Caffe reader. The observed problem was that shards with `shard_id > 0` were containing samples they shouldn't, in particular there was an overlap between subsequent shards.

### The root cause
Our LMDB wrapper (`IndexedLMDB`) assumed that the cursor is pointing at index `0` when created, which turned out to be false - actually it seems that the cursor position is initialized to `-1`.  

I found no mention in the docs of initial cursor position being defined or undefined,  but in their [getting started](http://www.lmdb.tech/doc/starting.html) they state that:

> For example, to list all key/value pairs in a database, use operation `MDB_FIRST` for the first call to `mdb_cursor_get()`, and `MDB_NEXT` on subsequent calls, until the end is hit.

which suggests that the cursor first needs to be positioned at initial position with `MDB_FIRST`.

### The solution
I now reset the cursor with `MDB_FIRST` in `Open`.

### Why did it work with one shard?
When in the first shard, we reset to `index = 0`, causing `SeekByIndex` to use absolute `MDB_FIRST` instead of relative `MDB_NEXT`.
https://github.com/NVIDIA/DALI/blob/b350581a3eca6491fd772903666aa64fe0b23336/dali/operators/reader/loader/lmdb.h#L80-L90

## Additional information:

### Affected modules and functionalities:
- LMDB loader, Caffe(2) readers

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:

- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
