### PR TITLE
Support checkpointing in Numpy reader

### DIFF
--- a/dali/operators/reader/fits_reader_gpu_op.h
+++ b/dali/operators/reader/fits_reader_gpu_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class FitsReaderGPU : public FitsReader<GPUBackend, FitsFileWrapperGPU> {
   using Operator<GPUBackend>::RunImpl;
 
  private:
-  USE_READER_OPERATOR_MEMBERS(GPUBackend, FitsFileWrapperGPU);
+  USE_READER_OPERATOR_MEMBERS_3(GPUBackend, FitsFileWrapperGPU, FitsFileWrapperGPU, true);
 };
 
 }  // namespace dali

--- a/dali/operators/reader/fits_reader_gpu_op.h
+++ b/dali/operators/reader/fits_reader_gpu_op.h
@@ -35,7 +35,7 @@ class FitsReaderGPU : public FitsReader<GPUBackend, FitsFileWrapperGPU> {
   using Operator<GPUBackend>::RunImpl;
 
  private:
-  USE_READER_OPERATOR_MEMBERS_3(GPUBackend, FitsFileWrapperGPU, FitsFileWrapperGPU, true);
+  USE_READER_OPERATOR_MEMBERS(GPUBackend, FitsFileWrapperGPU, FitsFileWrapperGPU, true);
 };
 
 }  // namespace dali

--- a/dali/operators/reader/fits_reader_op.h
+++ b/dali/operators/reader/fits_reader_op.h
@@ -44,7 +44,7 @@ class FitsReader : public DataReader<Backend, Target, Target, true> {
     DALI_FAIL("Fits reader does not support checkpointing.");
   }
 
-  USE_READER_OPERATOR_MEMBERS_3(Backend, Target, Target, true);
+  USE_READER_OPERATOR_MEMBERS(Backend, Target, Target, true);
   using DataReader<Backend, Target, Target, true>::GetCurrBatchSize;
   using DataReader<Backend, Target, Target, true>::GetSample;
   using Operator<Backend>::spec_;
@@ -112,7 +112,7 @@ class FitsReaderCPU : public FitsReader<CPUBackend, FitsFileWrapper> {
   using Operator<CPUBackend>::RunImpl;
 
  private:
-  USE_READER_OPERATOR_MEMBERS_3(CPUBackend, FitsFileWrapper, FitsFileWrapper, true);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, FitsFileWrapper, FitsFileWrapper, true);
 };
 
 }  // namespace dali

--- a/dali/operators/reader/fits_reader_op.h
+++ b/dali/operators/reader/fits_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,22 +27,31 @@
 namespace dali {
 
 template <typename Backend, typename Target>
-class FitsReader : public DataReader<Backend, Target> {
+class FitsReader : public DataReader<Backend, Target, Target, true> {
  public:
-  explicit FitsReader(const OpSpec& spec) : DataReader<Backend, Target>(spec) {}
+  explicit FitsReader(const OpSpec& spec) : DataReader<Backend, Target, Target, true>(spec) {}
 
   bool CanInferOutputs() const override {
     return true;
   }
 
-  USE_READER_OPERATOR_MEMBERS(Backend, Target);
-  using DataReader<Backend, Target>::GetCurrBatchSize;
-  using DataReader<Backend, Target>::GetSample;
+  // TODO(skarpinski) Debug fits reader and add checkpointing support
+  void SaveState(OpCheckpoint &cpt, AccessOrder order) override {
+    DALI_FAIL("Fits reader does not support checkpointing.");
+  }
+
+  void RestoreState(const OpCheckpoint &cpt) override {
+    DALI_FAIL("Fits reader does not support checkpointing.");
+  }
+
+  USE_READER_OPERATOR_MEMBERS_3(Backend, Target, Target, true);
+  using DataReader<Backend, Target, Target, true>::GetCurrBatchSize;
+  using DataReader<Backend, Target, Target, true>::GetSample;
   using Operator<Backend>::spec_;
 
   bool SetupImpl(std::vector<OutputDesc>& output_desc, const Workspace& ws) override {
     // If necessary start prefetching thread and wait for a consumable batch
-    DataReader<Backend, Target>::SetupImpl(output_desc, ws);
+    DataReader<Backend, Target, Target, true>::SetupImpl(output_desc, ws);
 
     int num_outputs = ws.NumOutput();
     int num_samples = GetCurrBatchSize();             // samples here are synonymous with files
@@ -103,7 +112,7 @@ class FitsReaderCPU : public FitsReader<CPUBackend, FitsFileWrapper> {
   using Operator<CPUBackend>::RunImpl;
 
  private:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend, FitsFileWrapper);
+  USE_READER_OPERATOR_MEMBERS_3(CPUBackend, FitsFileWrapper, FitsFileWrapper, true);
 };
 
 }  // namespace dali

--- a/dali/operators/reader/loader/numpy_loader.cc
+++ b/dali/operators/reader/loader/numpy_loader.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,6 +113,10 @@ void NumpyLoader::ReadSample(NumpyFileWrapper& target) {
 
   // set meta
   target.fortran_order = header.fortran_order;
+}
+
+void NumpyLoader::Skip() {
+  MoveToNextShard(++current_index_);
 }
 
 }  // namespace dali

--- a/dali/operators/reader/loader/numpy_loader.h
+++ b/dali/operators/reader/loader/numpy_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -100,6 +100,7 @@ class NumpyLoader : public FileLoader<CPUBackend, NumpyFileWrapper> {
 
   // we want to make it possible to override this function as well
   void ReadSample(NumpyFileWrapper& target) override;
+  void Skip() override;
 
  private:
   detail::NumpyHeaderCache header_cache_;

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ NumpyReaderGPU::NumpyReaderGPU(const OpSpec& spec)
   // init loader
   bool shuffle_after_epoch = spec.GetArgument<bool>("shuffle_after_epoch");
   loader_ = InitLoader<NumpyLoaderGPU>(spec, std::vector<string>(), shuffle_after_epoch);
+  this->SetInitialSnapshot();
 
   kmgr_transpose_.Resize<TransposeKernel>(1);
 }
@@ -54,7 +55,7 @@ void NumpyReaderGPU::Prefetch() {
   // We actually prepare the next batch
   DomainTimeRange tr("[DALI][NumpyReaderGPU] Prefetch #" + to_string(curr_batch_producer_),
                       DomainTimeRange::kRed);
-  DataReader<GPUBackend, NumpyFileWrapperGPU>::Prefetch();
+  DataReader<GPUBackend, NumpyFileWrapperGPU, NumpyFileWrapperGPU, true>::Prefetch();
   auto &curr_batch = prefetched_batch_queue_[curr_batch_producer_];
   auto &curr_tensor_list = prefetched_batch_tensors_[curr_batch_producer_];
 

--- a/dali/operators/reader/numpy_reader_gpu_op.h
+++ b/dali/operators/reader/numpy_reader_gpu_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ class NumpyReaderGPU : gds::GDSLazyInit, public NumpyReader<GPUBackend, NumpyFil
   using Operator<GPUBackend>::RunImpl;
 
 
-  USE_READER_OPERATOR_MEMBERS(GPUBackend, NumpyFileWrapperGPU);
+  USE_READER_OPERATOR_MEMBERS_3(GPUBackend, NumpyFileWrapperGPU, NumpyFileWrapperGPU, true);
 
  private:
   using TransposeKernel = kernels::TransposeGPU;

--- a/dali/operators/reader/numpy_reader_gpu_op.h
+++ b/dali/operators/reader/numpy_reader_gpu_op.h
@@ -70,7 +70,7 @@ class NumpyReaderGPU : gds::GDSLazyInit, public NumpyReader<GPUBackend, NumpyFil
   using Operator<GPUBackend>::RunImpl;
 
 
-  USE_READER_OPERATOR_MEMBERS_3(GPUBackend, NumpyFileWrapperGPU, NumpyFileWrapperGPU, true);
+  USE_READER_OPERATOR_MEMBERS(GPUBackend, NumpyFileWrapperGPU, NumpyFileWrapperGPU, true);
 
  private:
   using TransposeKernel = kernels::TransposeGPU;

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -244,7 +244,7 @@ void NumpyReaderCPU::Prefetch() {
   // We actually prepare the next batch
   DomainTimeRange tr("[DALI][NumpyReaderCPU] Prefetch #" + to_string(curr_batch_producer_),
                       DomainTimeRange::kRed);
-  DataReader<CPUBackend, NumpyFileWrapper>::Prefetch();
+  DataReader<CPUBackend, NumpyFileWrapper, NumpyFileWrapper, true>::Prefetch();
 
   if (!dont_use_mmap_)
     return;

--- a/dali/operators/reader/numpy_reader_op.h
+++ b/dali/operators/reader/numpy_reader_op.h
@@ -48,7 +48,7 @@ class NumpyReader : public DataReader<Backend, Target, Target, true> {
     return true;
   }
 
-  USE_READER_OPERATOR_MEMBERS_3(Backend, Target, Target, true);
+  USE_READER_OPERATOR_MEMBERS(Backend, Target, Target, true);
   using DataReader<Backend, Target, Target, true>::GetCurrBatchSize;
   using DataReader<Backend, Target, Target, true>::GetSample;
   using Operator<Backend>::spec_;
@@ -177,7 +177,7 @@ class NumpyReaderCPU : public NumpyReader<CPUBackend, NumpyFileWrapper> {
   using Operator<CPUBackend>::RunImpl;
 
  private:
-  USE_READER_OPERATOR_MEMBERS_3(CPUBackend, NumpyFileWrapper, NumpyFileWrapper, true);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, NumpyFileWrapper, NumpyFileWrapper, true);
 
   bool dont_use_mmap_ = false;
   bool use_o_direct_ = false;

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -565,6 +565,7 @@ def test_nemo_asr_reader(
 
     manifest.close()
 
+
 # device,
 # num_epochs, batch_size, shard_id, num_shards,
 # random_shuffle, shuffle_after_epoch, stick_to_shard, pad_last_batch,

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -565,7 +565,10 @@ def test_nemo_asr_reader(
 
     manifest.close()
 
-
+# device,
+# num_epochs, batch_size, shard_id, num_shards,
+# random_shuffle, shuffle_after_epoch, stick_to_shard, pad_last_batch,
+# iters_into_epoch, initial_fill
 @params(
     ("cpu", 0, 1, 0, 1, False, False, False, False, None),
     ("cpu", 5, 2, 4, 7, False, False, False, True, 1),

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -23,6 +23,7 @@ from nose2.tools import params, cartesian_params
 from nose.plugins.attrib import attr
 from dataclasses import dataclass
 from nvidia.dali import tfrecord as tfrec
+from reader.test_numpy import is_gds_supported
 
 data_root = get_dali_extra_path()
 images_dir = os.path.join(data_root, "db", "single", "jpeg")
@@ -581,16 +582,22 @@ def test_nemo_asr_reader(
     ("cpu", 3, 8, 1, 4, True, False, False, True, 1),
     ("cpu", 2, 1, 1, 2, True, False, True, False, None),
     ("cpu", 0, 2, 0, 1, True, False, True, True, 2),
-    ("gpu", 2, 1, 1, 2, False, False, False, False, None),
-    ("gpu", 5, 2, 0, 5, False, False, False, True, 1),
-    ("gpu", 3, 4, 2, 3, False, False, True, False, 2),
-    ("gpu", 6, 8, 3, 5, False, False, True, True, 3),
-    ("gpu", 7, 1, 1, 4, False, True, False, False, 4),
-    ("gpu", 3, 2, 2, 4, False, True, False, True, 3),
-    ("gpu", 3, 4, 2, 5, True, False, False, False, 2),
-    ("gpu", 4, 8, 0, 2, True, False, False, True, 1),
-    ("gpu", 1, 1, 2, 3, True, False, True, False, None),
-    ("gpu", 0, 2, 0, 2, True, False, True, True, 2),
+    *(
+        [
+            ("gpu", 2, 1, 1, 2, False, False, False, False, None),
+            ("gpu", 5, 2, 0, 5, False, False, False, True, 1),
+            ("gpu", 3, 4, 2, 3, False, False, True, False, 2),
+            ("gpu", 6, 8, 3, 5, False, False, True, True, 3),
+            ("gpu", 7, 1, 1, 4, False, True, False, False, 4),
+            ("gpu", 3, 2, 2, 4, False, True, False, True, 3),
+            ("gpu", 3, 4, 2, 5, True, False, False, False, 2),
+            ("gpu", 4, 8, 0, 2, True, False, False, True, 1),
+            ("gpu", 1, 1, 2, 3, True, False, True, False, None),
+            ("gpu", 0, 2, 0, 2, True, False, True, True, 2),
+        ]
+        if is_gds_supported()
+        else []
+    ),
 )
 def test_numpy_reader(
     device,

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -566,6 +566,60 @@ def test_nemo_asr_reader(
     manifest.close()
 
 
+@params(
+    ("cpu", 0, 1, 0, 1, False, False, False, False, None),
+    ("cpu", 5, 2, 4, 7, False, False, False, True, 1),
+    ("cpu", 4, 4, 0, 2, False, False, True, False, 2),
+    ("cpu", 3, 8, 4, 6, False, False, True, True, 3),
+    ("cpu", 6, 1, 2, 3, False, True, False, False, 4),
+    ("cpu", 5, 2, 2, 5, False, True, False, True, 3),
+    ("cpu", 4, 4, 3, 4, True, False, False, False, 2),
+    ("cpu", 3, 8, 1, 4, True, False, False, True, 1),
+    ("cpu", 2, 1, 1, 2, True, False, True, False, None),
+    ("cpu", 0, 2, 0, 1, True, False, True, True, 2),
+    ("gpu", 2, 1, 1, 2, False, False, False, False, None),
+    ("gpu", 5, 2, 0, 5, False, False, False, True, 1),
+    ("gpu", 3, 4, 2, 3, False, False, True, False, 2),
+    ("gpu", 6, 8, 3, 5, False, False, True, True, 3),
+    ("gpu", 7, 1, 1, 4, False, True, False, False, 4),
+    ("gpu", 3, 2, 2, 4, False, True, False, True, 3),
+    ("gpu", 3, 4, 2, 5, True, False, False, False, 2),
+    ("gpu", 4, 8, 0, 2, True, False, False, True, 1),
+    ("gpu", 1, 1, 2, 3, True, False, True, False, None),
+    ("gpu", 0, 2, 0, 2, True, False, True, True, 2),
+)
+def test_numpy_reader(
+    device,
+    num_epochs,
+    batch_size,
+    shard_id,
+    num_shards,
+    random_shuffle,
+    shuffle_after_epoch,
+    stick_to_shard,
+    pad_last_batch,
+    iters_into_epoch=None,
+    initial_fill=1024,
+):
+    numpy_dir = os.path.join(data_root, "db", "3D", "MRI", "Knee", "npy_2d_slices", "STU00001")
+
+    check_reader_checkpointing(
+        fn.readers.numpy,
+        num_epochs,
+        batch_size,
+        iters_into_epoch,
+        device=device,
+        file_root=numpy_dir,
+        pad_last_batch=pad_last_batch,
+        random_shuffle=random_shuffle,
+        shuffle_after_epoch=shuffle_after_epoch,
+        shard_id=shard_id,
+        num_shards=num_shards,
+        stick_to_shard=stick_to_shard,
+        initial_fill=initial_fill,
+    )
+
+
 @attr("pytorch")
 @params(
     (1, 3, 0, 1, True, False, False),


### PR DESCRIPTION
## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:

This PR adds checkpointing support to `FileLoader` and `fn.readers.numpy` reader.

`FitsLoader` is also based on `FileLoader`, but has bugs that made me unable to test checkpointing in it. I made it fail on `SaveState` and `RestoreState` for now, but I plan to fix the bugs and enable checkpointing there in the following weeks.

## Additional information:

Adding checkpointing support is a simple task, similar for every loader and reader.

The following changes were required to enable checkpointing in the loader:
- Make it inherit from `Loader<..., supports_checkpointing=true>`
- Implement `Skip()` method. `Skip` should behave like `ReadSample` in terms of side effects, but should skip a sample instead of reading it. This method is used to implement fast-forwarding in `Loader` baseclass.
- Change `Reset` to use `virtual_shard_id_` (which is the shard currently processed)
  instead of `shard_id_` (which is the initial shard requested by the user). See [2] for more details.

The following changes were required to enable checkpointing in the reader:
- Make it inherit from `DataReader<..., supports_checkpointing=true>`. See [1] for more details.
- Store the very first snapshot in the constructor with `this->SetInitialSnapshot()`.
  Subsequent snapshots are saved by `DataReader` baseclass.

#### [1] Changing `DataReader` template parameters
Inheriting from `DataReader<..., supports_checkpointing=true>` might look strange in the diff, because the `DataReader` is defined as:
```cpp
template <typename Backend, typename LoadTarget,
          typename ParseTarget = LoadTarget, bool supports_checkpointing = false>
```
and is used mostly as:
```cpp
DataReader<Backend, Target>
```
so to enable checkpointing one needs to add two parameters:
```cpp
DataReader<Backend, Target, Target, true>
```

#### [2] `virtual_shard_id_`
`virtual_shard_id_` and `shard_id_`  might differ when `stick_to_shard=False`.

This change doesn't impact existing code, because `Reset` is normally called after each full pass over the data, so then those two are equal. It might happen that a checkpoint is saved when the reader was is processing a different shard that `shard_id_`,  so to restore from such checkpoint we need to be able to reset to the current shard (`virtual_shard_id_`).

The same change was made in `FileReader` in #4954.

### Affected modules and functionalities:
- Numpy reader and loader

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3692
<!--- DALI-XXXX or NA --->
