### PR TITLE
Fixes support for video sequences bigger than 2GB

### DIFF
--- a/dali/operators/reader/nvdecoder/imgproc.cu
+++ b/dali/operators/reader/nvdecoder/imgproc.cu
@@ -193,7 +193,8 @@ void process_frame(
   dim3 block(32, 8);
   dim3 grid(divUp(output.width, block.x), divUp(output.height, block.y));
 
-  int frame_stride = index * output.height * output.width * output.channels;
+  auto frame_stride =
+          static_cast<ptrdiff_t>(index) * output.height * output.width * output.channels;
   LOG_LINE << "Processing frame " << index
             << " (frame_stride=" << frame_stride << ")" << std::endl;
   auto* tensor_out = output.sequence.mutable_data<T>() + frame_stride;

--- a/dali/test/python/test_video_pipeline.py
+++ b/dali/test/python/test_video_pipeline.py
@@ -631,7 +631,7 @@ def test_10bit_vid_reconfigure():
 
 
 def test_2gb_sequence():
-    # make sure the sequence extends 2GB
+    # make sure the sequence exceeds beyond 2GB
     sequence_length = int(math.ceil((1 << 31) / 720 / 1280 / 3) + 3)
 
     @pipeline_def


### PR DESCRIPTION
- fixes wrong pointer arithmetic based on int that leads to overflow
  and illegal memory access  when the video sequence length is bigger than 2GB
- relates https://github.com/NVIDIA/DALI/issues/3542

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- fixes wrong pointer arithmetic based on int that leads to overflow
  and illegal memory access  when the video sequence length is bigger than 2GB
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- video reader and video reader resize
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_video_pipeline.test_2gb_sequence
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
