### PR TITLE
Avoids infinite video decoder seek loop

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -591,6 +591,9 @@ void VideoLoader::read_file() {
     if (last_key_frame != -1 &&
         ((key && last_key_frame != frame) || frame > last_key_frame + kStartupFrameTreshold) &&
         dec_status == VidReqStatus::REQ_NOT_STARTED) {
+      DALI_ENFORCE(last_key_frame > 0, "Decoding not started when starting from frame 0, "
+                                       "no point in seeking to preceding keyframe which is "
+                                       "already 0");
       LOG_LINE << "Decoding not started, seek to preceding key frame, "
                 << "current frame " << frame
                 << ", last key frame " << last_key_frame

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -356,7 +356,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper, true> {
   int additional_decode_surfaces_;
   static constexpr int channels_ = 3;
   // 10 is rather an arbitrary decision
-  static constexpr int kStartupFrameTreshold = 10;
+  static constexpr int kStartupFrameThreshold = 10;
   DALIImageType image_type_;
   DALIDataType dtype_;
   bool normalized_;


### PR DESCRIPTION
- when the video decoder is not able to start decoding from a given keyframe
  it seeks a preceding one compared to it. When it happens for the keyframe
  0 we end up in an infinite try and fail loop. This PR makes this case a hard error.
- adds graceful shutdown of the decoder when reading packets or submitting
  them to the decoder fails

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- when the video decoder is not able to start decoding from a given keyframe
  it seeks a preceding one compared to it. When it happens for the keyframe
  0 we end up in an infinite try and fail loop. This PR makes this case a hard error.
- adds graceful shutdown of the decoder when reading packets or submitting
  them to the decoder fails
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- video reader
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
