### PR TITLE
Add error message when GPU is not available

### DIFF
--- a/dali/core/dynlink_cuda.cc
+++ b/dali/core/dynlink_cuda.cc
@@ -35,7 +35,7 @@ CUDADRIVER loadCudaLibrary() {
     ret = dlopen(__CudaLibName, RTLD_NOW);
 
     if (!ret) {
-      fprintf(stderr, "dlopen libcuda.so failed!. Please install GPU dirver");
+      fprintf(stderr, "dlopen libcuda.so failed. Please install GPU driver.");
     }
   }
   return ret;

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -180,6 +180,11 @@ void Pipeline::Init(int max_batch_size, int num_threads, int device_id, int64_t 
                     bool pipelined_execution, bool separated_execution, bool async_execution,
                     size_t bytes_per_sample_hint, bool set_affinity, int max_num_stream,
                     int default_cuda_stream_priority, QueueSizes prefetch_queue_depth) {
+    DALI_ENFORCE(cuInitChecked() || device_id == CPU_ONLY_DEVICE_ID, 
+                "You are trying to create a GPU DALI pipeline, while CUDA is not available. "
+                "Please install CUDA or set `device_id = None` in Pipeline constructor. "
+                "If running inside Docker container, you may need to pass `--gpus all` option.");
+
     // guard cudaDeviceGetStreamPriorityRange call
     DeviceGuard g(device_id);
     this->max_batch_size_ = max_batch_size;

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -183,7 +183,7 @@ void Pipeline::Init(int max_batch_size, int num_threads, int device_id, int64_t 
     DALI_ENFORCE(device_id == CPU_ONLY_DEVICE_ID || cuInitChecked(),
                 "You are trying to create a GPU DALI pipeline, while CUDA is not available. "
                 "Please install CUDA or set `device_id = None` in Pipeline constructor. "
-                "If running inside Docker container, you may need to pass `--gpus all` option.");
+                "If running inside Docker container, you may need to use  `--gpus` option.");
 
     // guard cudaDeviceGetStreamPriorityRange call
     DeviceGuard g(device_id);

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -180,7 +180,7 @@ void Pipeline::Init(int max_batch_size, int num_threads, int device_id, int64_t 
                     bool pipelined_execution, bool separated_execution, bool async_execution,
                     size_t bytes_per_sample_hint, bool set_affinity, int max_num_stream,
                     int default_cuda_stream_priority, QueueSizes prefetch_queue_depth) {
-    DALI_ENFORCE(cuInitChecked() || device_id == CPU_ONLY_DEVICE_ID, 
+    DALI_ENFORCE(cuInitChecked() || device_id == CPU_ONLY_DEVICE_ID,
                 "You are trying to create a GPU DALI pipeline, while CUDA is not available. "
                 "Please install CUDA or set `device_id = None` in Pipeline constructor. "
                 "If running inside Docker container, you may need to pass `--gpus all` option.");

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -180,7 +180,7 @@ void Pipeline::Init(int max_batch_size, int num_threads, int device_id, int64_t 
                     bool pipelined_execution, bool separated_execution, bool async_execution,
                     size_t bytes_per_sample_hint, bool set_affinity, int max_num_stream,
                     int default_cuda_stream_priority, QueueSizes prefetch_queue_depth) {
-    DALI_ENFORCE(cuInitChecked() || device_id == CPU_ONLY_DEVICE_ID,
+    DALI_ENFORCE(device_id == CPU_ONLY_DEVICE_ID || cuInitChecked(),
                 "You are trying to create a GPU DALI pipeline, while CUDA is not available. "
                 "Please install CUDA or set `device_id = None` in Pipeline constructor. "
                 "If running inside Docker container, you may need to pass `--gpus all` option.");

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -134,7 +134,7 @@ def test_gpu_op_bad_device():
     device_ids = [None, 0]
     error_msgs = [
         "Cannot add a GPU operator ExternalSource, device_id should not be equal CPU_ONLY_DEVICE_ID.",  # noqa: E501
-        "Failed to load libcuda.so. Check your library paths and if the driver is installed correctly.",  # noqa: E501
+        "You are trying to create a GPU DALI pipeline, while CUDA is not available.*",
     ]
 
     for device_id, error_msg in zip(device_ids, error_msgs):
@@ -153,7 +153,7 @@ def test_mixed_op_bad_device():
     device_ids = [None, 0]
     error_msgs = [
         "Cannot add a mixed operator decoders__Image with a GPU output, device_id should not be CPU_ONLY_DEVICE_ID.",  # noqa: E501
-        "Failed to load libcuda.so. Check your library paths and if the driver is installed correctly.",  # noqa: E501
+        "You are trying to create a GPU DALI pipeline, while CUDA is not available.*",
     ]
 
     for device_id, error_msg in zip(device_ids, error_msgs):


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Other** (*e.g. Documentation, Tests, Configuration*)

## Description:
Currently, when DALI pipeline is created in Triton, but user forgets to pass `--gpus` flag to the run command, he gets an obscure error message:
```
dlopen libcuda.so failed!. Please install GPU dirverTraceback (most recent call last):
  File "<string>", line 8, in <module>
  File "/opt/tritonserver/backends/dali/conda/envs/dalienv/lib/python3.10/site-packages/nvidia/dali/_utils/autoserialize.py", line 77, in invoke_autoserialize
    dali_pipeline().serialize(filename=filename)
  File "/opt/tritonserver/backends/dali/conda/envs/dalienv/lib/python3.10/site-packages/nvidia/dali/pipeline.py", line 1261, in serialize
    self._init_pipeline_backend()
  File "/opt/tritonserver/backends/dali/conda/envs/dalienv/lib/python3.10/site-packages/nvidia/dali/pipeline.py", line 725, in _init_pipeline_backend
    self._pipe = b.Pipeline(self._max_batch_size,
RuntimeError: [/opt/dali/dali/core/device_guard.cc:31] Assert on "cuInitChecked()" failed: Failed to load libcuda.so. Check your library paths and if the driver is installed correctly.
Stacktrace (31 entries):
[frame 0]: /opt/tritonserver/backends/dali/conda/envs/dalienv/lib/python3.10/site-packages/nvidia/dali/libdali_core.so(+0x233fb) [0x7fed69bb13fb]
[frame 1]: /opt/tritonserver/backends/dali/conda/envs/dalienv/lib/python3.10/site-packages/nvidia/dali/libdali_core.so(dali::DeviceGuard::DeviceGuard(int)+0x1a8) [0x7fed69bd4548]
[frame 2]: /opt/tritonserver/backends/dali/conda/envs/dalienv/lib/python3.10/site-packages/nvidia/dali/libdali.so(dali::Pipeline::Init(int, int, int, long, bool, bool, bool, unsigned long, bool, int, int, dali::QueueSizes)+0x50) [0x7fed6f81a620]
[frame 3]: /opt/tritonserver/backends/dali/conda/envs/dalienv/lib/python3.10/site-packages/nvidia/dali/backend_impl.cpython-310-x86_64-linux-gnu.so(dali::Pipeline::Pipeline(int, int, int, long, bool, int, bool, unsigned long, bool, int, int)+0x363) [0x7fed64c05a53]
```
This PR introduces more descriptive error message.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
