### PR TITLE
Generalize iterator checkpointing tests

### DIFF
--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -1134,7 +1134,7 @@ unsupported_ops = [
 
 
 def test_coverage():
-    from test_dali_stateless_operators import stateless_signed_off
+    from checkpointing.test_dali_stateless_operators import stateless_signed_off
 
     tested_ops = (
         stateless_signed_off.tested_ops

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -29,7 +29,6 @@ from test_utils import (
 )
 from nose_utils import assert_warns
 from nose2.tools import params, cartesian_params
-from nose.plugins.attrib import attr
 from dataclasses import dataclass
 from nvidia.dali import tfrecord as tfrec
 from nvidia.dali.auto_aug import auto_augment as aa

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,29 +83,6 @@ def check_pipeline_checkpointing_native(pipeline_factory):
     compare_pipelines(pipe, restored, pipeline_args["batch_size"], comparsion_iterations)
 
 
-def check_pipeline_checkpointing_pytorch(pipeline_factory, reader_name=None, size=-1):
-    from nvidia.dali.plugin.pytorch import DALIGenericIterator
-
-    pipe = pipeline_factory(**pipeline_args)
-    pipe.build()
-
-    iter = DALIGenericIterator(pipe, ["data"], auto_reset=True, reader_name=reader_name, size=size)
-    for _ in range(warmup_epochs):
-        for _ in iter:
-            pass
-
-    restored = pipeline_factory(**pipeline_args, checkpoint=iter.checkpoints()[0])
-    restored.build()
-    iter2 = DALIGenericIterator(
-        restored, ["data"], auto_reset=True, reader_name=reader_name, size=size
-    )
-
-    for out1, out2 in zip(iter, iter2):
-        for d1, d2 in zip(out1, out2):
-            for key in d1.keys():
-                assert (d1[key] == d2[key]).all()
-
-
 def check_single_input_operator_pipeline(op, device, **kwargs):
     @pipeline_def
     def pipeline():
@@ -126,25 +103,12 @@ def check_single_input_operator(op, device, **kwargs):
     check_pipeline_checkpointing_native(pipeline_factory)
 
 
-def check_single_input_operator_pytorch(op, device, **kwargs):
-    pipeline_factory = check_single_input_operator_pipeline(op, device, **kwargs)
-    check_pipeline_checkpointing_pytorch(pipeline_factory, reader_name="Reader")
-
-
 def check_no_input_operator(op, device, **kwargs):
     @pipeline_def
     def pipeline_factory():
         return op(device=device, **kwargs)
 
     check_pipeline_checkpointing_native(pipeline_factory)
-
-
-def check_no_input_operator_pytorch(op, device, **kwargs):
-    @pipeline_def
-    def pipeline_factory():
-        return op(device=device, **kwargs)
-
-    check_pipeline_checkpointing_pytorch(pipeline_factory, size=8)
 
 
 # Readers section
@@ -668,68 +632,6 @@ def test_numpy_reader(
         )
 
 
-@attr("pytorch")
-@params(
-    (1, 3, 0, 1, True, False, False),
-    (5, 10, 0, 2, True, False, False),
-    (3, 64, 3, 4, False, False, False),
-    (0, 32, 1, 4, False, False, True),
-    (3, 64, 3, 4, False, False, True),
-    (1, 8, 0, 2, False, True, False),
-    (1, 8, 1, 2, False, True, False),
-    (1, 8, 3, 4, False, True, False),
-    (1, 3, 0, 1, True, False, False, 1),
-    (5, 10, 0, 2, True, False, False, 2),
-    (3, 64, 3, 4, False, False, True, 3),
-)
-def test_file_reader_pytorch(
-    num_epochs,
-    batch_size,
-    shard_id,
-    num_shards,
-    random_shuffle,
-    shuffle_after_epoch,
-    stick_to_shard,
-    iters_into_epoch=None,
-):
-    from nvidia.dali.plugin.pytorch import DALIGenericIterator
-
-    @pipeline_def(batch_size=batch_size, device_id=0, num_threads=4, enable_checkpointing=True)
-    def pipeline():
-        data, label = fn.readers.file(
-            name="Reader",
-            file_root=images_dir,
-            pad_last_batch=True,
-            random_shuffle=random_shuffle,
-            shard_id=shard_id,
-            num_shards=num_shards,
-            shuffle_after_epoch=shuffle_after_epoch,
-            stick_to_shard=stick_to_shard,
-        )
-        image = fn.decoders.image_random_crop(data, device="mixed")
-        image = fn.resize(image, size=(200, 200))
-        return image, label
-
-    p = pipeline()
-    p.build()
-
-    iter = DALIGenericIterator(p, ["data", "labels"], auto_reset=True, reader_name="Reader")
-    for epoch in range(num_epochs):
-        for i, _ in enumerate(iter):
-            if iters_into_epoch is not None:
-                if epoch == num_epochs - 1 and i == iters_into_epoch - 1:
-                    break
-
-    restored = pipeline(checkpoint=iter.checkpoints()[0])
-    restored.build()
-    iter2 = DALIGenericIterator(restored, ["data", "labels"], auto_reset=True, reader_name="Reader")
-
-    for out1, out2 in zip(iter, iter2):
-        for d1, d2 in zip(out1, out2):
-            for key in d1.keys():
-                assert (d1[key] == d2[key]).all()
-
-
 @params(0, 1, 2, 3, 4, 5, 6, 7, 8)
 def test_multiple_readers(num_iters):
     my_images = os.path.join(images_dir, "134")
@@ -969,34 +871,16 @@ def test_random_coin_flip(device, shape):
     check_no_input_operator(fn.random.coin_flip, device, shape=shape)
 
 
-@attr("pytorch")
-@cartesian_params(("cpu", "gpu"), (None, (1,), (10,)))
-def test_random_coin_flip_pytorch(device, shape):
-    check_no_input_operator_pytorch(fn.random.coin_flip, device, shape=shape)
-
-
 @cartesian_params(("cpu",), (None, (1,), (10,)))
 @random_signed_off("random.normal", "normal_distribution")
 def test_random_normal(device, shape):
     check_no_input_operator(fn.random.normal, device, shape=shape)
 
 
-@attr("pytorch")
-@cartesian_params(("cpu", "gpu"), (None, (1,), (10,)))
-def test_random_normal_pytorch(device, shape):
-    check_no_input_operator_pytorch(fn.random.normal, device, shape=shape)
-
-
 @cartesian_params(("cpu", "gpu"), (None, (1,), (10,)))
 @random_signed_off("random.uniform", "uniform")
 def test_random_uniform(device, shape):
     check_no_input_operator(fn.random.uniform, device, shape=shape)
-
-
-@attr("pytorch")
-@cartesian_params(("cpu", "gpu"), (None, (1,), (10,)))
-def test_random_uniform_pytorch(device, shape):
-    check_no_input_operator_pytorch(fn.random.uniform, device, shape=shape)
 
 
 @random_signed_off("segmentation.random_object_bbox")
@@ -1114,34 +998,6 @@ def check_external_source_pipeline_checkpointing(pipeline_factory, iterations, c
     compare_external_source_pipelines(p1, p2, compare_iterations)
 
 
-def check_external_source_pipeline_checkpointing_pytorch(pipeline_factory, iterations, *, size=-1):
-    from nvidia.dali.plugin.pytorch import DALIGenericIterator
-
-    def run(iterator, iterations):
-        completed_iterations = 0
-        while completed_iterations < iterations:
-            for _ in iterator:
-                completed_iterations += 1
-                if completed_iterations == iterations:
-                    break
-
-    pipeline = pipeline_factory()
-    pipeline.build()
-
-    iter = DALIGenericIterator(pipeline, ["data"], auto_reset=True, size=size)
-
-    run(iter, iterations)
-
-    restored = pipeline_factory(checkpoint=iter.checkpoints()[0])
-    restored.build()
-    iter2 = DALIGenericIterator(restored, ["data"], auto_reset=True, size=size)
-
-    for out1, out2 in zip(iter, iter2):
-        for d1, d2 in zip(out1, out2):
-            for key in d1.keys():
-                assert (d1[key] == d2[key]).all()
-
-
 def make_external_source_test_pipeline_factory(source, mode, batch_size, parallel, **kwargs):
     kwargs["parallel"] = parallel
     if mode == "idx":
@@ -1206,20 +1062,6 @@ def test_external_source_checkpointing(dataset_info, iterations, mode, parallel)
     source = make_dummy_source(epoch_size, batch_size, mode)
     pf = make_external_source_test_pipeline_factory(source, mode, batch_size, parallel)
     check_external_source_pipeline_checkpointing(pf, iterations, 2 * epoch_size)
-
-
-@attr("pytorch")
-@cartesian_params(
-    ((1, 1), (4, 5)),  # (epoch size, batch size)
-    (0, 4, 11),  # test iterations
-    ("idx", "batch_info", "sample_info"),  # indexing mode
-    (True, False),  # parallel
-)
-def test_external_source_checkpointing_pytorch(dataset_info, iterations, mode, parallel):
-    epoch_size, batch_size = dataset_info
-    source = make_dummy_source(epoch_size, batch_size, mode)
-    pf = make_external_source_test_pipeline_factory(source, mode, batch_size, parallel)
-    check_external_source_pipeline_checkpointing_pytorch(pf, iterations)
 
 
 @cartesian_params(

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -33,6 +33,12 @@ class FwTestBase:
 
     # Helpers
 
+    def compare_iters(self, iter, iter2):
+        for out1, out2 in zip(iter, iter2):
+            for d1, d2 in zip(out1, out2):
+                for key in d1.keys():
+                    assert self.equal(d1[key], d2[key])
+
     def check_pipeline_checkpointing(self, pipeline_factory, reader_name=None, size=-1):
         pipe = pipeline_factory(**pipeline_args)
         pipe.build()
@@ -48,10 +54,7 @@ class FwTestBase:
             restored, ["data"], auto_reset=True, reader_name=reader_name, size=size
         )
 
-        for out1, out2 in zip(iter, iter2):
-            for d1, d2 in zip(out1, out2):
-                for key in d1.keys():
-                    assert self.equal(d1[key], d2[key])
+        self.compare_iters(iter, iter2)
 
     def check_single_input_operator(self, op, device, **kwargs):
         pipeline_factory = check_single_input_operator_pipeline(op, device, **kwargs)
@@ -120,10 +123,7 @@ class FwTestBase:
         restored.build()
         iter2 = self.FwIterator(restored, ["data", "labels"], auto_reset=True, reader_name="Reader")
 
-        for out1, out2 in zip(iter, iter2):
-            for d1, d2 in zip(out1, out2):
-                for key in d1.keys():
-                    assert self.equal(d1[key], d2[key])
+        self.compare_iters(iter, iter2)
 
     # Random operators section
 
@@ -169,10 +169,7 @@ class FwTestBase:
         restored.build()
         iter2 = self.FwIterator(restored, ["data"], auto_reset=True, size=size)
 
-        for out1, out2 in zip(iter, iter2):
-            for d1, d2 in zip(out1, out2):
-                for key in d1.keys():
-                    assert self.equal(d1[key], d2[key])
+        self.compare_iters(iter, iter2)
 
     @cartesian_params(
         ((1, 1), (4, 5)),  # (epoch size, batch size)

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from checkpointing.test_dali_checkpointing import (
+    warmup_epochs,
+    pipeline_args,
+    check_single_input_operator_pipeline,
+    make_dummy_source,
+    make_external_source_test_pipeline_factory,
+    images_dir,
+)
+import nvidia.dali.fn as fn
+from nvidia.dali.pipeline import pipeline_def
+from nose2.tools import params, cartesian_params
+
+class FwTestBase:
+    FwIterator = None
+
+    def equal(self, a, b):
+        raise NotImplementedError
+
+    # Helpers
+
+    def check_pipeline_checkpointing(self, pipeline_factory, reader_name=None, size=-1):
+        pipe = pipeline_factory(**pipeline_args)
+        pipe.build()
+
+        iter = self.FwIterator(pipe, ["data"], auto_reset=True, reader_name=reader_name, size=size)
+        for _ in range(warmup_epochs):
+            for _ in iter:
+                pass
+
+        restored = pipeline_factory(**pipeline_args, checkpoint=iter.checkpoints()[0])
+        restored.build()
+        iter2 = self.FwIterator(restored, ["data"], auto_reset=True, reader_name=reader_name, size=size)
+
+        for out1, out2 in zip(iter, iter2):
+            for d1, d2 in zip(out1, out2):
+                for key in d1.keys():
+                    assert self.equal(d1[key], d2[key])
+
+
+    def check_single_input_operator(self, op, device, **kwargs):
+        pipeline_factory = check_single_input_operator_pipeline(op, device, **kwargs)
+        self.check_pipeline_checkpointing(pipeline_factory, reader_name="Reader")
+
+
+    def check_no_input_operator(self, op, device, **kwargs):
+        @pipeline_def
+        def pipeline_factory():
+            return op(device=device, **kwargs)
+
+        self.check_pipeline_checkpointing(pipeline_factory, size=8)
+
+
+    # Reader tests section
+
+    @params(
+        (1, 3, 0, 1, True, False, False),
+        (5, 10, 0, 2, True, False, False),
+        (3, 64, 3, 4, False, False, False),
+        (0, 32, 1, 4, False, False, True),
+        (3, 64, 3, 4, False, False, True),
+        (1, 8, 0, 2, False, True, False),
+        (1, 8, 1, 2, False, True, False),
+        (1, 8, 3, 4, False, True, False),
+        (1, 3, 0, 1, True, False, False, 1),
+        (5, 10, 0, 2, True, False, False, 2),
+        (3, 64, 3, 4, False, False, True, 3),
+    )
+    def test_file_reader(
+        self,
+        num_epochs,
+        batch_size,
+        shard_id,
+        num_shards,
+        random_shuffle,
+        shuffle_after_epoch,
+        stick_to_shard,
+        iters_into_epoch=None,
+    ):
+        @pipeline_def(batch_size=batch_size, device_id=0, num_threads=4, enable_checkpointing=True)
+        def pipeline():
+            data, label = fn.readers.file(
+                name="Reader",
+                file_root=images_dir,
+                pad_last_batch=True,
+                random_shuffle=random_shuffle,
+                shard_id=shard_id,
+                num_shards=num_shards,
+                shuffle_after_epoch=shuffle_after_epoch,
+                stick_to_shard=stick_to_shard,
+            )
+            image = fn.decoders.image_random_crop(data, device="mixed")
+            image = fn.resize(image, size=(200, 200))
+            return image, label
+
+        p = pipeline()
+        p.build()
+
+        iter = self.FwIterator(p, ["data", "labels"], auto_reset=True, reader_name="Reader")
+        for epoch in range(num_epochs):
+            for i, _ in enumerate(iter):
+                if iters_into_epoch is not None:
+                    if epoch == num_epochs - 1 and i == iters_into_epoch - 1:
+                        break
+
+        restored = pipeline(checkpoint=iter.checkpoints()[0])
+        restored.build()
+        iter2 = self.FwIterator(restored, ["data", "labels"], auto_reset=True, reader_name="Reader")
+
+        for out1, out2 in zip(iter, iter2):
+            for d1, d2 in zip(out1, out2):
+                for key in d1.keys():
+                    assert self.equal(d1[key], d2[key])
+
+    # Random operators section
+
+    @cartesian_params(("cpu", "gpu"), (None, (1,), (10,)))
+    def test_random_coin_flip(self, device, shape):
+        self.check_no_input_operator(fn.random.coin_flip, device, shape=shape)
+
+    @cartesian_params(("cpu", "gpu"), (None, (1,), (10,)))
+    def test_random_normal(self, device, shape):
+        self.check_no_input_operator(fn.random.normal, device, shape=shape)
+
+    @cartesian_params(("cpu", "gpu"), (None, (1,), (10,)))
+    def test_random_uniform(self, device, shape):
+        self.check_no_input_operator(fn.random.uniform, device, shape=shape)
+
+    # Stateless operators section
+
+    @cartesian_params(("cpu", "gpu"), (None, (1,), (10,)))
+    def test_constant(self, device, shape):
+        self.check_no_input_operator(fn.constant, device, idata=42, shape=shape)
+
+    # External source section
+
+    def check_external_source_pipeline_checkpointing(
+        self, pipeline_factory, iterations, *, size=-1
+    ):
+        def run(iterator, iterations):
+            completed_iterations = 0
+            while completed_iterations < iterations:
+                for _ in iterator:
+                    completed_iterations += 1
+                    if completed_iterations == iterations:
+                        break
+
+        pipeline = pipeline_factory()
+        pipeline.build()
+
+        iter = self.FwIterator(pipeline, ["data"], auto_reset=True, size=size)
+
+        run(iter, iterations)
+
+        restored = pipeline_factory(checkpoint=iter.checkpoints()[0])
+        restored.build()
+        iter2 = self.FwIterator(restored, ["data"], auto_reset=True, size=size)
+
+        for out1, out2 in zip(iter, iter2):
+            for d1, d2 in zip(out1, out2):
+                for key in d1.keys():
+                    assert self.equal(d1[key], d2[key])
+
+    @cartesian_params(
+        ((1, 1), (4, 5)),  # (epoch size, batch size)
+        (0, 4, 11),  # test iterations
+        ("idx", "batch_info", "sample_info"),  # indexing mode
+        (True, False),  # parallel
+    )
+    def test_external_source_checkpointing(self, dataset_info, iterations, mode, parallel):
+        epoch_size, batch_size = dataset_info
+        source = make_dummy_source(epoch_size, batch_size, mode)
+        pf = make_external_source_test_pipeline_factory(source, mode, batch_size, parallel)
+        self.check_external_source_pipeline_checkpointing(pf, iterations)
+
+
+# Framework tests
+
+
+class TestPytorch(FwTestBase):
+    def __init__(self):
+        from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
+
+        self.FwIterator = PyTorchIterator
+
+    def equal(self, a, b):
+        return (a == b).all()

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -24,6 +24,7 @@ import nvidia.dali.fn as fn
 from nvidia.dali.pipeline import pipeline_def
 from nose2.tools import params, cartesian_params
 
+
 class FwTestBase:
     FwIterator = None
 
@@ -43,18 +44,18 @@ class FwTestBase:
 
         restored = pipeline_factory(**pipeline_args, checkpoint=iter.checkpoints()[0])
         restored.build()
-        iter2 = self.FwIterator(restored, ["data"], auto_reset=True, reader_name=reader_name, size=size)
+        iter2 = self.FwIterator(
+            restored, ["data"], auto_reset=True, reader_name=reader_name, size=size
+        )
 
         for out1, out2 in zip(iter, iter2):
             for d1, d2 in zip(out1, out2):
                 for key in d1.keys():
                     assert self.equal(d1[key], d2[key])
 
-
     def check_single_input_operator(self, op, device, **kwargs):
         pipeline_factory = check_single_input_operator_pipeline(op, device, **kwargs)
         self.check_pipeline_checkpointing(pipeline_factory, reader_name="Reader")
-
 
     def check_no_input_operator(self, op, device, **kwargs):
         @pipeline_def
@@ -62,7 +63,6 @@ class FwTestBase:
             return op(device=device, **kwargs)
 
         self.check_pipeline_checkpointing(pipeline_factory, size=8)
-
 
     # Reader tests section
 

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -26,7 +26,11 @@ from nose2.tools import params, cartesian_params
 
 
 class FwTestBase:
-    FwIterator = None
+    def __init__(self):
+        self.FwIterator = self.get_fw_iterator_class()
+
+    def get_fw_iterator_class(self):
+        raise NotImplementedError
 
     def equal(self, a, b):
         raise NotImplementedError
@@ -188,10 +192,10 @@ class FwTestBase:
 
 
 class TestPytorch(FwTestBase):
-    def __init__(self):
+    def get_fw_iterator_class(self):
         from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
 
-        self.FwIterator = PyTorchIterator
+        return PyTorchIterator
 
     def equal(self, a, b):
         return (a == b).all()

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -199,3 +199,12 @@ class TestPytorch(FwTestBase):
 
     def equal(self, a, b):
         return (a == b).all()
+
+class TestPytorchRagged(FwTestBase):
+    def get_fw_iterator_class(self):
+        from nvidia.dali.plugin.pytorch import DALIRaggedIterator
+
+        return DALIRaggedIterator
+
+    def equal(self, a, b):
+        return (a == b).all()

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -198,6 +198,7 @@ class TestPytorch(FwTestBase):
     def equal(self, a, b):
         return (a == b).all()
 
+
 class TestPytorchRagged(FwTestBase):
     def __init__(self):
         super().__init__()

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -27,10 +27,7 @@ from nose2.tools import params, cartesian_params
 
 class FwTestBase:
     def __init__(self):
-        self.FwIterator = self.get_fw_iterator_class()
-
-    def get_fw_iterator_class(self):
-        raise NotImplementedError
+        self.FwIterator = None
 
     def equal(self, a, b):
         raise NotImplementedError
@@ -192,19 +189,21 @@ class FwTestBase:
 
 
 class TestPytorch(FwTestBase):
-    def get_fw_iterator_class(self):
-        from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
+    def __init__(self):
+        super().__init__()
+        from nvidia.dali.plugin.pytorch import DALIRaggedIterator
 
-        return PyTorchIterator
+        self.FwIterator = DALIRaggedIterator
 
     def equal(self, a, b):
         return (a == b).all()
 
 class TestPytorchRagged(FwTestBase):
-    def get_fw_iterator_class(self):
+    def __init__(self):
+        super().__init__()
         from nvidia.dali.plugin.pytorch import DALIRaggedIterator
 
-        return DALIRaggedIterator
+        self.FwIterator = DALIRaggedIterator
 
     def equal(self, a, b):
         return (a == b).all()

--- a/qa/TL0_python-self-test-core/test_body.sh
+++ b/qa/TL0_python-self-test-core/test_body.sh
@@ -46,7 +46,8 @@ test_pytorch() {
 }
 
 test_checkpointing() {
-    ${python_new_invoke_test} -A '!slow,!pytorch,!mxnet,!cupy,!numba' -s checkpointing
+    ${python_new_invoke_test} -A '!slow,!pytorch,!mxnet,!cupy,!numba' checkpointing.test_dali_checkpointing
+    ${python_new_invoke_test} -A '!slow,!pytorch,!mxnet,!cupy,!numba' checkpointing.test_dali_stateless_operators
 }
 
 test_no_fw() {

--- a/qa/TL0_python-self-test-core/test_body.sh
+++ b/qa/TL0_python-self-test-core/test_body.sh
@@ -40,7 +40,7 @@ test_type_annotations() {
 
 test_pytorch() {
     ${python_invoke_test} --attr '!slow,pytorch' test_dali_variable_batch_size.py
-    ${python_new_invoke_test} -A '!slow,pytorch' -s checkpointing
+    ${python_new_invoke_test} -A '!slow' checkpointing.test_dali_checkpointing_fw_iterators.TestPytorch
     ${python_new_invoke_test} -A 'pytorch' -s type_annotations
 }
 

--- a/qa/TL0_python-self-test-core/test_body.sh
+++ b/qa/TL0_python-self-test-core/test_body.sh
@@ -41,6 +41,7 @@ test_type_annotations() {
 test_pytorch() {
     ${python_invoke_test} --attr '!slow,pytorch' test_dali_variable_batch_size.py
     ${python_new_invoke_test} -A '!slow' checkpointing.test_dali_checkpointing_fw_iterators.TestPytorch
+    ${python_new_invoke_test} -A '!slow' checkpointing.test_dali_checkpointing_fw_iterators.TestPytorchRagged
     ${python_new_invoke_test} -A 'pytorch' -s type_annotations
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:
This change is a preparation for extending checkpointing support to other framework iterators.

I move all Pytorch tests from `test_dali_checkpointing.py` to a new file, `test_dali_checkpointing_fw_iterators.py`. 
A generic base class, `FwTestBase` is created. Tests for particular frameworks will inherit from it just as `TestPytorch` does.

I also took an opportunity to add tests for pytorch's `DALIRaggedIterator`, which wasn't tested

## Additional information:

### Affected modules and functionalities:
Checkpointing tests

### Key points relevant for the review:
This way of testing iterators should work for those based on `base_iterator._DaliBaseIterator` (PyTorch, MxNet, PaddlePaddle, JAX). TF iterator will be probably hard to fit into this scheme.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added _(in fact, moved)_
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
