### PR TITLE
Support checkpointing in Caffe reader

### DIFF
--- a/dali/operators/reader/caffe2_reader_op.h
+++ b/dali/operators/reader/caffe2_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2018, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,12 +21,13 @@
 
 namespace dali {
 
-class Caffe2Reader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
+class Caffe2Reader : public DataReader<CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true> {
  public:
   explicit Caffe2Reader(const OpSpec& spec)
-  : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
+  : DataReader<CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true>(spec) {
     loader_ = InitLoader<LMDBLoader>(spec);
     parser_.reset(new Caffe2Parser(spec));
+    this->SetInitialSnapshot();
   }
 
   void RunImpl(SampleWorkspace &ws) override {
@@ -35,7 +36,7 @@ class Caffe2Reader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   }
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true);
 };
 
 }  // namespace dali

--- a/dali/operators/reader/caffe_reader_op.h
+++ b/dali/operators/reader/caffe_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2018, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,12 +21,13 @@
 
 namespace dali {
 
-class CaffeReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
+class CaffeReader : public DataReader<CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true> {
  public:
   explicit CaffeReader(const OpSpec& spec)
-  : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
+  : DataReader<CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true>(spec) {
     loader_ = InitLoader<LMDBLoader>(spec);
     parser_.reset(new CaffeParser(spec));
+    this->SetInitialSnapshot();
   }
 
   void RunImpl(SampleWorkspace &ws) override {
@@ -35,7 +36,7 @@ class CaffeReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   }
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>, Tensor<CPUBackend>, true);
 };
 
 }  // namespace dali

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -238,6 +238,34 @@ def test_coco_reader(
         image_ids=True)
 
 
+@params(
+        (1, 3, 0, 1, True, True, True, 1),
+        (5, 5, 1, 3, True, True, False, 2),
+        (6, 7, 2, 3, True, False, True, 3),
+        (5, 3, 0, 1, True, False, False, 1),
+        (7, 5, 2, 3, False, True, True, None),
+        (4, 1, 1, 2, False, True, False, 2),
+        (0, 3, 3, 4, False, False, True, None),
+        (1, 4, 2, 3, False, False, False, 3),
+)
+def test_caffe_reader(
+        num_epochs, batch_size, shard_id, num_shards,
+        random_shuffle, stick_to_shard, pad_last_batch,
+        iters_into_epoch=None, initial_fill=1024):
+
+    caffe_dir = os.path.join(data_root, 'db', 'lmdb')
+
+    check_reader_checkpointing(
+        fn.readers.caffe, num_epochs, batch_size, iters_into_epoch,
+        path=caffe_dir,
+        pad_last_batch=pad_last_batch,
+        random_shuffle=random_shuffle,
+        shard_id=shard_id,
+        num_shards=num_shards,
+        stick_to_shard=stick_to_shard,
+        initial_fill=initial_fill)
+
+
 @attr('pytorch')
 @params(
         (1, 3, 0, 1, True, False, False),

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -266,6 +266,34 @@ def test_caffe_reader(
         initial_fill=initial_fill)
 
 
+@params(
+        (1, 2, 0, 2, True, True, True, 1),
+        (4, 4, 1, 2, True, True, False, 2),
+        (5, 6, 0, 2, True, False, True, None),
+        (6, 2, 1, 3, True, False, False, 1),
+        (3, 4, 3, 4, False, True, True, 2),
+        (8, 1, 2, 3, False, True, False, None),
+        (0, 2, 4, 5, False, False, True, None),
+        (3, 3, 1, 3, False, False, False, 2),
+)
+def test_caffe2_reader(
+        num_epochs, batch_size, shard_id, num_shards,
+        random_shuffle, stick_to_shard, pad_last_batch,
+        iters_into_epoch=None, initial_fill=1024):
+
+    caffe2_dir = os.path.join(data_root, 'db', 'c2lmdb')
+
+    check_reader_checkpointing(
+        fn.readers.caffe2, num_epochs, batch_size, iters_into_epoch,
+        path=caffe2_dir,
+        pad_last_batch=pad_last_batch,
+        random_shuffle=random_shuffle,
+        shard_id=shard_id,
+        num_shards=num_shards,
+        stick_to_shard=stick_to_shard,
+        initial_fill=initial_fill)
+
+
 @attr('pytorch')
 @params(
         (1, 3, 0, 1, True, False, False),


### PR DESCRIPTION
## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:

This PR adds checkpointing support to `fn.readers.caffe` and `fn.readers.caffe2`.

## Additional information:

Adding checkpointing support is a simple task, similar for every loader and reader.

The following changes were required to enable checkpointing in LMDB loader:
- Make it inherit from `Loader<..., supports_checkpointing=true>`
- Implement `Skip()` method. `Skip` should behave like `ReadSample` in terms of side effects, but should skip a sample instead of reading it. This method is used to implement fast-forwarding in `Loader` baseclass.
- Change `Reset` to use `virtual_shard_id_` (which is the shard currently processed)
  instead of `shard_id_` (which is the initial shard requested by the user). See [2] for more details.

The following changes were required to enable checkpointing in caffe and caffe2 readers:
- Make it inherit from `DataReader<..., supports_checkpointing=true>`. See [1] for more details.
- Store the very first snapshot in the constructor with `this->SetInitialSnapshot()`.
  Subsequent snapshots are saved by `DataReader` baseclass.

#### [1] Changing `DataReader` template parameters
Inheriting from `DataReader<..., supports_checkpointing=true>` might look strange in the diff, because the `DataReader` is defined as:
```cpp
template <typename Backend, typename LoadTarget,
          typename ParseTarget = LoadTarget, bool supports_checkpointing = false>
```
and is used mostly as:
```cpp
DataReader<Backend, Target>
```
so to enable checkpointing one needs to add two parameters:
```cpp
DataReader<Backend, Target, Target, true>
```

#### [2] `virtual_shard_id_`
`virtual_shard_id_` and `shard_id_`  might differ when `stick_to_shard=False`.

This change doesn't impact existing code, because `Reset` is normally called after each full pass over the data, so then those two are equal. It might happen that a checkpoint is saved when the reader was is processing a different shard that `shard_id_`,  so to restore from such checkpoint we need to be able to reset to the current shard (`virtual_shard_id_`).

The same change was made in `FileReader` in #4954.


### Affected modules and functionalities:
- Caffe and caffe2 readers
- LMDB loader

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3693
<!--- DALI-XXXX or NA --->
