### PR TITLE
Fix tensorflow-dataset example for Python 3.11 and TF < 2.14

### DIFF
--- a/docs/examples/frameworks/tensorflow/tensorflow-dataset.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-dataset.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from nvidia.dali import pipeline_def, Pipeline\n",
+    "from nvidia.dali import pipeline_def\n",
     "import nvidia.dali.fn as fn\n",
     "import nvidia.dali.types as types\n",
     "import os\n",
@@ -46,10 +46,10 @@
     "        jpegs, device='mixed' if device == 'gpu' else 'cpu', output_type=types.GRAY)\n",
     "    images = fn.crop_mirror_normalize(\n",
     "        images, device=device, dtype=types.FLOAT, std=[255.], output_layout=\"CHW\")\n",
-    "    \n",
+    "\n",
     "    if device == 'gpu':\n",
     "        labels = labels.gpu()\n",
-    "            \n",
+    "\n",
     "    return images, labels"
    ]
   },
@@ -190,8 +190,7 @@
     "    model.compile(\n",
     "        optimizer='adam',\n",
     "        loss='sparse_categorical_crossentropy',\n",
-    "        metrics=['accuracy'])\n",
-    "    "
+    "        metrics=['accuracy'])\n"
    ]
   },
   {
@@ -305,7 +304,7 @@
     "            device_id=0)\n",
     "        mnist_set = mnist_set.map(\n",
     "            lambda features, labels: ({'images': features}, labels))\n",
-    "        \n",
+    "\n",
     "    return mnist_set"
    ]
   },
@@ -333,6 +332,20 @@
     }
    ],
    "source": [
+    "import sys\n",
+    "from distutils.version import LooseVersion\n",
+    "# fix incompability of tensorflow_extimator and Python 3.11\n",
+    "if sys.version_info >= (3, 11) and LooseVersion(tf.__version__) < LooseVersion(\"2.14\"):\n",
+    "    import inspect\n",
+    "    from collections import namedtuple\n",
+    "\n",
+    "    def legacy_getargspec(fun):\n",
+    "        args, varargs, varkw, defaults, *_ = inspect.getfullargspec(fun)\n",
+    "        ArgSpec = namedtuple(\"ArgSpec\", \"args varargs keywords defaults\")\n",
+    "        return ArgSpec(args, varargs, varkw, defaults)\n",
+    "\n",
+    "    inspect.getargspec = legacy_getargspec\n",
+    "\n",
     "# Running the training on the GPU\n",
     "model.train(input_fn=train_data_fn, steps=EPOCHS * ITERATIONS_PER_EPOCH)"
    ]
@@ -368,7 +381,7 @@
     "            device_id=0)\n",
     "        mnist_set = mnist_set.map(\n",
     "            lambda features, labels: ({'images': features}, labels))\n",
-    "        \n",
+    "\n",
     "    return mnist_set\n",
     "\n",
     "model.evaluate(input_fn=test_data_fn, steps=ITERATIONS_PER_EPOCH)"
@@ -423,7 +436,7 @@
     "    labels = tf_v1.reshape(\n",
     "        tf_v1.one_hot(labels, NUM_CLASSES),\n",
     "        [BATCH_SIZE, NUM_CLASSES])\n",
-    "    \n",
+    "\n",
     "    with tf_v1.variable_scope('mnist_net', reuse=False):\n",
     "        images = tf_v1.layers.flatten(images)\n",
     "        images = tf_v1.layers.dense(images, HIDDEN_SIZE, activation=tf_v1.nn.relu)\n",

--- a/qa/nose_wrapper/__main__.py
+++ b/qa/nose_wrapper/__main__.py
@@ -16,10 +16,12 @@ if sys.version_info >= (3, 10) and not hasattr(collections, "Callable"):
     nose.plugins.attrib.collections = collections.abc
 
 if sys.version_info >= (3, 11):
+    from collections import namedtuple
 
     def legacy_getargspec(fun):
         args, varargs, varkw, defaults, *_ = inspect.getfullargspec(fun)
-        return (args, varargs, varkw, defaults)
+        ArgSpec = namedtuple("ArgSpec", "args varargs keywords defaults")
+        return ArgSpec(args, varargs, varkw, defaults)
 
     inspect.getargspec = legacy_getargspec
 


### PR DESCRIPTION
 - TensorFlow Estimator doesn't work for Python 3.11 as it uses
   removed getargspec. This PR adds a fix for tensorflow-dataset
   to enable testing of DALI with Python 3.11 and TensorFlow 2.13
   which is the last release supporting Python 3.8 at the same time
 - improves nose_wrapper to provide a comprehensive replacement for getargspec

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
 - TensorFlow Estimator doesn't work for Python 3.11 as it uses
   removed getargspec. This PR adds a fix for tensorflow-dataset
   to enable testing of DALI with Python 3.11 and TensorFlow 2.13
   which is the last release supporting Python 3.8 at the same time
 - improves nose_wrapper to provide a comprehensive replacement for getargspec

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- docs/examples/frameworks/tensorflow/tensorflow-dataset.ipynb
- qa/nose_wrapper/__main__.py
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- is this work around acceptable in the example?
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - TL1_tensorflow_dataset
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
