### PR TITLE
Make sure that GDS on SBSA is not tested for drivers below cuda 12.2

### DIFF
--- a/dali/test/python/reader/test_numpy.py
+++ b/dali/test/python/reader/test_numpy.py
@@ -46,18 +46,22 @@ def is_gds_supported(device_id=0):
         return is_gds_supported_var
 
     compute_cap = 0
+    cuda_drv_ver = 0
     try:
         import pynvml
         pynvml.nvmlInit()
         handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
         compute_cap = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
         compute_cap = compute_cap[0] + compute_cap[1] / 10.
+        cuda_drv_ver = pynvml.nvmlSystemGetCudaDriverVersion()
     except ModuleNotFoundError:
         print("Python bindings for NVML not found")
 
     # for CUDA < 12.2 only x86 platform is supported, above aarch64 is supported as well
-    is_gds_supported_var = (platform.processor() == "x86_64" or
-                            dali_b.__cuda_version__ >= 12200) and compute_cap >= 6.0
+    is_gds_supported_var = (
+        platform.processor() == "x86_64"
+        or (dali_b.__cuda_version__ >= 12200 and cuda_drv_ver >= 12020)
+    ) and compute_cap >= 6.0
     return is_gds_supported_var
 
 


### PR DESCRIPTION
- as the SBSA started supporting GDS from CUDA 12.2 we should not test
  this using driver which don't support it

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:,
- as the SBSA started supporting GDS from CUDA 12.2 we should not test
  this using driver which don't support it
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- dali/test/python/reader/test_numpy.py
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_numpy 
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
