### PR TITLE
Support checkpointing in Nemo reader

### DIFF
--- a/dali/operators/reader/loader/nemo_asr_loader.h
+++ b/dali/operators/reader/loader/nemo_asr_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,10 +107,10 @@ DLL_PUBLIC void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream &
 
 }  // namespace detail
 
-class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
+class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample, true> {
  public:
   explicit inline NemoAsrLoader(const OpSpec &spec)
-      : Loader<CPUBackend, AsrSample>(spec),
+      : Loader<CPUBackend, AsrSample, true>(spec),
         manifest_filepaths_(spec.GetRepeatedArgument<std::string>("manifest_filepaths")),
         shuffle_after_epoch_(spec.GetArgument<bool>("shuffle_after_epoch")),
         sample_rate_(spec.GetArgument<float>("sample_rate")),
@@ -150,11 +150,13 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
   ~NemoAsrLoader() override = default;
   void PrepareEmpty(AsrSample &sample) override;
   void ReadSample(AsrSample& sample) override;
+  void Skip() override;
 
  protected:
   void PrepareMetadataImpl() override;
   Index SizeImpl() override;
   void Reset(bool wrap_to_shard) override;
+  void RestoreStateImpl(const LoaderStateSnapshot &state) override;
 
  private:
   template <typename OutputType>

--- a/dali/operators/reader/nemo_asr_reader_op.cc
+++ b/dali/operators/reader/nemo_asr_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -125,7 +125,7 @@ submodule and renamed to follow a common pattern. This is a placeholder operator
 functionality to allow for backward compatibility.)code");  // Deprecated in 1.0;
 
 NemoAsrReader::NemoAsrReader(const OpSpec& spec)
-    : DataReader<CPUBackend, AsrSample>(spec),
+    : DataReader<CPUBackend, AsrSample, AsrSample, true>(spec),
       read_sr_(spec.GetArgument<bool>("read_sample_rate")),
       read_text_(spec.GetArgument<bool>("read_text")),
       read_idxs_(spec.GetArgument<bool>("read_idxs")),
@@ -133,6 +133,7 @@ NemoAsrReader::NemoAsrReader(const OpSpec& spec)
       num_threads_(std::max(1, spec.GetArgument<int>("num_threads"))),
       thread_pool_(num_threads_, spec.GetArgument<int>("device_id"), false, "NemoAsrReader") {
   loader_ = InitLoader<NemoAsrLoader>(spec);
+  this->SetInitialSnapshot();
 
   prefetched_decoded_audio_.resize(prefetch_queue_depth_);
   for (auto& batch : prefetched_decoded_audio_) {
@@ -143,13 +144,13 @@ NemoAsrReader::NemoAsrReader(const OpSpec& spec)
 
 NemoAsrReader::~NemoAsrReader() {
   // Need to stop the prefetch thread before destroying the thread pool
-  DataReader<CPUBackend, AsrSample>::StopPrefetchThread();
+  DataReader<CPUBackend, AsrSample, AsrSample, true>::StopPrefetchThread();
 }
 
 void NemoAsrReader::Prefetch() {
   DomainTimeRange tr("[DALI][NemoAsrReader] Prefetch #" + to_string(curr_batch_producer_),
                       DomainTimeRange::kRed);
-  DataReader<CPUBackend, AsrSample>::Prefetch();
+  DataReader<CPUBackend, AsrSample, AsrSample, true>::Prefetch();
   auto &curr_batch = prefetched_batch_queue_[curr_batch_producer_];
   auto &audio_batch = *prefetched_decoded_audio_[curr_batch_producer_];
   int nsamples = static_cast<int>(curr_batch.size());

--- a/dali/operators/reader/nemo_asr_reader_op.h
+++ b/dali/operators/reader/nemo_asr_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 #include "dali/operators/reader/loader/nemo_asr_loader.h"
 
 namespace dali {
-class NemoAsrReader : public DataReader<CPUBackend, AsrSample> {
+class NemoAsrReader : public DataReader<CPUBackend, AsrSample, AsrSample, true> {
  public:
   explicit NemoAsrReader(const OpSpec& spec);
   ~NemoAsrReader() override;


### PR DESCRIPTION
## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:

This PR adds checkpointing support to `fn.readers.nemo_asr`.

## Additional information:

**Note:** Nemo reader supports `shuffle_after_epoch`, so two additional steps (marked with **[!]** in the description below) are needed.

The following changes were required to enable checkpointing in the loader:
- Make it inherit from `Loader<..., supports_checkpointing=true>`
- Implement `Skip()` method. `Skip` should behave like `ReadSample` in terms of side effects, but should skip a sample instead of reading it. This method is used to implement fast-forwarding in `Loader` baseclass.
- Change `Reset` to use `virtual_shard_id_` (which is the shard currently processed)
  instead of `shard_id_` (which is the initial shard requested by the user). See [2] for more details.
- **[!]** Restore `current_epoch_ ` from the state in `RestoreStateImpl`. This loader needs to keep track of the epoch, because it's used as a seed for shuffling.
- **[!]** Change the way shuffling after epoch works. See [3] for more details.

The following changes were required to enable checkpointing in the reader:
- Make it inherit from `DataReader<..., supports_checkpointing=true>`. See [1] for more details.
- Store the very first snapshot in the constructor with `this->SetInitialSnapshot()`.
  Subsequent snapshots are saved by `DataReader` baseclass.

#### [1] Changing `DataReader` template parameters
Inheriting from `DataReader<..., supports_checkpointing=true>` might look strange in the diff, because the `DataReader` is defined as:
```cpp
template <typename Backend, typename LoadTarget,
          typename ParseTarget = LoadTarget, bool supports_checkpointing = false>
```
and is used mostly as:
```cpp
DataReader<Backend, Target>
```
so to enable checkpointing one needs to add two parameters:
```cpp
DataReader<Backend, Target, Target, true>
```

#### [2] `virtual_shard_id_`
`virtual_shard_id_` and `shard_id_`  might differ when `stick_to_shard=False`.

This change doesn't impact existing code, because `Reset` is normally called after each full pass over the data, so then those two are equal. It might happen that a checkpoint is saved when the reader was is processing a different shard that `shard_id_`,  so to restore from such checkpoint we need to be able to reset to the current shard (`virtual_shard_id_`).

The same change was made in `FileReader` in #4954.


#### [3] Shuffling after epoch
Originally, the list of indices was shuffled multiple times, once after each epoch. Each time shuffling was applied to already shuffled list. This meant that the list of indices after three epochs was:
```
shuffle(shuffle(shuffle([1, 2, ..., n], seed=S+0), seed=S+1), seed=S+2)
```
To make restoring from checkpoint easier, we now restore the list of indices to 1..n before shuffling it.
So now after three epochs it's just:
```
shuffle([1, 2, ..., n], seed=S+2)
```
It's still as random as it was, but much easier to restore.

### Affected modules and functionalities:
- Nemo reader and loader

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
A minor change in the check_reader_checkpointing helper was required to support single-output readers.
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3705
<!--- DALI-XXXX or NA --->
