### PR TITLE
Fix synchronization issues in RNG checkpointing utils

### DIFF
--- a/dali/operators/random/rng_checkpointing_utils.h
+++ b/dali/operators/random/rng_checkpointing_utils.h
@@ -63,6 +63,7 @@ class RngCheckpointUtils<GPUBackend, curand_states> {
   static void SaveState(OpCheckpoint &cpt, AccessOrder order, const curand_states &rng) {
     cpt.SetOrder(order);
     cpt.MutableCheckpointState() = rng.copy(order);
+    // The pipeline will perform host synchronization before serializing the checkpoints.
   }
 
   static void RestoreState(const OpCheckpoint &cpt, curand_states &rng) {

--- a/dali/operators/random/rng_checkpointing_utils.h
+++ b/dali/operators/random/rng_checkpointing_utils.h
@@ -85,10 +85,11 @@ class RngCheckpointUtils<GPUBackend, curand_states> {
   static void DeserializeCheckpoint(OpCheckpoint &cpt, const std::string &data) {
     auto deserialized = SnapshotSerializer().Deserialize<std::vector<curandState>>(data);
     curand_states states(deserialized.size());
-    CUDA_CALL(cudaMemcpy(states.states(),
-                         deserialized.data(),
-                         sizeof(curandState) * deserialized.size(),
-                         cudaMemcpyHostToDevice));
+    CUDA_CALL(cudaMemcpyAsync(states.states(),
+                              deserialized.data(),
+                              sizeof(curandState) * deserialized.size(),
+                              cudaMemcpyHostToDevice, cudaStreamDefault));
+    CUDA_CALL(cudaStreamSynchronize(cudaStreamDefault));
     cpt.MutableCheckpointState() = states;
   }
 };

--- a/dali/operators/random/rng_checkpointing_utils.h
+++ b/dali/operators/random/rng_checkpointing_utils.h
@@ -64,6 +64,7 @@ class RngCheckpointUtils<GPUBackend, curand_states> {
     cpt.SetOrder(order);
     cpt.MutableCheckpointState() = rng.copy(order);
     // The pipeline will perform host synchronization before serializing the checkpoints.
+    // TODO(skarpinski) Move synchronization out from pipeline's GetCheckpoint.
   }
 
   static void RestoreState(const OpCheckpoint &cpt, curand_states &rng) {

--- a/dali/operators/util/randomizer.cuh
+++ b/dali/operators/util/randomizer.cuh
@@ -59,8 +59,9 @@ struct curand_states {
   }
 
   DALI_HOST inline void set(const curand_states &other) {
-    CUDA_CALL(cudaMemcpy(states_, other.states_, sizeof(curandState) * len_,
-                         cudaMemcpyDeviceToDevice));
+    CUDA_CALL(cudaMemcpyAsync(states_, other.states_, sizeof(curandState) * len_,
+                              cudaMemcpyDeviceToDevice, cudaStreamDefault));
+    CUDA_CALL(cudaStreamSynchronize(cudaStreamDefault));
   }
 
  private:


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**Bug fix** (*non-breaking change which fixes an issue*)

<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

## Description:
This PR fixes two synchronization bugs pointed out by @mzient . Both problems happen when you're restoring from checkpoint in random GPU operators and are due to lack of synchronization after H2D & D2D copies.

PS. Another problem pointed out was that synchronization between `SaveState` and `Serialize` is handled by the pipeline and not by those functions. This is a design problem and I added a TODO to fix it. I'm currently reworking how synchronization works when a checkpoint is saved, so I'll fix it there.

## Additional information:

### Affected modules and functionalities:
RngCheckpointingUtils

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3777
<!--- DALI-XXXX or NA --->
