### PR TITLE
Simplify workspace object. Ensure predictable argument order in OpSpec.

### DIFF
--- a/dali/operators/image/convolution/filter.h
+++ b/dali/operators/image/convolution/filter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@ class Filter : public SequenceOperator<Backend, StatelessOperator> {
   }
 
   bool ShouldExpand(const Workspace& ws) override {
-    const auto& input_layout = GetInputLayout(ws, 0);
+    const auto& input_layout = ws.GetInputLayout(0);
     int frame_idx = VideoLayoutInfo::FrameDimIndex(input_layout);
     DALI_ENFORCE(frame_idx == -1 || frame_idx == 0,
                  make_string("When the input is video-like (i.e. contains frames), the frames must "
@@ -246,7 +246,7 @@ class Filter : public SequenceOperator<Backend, StatelessOperator> {
 
   bool HasPerFrameFilters(const Workspace& ws) {
     auto filter_dim = ws.GetInputDim(1);
-    const auto& filter_layout = GetInputLayout(ws, 1);
+    const auto& filter_layout = ws.GetInputLayout(1);
     return filter_dim == 3 && filter_layout.size() == 3 && filter_layout[0] == 'F';
   }
 
@@ -254,7 +254,7 @@ class Filter : public SequenceOperator<Backend, StatelessOperator> {
     if (ws.NumInput() < 3) {
       return false;
     }
-    const auto& layout = GetInputLayout(ws, 2);
+    const auto& layout = ws.GetInputLayout(2);
     return layout.size() == 1 && layout[0] == 'F';
   }
 

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -59,7 +59,6 @@ bool AnyBatchPartial(const Workspace &ws, const OpSpec &spec, int max_batch_size
     for (int i = 0; i < ws.NumInput(); i++) {
       any_batch_partial = any_batch_partial || ws.GetInputBatchSize(i) < max_batch_size;
     }
-    const ArgumentWorkspace &argument_ws = ws;
     for (const auto &arg : ws.ArgumentInputs()) {
       any_batch_partial = any_batch_partial || arg.cpu->num_samples() < max_batch_size;
     }

--- a/dali/pipeline/operator/op_spec.cc
+++ b/dali/pipeline/operator/op_spec.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ OpSpec& OpSpec::AddInput(const string &name, const string &device, bool regular_
       "Valid options are \"cpu\" or \"gpu\"");
   if (regular_input) {
     // We rely on the fact that regular inputs are first in inputs_ vector
-    DALI_ENFORCE(argument_inputs_indexes_.empty(),
+    DALI_ENFORCE(NumArgumentInput() == 0,
         "All regular inputs (particularly, `" + name + "`) need to be added to the op `" +
         this->name() + "` before argument inputs.");
   }
@@ -56,8 +56,9 @@ OpSpec& OpSpec::AddArgumentInput(const string &arg_name, const string &inp_name)
       "Argument '", arg_name, "' is not part of the op schema '", schema.name(), "'"));
   DALI_ENFORCE(schema.IsTensorArgument(arg_name), make_string(
       "Argument `", arg_name, "` in operator `", schema.name(), "` is not a a tensor argument."));
-  argument_inputs_[arg_name] = inputs_.size();
-  argument_inputs_indexes_.insert(inputs_.size());
+  int idx = inputs_.size();
+  argument_inputs_.push_back({ arg_name, idx });
+  argument_input_idxs_[arg_name] = idx;
   AddInput(inp_name, "cpu", false);
   return *this;
 }

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/pipeline/operator/operator.cc
+++ b/dali/pipeline/operator/operator.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,10 +38,9 @@ void OperatorBase::EnforceUniformInputBatchSize(const Workspace &ws) const {
     DALI_ENFORCE(curr_batch_size == ws.GetInputBatchSize(i),
                  "Batch size has to be uniform across one iteration.");
   }
-  const ArgumentWorkspace &argument_ws = ws;
-  for (const auto &arg : argument_ws) {
+  for (const auto &arg : ws.ArgumentInputs()) {
     DALI_ENFORCE(
-        curr_batch_size == static_cast<decltype(curr_batch_size)>(arg.second.tvec->num_samples()),
+        curr_batch_size == static_cast<decltype(curr_batch_size)>(arg.cpu->num_samples()),
         "ArgumentInput has to have the same batch size as an input.");
   }
 }

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -247,28 +247,6 @@ class DLL_PUBLIC OperatorBase {
  */
 template <typename Backend>
 class Operator : public OperatorBase {};
-
-inline TensorLayout GetInputLayout(const Workspace &ws, int i) {
-  if (ws.InputIsType<CPUBackend>(i)) {
-    auto &in = ws.Input<CPUBackend>(i);
-    return in.GetLayout();
-  }
-
-  assert(ws.InputIsType<GPUBackend>(i));
-  auto &in = ws.Input<GPUBackend>(i);
-  return in.GetLayout();
-}
-
-inline TensorLayout GetOutputLayout(const Workspace &ws, int i) {
-  if (ws.OutputIsType<CPUBackend>(i)) {
-    auto &out = ws.Output<CPUBackend>(i);
-    return out.GetLayout();
-  }
-
-  assert(ws.OutputIsType<GPUBackend>(i));
-  auto &out = ws.Output<GPUBackend>(i);
-  return out.GetLayout();
-}
 
 template <>
 class Operator<CPUBackend> : public OperatorBase {

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -332,7 +332,7 @@ class SequenceOperator : public BaseOp<Backend>, protected SampleBroadcasting<Ba
     input_expand_desc_.reserve(num_inputs);
     for (int input_idx = 0; input_idx < num_inputs; input_idx++) {
       const auto &input_shape = ws.GetInputShape(input_idx);
-      const auto &layout = GetInputLayout(ws, input_idx);
+      const auto &layout = ws.GetInputLayout(input_idx);
       input_expand_desc_.emplace_back(input_idx, input_shape, layout,
                                       ShouldExpandChannels(input_idx));
     }

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022, 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -363,11 +363,11 @@ class SequenceOperator : public BaseOp<Backend>, protected SampleBroadcasting<Ba
 
   virtual std::unique_ptr<ExpandDesc> InferNonPositionalReferenceExpandDesc(
       const Workspace &ws) {
-    for (const auto &arg_input : ws) {
-      auto &shared_tvec = arg_input.second.tvec;
-      assert(shared_tvec);
-      const std::string &name = arg_input.first;
-      const auto &batch = *shared_tvec;
+    for (const auto &arg_input : ws.ArgumentInputs()) {
+      auto &shared_tl = arg_input.cpu;
+      assert(shared_tl);
+      const std::string &name = arg_input.name;
+      const auto &batch = *shared_tl;
       if (IsPerFrameArg(name, batch)) {
         return std::make_unique<ExpandDesc>(name, batch.shape(), batch.GetLayout(), false);
       }
@@ -398,18 +398,18 @@ class SequenceOperator : public BaseOp<Backend>, protected SampleBroadcasting<Ba
   }
 
   void ExpandArguments(const ArgumentWorkspace &ws) {
-    for (const auto &arg_input : ws) {
-      auto &shared_tvec = arg_input.second.tvec;
-      assert(shared_tvec);
-      ExpandArgument(ws, arg_input.first, *shared_tvec);
+    for (const auto &arg_input : ws.ArgumentInputs()) {
+      auto &shared_tl = arg_input.cpu;
+      assert(shared_tl);
+      ExpandArgument(ws, arg_input.name, *shared_tl);
     }
   }
 
   bool HasPerFrameArgInputs(const Workspace &ws) {
-    for (const auto &arg_input : ws) {
-      auto &shared_tvec = arg_input.second.tvec;
-      assert(shared_tvec);
-      if (IsPerFrameArg(arg_input.first, *shared_tvec)) {
+    for (const auto &arg_input : ws.ArgumentInputs()) {
+      auto &shared_tl = arg_input.cpu;
+      assert(shared_tl);
+      if (IsPerFrameArg(arg_input.name, *shared_tl)) {
         return true;
       }
     }
@@ -499,10 +499,10 @@ class SequenceOperator : public BaseOp<Backend>, protected SampleBroadcasting<Ba
   }
 
   void InitializeExpandedArguments(const Workspace &ws) {
-    for (const auto &arg_input : ws) {
-      auto &shared_tvec = arg_input.second.tvec;
-      assert(shared_tvec);
-      InitializeExpandedArgument(ws, arg_input.first, *shared_tvec);
+    for (const auto &arg_input : ws.ArgumentInputs()) {
+      auto &shared_tl = arg_input.cpu;
+      assert(shared_tl);
+      InitializeExpandedArgument(ws, arg_input.name, *shared_tl);
     }
   }
 
@@ -545,7 +545,7 @@ class SequenceOperator : public BaseOp<Backend>, protected SampleBroadcasting<Ba
   }
 
   TensorList<CPUBackend> &ExpandedArg(const std::string &arg_name) {
-    return expanded_.UnsafeMutableArgumentInput(arg_name);
+    return *expanded_.UnsafeMutableArgumentInput(arg_name);
   }
 
   template <typename BatchType>

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -324,8 +324,7 @@ int Pipeline::AddOperator(const OpSpec &const_spec, const std::string& inst_name
   }
 
   // Verify the argument inputs to the op
-  for (const auto& arg_pair : spec.ArgumentInputs()) {
-    Index input_idx = arg_pair.second;
+  for (const auto &[arg_name, input_idx] : spec.ArgumentInputs()) {
     std::string input_name = spec.InputName(input_idx);
     auto it = edge_names_.find(input_name);
 
@@ -737,16 +736,17 @@ void SerializeToProtobuf(dali_proto::OpDef *op, const string &inst_name, const O
   for (auto& a : spec.Arguments()) {
     // filter out args that need to be dealt with on
     // loading a serialized pipeline
-    if (a.first == "max_batch_size" ||
-        a.first == "num_threads" ||
-        a.first == "bytes_per_sample_hint") {
+    auto &name = a->get_name();
+    if (name == "max_batch_size" ||
+        name == "num_threads" ||
+        name == "bytes_per_sample_hint") {
       continue;
     }
 
     dali_proto::Argument *arg = op->add_args();
     DaliProtoPriv arg_wrap(arg);
 
-    a.second->SerializeToProtobuf(&arg_wrap);
+    a->SerializeToProtobuf(&arg_wrap);
   }
 }
 

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -524,8 +524,8 @@ TYPED_TEST(PipelineTest, TestSeedSet) {
   OpGraph &original_graph = this->GetGraph(&pipe);
 
   // Check if seed can be manually set to the reader
-  ASSERT_EQ(original_graph.Node(3).spec.Arguments().at("seed")->Get<int64_t>(), seed_set);
-  ASSERT_NE(original_graph.Node(0).spec.Arguments().at("seed")->Get<int64_t>(), seed_set);
+  ASSERT_EQ(original_graph.Node(3).spec.GetArgument<int64_t>("seed"), seed_set);
+  ASSERT_NE(original_graph.Node(0).spec.GetArgument<int64_t>("seed"), seed_set);
 }
 
 

--- a/dali/pipeline/workspace/sample_workspace.cc
+++ b/dali/pipeline/workspace/sample_workspace.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,8 +44,8 @@ void MakeSampleView(SampleWorkspace &sample, Workspace &batch, int data_idx, int
       sample.AddOutput(&output_ref.tensor_handle(data_idx));
     }
   }
-  for (auto& arg_pair : batch) {
-    sample.AddArgumentInput(arg_pair.first, arg_pair.second.tvec);
+  for (auto &arg_inp : batch.ArgumentInputs()) {
+    sample.AddArgumentInput(arg_inp.name, arg_inp.cpu);
   }
 }
 

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -223,7 +223,7 @@ class WorkspaceBase : public ArgumentWorkspace {
   /** @} */
 
   /**
-   * Returns shape of input at given index
+   * Returns shape of the input at given index
    * @return TensorShape<> for SampleWorkspace, TensorListShape<> for other Workspaces
    */
   auto GetInputShape(int input_idx) const {
@@ -231,18 +231,39 @@ class WorkspaceBase : public ArgumentWorkspace {
   }
 
   /**
-   * Returns the data type of the input at given index
-   * @return DALIDataType
+   * Returns shape of the output at given index
+   * @return TensorShape<> for SampleWorkspace, TensorListShape<> for other Workspaces
+   */
+  auto GetOutputShape(int output_idx) const {
+    return GetBufferProperty(outputs_, output_idx, [](auto &buf) { return buf->shape(); });
+  }
+
+  /**
+   * @brief Returns the type of the data in the input at given index.
    */
   DALIDataType GetInputDataType(int input_idx) const {
     return GetBufferProperty(inputs_, input_idx, [](auto &buf) { return buf->type(); });
   }
 
   /**
-   * @return Type of the data in the output with given index.
+   * @brief Returns the type of the data in the output at given index.
    */
   DALIDataType GetOutputDataType(int output_idx) const {
     return GetBufferProperty(outputs_, output_idx, [](auto &buf) { return buf->type(); });
+  }
+
+  /**
+   * @brief Returns the layout of the input at given index
+   */
+  TensorLayout GetInputLayout(int input_idx) const {
+    return GetBufferProperty(inputs_, input_idx, [](auto &buf) { return buf->GetLayout(); });
+  }
+
+  /**
+   * @brief Returns the layout of the output at given index
+   */
+  TensorLayout GetOutputLayout(int output_idx) const {
+    return GetBufferProperty(outputs_, output_idx, [](auto &buf) { return buf->GetLayout(); });
   }
 
   /**
@@ -250,6 +271,13 @@ class WorkspaceBase : public ArgumentWorkspace {
    */
   int GetInputBatchSize(int input_idx) const {
     return GetBufferProperty(inputs_, input_idx, [](auto &buf) { return buf->num_samples(); });
+  }
+
+  /**
+   * Returns batch size for a given output
+   */
+  int GetOutputBatchSize(int output_idx) const {
+    return GetBufferProperty(outputs_, output_idx, [](auto &buf) { return buf->num_samples(); });
   }
 
   /**

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -222,16 +222,6 @@ class WorkspaceBase : public ArgumentWorkspace {
 
   /** @} */
 
-  template <typename Buffers, typename Getter>
-  static auto GetBufferProperty(Buffers &buffers, int idx, Getter &&getter) {
-    DALI_ENFORCE_VALID_INDEX(idx, buffers.size());
-    auto &inp = buffers[idx];
-    if (inp.device == StorageDevice::GPU)
-      return getter(inp.gpu);
-    else
-      return getter(inp.cpu);
-  }
-
   /**
    * Returns shape of input at given index
    * @return TensorShape<> for SampleWorkspace, TensorListShape<> for other Workspaces
@@ -273,7 +263,7 @@ class WorkspaceBase : public ArgumentWorkspace {
    * Returns number of dimensions for a given output
    */
   int GetOutputDim(int output_idx) const {
-    return GetBufferProperty(inputs_, output_idx, [](auto &buf) { return buf->sample_dim(); });
+    return GetBufferProperty(outputs_, output_idx, [](auto &buf) { return buf->sample_dim(); });
   }
 
   /**
@@ -610,6 +600,16 @@ class WorkspaceBase : public ArgumentWorkspace {
   SmallVector<IOBuffers, 2> outputs_;
 
  private:
+  template <typename Buffers, typename Getter>
+  static auto GetBufferProperty(Buffers &buffers, int idx, Getter &&getter) {
+    DALI_ENFORCE_VALID_INDEX(idx, buffers.size());
+    auto &inp = buffers[idx];
+    if (inp.device == StorageDevice::GPU)
+      return getter(inp.gpu);
+    else
+      return getter(inp.cpu);
+  }
+
   AccessOrder output_order_ = AccessOrder::host();
   ThreadPool *thread_pool_ = nullptr;
   cudaEvent_t event_ = nullptr;

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -62,7 +62,7 @@ class ArgumentWorkspace {
   int AddArgumentInput(const std::string& arg_name, shared_ptr<TensorList<CPUBackend>> input) {
     int idx = argument_input_idxs_.size();
     argument_input_idxs_[arg_name] = idx;
-    argument_inputs_[idx] = { arg_name, std::move(input) };
+    argument_inputs_.push_back({ arg_name, std::move(input) });
     return idx;
   }
 
@@ -377,7 +377,7 @@ class WorkspaceBase : public ArgumentWorkspace {
    * ws.AddInput<CPUBackend>(nullptr);
    */
   template <typename Backend>
-  void AddInput(DataObjectPtr<Backend> input) {
+  void AddInput(DataObjectPtr<Backend> input, Backend = {}) {
     AddInput(input);
   }
 
@@ -403,7 +403,7 @@ class WorkspaceBase : public ArgumentWorkspace {
    * ws.AddOutput<CPUBackend>(nullptr);
    */
   template <typename Backend>
-  void AddOutput(DataObjectPtr<Backend> output) {
+  void AddOutput(DataObjectPtr<Backend> output, Backend = {}) {
     AddOutput(output);
   }
 
@@ -419,6 +419,62 @@ class WorkspaceBase : public ArgumentWorkspace {
    */
   void AddOutput(DataObjectPtr<GPUBackend> output) {
     outputs_.push_back(IOBuffers{ StorageDevice::GPU, nullptr, std::move(output) });
+  }
+
+
+  /**
+   * @brief Sets an input
+   *
+   * This overload can be useful when there's an automatic conversion, e.g. from a nullptr
+   * ws.SetInput<CPUBackend>(idx, nullptr);
+   */
+  template <typename Backend>
+  void SetInput(int idx, DataObjectPtr<Backend> input, Backend = {}) {
+    SetInput(idx, input);
+  }
+
+  /**
+   * @brief Sets a CPU input
+   */
+  void SetInput(int idx, DataObjectPtr<CPUBackend> input) {
+    DALI_ENFORCE_VALID_INDEX(idx, NumOutput());
+    inputs_[idx] = IOBuffers{ StorageDevice::CPU, std::move(input), nullptr };
+  }
+
+  /**
+   * @brief Sets a GPU input
+   */
+  void SetInput(int idx, DataObjectPtr<GPUBackend> input) {
+    DALI_ENFORCE_VALID_INDEX(idx, NumInput());
+    inputs_[idx] = IOBuffers{ StorageDevice::GPU, nullptr, std::move(input) };
+  }
+
+
+  /**
+   * @brief Sets an output
+   *
+   * This overload can be useful when there's an automatic conversion, e.g. from a nullptr
+   * ws.SetOutput<CPUBackend>(idx, nullptr);
+   */
+  template <typename Backend>
+  void SetOutput(int idx, DataObjectPtr<Backend> output, Backend = {}) {
+    SetOutput(idx, output);
+  }
+
+  /**
+   * @brief Sets a CPU output
+   */
+  void SetOutput(int idx, DataObjectPtr<CPUBackend> output) {
+    DALI_ENFORCE_VALID_INDEX(idx, NumOutput());
+    outputs_[idx] = IOBuffers{ StorageDevice::CPU, std::move(output), nullptr };
+  }
+
+  /**
+   * @brief Sets a GPU output
+   */
+  void SetOutput(int idx, DataObjectPtr<GPUBackend> output) {
+    DALI_ENFORCE_VALID_INDEX(idx, NumOutput());
+    outputs_[idx] = IOBuffers{ StorageDevice::GPU, nullptr, std::move(output) };
   }
 
 

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,50 +51,64 @@ class ArgumentWorkspace {
   virtual ~ArgumentWorkspace() = default;
 
   inline void Clear() {
+    argument_input_idxs_.clear();
     argument_inputs_.clear();
   }
 
-  void AddArgumentInput(const std::string& arg_name, shared_ptr<TensorList<CPUBackend>> input) {
-    argument_inputs_[arg_name] = { std::move(input) };
+  int NumArgumentInput() const {
+    return argument_inputs_.size();
   }
 
-  const TensorList<CPUBackend>& ArgumentInput(const std::string& arg_name) const {
-    auto it = argument_inputs_.find(arg_name);
-    DALI_ENFORCE(it != argument_inputs_.end(), "Argument \"" + arg_name + "\" not found.");
-    return *it->second.tvec;
+  int AddArgumentInput(const std::string& arg_name, shared_ptr<TensorList<CPUBackend>> input) {
+    int idx = argument_input_idxs_.size();
+    argument_input_idxs_[arg_name] = idx;
+    argument_inputs_[idx] = { arg_name, std::move(input) };
+    return idx;
   }
 
-  TensorList<CPUBackend>& UnsafeMutableArgumentInput(const std::string& arg_name) {
-    return const_cast<TensorList<CPUBackend>&>(ArgumentInput(arg_name));
+  void SetArgumentInput(int idx, shared_ptr<TensorList<CPUBackend>> input) {
+    assert(idx >= 0 && idx < static_cast<int>(argument_inputs_.size()));
+    argument_inputs_[idx].cpu = std::move(input);
   }
 
- protected:
-  struct ArgumentInputDesc {
-    std::shared_ptr<TensorList<CPUBackend>> tvec;
+  const TensorList<CPUBackend>& ArgumentInput(const std::string &arg_name) const {
+    auto it = argument_input_idxs_.find(arg_name);
+    DALI_ENFORCE(it != argument_input_idxs_.end(), "Argument \"" + arg_name + "\" not found.");
+    return *argument_inputs_[it->second].cpu;
+  }
+
+  const std::string& ArgumentInputName(int idx) const {
+    DALI_ENFORCE_VALID_INDEX(idx, NumArgumentInput());
+    return argument_inputs_[idx].name;
+  }
+
+  const TensorList<CPUBackend>& ArgumentInput(int idx) const {
+    DALI_ENFORCE_VALID_INDEX(idx, NumArgumentInput());
+    return *argument_inputs_[idx].cpu;
+  }
+
+  std::shared_ptr<TensorList<CPUBackend>>&
+  UnsafeMutableArgumentInput(const std::string &arg_name) {
+    auto it = argument_input_idxs_.find(arg_name);
+    DALI_ENFORCE(it != argument_input_idxs_.end(), "Argument \"" + arg_name + "\" not found.");
+    return argument_inputs_[it->second].cpu;
+  }
+
+  const auto &ArgumentInputs() const {
+    return argument_inputs_;
+  }
+
+  struct ArgumentInputBuffers {
+    std::string name;
+    std::shared_ptr<TensorList<CPUBackend>> cpu;
+    // In the future, we may add GPU data here
   };
 
+ protected:
   // Argument inputs
-  using argument_input_storage_t = std::unordered_map<std::string, ArgumentInputDesc>;
-  argument_input_storage_t argument_inputs_;
-
- public:
-  using const_iterator = argument_input_storage_t::const_iterator;
-  friend const_iterator begin(const ArgumentWorkspace&);
-  friend const_iterator end(const ArgumentWorkspace&);
+  std::unordered_map<std::string, int> argument_input_idxs_;
+  SmallVector<ArgumentInputBuffers, 4> argument_inputs_;
 };
-
-/** @{ */
-/**
- * @brief Iterator-handling functions for ArgumentWorkspace
- */
-inline ArgumentWorkspace::const_iterator begin(const ArgumentWorkspace& ws) {
-  return ws.argument_inputs_.begin();
-}
-
-inline ArgumentWorkspace::const_iterator end(const ArgumentWorkspace& ws) {
-  return ws.argument_inputs_.end();
-}
-/** @} */
 
 /**
  * @brief WorkspaceBase is a base class of objects
@@ -123,16 +137,8 @@ class WorkspaceBase : public ArgumentWorkspace {
    */
   inline void Clear() {
     ArgumentWorkspace::Clear();
-    cpu_inputs_.clear();
-    gpu_inputs_.clear();
-    cpu_outputs_.clear();
-    gpu_outputs_.clear();
-    input_index_map_.clear();
-    output_index_map_.clear();
-    cpu_inputs_index_.clear();
-    gpu_inputs_index_.clear();
-    cpu_outputs_index_.clear();
-    gpu_outputs_index_.clear();
+    inputs_.clear();
+    outputs_.clear();
   }
 
   /** @name Input and output APIs
@@ -147,8 +153,8 @@ class WorkspaceBase : public ArgumentWorkspace {
    * The operator implementation can use this function to access its inputs.
    */
   template <typename Backend>
-  const auto& Input(int idx) const {
-    return *InputHandle(idx, Backend{});
+  const auto& Input(int idx, Backend backend = {}) const {
+    return *InputHandle(idx, backend);
   }
 
   /**
@@ -157,22 +163,22 @@ class WorkspaceBase : public ArgumentWorkspace {
    * The operator implementation can use this function to access its outputs.
    */
   template <typename Backend>
-  auto& Output(int idx) const {
-    return *OutputHandle(idx, Backend{});
+  auto& Output(int idx, Backend backend = {}) const {
+    return *OutputHandle(idx, backend);
   }
 
   /**
    * @brief Returns the number of inputs.
    */
   inline int NumInput() const {
-    return input_index_map_.size();
+    return inputs_.size();
   }
 
   /**
    * @brief Returns the number of outputs.
    */
   inline int NumOutput() const {
-    return output_index_map_.size();
+    return outputs_.size();
   }
 
 
@@ -190,8 +196,8 @@ class WorkspaceBase : public ArgumentWorkspace {
    * Intended only for executor and other internal APIs.
    */
   template <typename Backend>
-  auto& UnsafeMutableInput(int idx) const {
-    return *InputHandle(idx, Backend{});
+  auto& UnsafeMutableInput(int idx, Backend backend = {}) const {
+    return *InputHandle(idx, backend);
   }
 
   /**
@@ -200,8 +206,8 @@ class WorkspaceBase : public ArgumentWorkspace {
    * Intended only for executor and other internal APIs.
    */
   template <typename Backend>
-  const DataObjectPtr<Backend>& InputPtr(int idx) const {
-    return InputHandle(idx, Backend{});
+  const DataObjectPtr<Backend>& InputPtr(int idx, Backend backend = {}) const {
+    return InputHandle(idx, backend);
   }
 
   /**
@@ -210,22 +216,28 @@ class WorkspaceBase : public ArgumentWorkspace {
    * Intended only for executor and other internal APIs.
    */
   template <typename Backend>
-  const DataObjectPtr<Backend>& OutputPtr(int idx) const {
-    return OutputHandle(idx, Backend{});
+  const DataObjectPtr<Backend>& OutputPtr(int idx, Backend backend = {}) const {
+    return OutputHandle(idx, backend);
   }
 
   /** @} */
+
+  template <typename Buffers, typename Getter>
+  static auto GetBufferProperty(Buffers &buffers, int idx, Getter &&getter) {
+    DALI_ENFORCE_VALID_INDEX(idx, buffers.size());
+    auto &inp = buffers[idx];
+    if (inp.device == StorageDevice::GPU)
+      return getter(inp.gpu);
+    else
+      return getter(inp.cpu);
+  }
 
   /**
    * Returns shape of input at given index
    * @return TensorShape<> for SampleWorkspace, TensorListShape<> for other Workspaces
    */
   auto GetInputShape(int input_idx) const {
-    if (InputIsType<GPUBackend>(input_idx)) {
-      return Input<GPUBackend>(input_idx).shape();
-    } else {
-      return Input<CPUBackend>(input_idx).shape();
-    }
+    return GetBufferProperty(inputs_, input_idx, [](auto &buf) { return buf->shape(); });
   }
 
   /**
@@ -233,69 +245,35 @@ class WorkspaceBase : public ArgumentWorkspace {
    * @return DALIDataType
    */
   DALIDataType GetInputDataType(int input_idx) const {
-    if (InputIsType<GPUBackend>(input_idx)) {
-      return Input<GPUBackend>(input_idx).type();
-    } else {
-      return Input<CPUBackend>(input_idx).type();
-    }
+    return GetBufferProperty(inputs_, input_idx, [](auto &buf) { return buf->type(); });
   }
 
   /**
    * @return Type of the data in the output with given index.
    */
   DALIDataType GetOutputDataType(int output_idx) const {
-    DALI_ENFORCE(NumOutput() > 0, "No outputs found");
-    DALI_ENFORCE(
-        output_idx >= 0 && output_idx < NumOutput(),
-        make_string("Invalid output index: ", output_idx, "; while NumOutput: ", NumOutput()));
-    if (OutputIsType<GPUBackend>(output_idx)) {
-      return Output<GPUBackend>(output_idx).type();
-    } else {
-      return Output<CPUBackend>(output_idx).type();
-    }
+    return GetBufferProperty(outputs_, output_idx, [](auto &buf) { return buf->type(); });
   }
 
   /**
    * Returns batch size for a given input
    */
   int GetInputBatchSize(int input_idx) const {
-    DALI_ENFORCE(NumInput() > 0, "No inputs found");
-    DALI_ENFORCE(input_idx >= 0 && input_idx < NumInput(),
-                 make_string("Invalid input index: ", input_idx, "; while NumInput: ", NumInput()));
-    if (InputIsType<GPUBackend>(input_idx)) {
-      return Input<GPUBackend>(input_idx).num_samples();
-    } else {
-      return Input<CPUBackend>(input_idx).num_samples();
-    }
+    return GetBufferProperty(inputs_, input_idx, [](auto &buf) { return buf->num_samples(); });
   }
 
   /**
    * Returns number of dimensions for a given input
    */
   int GetInputDim(int input_idx) const {
-    DALI_ENFORCE(NumInput() > 0, "No inputs found");
-    DALI_ENFORCE(input_idx >= 0 && input_idx < NumInput(),
-                 make_string("Invalid input index: ", input_idx, "; while NumInput: ", NumInput()));
-    if (InputIsType<GPUBackend>(input_idx)) {
-      return Input<GPUBackend>(input_idx).sample_dim();
-    } else {
-      return Input<CPUBackend>(input_idx).sample_dim();
-    }
+    return GetBufferProperty(inputs_, input_idx, [](auto &buf) { return buf->sample_dim(); });
   }
 
   /**
    * Returns number of dimensions for a given output
    */
   int GetOutputDim(int output_idx) const {
-    DALI_ENFORCE(NumOutput() > 0, "No outputs found");
-    DALI_ENFORCE(
-        output_idx >= 0 && output_idx < NumOutput(),
-        make_string("Invalid output index: ", output_idx, "; while NumOutput: ", NumOutput()));
-    if (OutputIsType<GPUBackend>(output_idx)) {
-      return Output<GPUBackend>(output_idx).sample_dim();
-    } else {
-      return Output<CPUBackend>(output_idx).sample_dim();
-    }
+    return GetBufferProperty(inputs_, output_idx, [](auto &buf) { return buf->sample_dim(); });
   }
 
   /**
@@ -319,8 +297,8 @@ class WorkspaceBase : public ArgumentWorkspace {
    */
   template <typename Backend>
   bool InputIsType(int idx) const {
-    DALI_ENFORCE_VALID_INDEX(idx, input_index_map_.size());
-    return input_index_map_[idx].storage_device == backend_to_storage_device<Backend>::value;
+    DALI_ENFORCE_VALID_INDEX(idx, inputs_.size());
+    return inputs_[idx].device == backend_to_storage_device<Backend>::value;
   }
 
   /**
@@ -329,56 +307,8 @@ class WorkspaceBase : public ArgumentWorkspace {
    */
   template <typename Backend>
   bool OutputIsType(int idx) const {
-    DALI_ENFORCE_VALID_INDEX(idx, output_index_map_.size());
-    return output_index_map_[idx].storage_device == backend_to_storage_device<Backend>::value;
-  }
-
-  /**
-   * @brief Adds new CPU input.
-   */
-  void AddInput(DataObjectPtr<CPUBackend> input) {
-    AddHelper(input, &cpu_inputs_, &cpu_inputs_index_, &input_index_map_, StorageDevice::CPU);
-  }
-
-  /**
-   * @brief Adds new GPU input.
-   */
-  void AddInput(DataObjectPtr<GPUBackend> input) {
-    AddHelper(input, &gpu_inputs_, &gpu_inputs_index_, &input_index_map_, StorageDevice::GPU);
-  }
-
-  /**
-   * @brief Sets the CPU input at the specified index to the given input argument
-   */
-  void SetInput(int idx, DataObjectPtr<CPUBackend> input) {
-    SetHelper<DataObjectPtr, CPUBackend>(
-      idx,
-      input,
-      &cpu_inputs_,
-      &cpu_inputs_index_,
-      &input_index_map_,
-      &cpu_inputs_,
-      &cpu_inputs_index_,
-      &gpu_inputs_,
-      &gpu_inputs_index_,
-      StorageDevice::CPU);
-  }
-
-  /**
-   * @brief Sets the GPU input at the specified index to the given input argument
-   */
-  void SetInput(int idx, DataObjectPtr<GPUBackend> input) {
-    SetHelper<DataObjectPtr, GPUBackend>(
-      idx,
-      input,
-      &gpu_inputs_,
-      &gpu_inputs_index_,
-      &input_index_map_,
-      &cpu_inputs_,
-      &cpu_inputs_index_,
-      &gpu_inputs_,
-      &gpu_inputs_index_,
-      StorageDevice::GPU);
+    DALI_ENFORCE_VALID_INDEX(idx, outputs_.size());
+    return outputs_[idx].device == backend_to_storage_device<Backend>::value;
   }
 
   inline void SetThreadPool(ThreadPool *pool) {
@@ -451,80 +381,56 @@ class WorkspaceBase : public ArgumentWorkspace {
   inline span<const cudaEvent_t> ParentEvents() const { return make_cspan(parent_events_); }
 
   /**
+   * @brief Adds a new input
+   *
+   * This overload can be useful when there's an automatic conversion, e.g. from a nullptr
+   * ws.AddInput<CPUBackend>(nullptr);
+   */
+  template <typename Backend>
+  void AddInput(DataObjectPtr<Backend> input) {
+    AddInput(input);
+  }
+
+  /**
+   * @brief Adds new CPU input
+   */
+  void AddInput(DataObjectPtr<CPUBackend> input) {
+    inputs_.push_back(IOBuffers{ StorageDevice::CPU, std::move(input), nullptr });
+  }
+
+  /**
+   * @brief Adds new GPU input
+   */
+  void AddInput(DataObjectPtr<GPUBackend> input) {
+    inputs_.push_back(IOBuffers{ StorageDevice::GPU, nullptr, std::move(input) });
+  }
+
+
+  /**
+   * @brief Adds a new output
+   *
+   * This overload can be useful when there's an automatic conversion, e.g. from a nullptr
+   * ws.AddOutput<CPUBackend>(nullptr);
+   */
+  template <typename Backend>
+  void AddOutput(DataObjectPtr<Backend> output) {
+    AddOutput(output);
+  }
+
+  /**
    * @brief Adds new CPU output
    */
   void AddOutput(DataObjectPtr<CPUBackend> output) {
-    AddHelper(output, &cpu_outputs_, &cpu_outputs_index_, &output_index_map_, StorageDevice::CPU);
+    outputs_.push_back(IOBuffers{ StorageDevice::CPU, std::move(output), nullptr });
   }
 
   /**
    * @brief Adds new GPU output
    */
   void AddOutput(DataObjectPtr<GPUBackend> output) {
-    AddHelper(output, &gpu_outputs_, &gpu_outputs_index_, &output_index_map_, StorageDevice::GPU);
+    outputs_.push_back(IOBuffers{ StorageDevice::GPU, nullptr, std::move(output) });
   }
 
-  /**
-   * @brief Sets the CPU output at the specified index
-   */
-  void SetOutput(int idx, DataObjectPtr<CPUBackend> output) {
-    SetHelper<DataObjectPtr, CPUBackend>(
-      idx,
-      output,
-      &cpu_outputs_,
-      &cpu_outputs_index_,
-      &output_index_map_,
-      &cpu_outputs_,
-      &cpu_outputs_index_,
-      &gpu_outputs_,
-      &gpu_outputs_index_,
-      StorageDevice::CPU);
-  }
-
-  /**
-   * @brief Sets the GPU output at the specified index
-   */
-  void SetOutput(int idx, DataObjectPtr<GPUBackend> output) {
-    SetHelper<DataObjectPtr, GPUBackend>(
-      idx,
-      output,
-      &gpu_outputs_,
-      &gpu_outputs_index_,
-      &output_index_map_,
-      &cpu_outputs_,
-      &cpu_outputs_index_,
-      &gpu_outputs_,
-      &gpu_outputs_index_,
-      StorageDevice::GPU);
-  }
-
-  /**
-   * @brief Returns reference to internal CPU output object at index `idx`.
-   *
-   * @throws runtime_error if the calling type does not match the
-   * type of the tensor at the given index
-   */
-  DataObjectPtr<CPUBackend> SharedCPUOutput(int idx) {
-    DALI_ENFORCE_VALID_INDEX(idx, output_index_map_.size());
-    auto tensor_meta = output_index_map_[idx];
-    DALI_ENFORCE(tensor_meta.storage_device == StorageDevice::CPU, "Output with given "
-        "index does not have the calling backend type (CPUBackend)");
-    return cpu_outputs_[tensor_meta.index];
-  }
-
-  /**
-   * @brief Returns reference to internal GPU output object at index `idx`.
-   *
-   * @throws runtime_error if the calling type does not match the
-   * type of the tensor at the given index
-   */
-  DataObjectPtr<GPUBackend> SharedGPUOutput(int idx) {
-    DALI_ENFORCE_VALID_INDEX(idx, output_index_map_.size());
-    auto tensor_meta = output_index_map_[idx];
-    DALI_ENFORCE(tensor_meta.storage_device == StorageDevice::GPU, "Output with given "
-        "index does not have the calling backend type (GPUBackend)");
-    return gpu_outputs_[tensor_meta.index];
-  }
 
   /**
    * @brief Returns the index of the sample that this workspace stores
@@ -639,118 +545,42 @@ class WorkspaceBase : public ArgumentWorkspace {
 
 
  protected:
-  struct InOutMeta {
-    // Storage device of given Input/Output
-    StorageDevice storage_device;
-    // Position in dedicated buffer for given storage_device
-    int index;
-
-    InOutMeta() : storage_device(static_cast<StorageDevice>(-1)), index(-1) {}
-    InOutMeta(StorageDevice storage_device, int index)
-        : storage_device(storage_device), index(index) {}
-  };
-
-  template <typename T>
-  void AddHelper(T entry,
-                 vector<T>* vec,
-                 vector<int>* index,
-                 vector<InOutMeta>* index_map,
-                 StorageDevice storage_device) {
-    // Save the vector of tensors
-    vec->push_back(entry);
-
-    // Update the input index map
-    index_map->emplace_back(storage_device, vec->size()-1);
-    index->push_back(index_map->size()-1);
+  template <typename Backend>
+  const DataObjectPtr<Backend>& InputHandle(int idx) const {
+    return InputHandle(idx, Backend{});
   }
 
-  template <template<typename> class T, typename Backend>
-  void SetHelper(int idx,
-                 T<Backend> entry,
-                 vector<T<Backend>>* vec,
-                 vector<int>* index,
-                 vector<InOutMeta>* index_map,
-                 vector<T<CPUBackend>>* cpu_vec,
-                 vector<int>* cpu_index,
-                 vector<T<GPUBackend>>* gpu_vec,
-                 vector<int>* gpu_index,
-                 StorageDevice storage_device
-                 ) {
-    DALI_ENFORCE_VALID_INDEX(idx, index_map->size());
-
-    // To remove the old input at `idx`, we need to remove it
-    // from its typed vector and update the index_map
-    // entry for all the elements in the vector following it.
-    auto tensor_meta = (*index_map)[idx];
-    if (tensor_meta.storage_device == StorageDevice::CPU) {
-      for (size_t i = tensor_meta.index; i < cpu_vec->size(); ++i) {
-        int &input_idx = (*index_map)[(*cpu_index)[i]].index;
-        --input_idx;
-      }
-      cpu_vec->erase(cpu_vec->begin() + tensor_meta.index);
-      cpu_index->erase(cpu_index->begin() + tensor_meta.index);
-    } else {
-      for (size_t i = tensor_meta.index; i < gpu_vec->size(); ++i) {
-        int &input_idx = (*index_map)[(*gpu_index)[i]].index;
-        --input_idx;
-      }
-      gpu_vec->erase(gpu_vec->begin() + tensor_meta.index);
-      gpu_index->erase(gpu_index->begin() + tensor_meta.index);
-    }
-
-    // Now we insert the new input and update its meta data
-    vec->push_back(entry);
-    index->push_back(idx);
-    (*index_map)[idx] = InOutMeta(storage_device, vec->size()-1);
+  template <typename Backend>
+  const DataObjectPtr<Backend>& OutputHandle(int idx) const {
+    return OutputHandle(idx, Backend{});
   }
-
 
   const DataObjectPtr<CPUBackend>& InputHandle(int idx, const CPUBackend&) const {
-    return CPUInput(idx);
+    DALI_ENFORCE_VALID_INDEX(idx, NumInput());
+    DALI_ENFORCE(inputs_[idx].device == StorageDevice::CPU,
+      make_string("The input ", idx, " is not on the requested device (CPU)."));
+    return inputs_[idx].cpu;
   }
 
   const DataObjectPtr<GPUBackend>& InputHandle(int idx, const GPUBackend&) const {
-    return GPUInput(idx);
+    DALI_ENFORCE_VALID_INDEX(idx, NumInput());
+    DALI_ENFORCE(inputs_[idx].device == StorageDevice::GPU,
+      make_string("The input ", idx, " is not on the requested device (GPU)."));
+    return inputs_[idx].gpu;
   }
 
   const DataObjectPtr<CPUBackend>& OutputHandle(int idx, const CPUBackend&) const {
-    return CPUOutput(idx);
+    DALI_ENFORCE_VALID_INDEX(idx, NumOutput());
+    DALI_ENFORCE(outputs_[idx].device == StorageDevice::CPU,
+      make_string("The output ", idx, " is not on the requested device (CPU)."));
+    return outputs_[idx].cpu;
   }
 
   const DataObjectPtr<GPUBackend>& OutputHandle(int idx, const GPUBackend&) const {
-    return GPUOutput(idx);
-  }
-
-  inline const DataObjectPtr<GPUBackend>& GPUInput(int idx) const {
-    auto tensor_meta = FetchAtIndex(input_index_map_, idx);
-    DALI_ENFORCE(tensor_meta.storage_device == StorageDevice::GPU, "Input with given "
-        "index (" + std::to_string(idx) +
-        ") does not have the calling backend type (GPUBackend)");
-    return gpu_inputs_[tensor_meta.index];
-  }
-
-  inline const DataObjectPtr<CPUBackend>& CPUInput(int idx) const {
-    auto tensor_meta = FetchAtIndex(input_index_map_, idx);
-    DALI_ENFORCE(tensor_meta.storage_device == StorageDevice::CPU, "Input with given "
-        "index (" + std::to_string(idx) +
-        ") does not have the calling backend type (CPUBackend)");
-    return cpu_inputs_[tensor_meta.index];
-  }
-
-  inline const DataObjectPtr<GPUBackend>& GPUOutput(int idx) const {
-    auto tensor_meta = FetchAtIndex(output_index_map_, idx);
-    DALI_ENFORCE(tensor_meta.storage_device == StorageDevice::GPU,
-                 make_string("Output with given index (", idx,
-                             ") does not have the calling backend type (GPUBackend)"));
-    return gpu_outputs_[tensor_meta.index];
-  }
-
-  inline const DataObjectPtr<CPUBackend>& CPUOutput(int idx) const {
-    auto tensor_meta = FetchAtIndex(output_index_map_, idx);
-    DALI_ENFORCE(tensor_meta.storage_device == StorageDevice::CPU,
-                 make_string("Output with given index (", idx,
-                             ") does not have the calling backend type (CPUBackend)"));
-    return cpu_outputs_[tensor_meta.index];
+    DALI_ENFORCE_VALID_INDEX(idx, NumOutput());
+    DALI_ENFORCE(outputs_[idx].device == StorageDevice::GPU,
+      make_string("The output ", idx, " is not on the requested device (GPU)."));
+    return outputs_[idx].gpu;
   }
 
   /**
@@ -758,31 +588,28 @@ class WorkspaceBase : public ArgumentWorkspace {
    */
   SmallVector<int, 4> batch_sizes_;
 
-  vector<DataObjectPtr<CPUBackend>> cpu_inputs_;
-  vector<DataObjectPtr<CPUBackend>> cpu_outputs_;
-  vector<DataObjectPtr<GPUBackend>> gpu_inputs_;
-  vector<DataObjectPtr<GPUBackend>> gpu_outputs_;
+  struct IOBuffers {
+    StorageDevice device;
+    DataObjectPtr<CPUBackend> cpu;
+    DataObjectPtr<GPUBackend> gpu;
 
-  // Maps from a Tensor position in its typed vector
-  // to its absolute position in the workspaces outputs
-  vector<int> cpu_inputs_index_, gpu_inputs_index_;
-  vector<int> cpu_outputs_index_, gpu_outputs_index_;
-  // Used to map input/output tensor indices (0, 1, ... , num_input-1)
-  // to actual tensor objects. The first element indicates if the
-  // Tensor is stored on cpu, and the second element is the index of
-  // that tensor in the {cpu, gpu}_inputs_ vector.
-  vector<InOutMeta> input_index_map_, output_index_map_;
+    template <typename Backend>
+    DataObjectPtr<Backend> &get(Backend = {}) {
+      static_assert(std::is_same_v<Backend, CPUBackend> || std::is_same_v<Backend, GPUBackend>);
+      if constexpr (std::is_same_v<Backend, CPUBackend>) {
+        DALI_ENFORCE(device == StorageDevice::CPU);
+        return cpu;
+      } else {
+        DALI_ENFORCE(device == StorageDevice::GPU);
+        return gpu;
+      }
+    }
+  };
+
+  SmallVector<IOBuffers, 4> inputs_;
+  SmallVector<IOBuffers, 2> outputs_;
 
  private:
-  inline const InOutMeta& FetchAtIndex(const vector<InOutMeta>& index_map, int idx) const {
-    DALI_ENFORCE(idx >= 0 && idx < (int) index_map.size(),
-      "Index out of range." + std::to_string(idx) +
-      " not in range [0, " + std::to_string(index_map.size())
-      + ")");
-    return index_map[idx];
-  }
-
-
   AccessOrder output_order_ = AccessOrder::host();
   ThreadPool *thread_pool_ = nullptr;
   cudaEvent_t event_ = nullptr;

--- a/dali/test/python/operator_1/test_affine_transforms.py
+++ b/dali/test/python/operator_1/test_affine_transforms.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ def check_results_sample(T1, mat_ref, T0=None, reverse=False, atol=1e-6):
         ref_T1 = mat_T1[:ndim, :]
     else:
         ref_T1 = mat_ref[:ndim, :]
-    assert np.allclose(T1, ref_T1, atol=1e-6)
+    assert np.allclose(T1, ref_T1, atol=atol)
 
 
 def check_results(T1, batch_size, mat_ref, T0=None, reverse=False, atol=1e-6):
@@ -248,7 +248,7 @@ def check_transform_rotation_op(
         T0 = out_T0.at(idx) if has_input else None
         angle = out_angle.at(idx) if random_angle else angle
         ref_mat = rotate_affine_mat(angle=angle, axis=axis, center=center)
-        check_results_sample(outs[0].at(idx), ref_mat, T0, reverse_order, atol=1e-6)
+        check_results_sample(outs[0].at(idx), ref_mat, T0, reverse_order, atol=2e-6)
 
 
 def test_transform_rotation_op(batch_size=3, num_threads=4, device_id=0):


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
### Workspace
* Workspace object contained very convoluted indexing structure. It's not necessary nor beneficial.
* There was a lot of dead code
* Some functions could be called with `<Backend>`, some not; some functions could be called with a `Backend()` argument, some not - this has been unified.
* Argument workspace didn't repsect any particular order of arguments, which will be required for rapid repopulation of workspaces. The argument input indices will now match those found in OpSpec.
* ArgumentWorkspace (and transitively, Workspace) were iterable - the iteration, however, was rather counterintuitive in derived classes. Now one has to call `.ArgumentInputs()` member to get a collection of argument inputs.
### OpSpec
* OpSpec now yields the arguments and argument inputs in the order of addition as opposed to an unpredictable order from unordered_map
* Linear-time lookup by index is replaced with constant-time lookup in an array
* Complexity of lookup by name is maintained

## Additional information:
This change affects the order of operators in the graph. As a butterfly effect, some seeds are different and some tests needed an adjustment of tolerance values.

### Affected modules and functionalities:
Workspace, executor, some operators.
OpSpec

### Key points relevant for the review:
The (almost completely new) contents of `workspace.h`.

### Tests:
Every test that touches workspaces? The API hasn't changed beyond the removal of unused members or adding new overloads.
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
