### PR TITLE
Support checkpointing in PaddlePaddle iterator

### DIFF
--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -269,11 +269,15 @@ class DALIGenericIterator(_DaliBaseIterator):
                 # here we should set if to False again
                 self._ever_consumed = False
             except StopIteration:
-                assert False, (
-                    "It seems that there is no data in the pipeline. This may happen "
-                    "if `last_batch_policy` is set to PARTIAL and the requested batch size is "
-                    "greater than the shard size."
-                )
+                # This case might not be an error if we're iterating over pipeline that is
+                # currently at the end of epoch, for example because it was restored from
+                # checkpoint.
+                if all(not p.is_restored_from_checkpoint or p._first_iter for p in self._pipes):
+                    raise RuntimeError(
+                        "It seems that there is no data in the pipeline. This may happen "
+                        "if `last_batch_policy` is set to PARTIAL and the requested batch size is "
+                        "greater than the shard size."
+                    )
 
     def __next__(self):
         self._ever_consumed = True

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -259,8 +259,6 @@ class DALIGenericIterator(_DaliBaseIterator):
             prepare_first_batch=prepare_first_batch,
         )
 
-        self._counter = 0
-
         self._first_batch = None
         if self._prepare_first_batch:
             try:

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -31,6 +31,7 @@ import numpy as npfrom nvidia.dali.plugin.base_iterator import LastBatchPolicy
 from nose import SkipTest
 
 
+
 class FwTestBase:
     def __init__(self):
         self.FwIterator = None
@@ -414,10 +415,11 @@ class TestJax(FwTestBase):
 
 
 class TestPaddle(FwTestBase):
-    def get_fw_iterator_class(self):
-        from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddleIterator
+    def __init__(self):
+        super().__init__()
+        from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddlePaddleIterator
 
-        return PaddleIterator
+        self.FwIterator = PaddlePaddleIterator
 
     def equal(self, a, b):
         return (np.array(a) == np.array(b)).all()

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -27,7 +27,7 @@ from checkpointing.test_dali_checkpointing import (
 import nvidia.dali.fn as fn
 from nvidia.dali.pipeline import pipeline_def
 from nose2.tools import params, cartesian_params
-from nvidia.dali.plugin.base_iterator import LastBatchPolicy
+import numpy as npfrom nvidia.dali.plugin.base_iterator import LastBatchPolicy
 from nose import SkipTest
 
 
@@ -403,6 +403,7 @@ class TestJax(FwTestBase):
         for key in out1.keys():
             assert (out1[key] == out2[key]).all()
 
+
     def supported_last_batch_policies(self):
         return (
             # (last_batch_policy, pad_last_batch)
@@ -410,3 +411,14 @@ class TestJax(FwTestBase):
             (LastBatchPolicy.DROP, False),
             (LastBatchPolicy.FILL, True),
         )
+
+
+class TestPaddle(FwTestBase):
+    def get_fw_iterator_class(self):
+        from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddleIterator
+
+        return PaddleIterator
+
+    def equal(self, a, b):
+        return (np.array(a) == np.array(b)).all()
+

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -27,9 +27,9 @@ from checkpointing.test_dali_checkpointing import (
 import nvidia.dali.fn as fn
 from nvidia.dali.pipeline import pipeline_def
 from nose2.tools import params, cartesian_params
-import numpy as npfrom nvidia.dali.plugin.base_iterator import LastBatchPolicy
+import numpy as np
+from nvidia.dali.plugin.base_iterator import LastBatchPolicy
 from nose import SkipTest
-
 
 
 class FwTestBase:
@@ -404,7 +404,6 @@ class TestJax(FwTestBase):
         for key in out1.keys():
             assert (out1[key] == out2[key]).all()
 
-
     def supported_last_batch_policies(self):
         return (
             # (last_batch_policy, pad_last_batch)
@@ -424,3 +423,12 @@ class TestPaddle(FwTestBase):
     def equal(self, a, b):
         return (np.array(a) == np.array(b)).all()
 
+    def supported_last_batch_policies(self):
+        return (
+            # (last_batch_policy, pad_last_batch)
+            (LastBatchPolicy.DROP, True),
+            (LastBatchPolicy.DROP, False),
+            (LastBatchPolicy.FILL, True),
+            (LastBatchPolicy.PARTIAL, False),
+            (LastBatchPolicy.PARTIAL, True),
+        )

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -1784,7 +1784,7 @@ def check_paddle_iterator_pass_reader_name(
 
     if batch_size > data_set_size // shards_num and last_batch_policy == LastBatchPolicy.DROP:
         assert_raises(
-            AssertionError,
+            RuntimeError,
             PaddleIterator,
             pipes,
             output_map=["data"],


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** (*non-breaking change which adds functionality*)

## Description:
Checkpointing support was already implemented in `BaseIterator` in https://github.com/NVIDIA/DALI/pull/5061, but wasn't tested for frameworks other than Pytorch. In this PR I add tests for PaddlePaddle Iterator and fix a problem with ES checkpointing. This work is very similar to #5282 

When an iterator is created and there's no data in the external source, DALI reports "no data in pipeline" error. The problem is that if we checkpoint after the last iteration and restore from such checkpoint, there's no data in the external source but it's not an error. In this PR I silence this error if we're restoring from checkpoint. Exactly the same change was made in https://github.com/NVIDIA/DALI/pull/5213 and #5282 

## Additional information:

### Affected modules and functionalities:

PaddlePaddle Iterator

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3751	
<!--- DALI-XXXX or NA --->
	