### PR TITLE
Fix scalar constant dimensionality

### DIFF
--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ the ``shape`` and ``dtype``, will be taken from the array.
   downgraded to 32-bit.)code")
   .NumInput(0)
   .NumOutput(1)
+  .MakeDocHidden()
   .AddOptionalArg("shape",
                   "The desired shape of the output. If not set, the data is assumed to be 1D",
                   std::vector<int>())

--- a/dali/python/nvidia/dali/_utils/eager_utils.py
+++ b/dali/python/nvidia/dali/_utils/eager_utils.py
@@ -100,7 +100,7 @@ class _Classification:
         type_name (str): Representation of argument type (input or keyword).
         arg_constant_len (int): Only applicable for argument inputs that are of array type
             (e.g. numpy array). If -1 does not modify the data. For positive value works like
-            `:class:ops.Constant`, repeats the data `arg_constant_len` times.
+            `:func:types.Constant`, repeats the data `arg_constant_len` times.
     """
 
     def __init__(self, data, type_name, arg_constant_len=-1):

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -478,9 +478,14 @@ def ConstantNode(device, value, dtype, shape, layout, **kwargs):
             shape = list(value.shape)  # torch uses torch.Size instead of list
         data = value.flatten().tolist()
     else:
+        def isseq(v):
+            return isinstance(v, (list, tuple))
+
+        if shape is None:
+            shape = (len(value),) if isseq(value) else ()
 
         def _type_from_value_or_list(v):
-            if not isinstance(v, (list, tuple)):
+            if not isseq(v):
                 v = [v]
 
             has_floats = False

--- a/dali/test/python/operator_1/test_color_twist.py
+++ b/dali/test/python/operator_1/test_color_twist.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -192,7 +192,7 @@ def test_color_twist_default_dtype():
     def impl(op, device, type):
         @pipeline_def(batch_size=1, num_threads=3, device_id=0)
         def pipeline():
-            data = fn.constant(idata=255, shape=(10, 10, 3), dtype=type, device=device)
+            data = types.Constant(255, shape=(10, 10, 3), dtype=type, device=device)
             return op(data)
 
         pipe = pipeline()

--- a/dali/test/python/operator_1/test_pad.py
+++ b/dali/test/python/operator_1/test_pad.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -325,7 +325,7 @@ def test_empty_axes():
 def check_pad_wrong_axes(device, wrong_axes_range=None):
     @pipeline_def(batch_size=1, num_threads=1, device_id=0)
     def make_pipe():
-        fake_data = fn.constant(idata=0, shape=[10, 10, 3], dtype=types.FLOAT, device=device)
+        fake_data = types.Constant(0, shape=[10, 10, 3], dtype=types.FLOAT, device=device)
         axes = fn.random.uniform(range=wrong_axes_range, shape=(2,), dtype=types.INT32)
         padded = fn.pad(fake_data, axes=axes)
         return padded

--- a/dali/test/python/operator_1/test_slice.py
+++ b/dali/test/python/operator_1/test_slice.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -895,7 +895,7 @@ def test_empty_axes():
 def check_wrong_axes(device, wrong_axes_range=None, named_args=False):
     @pipeline_def(batch_size=1, num_threads=1, device_id=0)
     def make_pipe():
-        fake_data = fn.constant(idata=0, shape=[10, 10, 3], dtype=types.FLOAT, device=device)
+        fake_data = types.Constant(0, shape=[10, 10, 3], dtype=types.FLOAT, device=device)
         axes = fn.random.uniform(range=wrong_axes_range, shape=(2,), dtype=types.INT32)
         rel_start = fn.random.uniform(range=[0.0, 0.3], shape=(2,), dtype=types.FLOAT)
         rel_shape = fn.random.uniform(range=[0.4, 0.6], shape=(2,), dtype=types.FLOAT)
@@ -960,7 +960,7 @@ def test_gpu_args():
 def test_wrong_arg_backend():
     @pipeline_def(batch_size=1, num_threads=1, device_id=0)
     def make_pipe():
-        fake_data = fn.constant(idata=0, shape=[10, 10, 3], dtype=types.FLOAT, device="cpu")
+        fake_data = types.Constant(0, shape=[10, 10, 3], dtype=types.FLOAT, device="cpu")
         rel_start = fn.random.uniform(range=[0.0, 0.3], shape=(2,), dtype=types.FLOAT, device="gpu")
         rel_shape = fn.random.uniform(range=[0.4, 0.6], shape=(2,), dtype=types.FLOAT, device="gpu")
         sliced = fn.slice(fake_data, rel_start, rel_shape, device="cpu")
@@ -975,7 +975,7 @@ def test_wrong_arg_backend():
 def test_wrong_backend_named_args():
     @pipeline_def(batch_size=1, num_threads=1, device_id=0)
     def make_pipe():
-        fake_data = fn.constant(idata=0, shape=[10, 10, 3], dtype=types.FLOAT, device="cpu")
+        fake_data = types.Constant(0, shape=[10, 10, 3], dtype=types.FLOAT, device="cpu")
         rel_start = fn.random.uniform(range=[0.0, 0.3], shape=(2,), dtype=types.FLOAT, device="gpu")
         rel_shape = fn.random.uniform(range=[0.4, 0.6], shape=(2,), dtype=types.FLOAT, device="gpu")
         sliced = fn.slice(fake_data, rel_start=rel_start, rel_shape=rel_shape, device="cpu")

--- a/dali/test/python/operator_2/test_reshape.py
+++ b/dali/test/python/operator_2/test_reshape.py
@@ -354,8 +354,7 @@ def test_reshape_src_dims_arg():
     for src_dims, rel_shape, shapes, expected_out_shapes in args:
         yield _testimpl_reshape_src_dims_arg, src_dims, rel_shape, shapes, expected_out_shapes
         if rel_shape is not None:
-            shape_inp = fn.constant(fdata=rel_shape, dtype=types.FLOAT)
-            yield _testimpl_reshape_src_dims_arg, src_dims, shape_inp, shapes, expected_out_shapes
+            yield _testimpl_reshape_src_dims_arg, src_dims, rel_shape, shapes, expected_out_shapes
 
 
 @params(

--- a/dali/test/python/test_pipeline_debug.py
+++ b/dali/test/python/test_pipeline_debug.py
@@ -642,7 +642,7 @@ def test_es_device_change():
 
 @pipeline_def(batch_size=8, num_threads=3, device_id=0, seed=47, debug=True)
 def nan_check_pipeline(source):
-    return fn.constant(fdata=next(source))
+    return next(source)
 
 
 def _test_nan_check(values):
@@ -666,8 +666,7 @@ def test_debug_pipeline_conditionals():
     @pipeline_def(batch_size=8, num_threads=3, device_id=0, enable_conditionals=False)
     def pipeline_split_merge():
         pred = fn.random.coin_flip(seed=42, dtype=types.BOOL)
-        input = fn.constant(idata=[10], shape=[])
-        true, false = fn._conditional.split(input, predicate=pred)
+        true, false = fn._conditional.split(10, predicate=pred)
         output_true = true + 2
         output_false = false + 100
         output = fn._conditional.merge(output_true, output_false, predicate=pred)
@@ -678,7 +677,7 @@ def test_debug_pipeline_conditionals():
     @pipeline_def(batch_size=8, num_threads=3, device_id=0, enable_conditionals=True)
     def pipeline_cond():
         pred = fn.random.coin_flip(seed=42, dtype=types.BOOL)
-        input = fn.constant(idata=[10], shape=[])
+        input = fn.copy(10)  # force it to become a DataNode
         print(f"Pred: {pred}")
         if pred:
             output = input + 2

--- a/dali/test/python/test_pipeline_debug.py
+++ b/dali/test/python/test_pipeline_debug.py
@@ -666,7 +666,8 @@ def test_debug_pipeline_conditionals():
     @pipeline_def(batch_size=8, num_threads=3, device_id=0, enable_conditionals=False)
     def pipeline_split_merge():
         pred = fn.random.coin_flip(seed=42, dtype=types.BOOL)
-        true, false = fn._conditional.split(10, predicate=pred)
+        input = types.Constant(10, device="cpu")  # TODO: Consant handling in debug mode
+        true, false = fn._conditional.split(input, predicate=pred)
         output_true = true + 2
         output_false = false + 100
         output = fn._conditional.merge(output_true, output_false, predicate=pred)
@@ -677,7 +678,7 @@ def test_debug_pipeline_conditionals():
     @pipeline_def(batch_size=8, num_threads=3, device_id=0, enable_conditionals=True)
     def pipeline_cond():
         pred = fn.random.coin_flip(seed=42, dtype=types.BOOL)
-        input = fn.copy(10)  # force it to become a DataNode
+        input = types.Constant(10, device="cpu")  # TODO: Consant handling in debug mode
         print(f"Pred: {pred}")
         if pred:
             output = input + 2

--- a/dali/test/python/test_pipeline_debug.py
+++ b/dali/test/python/test_pipeline_debug.py
@@ -642,7 +642,7 @@ def test_es_device_change():
 
 @pipeline_def(batch_size=8, num_threads=3, device_id=0, seed=47, debug=True)
 def nan_check_pipeline(source):
-    return next(source)
+    return fn.constant(fdata=next(source), shape=())  # TODO: Constant handling in debug mode
 
 
 def _test_nan_check(values):

--- a/docs/examples/use_cases/tensorflow/yolov4/src/dali/ops.py
+++ b/docs/examples/use_cases/tensorflow/yolov4/src/dali/ops.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Kacper Kluk, Piotr Kowalewski. All Rights Reserved.
+# Copyright 2021-2023 Kacper Kluk, Piotr Kowalewski. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -61,10 +61,7 @@ def select(predicate, if_true, if_false):
     joined = dali.fn.cat(if_true, if_false)
     sh = predicate * true_shape + (1 - predicate) * false_shape
 
-    st = dali.fn.cat(
-            dali.fn.slice(true_shape * (1 - predicate), start=[0], shape=[1], axes=[0]),
-            dali.fn.constant(idata=0, shape=[1])
-        )
+    st = dali.fn.stack(true_shape[0] * (1 - predicate), 0)
 
     return dali.fn.slice(joined, start=st, shape=sh, axes=[0,1], out_of_bounds_policy="trim_to_shape")
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Other** (*documentation*)

## Description:
The shape of scalar constants was sometimes boosted to `(1,)`, depending on the way the constant was passed to an operator. It should always have an empty shape. The bug was caused by not passing _any_ shape to the constant operator. The operator itself cannot distinguish between a scalar value and a vector of length 1 and, in the absence of shape, always yielded a flat 1D array with the length equal to the length of the argument (`idata` / `fdata`).

Hopefully no code depends on the buggy behavior - we certainly didn't test it either way; the tests were added.

Finally, this PR also hides ops.Constant/fn.constant from the documentation. This operator should not be used directly. Most of the time it should not be used at all, an in the rare cases when it's necessary, `types.Constant` should be used.


## Additional information:

### Affected modules and functionalities:
Everywhere where we use scalar constant->DataNode promotion.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation ~updated~ removed
  - [X] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
