### PR TITLE
Support checkpointing in Webdataset reader

### DIFF
--- a/dali/operators/reader/loader/webdataset_loader.cc
+++ b/dali/operators/reader/loader/webdataset_loader.cc
@@ -358,6 +358,10 @@ void WebdatasetLoader::ReadSample(vector<Tensor<CPUBackend>>& sample) {
   sample_index_++;
 }
 
+void WebdatasetLoader::Skip() {
+  MoveToNextShard(sample_index_++);
+}
+
 Index WebdatasetLoader::SizeImpl() {
   return samples_.size();
 }
@@ -477,7 +481,7 @@ void WebdatasetLoader::PrepareMetadataImpl() {
 }
 
 void WebdatasetLoader::Reset(bool wrap_to_shard) {
-  sample_index_ = wrap_to_shard ? start_index(shard_id_, num_shards_, samples_.size()) : 0;
+  sample_index_ = wrap_to_shard ? start_index(virtual_shard_id_, num_shards_, samples_.size()) : 0;
 }
 
 }  // namespace dali

--- a/dali/operators/reader/loader/webdataset_loader.h
+++ b/dali/operators/reader/loader/webdataset_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -87,13 +87,14 @@ struct SampleDesc {
 }  // namespace wds
 }  // namespace detail
 
-class DLL_PUBLIC WebdatasetLoader : public Loader<CPUBackend, vector<Tensor<CPUBackend>>> {
+class DLL_PUBLIC WebdatasetLoader : public Loader<CPUBackend, vector<Tensor<CPUBackend>>, true> {
  public:
   explicit WebdatasetLoader(const OpSpec& spec);
   ~WebdatasetLoader() override;
 
   void PrepareEmpty(std::vector<Tensor<CPUBackend>>&) override;
   void ReadSample(std::vector<Tensor<CPUBackend>>&) override;
+  void Skip() override;
 
  protected:
   Index SizeImpl() override;

--- a/dali/operators/reader/webdataset_reader_op.cc
+++ b/dali/operators/reader/webdataset_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 namespace dali {
 
 bool WebdatasetReader::SetupImpl(std::vector<OutputDesc>& output_desc, const Workspace &ws) {
-  DataReader<CPUBackend, std::vector<Tensor<CPUBackend>>>::SetupImpl(output_desc, ws);
+  DataReader::SetupImpl(output_desc, ws);
   int num_outputs = ws.NumOutput();
   int num_samples = GetCurrBatchSize();
 

--- a/dali/operators/reader/webdataset_reader_op.h
+++ b/dali/operators/reader/webdataset_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,11 +22,12 @@
 
 namespace dali {
 
-class DLL_PUBLIC WebdatasetReader : public DataReader<CPUBackend, vector<Tensor<CPUBackend>>> {
+class DLL_PUBLIC WebdatasetReader
+    : public DataReader<CPUBackend, vector<Tensor<CPUBackend>>, vector<Tensor<CPUBackend>>, true> {
  public:
-  explicit WebdatasetReader(const OpSpec& spec)
-      : DataReader<CPUBackend, vector<Tensor<CPUBackend>>>(spec) {
+  explicit WebdatasetReader(const OpSpec& spec) : DataReader(spec) {
     loader_ = InitLoader<WebdatasetLoader>(spec);
+    this->SetInitialSnapshot();
   }
 
   bool SetupImpl(std::vector<OutputDesc>& output_desc, const Workspace&) override;
@@ -36,7 +37,8 @@ class DLL_PUBLIC WebdatasetReader : public DataReader<CPUBackend, vector<Tensor<
   }
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend, vector<Tensor<CPUBackend>>);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, vector<Tensor<CPUBackend>>,
+                              vector<Tensor<CPUBackend>>, true);
 };
 
 }  // namespace dali


### PR DESCRIPTION
## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:

This PR adds checkpointing support to `fn.readers.webdataset`.

## Additional information:

Adding checkpointing support is a simple task, similar for every loader and reader.

The following changes were required to enable checkpointing in the loader:
- Make it inherit from `Loader<..., supports_checkpointing=true>`
- Implement `Skip()` method. `Skip` should behave like `ReadSample` in terms of side effects, but should skip a sample instead of reading it. This method is used to implement fast-forwarding in `Loader` baseclass.
- Change `Reset` to use `virtual_shard_id_` (which is the shard currently processed)
  instead of `shard_id_` (which is the initial shard requested by the user). See [2] for more details.

The following changes were required to enable checkpointing in the reader:
- Make it inherit from `DataReader<..., supports_checkpointing=true>`. See [1] for more details.
- Store the very first snapshot in the constructor with `this->SetInitialSnapshot()`.
  Subsequent snapshots are saved by `DataReader` baseclass.

#### [1] Changing `DataReader` template parameters
Inheriting from `DataReader<..., supports_checkpointing=true>` might look strange in the diff, because the `DataReader` is defined as:
```cpp
template <typename Backend, typename LoadTarget,
          typename ParseTarget = LoadTarget, bool supports_checkpointing = false>
```
and is used mostly as:
```cpp
DataReader<Backend, Target>
```
so to enable checkpointing one needs to add two parameters:
```cpp
DataReader<Backend, Target, Target, true>
```

#### [2] `virtual_shard_id_`
`virtual_shard_id_` and `shard_id_`  might differ when `stick_to_shard=False`.

This change doesn't impact existing code, because `Reset` is normally called after each full pass over the data, so then those two are equal. It might happen that a checkpoint is saved when the reader was is processing a different shard that `shard_id_`,  so to restore from such checkpoint we need to be able to reset to the current shard (`virtual_shard_id_`).

The same change was made in `FileReader` in #4954.


### Affected modules and functionalities:
- WDS reader and loader

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3706
<!--- DALI-XXXX or NA --->
