### PR TITLE
Fix missing Shutdown method warning in debug pipeline.

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1604,7 +1604,8 @@ void ExposePipelineDebug(py::module &m) {
       .def("AddMultipleOperators", &PipelineDebug::AddMultipleOperators)
       .def("RunOperatorCPU", &PipelineDebug::RunOperator<CPUBackend>)
       .def("RunOperatorGPU", &PipelineDebug::RunOperator<GPUBackend>)
-      .def("RunOperatorMixed", &PipelineDebug::RunOperator<MixedBackend>);
+      .def("RunOperatorMixed", &PipelineDebug::RunOperator<MixedBackend>)
+      .def("Shutdown", [](PipelineDebug *){});
 }
 
 template <typename Backend>


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
PipelineDebug class was missing a Shutdown method which was called from Python. It resulted in a flood of warnings when the object was being destroyed. This PR fixes that.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
`test_pipeline_debug.py`
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
