### PR TITLE
Enable AG-transformed code to show user code in exception

### DIFF
--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1687,7 +1687,7 @@ def _regroup_args(func, pipeline_def_kwargs, fn_call_kwargs):
 def _preprocess_pipe_func(func, conditionals_on):
     """Transform the pipeline definition function if the conditionals are enabled"""
     if conditionals_on:
-        return _conditionals._autograph.to_graph(func)
+        return _conditionals._autograph.convert(recursive=True, user_requested=True)(func)
     else:
         return func
 
@@ -1870,7 +1870,12 @@ def pipeline_def(
             conditionals_on = kwargs.get("enable_conditionals", enable_conditionals)
 
             pipe_func = _preprocess_pipe_func(func, conditionals_on)
-            pipeline_args, fn_kwargs = _regroup_args(pipe_func, pipeline_kwargs, kwargs)
+            # TODO(klecki): Rewrite _discriminate_args used by _regroup_args in the means of the
+            # inspect.signature, so it obeys the signature produced by the wrapper.
+            # The getfullargspec ignores wrappers, so we need to use func here for argument
+            # redistribution, as _preprocess_pipe_func returns a wrapper in conditional mode.
+            # After this we can pass pipe_func below.
+            pipeline_args, fn_kwargs = _regroup_args(func, pipeline_kwargs, kwargs)
             pipe = Pipeline(**pipeline_args)
             _preprocess_pipe_object(pipe, conditionals_on, args, fn_kwargs)
 
@@ -2070,7 +2075,8 @@ def _pipeline_def_experimental(fn=None, *, enable_conditionals=False, **pipeline
             conditionals_on = kwargs.get("enable_conditionals", enable_conditionals)
 
             pipe_func = _preprocess_pipe_func(func, conditionals_on)
-            pipeline_args, fn_kwargs = _regroup_args(pipe_func, pipeline_kwargs, kwargs)
+            # TODO(klecki): Use pipe_func here after similar todo is resolved in regular decorator.
+            pipeline_args, fn_kwargs = _regroup_args(func, pipeline_kwargs, kwargs)
             if debug_mode_on:
                 pipe = _PipelineDebug(
                     functools.partial(pipe_func, *args, **fn_kwargs), **pipeline_args


### PR DESCRIPTION


<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **New feature**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Autograph transforms all function invocations into converted_call statement. When an exception is raised in such AG-transformed code, every converted_call step will capture the exception and attach additional metadata pointing to the original code. As we traverse only the converted call, we produce call stack that is equivalent to the code before the transformation.

The change in pipeline from to_graph to convert enables the final step - attaching the equivalent call stack of user code to be added to the produced exception.

This makes errors that happen during tracing the pipeline definition more readable to the user by appending the "in user code <user callstack>" message.

As the processing of pipeline definition arguments doesn't work with decorators a WAR is used for now. The issue should be resolved in a separate commit.


## Additional information:

### Affected modules and functionalities:
A bit of pipeline (building graph, autograph transformation entrypoint),
error reporting when a pipeline definition is traced.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
