### PR TITLE
Fix MaxThreadsPerBlock caching. Add a non-caching variant.

### DIFF
--- a/dali/kernels/transpose/transpose_gpu.cu
+++ b/dali/kernels/transpose/transpose_gpu.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -255,7 +255,7 @@ class TransposeGPU::Impl {
       auto *gpu_descs = reinterpret_cast<TiledTransposeDesc<T>*>(
         ctx.scratchpad->ToGPU(ctx.gpu.stream, tiled_descs_));
 
-      int max_threads = MaxThreadsPerBlock(TransposeTiledBatch<T>);
+      int max_threads = MaxThreadsPerBlockStatic(TransposeTiledBatch<T>);
       assert(max_threads >= kTileSize);
 
       int block_y = 16;  // start with 32x16 block and try smaller until found

--- a/include/dali/core/cuda_rt_utils.h
+++ b/include/dali/core/cuda_rt_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,19 +30,12 @@ namespace dali {
  * @brief Gets the maximum number of threads per block for given kernel function on current device
  */
 template <typename KernelFunction>
-int MaxThreadsPerBlock(KernelFunction *f) {
-  static constexpr int kMaxDevices = 1024;
-  static int max_block_size[kMaxDevices] = {};
-  int device = 0;
-  CUDA_CALL(cudaGetDevice(&device));
-  assert(device >= 0 && device < kMaxDevices);
-  if (!max_block_size[device]) {
-    cudaFuncAttributes attr = {};
-    CUDA_CALL(cudaFuncGetAttributes(&attr, f));
-    max_block_size[device] = attr.maxThreadsPerBlock;
-  }
-  return max_block_size[device];
+inline int MaxThreadsPerBlock(KernelFunction *f) {
+  cudaFuncAttributes attr = {};
+  CUDA_CALL(cudaFuncGetAttributes(&attr, f));
+  return attr.maxThreadsPerBlock;
 }
+
 
 inline const cudaDeviceProp &GetDeviceProperties(int device_id = -1) {
   if (device_id < 0) {


### PR DESCRIPTION
## Category:

**Bug fix** (*non-breaking change which fixes an issue*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
Previously the MaxThreadsPerBlock had a static variable in which it cached the result. However, only the function _type_ was a part of the template, so different kernels sharing the same type would overwrite each other's MaxThreadsPerBlock, for example both
```C++
__global__ void foo(float *out, const float *in)
{ /* low register pressure */ }

__global__ void bar(float *out, const float *in)
{ /* high register pressure */ }
```
have the same type `void(*)(float *, const float *);`

This PR adds a macro `MaxThreadsPerBlockStatic(func)` which tries to pass the actual function pointer as a template argument. This creates separate instances of the static variables for each kernel function, resolving the ambiguity.
The old function `MaxThreadsPerBlock` is changed so that it doesn't use any caching at all.

### Performance
I decided to add MaxThreadsPerBlockStatic after benchmarking it against non-caching MaxThreadsPerBlock. The results are:

`MaxThreadsPerBlock `
- 1st call for a given function ~7µs
- subsequent calls for the same function ~350ns

`MaxThreadsPerBlockStatic`
- 1st call ~8µs
- subsequent calls - ~35ns

The overhead of 350ns before each kernel call isn't very high, but comparable to actual kernel launch latency.

NOTE:
The following code:
```C++
static int max_threads = MaxThreadsPerBlock(func);
```
is incorrect if used for different devices within one process, since those devices may have different register file sizes and the function may be compiled differently. MaxThreadsPerBlockStatic takes care of that extra complexity.

## Additional information:

### Affected modules and functionalities:
Normalize
Transpose


### Key points relevant for the review:
N/A

### Tests:
The function is not tested in isolation; it's used by Transpose and Normalize operators and their respective tests cover it.

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
