### PR TITLE
Fix hanlding of empty slices and slicing of empty inputs.

### DIFF
--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -307,11 +307,14 @@ void SliceKernel(ExecutionEngine &exec_engine,
   if (req_nblocks < 0)
     req_nblocks = exec_engine.NumThreads() * 8;
 
+  int64_t total_sz = volume(out_shape);
+  if (total_sz == 0)
+    return;  // the result is empty - nothing to do!
+
   // If the output and input data type is the same and the slice arguments take the whole extent
   // of the input, then we can simply run memcpy.
   if (CanRunPlainCopy<OutputType, InputType, Dims>(out_strides, in_strides,
                                                    out_shape, in_shape, args)) {
-    int64_t total_sz = volume(out_shape);
     int64_t nbytes = total_sz * sizeof(OutputType);
     int nblocks = std::min<int64_t>(req_nblocks, div_ceil(total_sz, min_blk_sz));
     assert(nblocks > 0);

--- a/dali/operators/generic/slice/subscript.h
+++ b/dali/operators/generic/slice/subscript.h
@@ -80,8 +80,7 @@ struct SubscriptArg {
       DALIDataType type_id = inp.type();
       TYPE_SWITCH(type_id, type2id, T, (INTEGER_TYPES), (
         for (int i = 0; i < n; i++) {
-          // TODO(michalz): Add tensor<T> and mutable_tensor<T> to TensorList?
-          values[i] = ConvertSat<int64_t>(static_cast<const T*>(inp.raw_tensor(i))[0]);
+          values[i] = ConvertSat<int64_t>(inp.tensor<T>(i)[0]);
         }
       ), DALI_FAIL(make_string("Array index must be of integral type. Got: ", type_id)));  // NOLINT
     } else if (src == ArgSource::Value) {
@@ -99,11 +98,11 @@ struct SubscriptInfo {
 
     if (at.IsDefined()) {
       if (lo.IsDefined() || hi.IsDefined()) {
-        DALI_FAIL(make_string("The subscript for dimension ", i,
+        DALI_FAIL(make_string("Internal error: The subscript for dimension ", i,
                               " must not be specified both as an index and as a range."));
       }
       if (step.IsDefined()) {
-        DALI_FAIL(make_string("The subscript for dimension ", i,
+        DALI_FAIL(make_string("Internal error: The subscript for dimension ", i,
                               " was specified as index - it cannot have a step."));
       }
     }
@@ -156,7 +155,7 @@ class TensorSubscript : public Operator<Backend> {
     if (spec_.TryGetArgument(nsub_declared_, "num_subscripts")) {
       DALI_ENFORCE(
           nsub_declared_ >= nsub,
-          make_string("The internal argument `num_subscripts` "
+          make_string("Internal error: The internal argument `num_subscripts` "
                       "declares fewer (",
                       nsub_declared_, ") subscripts than actually provided (", nsub, ")."));
     } else {
@@ -239,12 +238,17 @@ class TensorSubscript : public Operator<Backend> {
                                 " while processing sample #", i));
         }
 
-        if (lo < 0)
-          lo += in_extent;
-        if (hi < 0)
-          hi += in_extent;
-        lo = clamp(lo, 0_i64, in_extent - 1);
-        hi = clamp(hi, 0_i64, in_extent);
+        if (in_extent > 0) {
+          if (lo < 0)
+            lo += in_extent;
+          if (hi < 0)
+            hi += in_extent;
+          lo = clamp(lo, 0_i64, in_extent - 1);
+          hi = clamp(hi, 0_i64, in_extent);
+        } else {
+          lo = hi = 0;
+        }
+
         start_.tensor_shape_span(i)[d] = lo;
 
         if (step < 0 && !s.hi.IsDefined()) {

--- a/dali/test/python/operator_2/test_subscript.py
+++ b/dali/test/python/operator_2/test_subscript.py
@@ -305,3 +305,15 @@ def test_multiple_skipped_dims():
         x = inp.at(i)
         assert np.array_equal(x[1, :, :, 1], cpu.at(i))
         assert np.array_equal(x[1, :, :, 1], gpu.as_cpu().at(i))
+
+
+def test_empty_slice():
+    data = [np.full((4, 5), 123), np.full((0, 1), 42)]
+    src = fn.external_source(lambda: data)
+    pipe = index_pipe(src, lambda x: x[0:0, 0:1])
+    pipe.build()
+    inp, cpu, gpu = pipe.run()
+    for i in range(len(inp)):
+        x = inp.at(i)
+        assert np.array_equal(x[0:0, 0:1], cpu.at(i))
+        assert np.array_equal(x[0:0, 0:1], gpu.as_cpu().at(i))


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
There were three bugs:
1. Slice operator
```Python
fn.slice([], 0, 0, axes=0)   # incorrect out of range error
fn.slice([42], 1, 0, axes=0)   # incorrect out of range error
```
0-element slices were possible in the middle, but not at the end of an array, which was most visible for empty inputs.

2. Subscript operator:
```Python
x = types.Constant([], device="cpu")
x[0:0]  # this would produce a non-empty array with a 0 inside
```
While the handling of out-of-bounds indices was being adjusted to follow Python's slicing convention (however stupid that convention may be), the empty input case was missed - 0-element slices of non-empty arrays were handled correctly.

3. Assertion (sometimes) raised when producing an empty slice in CPU slice op.

This PR fixes all three.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
test_slice - added empty slice tests
test_subscript - added empty input tests
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3736
<!--- DALI-XXXX or NA --->
