### PR TITLE
Unify positional input name handling in docs and signatures

### DIFF
--- a/dali/python/nvidia/dali/ops/_docs.py
+++ b/dali/python/nvidia/dali/ops/_docs.py
@@ -64,13 +64,13 @@ Args
                 schema.GetSupportedLayouts(i)
             )
             dox = schema.GetInputDox(i)
-            input_name = schema.GetInputName(i)
+            input_name = _names._get_input_name(schema, i)
             ret += _numpydoc_formatter(input_name, input_type_str, dox, optional) + "\n"
     else:
         for i in range(schema.MinNumInput()):
             input_type_str = "TensorList" + _supported_layouts_str(schema.GetSupportedLayouts(i))
             dox = "Input to the operator."
-            input_name = f"input{i}" if schema.MaxNumInput() > 1 else "input"
+            input_name = _names._get_input_name(schema, i)
             ret += _numpydoc_formatter(input_name, input_type_str, dox, False) + "\n"
 
         extra_opt_args = schema.MaxNumInput() - schema.MinNumInput()
@@ -78,11 +78,12 @@ Args
             i = schema.MinNumInput()
             input_type_str = "TensorList" + _supported_layouts_str(schema.GetSupportedLayouts(i))
             dox = "Input to the operator."
-            input_name = f"input{i}" if schema.MaxNumInput() > 1 else "input"
+            input_name = _names._get_input_name(schema, i)
             ret += _numpydoc_formatter(input_name, input_type_str, dox, True) + "\n"
         elif extra_opt_args > 1:
             input_type_str = "TensorList"
-            input_name = f"input[{schema.MinNumInput()}..{schema.MaxNumInput()-1}]"
+            generic_name = _names._get_generic_input_name(False)
+            input_name = f"{generic_name}[{schema.MinNumInput()}..{schema.MaxNumInput()-1}]"
             dox = f"This function accepts up to {extra_opt_args} optional positional inputs"
             ret += _numpydoc_formatter(input_name, input_type_str, dox, True) + "\n"
 
@@ -259,7 +260,8 @@ def _docstring_prefix_auto(op_name):
 Operator call to be used in graph definition. This operator doesn't have any inputs.
 """
     elif schema.MaxNumInput() == 1:
-        ret = """__call__(data, **kwargs)
+        input_name = _names._get_input_name(schema, 0)
+        ret = f"""__call__({input_name}, **kwargs)
 
 Operator call to be used in graph definition.
 
@@ -268,7 +270,7 @@ Args
 """
         dox = "Input to the operator.\n"
         fmt = "TensorList" + _supported_layouts_str(schema.GetSupportedLayouts(0))
-        ret += _numpydoc_formatter("data", fmt, dox, optional=False)
+        ret += _numpydoc_formatter(input_name, fmt, dox, optional=False)
         return ret
     return ""
 

--- a/dali/python/nvidia/dali/ops/_names.py
+++ b/dali/python/nvidia/dali/ops/_names.py
@@ -79,3 +79,37 @@ def _op_name(op_schema_name, api="fn"):
         return full_name
     else:
         raise ValueError(f'{api} is not a valid DALI api name, try one of {"fn", "ops"}')
+
+
+def _get_input_name(schema, input_idx):
+    """Return the string representing the name of positional-only input to the operator.
+    This function appends the double underscore `__`, that indicates via the mypy convention,
+    that all inputs are positional-only. This happens also for the names introduced via schema.
+
+    Parameters
+    ----------
+    schema : OpSchema
+        schema to query
+    input_idx : int
+        Index of the input
+    """
+    if schema.HasInputDox():
+        return f"__{schema.GetInputName(input_idx)}"
+    if schema.MaxNumInput() == 1:
+        return "__input"
+    return f"__input_{input_idx}"
+
+
+def _get_generic_input_name(is_var_positional=True):
+    """Return the string representing the name of positional-only input for a generic context.
+
+    Parameters
+    ----------
+    is_var_positional : bool, optional
+        If the generic name represents `*inputs` or is used in context specific arguments,
+        by default True
+    """
+    if is_var_positional:
+        return "input"
+    else:
+        return "__input_"

--- a/dali/python/nvidia/dali/ops/_names.py
+++ b/dali/python/nvidia/dali/ops/_names.py
@@ -100,16 +100,16 @@ def _get_input_name(schema, input_idx):
     return f"__input_{input_idx}"
 
 
-def _get_generic_input_name(is_var_positional=True):
+def _get_generic_input_name(is_only_input=True):
     """Return the string representing the name of positional-only input for a generic context.
 
     Parameters
     ----------
-    is_var_positional : bool, optional
-        If the generic name represents `*inputs` or is used in context specific arguments,
-        by default True
+    is_only_input : bool, optional
+        If the generic name represents is the only input name, like `foo(*inputs, /, ...)`
+        or used as some follow-up `foo(__input_0, /, *__input_, ...)`
     """
-    if is_var_positional:
+    if is_only_input:
         return "input"
     else:
         return "__input_"

--- a/dali/python/nvidia/dali/ops/_signatures.py
+++ b/dali/python/nvidia/dali/ops/_signatures.py
@@ -200,7 +200,7 @@ def _get_annotation_return_mis(schema):
     return return_annotation
 
 
-def _get_positional_input_params(schema, input_annotation_gen=lambda x, y: _DataNode):
+def _get_positional_input_params(schema, input_annotation_gen=_get_annotation_input_regular):
     """Get the list of positional only inputs to the operator.
 
     Parameters
@@ -210,18 +210,35 @@ def _get_positional_input_params(schema, input_annotation_gen=lambda x, y: _Data
         See _get_annotation_* functions.
     """
     param_list = []
-    if not schema.HasInputDox() and schema.MaxNumInput() > _MAX_INPUT_SPELLED_OUT:
-        param_list.append(
-            Parameter(
-                _names._get_generic_input_name(),
-                Parameter.VAR_POSITIONAL,
-                annotation=input_annotation_gen(schema),
-            )
-        )
-    else:
+    # If outputs are documented, list all of them
+    if schema.HasInputDox():
         for i in range(schema.MaxNumInput()):
             param_list.append(
                 _get_positional_input_param(schema, i, annotation=input_annotation_gen(schema))
+            )
+    else:
+        # List all mandatory inputs
+        for i in range(schema.MinNumInput()):
+            param_list.append(
+                _get_positional_input_param(schema, i, annotation=input_annotation_gen(schema))
+            )
+        # If they fit below limit, list all inputs (with optional ones)
+        if schema.MaxNumInput() < _MAX_INPUT_SPELLED_OUT:
+            for i in range(schema.MinNumInput(), schema.MaxNumInput()):
+                param_list.append(
+                    _get_positional_input_param(schema, i, annotation=input_annotation_gen(schema))
+                )
+        # List the rest of optional inputs in general fashion
+        elif schema.MaxNumInput() > schema.MinNumInput():
+            # Note that the VAR_POSTIONAL annotation means that all arguments passed this way
+            # have to conform to this type, it doesn't get a default None value as it already is
+            # "empty" by default - def(*args = None) is invalid syntax.
+            param_list.append(
+                Parameter(
+                    _names._get_generic_input_name(schema.MinNumInput() == 0),
+                    Parameter.VAR_POSITIONAL,
+                    annotation=Optional[input_annotation_gen(schema)],
+                )
             )
     return param_list
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Other**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Extract the common name processing and use the same naming format for positional-only input parameter names for both generated docstrings and the generated signatures.

The documentation generated names as `input0`, `input1`, ... (or just `input`). 
In the case of signatures, we used `__input_0` - the double underscore at the start is the convention to indicate argument as positional only. Based on the experiments, it is needed by some IDEs to not suggest setting the name as a keyword parameter.
Also, in case of named inputs, without the `__` there might be clash between them and the keywords otherwise (for example `shape` in slice). 

Formatting is unified to the latter form of `__input_0`, `__input` in case there is only one.

Adjust the way that the signatures are generated, so they list all mandatory inputs.
* signature has a cutoff point for too many inputs: https://github.com/NVIDIA/DALI/blob/main/dali/python/nvidia/dali/ops/_signatures.py#L80
* Previously, if there were any kind of inputs (mandatory or optional, above 10) we just represented all of them as `*input`.
* Documentation lists all the mandatory inputs, and adds a generic: `input[XX..YY]` for optional ones. 

Now, the signatures are generated in the form `def foo(__input_0, __input_1, ..., __input_9, /, *inputs)` - we will list all mandatory inputs, and hide the optional ones behind `VAR_POSITIONAL` only if it would be over threshold, to list all of them.
DALI doesn't have an op with more than 3 mandatory inputs. You can verify this by grepping for `NumInput(...`

This should match closer between the docs and the signatures.
The only downside is the complicated looking signature (but fully Python conformant): 
`def op(positional_only, /, *var_positional, *, keyword=default)`. 

Cleanup some todos on the way.

## Additional information:

### Affected modules and functionalities:
Docs and signatures generation



### Key points relevant for the review:
Verify if everything renders ok in sphinx and if there are no hidden cases somewhere in the source code.
Specifically check the operators, that have more than 1 input or other non-trivial cases:
* Slice and the slice decoders
* CastLike
* Cat and Stack
* transforms.combine
* numba func, python func,
* some random operators

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [x] Other: Generated docstrings and signatures.
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
