### PR TITLE
Fix capitalized property descriptions

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -80,7 +80,7 @@
     border-top: solid 3px rgba(59,93,0,1);
   }
 
-  html.writer-html4 .rst-content dl:not(.docutils) .property, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) .property {
+  html.writer-html4 .rst-content dl:not(.docutils):not(.py) .property, html.writer-html5 .rst-content dl[class]:not(.py):not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) .property {
     text-transform: capitalize;
     display: inline-block;
     padding-right: 8px;


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**Bug fix** (*non-breaking change which fixes an issue*)

<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
This PR fixes capitalized property descriptions, which since 1.25 look like this:
<img width="443" alt="image" src="https://github.com/NVIDIA/DALI/assets/34919255/4c5cb909-a283-42aa-b5aa-fcada756948b">
And are sometimes aligned next to each other like this:
<img width="675" alt="image" src="https://github.com/NVIDIA/DALI/assets/34919255/4bc0dc56-34b1-4a34-86d8-1bc2a1203554">

This is because the _Property_ text itself is (and always has been) of class `.property` and we added some custom styling to it in #2175 (in particular `capitalize` transform to make it _Property_ not _property_ and `display:inline-box`).

It was all fine util the property entries (whole entries, including doc text) started to be rendered as `<... class="py property">` which conflicted with already used class `.property`. This way our styling was applied to whole text.

In this PR I change the selectors to still apply to `property`, but not `py property`.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [x] Other - **template**
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3780
<!--- DALI-XXXX or NA --->
