### PR TITLE
Support checkpointing in sequence reader

### DIFF
--- a/dali/operators/reader/loader/sequence_loader.cc
+++ b/dali/operators/reader/loader/sequence_loader.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,6 +111,10 @@ void SequenceLoader::ReadSample(TensorSequence &sequence) {
   current_sequence_++;
   // wrap-around
   MoveToNextShard(current_sequence_);
+}
+
+void SequenceLoader::Skip() {
+  MoveToNextShard(++current_sequence_);
 }
 
 Index SequenceLoader::SizeImpl() {

--- a/dali/operators/reader/loader/sequence_loader.h
+++ b/dali/operators/reader/loader/sequence_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ struct TensorSequence {
 //              sequentially, and allow for SequenceLoader to wrap any other
 //              loader, similar for parser and reader
 // TODO(klecki) loader is responsible for handling shuffle_
-class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
+class SequenceLoader : public Loader<CPUBackend, TensorSequence, true> {
  public:
   explicit SequenceLoader(const OpSpec &spec)
       : Loader(spec),
@@ -97,6 +97,7 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
 
   void PrepareEmpty(TensorSequence &tensor) override;
   void ReadSample(TensorSequence &tensor) override;
+  void Skip() override;
 
  protected:
   Index SizeImpl() override;
@@ -126,7 +127,7 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
  private:
   void Reset(bool wrap_to_shard) override {
     if (wrap_to_shard) {
-      current_sequence_ = start_index(shard_id_, num_shards_, SizeImpl());
+      current_sequence_ = start_index(virtual_shard_id_, num_shards_, SizeImpl());
     } else {
       current_sequence_ = 0;
     }

--- a/dali/operators/reader/sequence_reader_op.h
+++ b/dali/operators/reader/sequence_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,17 +21,19 @@
 
 namespace dali {
 
-class SequenceReader : public DataReader<CPUBackend, TensorSequence> {
+class SequenceReader : public DataReader<CPUBackend, TensorSequence, TensorSequence, true> {
  public:
-  explicit SequenceReader(const OpSpec& spec) : DataReader<CPUBackend, TensorSequence>(spec) {
+  explicit SequenceReader(const OpSpec& spec)
+      : DataReader<CPUBackend, TensorSequence, TensorSequence, true>(spec) {
     loader_ = InitLoader<SequenceLoader>(spec);
+    this->SetInitialSnapshot();
     parser_.reset(new SequenceParser(spec));
   }
 
   void RunImpl(SampleWorkspace &ws) override;
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend, TensorSequence);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, TensorSequence, TensorSequence, true);
 };
 
 }  // namespace dali

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -259,7 +259,7 @@ def test_sequence_reader(num_epochs, batch_size, shard_id, num_shards,
     check_reader_checkpointing(
         fn.readers.sequence, num_epochs, batch_size, iters_into_epoch,
         file_root=os.path.join(data_root, 'db', 'sequence', 'frames'),
-        sequence_length = 5,
+        sequence_length=5,
         pad_last_batch=pad_last_batch,
         random_shuffle=random_shuffle,
         shard_id=shard_id, num_shards=num_shards,


### PR DESCRIPTION
## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:

This PR adds checkpointing support to `fn.readers.sequence`.

## Additional information:

Adding checkpointing support is a simple task, similar for every loader and reader.

The following changes were required to enable checkpointing in the loader:
- Make it inherit from `Loader<..., supports_checkpointing=true>`
- Implement `Skip()` method. `Skip` should behave like `ReadSample` in terms of side effects, but should skip a sample instead of reading it. This method is used to implement fast-forwarding in `Loader` baseclass.
- Change `Reset` to use `virtual_shard_id_` (which is the shard currently processed)
  instead of `shard_id_` (which is the initial shard requested by the user). See [2] for more details.

The following changes were required to enable checkpointing in the reader:
- Make it inherit from `DataReader<..., supports_checkpointing=true>`. See [1] for more details.
- Store the very first snapshot in the constructor with `this->SetInitialSnapshot()`.
  Subsequent snapshots are saved by `DataReader` baseclass.

#### [1] Changing `DataReader` template parameters
Inheriting from `DataReader<..., supports_checkpointing=true>` might look strange in the diff, because the `DataReader` is defined as:
```cpp
template <typename Backend, typename LoadTarget,
          typename ParseTarget = LoadTarget, bool supports_checkpointing = false>
```
and is used mostly as:
```cpp
DataReader<Backend, Target>
```
so to enable checkpointing one needs to add two parameters:
```cpp
DataReader<Backend, Target, Target, true>
```

#### [2] `virtual_shard_id_`
`virtual_shard_id_` and `shard_id_`  might differ when `stick_to_shard=False`.

This change doesn't impact existing code, because `Reset` is normally called after each full pass over the data, so then those two are equal. It might happen that a checkpoint is saved when the reader was is processing a different shard that `shard_id_`,  so to restore from such checkpoint we need to be able to reset to the current shard (`virtual_shard_id_`).

The same change was made in `FileReader` in #4954.


### Affected modules and functionalities:
- Sequence reader and loader

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
A minor change in the check_reader_checkpointing helper was required to support single-output readers.
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3707
<!--- DALI-XXXX or NA --->
