### PR TITLE
Support checkpointing in JAX iterator

### DIFF
--- a/dali/python/nvidia/dali/plugin/jax/iterator.py
+++ b/dali/python/nvidia/dali/plugin/jax/iterator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -153,11 +153,15 @@ class DALIGenericIterator(_DaliBaseIterator):
                 # here we should set if to False again
                 self._ever_consumed = False
             except StopIteration:
-                assert False, (
-                    "It seems that there is no data in the pipeline. This may happen "
-                    "if `last_batch_policy` is set to PARTIAL and the requested batch size is "
-                    "greater than the shard size."
-                )
+                # This case might not be an error if we're iterating over pipeline that is
+                # currently at the end of epoch, for example because it was restored from
+                # checkpoint.
+                if all(not p.is_restored_from_checkpoint or p._first_iter for p in self._pipes):
+                    raise RuntimeError(
+                        "It seems that there is no data in the pipeline. This may happen "
+                        "if `last_batch_policy` is set to PARTIAL and the requested batch size is "
+                        "greater than the shard size."
+                    )
 
     def _next_impl(self):
         self._ever_consumed = True

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -34,11 +34,14 @@ class FwTestBase:
 
     # Helpers
 
+    def compare_outs(self, out1, out2):
+        for d1, d2 in zip(out1, out2):
+            for key in d1.keys():
+                assert self.equal(d1[key], d2[key])
+
     def compare_iters(self, iter, iter2):
         for out1, out2 in zip(iter, iter2):
-            for d1, d2 in zip(out1, out2):
-                for key in d1.keys():
-                    assert self.equal(d1[key], d2[key])
+            self.compare_outs(out1, out2)
 
     def check_pipeline_checkpointing(self, pipeline_factory, reader_name=None, size=-1):
         pipe = pipeline_factory(**pipeline_args)
@@ -208,3 +211,15 @@ class TestPytorchRagged(FwTestBase):
 
     def equal(self, a, b):
         return (a == b).all()
+
+
+class TestJax(FwTestBase):
+    def __init__(self):
+        super().__init__()
+        from nvidia.dali.plugin.jax import DALIGenericIterator
+
+        self.FwIterator = DALIGenericIterator
+
+    def compare_outs(self, out1, out2):
+        for key in out1.keys():
+            assert (out1[key] == out2[key]).all()

--- a/qa/TL0_FW_iterators/test_jax.sh
+++ b/qa/TL0_FW_iterators/test_jax.sh
@@ -15,6 +15,7 @@ test_body() {
 
     # More specific JAX tests
     ${python_new_invoke_test} -s jax_plugin/ test_integration test_iterator test_peekable_iterator
+    ${python_new_invoke_test} checkpointing.test_dali_checkpointing_fw_iterators.TestJax
 }
 
 pushd ../..


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** (*non-breaking change which adds functionality*)

## Description:
Checkpointing support was already implemented in `BaseIterator` in https://github.com/NVIDIA/DALI/pull/5061, but wasn't tested for frameworks other than Pytorch. In this PR I add tests for JAX Iterator and fix a problem with ES checkpointing.

When an iterator is created and there's no data in the external source, DALI reports "no data in pipeline" error. The problem is that if we checkpoint after the last iteration and restore from such checkpoint, there's no data in the external source but it's not an error. In this PR I silence this error if we're restoring from checkpoint. Exactly the same change was made in https://github.com/NVIDIA/DALI/pull/5213.

## Additional information:

### Affected modules and functionalities:

JAX Iterator

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3749	
<!--- DALI-XXXX or NA --->
	