### PR TITLE
Support checkpointing in experimental video reader

### DIFF
--- a/dali/operators/reader/loader/video/video_loader_decoder_cpu.cc
+++ b/dali/operators/reader/loader/video/video_loader_decoder_cpu.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,6 +51,10 @@ Index VideoLoaderDecoderCpu::SizeImpl() {
   return sample_spans_.size();
 }
 
+void VideoLoaderDecoderCpu::Skip() {
+  MoveToNextShard(++current_index_);
+}
+
 void VideoLoaderDecoderCpu::PrepareMetadataImpl() {
   video_files_.reserve(filenames_.size());
   for (auto &filename : filenames_) {
@@ -80,7 +84,7 @@ void VideoLoaderDecoderCpu::PrepareMetadataImpl() {
 }
 
 void VideoLoaderDecoderCpu::Reset(bool wrap_to_shard) {
-  current_index_ = wrap_to_shard ? start_index(shard_id_, num_shards_, SizeImpl()) : 0;
+  current_index_ = wrap_to_shard ? start_index(virtual_shard_id_, num_shards_, SizeImpl()) : 0;
 }
 
 }  // namespace dali

--- a/dali/operators/reader/loader/video/video_loader_decoder_cpu.h
+++ b/dali/operators/reader/loader/video/video_loader_decoder_cpu.h
@@ -26,7 +26,8 @@
 namespace dali {
 using VideoSampleCpu = VideoSample<CPUBackend>;
 
-class VideoLoaderDecoderCpu : public Loader<CPUBackend, VideoSampleCpu, true>, VideoLoaderDecoderBase {
+class VideoLoaderDecoderCpu
+  : public Loader<CPUBackend, VideoSampleCpu, true>, VideoLoaderDecoderBase {
  public:
   explicit inline VideoLoaderDecoderCpu(const OpSpec &spec) :
     Loader<CPUBackend, VideoSampleCpu, true>(spec),

--- a/dali/operators/reader/loader/video/video_loader_decoder_cpu.h
+++ b/dali/operators/reader/loader/video/video_loader_decoder_cpu.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021 - 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,15 +26,17 @@
 namespace dali {
 using VideoSampleCpu = VideoSample<CPUBackend>;
 
-class VideoLoaderDecoderCpu : public Loader<CPUBackend, VideoSampleCpu>, VideoLoaderDecoderBase {
+class VideoLoaderDecoderCpu : public Loader<CPUBackend, VideoSampleCpu, true>, VideoLoaderDecoderBase {
  public:
   explicit inline VideoLoaderDecoderCpu(const OpSpec &spec) :
-    Loader<CPUBackend, VideoSampleCpu>(spec),
+    Loader<CPUBackend, VideoSampleCpu, true>(spec),
     VideoLoaderDecoderBase(spec) { }
 
   void ReadSample(VideoSampleCpu &sample) override;
 
   void PrepareEmpty(VideoSampleCpu &sample) override;
+
+  void Skip() override;
 
  protected:
   Index SizeImpl() override;

--- a/dali/operators/reader/loader/video/video_loader_decoder_gpu.cc
+++ b/dali/operators/reader/loader/video/video_loader_decoder_gpu.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,8 +114,13 @@ void VideoLoaderDecoderGpu::PrepareMetadataImpl() {
   Reset(true);
 }
 
+void VideoLoaderDecoderGpu::Skip() {
+  MoveToNextShard(++current_index_);
+}
+
+
 void VideoLoaderDecoderGpu::Reset(bool wrap_to_shard) {
-  current_index_ = wrap_to_shard ? start_index(shard_id_, num_shards_, SizeImpl()) : 0;
+  current_index_ = wrap_to_shard ? start_index(virtual_shard_id_, num_shards_, SizeImpl()) : 0;
 }
 
 }  // namespace dali

--- a/dali/operators/reader/loader/video/video_loader_decoder_gpu.h
+++ b/dali/operators/reader/loader/video/video_loader_decoder_gpu.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,10 +38,10 @@ class VideoSampleGpu {
 };
 
 
-class VideoLoaderDecoderGpu : public Loader<GPUBackend, VideoSampleGpu>, VideoLoaderDecoderBase {
+class VideoLoaderDecoderGpu : public Loader<GPUBackend, VideoSampleGpu, true>, VideoLoaderDecoderBase {
  public:
   explicit inline VideoLoaderDecoderGpu(const OpSpec &spec) :
-    Loader<GPUBackend, VideoSampleGpu>(spec),
+    Loader<GPUBackend, VideoSampleGpu, true>(spec),
     VideoLoaderDecoderBase(spec) {
     InitCudaStream();
   }
@@ -49,6 +49,8 @@ class VideoLoaderDecoderGpu : public Loader<GPUBackend, VideoSampleGpu>, VideoLo
   void ReadSample(VideoSampleGpu &sample) override;
 
   void PrepareEmpty(VideoSampleGpu &sample) override;
+
+  void Skip() override;
 
  protected:
   Index SizeImpl() override;

--- a/dali/operators/reader/loader/video/video_loader_decoder_gpu.h
+++ b/dali/operators/reader/loader/video/video_loader_decoder_gpu.h
@@ -38,7 +38,8 @@ class VideoSampleGpu {
 };
 
 
-class VideoLoaderDecoderGpu : public Loader<GPUBackend, VideoSampleGpu, true>, VideoLoaderDecoderBase {
+class VideoLoaderDecoderGpu
+  : public Loader<GPUBackend, VideoSampleGpu, true>, VideoLoaderDecoderBase {
  public:
   explicit inline VideoLoaderDecoderGpu(const OpSpec &spec) :
     Loader<GPUBackend, VideoSampleGpu, true>(spec),

--- a/dali/operators/reader/video_reader_decoder_cpu_op.cc
+++ b/dali/operators/reader/video_reader_decoder_cpu_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,9 +19,10 @@
 namespace dali {
 
 VideoReaderDecoderCpu::VideoReaderDecoderCpu(const OpSpec &spec)
-    : DataReader<CPUBackend, VideoSampleCpu>(spec),
+    : DataReader<CPUBackend, VideoSampleCpu, VideoSampleCpu, true>(spec),
       has_labels_(spec.HasArgument("labels")) {
       loader_ = InitLoader<VideoLoaderDecoderCpu>(spec);
+      this->SetInitialSnapshot();
 }
 
 void VideoReaderDecoderCpu::RunImpl(SampleWorkspace &ws) {

--- a/dali/operators/reader/video_reader_decoder_cpu_op.h
+++ b/dali/operators/reader/video_reader_decoder_cpu_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include "dali/operators/reader/loader/video/video_loader_decoder_cpu.h"
 
 namespace dali {
-class VideoReaderDecoderCpu : public DataReader<CPUBackend, VideoSample<CPUBackend>> {
+class VideoReaderDecoderCpu : public DataReader<CPUBackend, VideoSample<CPUBackend>, VideoSample<CPUBackend>, true> {
  public:
   explicit VideoReaderDecoderCpu(const OpSpec &spec);
 

--- a/dali/operators/reader/video_reader_decoder_cpu_op.h
+++ b/dali/operators/reader/video_reader_decoder_cpu_op.h
@@ -19,7 +19,8 @@
 #include "dali/operators/reader/loader/video/video_loader_decoder_cpu.h"
 
 namespace dali {
-class VideoReaderDecoderCpu : public DataReader<CPUBackend, VideoSample<CPUBackend>, VideoSample<CPUBackend>, true> {
+class VideoReaderDecoderCpu
+  : public DataReader<CPUBackend, VideoSample<CPUBackend>, VideoSample<CPUBackend>, true> {
  public:
   explicit VideoReaderDecoderCpu(const OpSpec &spec);
 

--- a/dali/operators/reader/video_reader_decoder_gpu_op.cc
+++ b/dali/operators/reader/video_reader_decoder_gpu_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@
 namespace dali {
 
 VideoReaderDecoderGpu::VideoReaderDecoderGpu(const OpSpec &spec)
-    : DataReader<GPUBackend, VideoSampleGpu>(spec),
+    : DataReader<GPUBackend, VideoSampleGpu,VideoSampleGpu, true>(spec),
       has_labels_(spec.HasArgument("labels")) {
       loader_ = InitLoader<VideoLoaderDecoderGpu>(spec);
+      this->SetInitialSnapshot();
 }
 
 void VideoReaderDecoderGpu::Prefetch() {
-  DataReader<GPUBackend, VideoSampleGpu>::Prefetch();
+  DataReader<GPUBackend, VideoSampleGpu, VideoSampleGpu, true>::Prefetch();
 
   auto &current_batch = prefetched_batch_queue_[curr_batch_producer_];
   for (auto &sample : current_batch) {
@@ -35,7 +36,7 @@ void VideoReaderDecoderGpu::Prefetch() {
 
 bool VideoReaderDecoderGpu::SetupImpl(
   std::vector<OutputDesc> &output_desc, const Workspace &ws) {
-  DataReader<GPUBackend, VideoSampleGpu>::SetupImpl(output_desc, ws);
+  DataReader<GPUBackend, VideoSampleGpu, VideoSampleGpu, true>::SetupImpl(output_desc, ws);
 
   output_desc.resize(has_labels_ ? 2 : 1);
   int batch_size = GetCurrBatchSize();

--- a/dali/operators/reader/video_reader_decoder_gpu_op.cc
+++ b/dali/operators/reader/video_reader_decoder_gpu_op.cc
@@ -19,7 +19,7 @@
 namespace dali {
 
 VideoReaderDecoderGpu::VideoReaderDecoderGpu(const OpSpec &spec)
-    : DataReader<GPUBackend, VideoSampleGpu,VideoSampleGpu, true>(spec),
+    : DataReader<GPUBackend, VideoSampleGpu, VideoSampleGpu, true>(spec),
       has_labels_(spec.HasArgument("labels")) {
       loader_ = InitLoader<VideoLoaderDecoderGpu>(spec);
       this->SetInitialSnapshot();

--- a/dali/operators/reader/video_reader_decoder_gpu_op.h
+++ b/dali/operators/reader/video_reader_decoder_gpu_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include "dali/operators/reader/loader/video/video_loader_decoder_gpu.h"
 
 namespace dali {
-class VideoReaderDecoderGpu : public DataReader<GPUBackend, VideoSampleGpu> {
+class VideoReaderDecoderGpu : public DataReader<GPUBackend, VideoSampleGpu, VideoSampleGpu, true> {
  public:
   explicit VideoReaderDecoderGpu(const OpSpec &spec);
 

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -412,7 +412,8 @@ def test_video_reader(num_epochs, batch_size, iters_into_epoch,
 def test_experimental_video_reader(device, num_epochs, batch_size, iters_into_epoch,
                                    config: BaseDecoderConfig, video: VideoConfig):
 
-    files = [os.path.join(get_dali_extra_path(), 'db', 'video', 'vfr', f'test_{i}.mp4') for i in (1, 2)]
+    files = [os.path.join(get_dali_extra_path(), 'db', 'video', 'vfr', f'test_{i}.mp4')
+             for i in (1, 2)]
 
     check_reader_checkpointing(
         fn.experimental.readers.video, num_epochs, batch_size, iters_into_epoch,

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -394,6 +394,43 @@ def test_video_reader(num_epochs, batch_size, iters_into_epoch,
         step=video.step)
 
 
+@cartesian_params(
+    ('cpu', 'gpu',),
+    (0, 4),
+    (4,),
+    (0, 2),
+    (
+        BaseDecoderConfig(shard_id=1, num_shards=2, stick_to_shard=True, pad_last_batch=True,
+                          random_shuffle=True),
+        BaseDecoderConfig(shard_id=2, num_shards=3, stick_to_shard=False, pad_last_batch=False,
+                          random_shuffle=False),
+    ),
+    (
+        VideoConfig(sequence_length=3, stride=1, step=5),
+    ),
+)
+def test_experimental_video_reader(device, num_epochs, batch_size, iters_into_epoch,
+                                   config: BaseDecoderConfig, video: VideoConfig):
+
+    files = [os.path.join(get_dali_extra_path(), 'db', 'video', 'vfr', f'test_{i}.mp4') for i in (1, 2)]
+
+    check_reader_checkpointing(
+        fn.experimental.readers.video, num_epochs, batch_size, iters_into_epoch,
+        device=device,
+        filenames=files,
+        labels=list(range(len(files))),
+        random_shuffle=config.random_shuffle,
+
+        num_shards=config.num_shards,
+        shard_id=config.shard_id,
+        stick_to_shard=config.stick_to_shard,
+        pad_last_batch=config.pad_last_batch,
+
+        sequence_length=video.sequence_length,
+        stride=video.stride,
+        step=video.step)
+
+
 # Randomized operators section
 # note: fn.decoders.image_random_crop is tested by
 # `check_single_input_operator`


### PR DESCRIPTION
## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:

This PR adds checkpointing support to `fn.experimental.readers.video`.

## Additional information:

Adding checkpointing support is a simple task, similar for every loader and reader.

The following changes were required to enable checkpointing in video loader:
- Make it inherit from `Loader<..., supports_checkpointing=true>`
- Implement `Skip()` method. `Skip` should behave like `ReadSample` in terms of side effects, but should skip a sample instead of reading it. This method is used to implement fast-forwarding in `Loader` baseclass.
- Change `Reset` to use `virtual_shard_id_` (which is the shard currently processed)
  instead of `shard_id_` (which is the initial shard requested by the user). See [2] for more details.


The following changes were required to enable checkpointing in video reader:
- Make it inherit from `DataReader<..., supports_checkpointing=true>`. See [1] for more details.
- Store the very first snapshot in the constructor with `this->SetInitialSnapshot()`.
  Subsequent snapshots are saved by `DataReader` baseclass.

#### [1] Changing `DataReader` template parameters
Inheriting from `DataReader<..., supports_checkpointing=true>` might look strange in the diff, because the `DataReader` is defined as:
```cpp
template <typename Backend, typename LoadTarget,
          typename ParseTarget = LoadTarget, bool supports_checkpointing = false>
```
and is used mostly as:
```cpp
DataReader<Backend, Target>
```
so to enable checkpointing one needs to add two parameters:
```cpp
DataReader<Backend, Target, Target, true>
```

#### [2] `virtual_shard_id_`
`virtual_shard_id_` and `shard_id_`  might differ when `stick_to_shard=False`. 

This change doesn't impact existing code, because `Reset` is normally called after each full pass over the data, so then those two are equal. It might happen that a checkpoint is saved when the reader was is processing a different shard that `shard_id_`,  so to restore from such checkpoint we need to be able to reset to the current shard (`virtual_shard_id_`).

The same change was made in `FileReader` in #4954.


### Affected modules and functionalities:
- Video reader
- Video loader

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3702
<!--- DALI-XXXX or NA --->
