### PR TITLE
Add validation preventing running PES without Python workers

### DIFF
--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -864,16 +864,3 @@ def _blocking_destructor(device):
 def test_blocking_destructor():
     for device in ["cpu", "gpu"]:
         yield _blocking_destructor, device
-
-
-@raises(
-    RuntimeError,
-    glob="The external source cannot run in parallel mode without Python workers pool",
-)
-def test_no_workers_parallel_validation():
-    @pipeline_def(py_num_workers=0, num_threads=1, device_id=0, batch_size=4)
-    def pipeline():
-        return fn.external_source(lambda x: np.array([x.idx_in_epoch]), parallel=True)
-
-    p = pipeline()
-    p.build()

--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -864,3 +864,16 @@ def _blocking_destructor(device):
 def test_blocking_destructor():
     for device in ["cpu", "gpu"]:
         yield _blocking_destructor, device
+
+
+@raises(
+    RuntimeError,
+    glob="The external source cannot run in parallel mode without Python workers pool",
+)
+def test_no_workers_parallel_validation():
+    @pipeline_def(py_num_workers=0, num_threads=1, device_id=0, batch_size=4)
+    def pipeline():
+        return fn.external_source(lambda x: np.array([x.idx_in_epoch]), parallel=True)
+
+    p = pipeline()
+    p.build()

--- a/dali/test/python/test_external_source_parallel.py
+++ b/dali/test/python/test_external_source_parallel.py
@@ -166,6 +166,10 @@ def test_parallel_fork_cpu_only():
         utils.compare_pipelines(pipe0, pipe1, batch_size, iters)
 
 
+@raises(
+    RuntimeError,
+    glob="The external source cannot run in parallel mode without Python workers pool",
+)
 def test_parallel_no_workers():
     batch_size = 10
     iters = 4
@@ -180,8 +184,6 @@ def test_parallel_no_workers():
         device_id=None,
     )
     parallel_pipe.build()
-    assert parallel_pipe._py_pool is None
-    assert not parallel_pipe._py_pool_started
 
 
 @with_setup(utils.setup_function, utils.teardown_function)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Without the PR, it's possible to specify both `py_num_worksers=0` and `fn.external_source(..., parallel=True)`. 
This may lead to unexpected bahviour, as the external_source will run in `no_copy` mode, assuming the tensors
fed into the pipeline reside in a buffer that is managed by DALI. However, with no workers, there's no pool nor buffer, so the user must handle the tensor more carefully.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

This should help avoid first of the two problems faced in the issue: https://github.com/NVIDIA/DALI/issues/5222

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3740
<!--- DALI-XXXX or NA --->
