### PR TITLE
Remove redundant wrapper from autograph.do_not_convert

### DIFF
--- a/dali/python/nvidia/dali/_autograph/impl/api.py
+++ b/dali/python/nvidia/dali/_autograph/impl/api.py
@@ -615,14 +615,7 @@ def do_not_convert(func=None):
     if func is None:
         return do_not_convert
 
-    def wrapper(*args, **kwargs):
-        with ag_ctx.ControlStatusCtx(status=ag_ctx.Status.DISABLED):
-            return func(*args, **kwargs)
-
-    if inspect.isfunction(func) or inspect.ismethod(func):
-        wrapper = functools.update_wrapper(wrapper, func)
-
-    return autograph_artifact(wrapper)
+    return autograph_artifact(func)
 
 
 # TODO(mdan): Make private.


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
Autograph's do_not_convert changes the functions signature and `__code__`. This isn't necessary. The `with` statement is redundant; it goes down the same road as `is_autograph_artifact`, and `do_not_convert` can mark the function as such.
See [`api.h`:](https://github.com/NVIDIA/DALI/blob/2fb26dcb6ce013b7b008bcdad293fca684376fad/dali/python/nvidia/dali/_autograph/impl/api.py#L323)
```Python
    if ag_ctx.control_status_ctx().status == ag_ctx.Status.DISABLED:
        logging.log(2, "Allowlisted: %s: AutoGraph is disabled in context", f)
        return _call_unconverted(f, args, kwargs, options, False)

    if is_autograph_artifact(f):
        logging.log(2, "Permanently allowed: %s: AutoGraph artifact", f)
        return _call_unconverted(f, args, kwargs, options)
```

Thus, simply marking the original function as autograph artifact (or possibly coming up with a different, specific marker) is indeed enough.

## Additional information:

### Affected modules and functionalities:
Autograph



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
See #5268
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
