### PR TITLE
Allow source to be a decorated function or method

### DIFF
--- a/dali/python/nvidia/dali/_utils/external_source_impl.py
+++ b/dali/python/nvidia/dali/_utils/external_source_impl.py
@@ -274,7 +274,7 @@ def accepted_arg_count(callable):
             raise TypeError(
                 error_msg + f" Found keyword-only argument `{p.name}` which is not allowed."
             )
-    result = len(inspect.signature(callable).parameters) - implicit_args
+    result = len(signature.parameters) - implicit_args
     if result not in [0, 1]:
         raise TypeError(
             error_msg + " Found more than one positional argument, which is not allowed."

--- a/dali/python/nvidia/dali/_utils/external_source_impl.py
+++ b/dali/python/nvidia/dali/_utils/external_source_impl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -247,7 +247,7 @@ def accepted_arg_count(callable):
     else:
         implicit_args = 1
         callable = callable.__func__
-    return callable.__code__.co_argcount - implicit_args
+    return len(inspect.signature(callable).parameters) - implicit_args
 
 
 def get_callback_from_source(source, cycle, batch_info=False):

--- a/dali/python/nvidia/dali/_utils/external_source_impl.py
+++ b/dali/python/nvidia/dali/_utils/external_source_impl.py
@@ -246,10 +246,13 @@ def accepted_arg_count(callable):
     TypeError
         Indicates that the `source` callable accepts wrong number of type of arguments.
     """
+
     if not (inspect.isfunction(callable) or inspect.ismethod(callable)) and hasattr(
         callable, "__call__"
     ):
         callable = callable.__call__
+    # Extracting the `__call__` for a method causes the signature to report `self` as a parameter,
+    # so we have to subtract it.
     if not inspect.ismethod(callable):
         implicit_args = 0
     else:

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -171,10 +171,7 @@ class _ExternalSourceGroup(object):
         self.prefetch_queue_depth = prefetch_queue_depth
         self.bytes_per_sample_hint = bytes_per_sample_hint
         if callback is not None:
-            arg_count = _accepted_arg_count(callback)
-            if arg_count not in [0, 1]:
-                raise TypeError("External source callback must be a callable with 0 or 1 argument")
-            self.accepts_arg = arg_count > 0
+            self.accepts_arg = _accepted_arg_count(callback) > 0
 
     def append(self, instance):
         self.instances.append(instance)

--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -886,7 +886,7 @@ def test_decorated_external_source():
 
         return wrapper
 
-    # @code_smashing_decorator
+    @code_smashing_decorator
     def my_source(sample_info):
         return np.array([sample_info.idx_in_epoch])
 

--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -964,7 +964,7 @@ def test_external_source_with_disallowed_arg_and_var_kwargs():
 
 
 @raises(TypeError, glob="Found keyword-only argument `kw_only` which is not allowed.")
-def test_external_source_with_disallowed_arg_and_var_kwargs():
+def test_external_source_with_disallowed_kwarg_only():
     def my_source(*, kw_only=10):
         return np.array([kw_only])
 

--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -886,7 +886,7 @@ def test_decorated_external_source():
 
         return wrapper
 
-    @code_smashing_decorator
+    # @code_smashing_decorator
     def my_source(sample_info):
         return np.array([sample_info.idx_in_epoch])
 
@@ -909,3 +909,81 @@ def test_decorated_external_source():
     (out0, out1) = pipe.run()
     np.array_equal(np.array(out0.as_tensor()), np.array([0, 1, 2, 3]))
     np.array_equal(np.array(out1.as_tensor()), np.array([2, 3, 4, 5]))
+
+
+@raises(TypeError, glob="Found var-positional argument `*args` which is not allowed")
+def test_external_source_with_disallowed_var_args():
+    def my_source(*args):
+        return np.array([args[0].idx_in_epoch])
+
+    @pipeline_def(batch_size=4, device_id=0, num_threads=4)
+    def test_pipe():
+        return fn.external_source(source=my_source, batch=False)
+
+    pipe = test_pipe()
+    pipe.build()
+
+
+@raises(TypeError, glob="Found var-positional argument `*args` which is not allowed")
+def test_external_source_with_disallowed_arg_and_var_args():
+    def my_source(arg, *args):
+        return np.array([arg.idx_in_epoch])
+
+    @pipeline_def(batch_size=4, device_id=0, num_threads=4)
+    def test_pipe():
+        return fn.external_source(source=my_source, batch=False)
+
+    pipe = test_pipe()
+    pipe.build()
+
+
+@raises(TypeError, glob="Found var-keyword argument `**kwargs` which is not allowed")
+def test_external_source_with_disallowed_var_kwargs():
+    def my_source(**kwargs):
+        return np.array([kwargs["sample_info"].idx_in_epoch])
+
+    @pipeline_def(batch_size=4, device_id=0, num_threads=4)
+    def test_pipe():
+        return fn.external_source(source=my_source, batch=False)
+
+    pipe = test_pipe()
+    pipe.build()
+
+
+@raises(TypeError, glob="Found var-keyword argument `**kwargs` which is not allowed")
+def test_external_source_with_disallowed_arg_and_var_kwargs():
+    def my_source(arg, **kwargs):
+        return np.array([arg.idx_in_epoch])
+
+    @pipeline_def(batch_size=4, device_id=0, num_threads=4)
+    def test_pipe():
+        return fn.external_source(source=my_source, batch=False)
+
+    pipe = test_pipe()
+    pipe.build()
+
+
+@raises(TypeError, glob="Found keyword-only argument `kw_only` which is not allowed.")
+def test_external_source_with_disallowed_arg_and_var_kwargs():
+    def my_source(*, kw_only=10):
+        return np.array([kw_only])
+
+    @pipeline_def(batch_size=4, device_id=0, num_threads=4)
+    def test_pipe():
+        return fn.external_source(source=my_source, batch=False)
+
+    pipe = test_pipe()
+    pipe.build()
+
+
+@raises(TypeError, glob="Found more than one positional argument, which is not allowed.")
+def test_external_source_with_disallowed_too_many():
+    def my_source(arg, a, b, /):
+        return np.array([arg.idx_in_epoch])
+
+    @pipeline_def(batch_size=4, device_id=0, num_threads=4)
+    def test_pipe():
+        return fn.external_source(source=my_source, batch=False)
+
+    pipe = test_pipe()
+    pipe.build()

--- a/dali/test/python/test_external_source_parallel.py
+++ b/dali/test/python/test_external_source_parallel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -118,7 +118,12 @@ def test_wrong_source():
         (no_arg_fun, (TypeError, callable_msg.format("a callable that does not accept arguments"))),
         (
             multi_arg_fun,
-            (TypeError, "External source callback must be a callable with 0 or 1 argument"),
+            (
+                TypeError,
+                "The `source` callable must accept either 0 or 1 positional arguments "
+                "to indicate whether it accepts the batch or sample indexing information. "
+                "Found more than one positional argument, which is not allowed.",
+            ),
         ),
         (Iterable(), (TypeError, batch_required_msg.format("an iterable"))),
         (generator_fun, (TypeError, batch_required_msg.format("a generator function"))),


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Bug fix**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
This changes how the external source counts the number of arguments that the source callback uses.
Instead of relying on the `__code__.co_argcount` we use `inspect.signature`.
The reason is that a decorator can (and usually does) propagate the signature, but due to the use of
generic `*args, **kwargs` parameters it will hide the original argcount of the original function that is wrapped.

Such simple decorator is added as a test case, before this change the following code won't work.

This fixes the potential error of DALI assuming that there are mandatory arguments to the function,
that doesn't expect them (or vice-versa) and invoking the callback with (or without) passing the source_info. 
The error would point to the callback invocation and would not indicate the decorators at all.

Now we can sensibly error out on:
* var-args
* var-kwargs
* kwarg-only argument

There is no need to differentiate between positional only and named argument, if we first detect
any disallowed constructs. Note, that sources like `foo(arg, *args)` were already disallowed, but the reported arg count was something like `-1` or `-2` by mistake rather than by design.

Next we can validate the correct number of arguments.

The detection of callbacks was done inside an exception handler, and throwing another exception
from there would chain the exception, so the construction of argument description is moved to line below.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
