### PR TITLE
[Cutmix] Make fn.multi_paste more flexible, fix validation

### DIFF
--- a/dali/kernels/imgproc/paste/paste_gpu.h
+++ b/dali/kernels/imgproc/paste/paste_gpu.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ template<class InputType, int ndims>
 struct PatchDesc {
   const InputType *in;
   int in_sample_idx;
+  int in_batch_idx;
   ivec<ndims> patch_start, patch_end, in_anchor, in_pitch;
 };
 
@@ -53,7 +54,7 @@ template <class OutputType, class InputType, int ndims>
 void FillPointers(span<SampleDescriptorGPU<OutputType, InputType, ndims - 1>> descs,
                   span<PatchDesc<InputType, ndims - 1>> patches,
                   const OutListGPU<OutputType, ndims> &out,
-                  const InListGPU<InputType, ndims> &in) {
+                  const span<InListGPU<InputType, ndims>> &ins) {
   int batch_size = descs.size();
 
   for (int i = 0; i < batch_size; i++) {
@@ -61,7 +62,7 @@ void FillPointers(span<SampleDescriptorGPU<OutputType, InputType, ndims - 1>> de
   }
 
   for (auto &p : patches) {
-    p.in = p.in_sample_idx < 0 ? nullptr : in.data[p.in_sample_idx];
+    p.in = p.in_sample_idx < 0 ? nullptr : ins[p.in_batch_idx].data[p.in_sample_idx];
   }
 }
 
@@ -73,9 +74,9 @@ void FillPointers(span<SampleDescriptorGPU<OutputType, InputType, ndims - 1>> de
  */
 template <class OutputType, class InputType, int ndims>
 void CreateSampleDescriptors(
-    vector<SampleDescriptorGPU<OutputType, InputType, ndims - 1>> &out_descs,
-    vector<PatchDesc<InputType, ndims - 1>> &out_patches,
-    const TensorListShape<ndims> &in_shape,
+    std::vector<SampleDescriptorGPU<OutputType, InputType, ndims - 1>> &out_descs,
+    std::vector<PatchDesc<InputType, ndims - 1>> &out_patches,
+    const span<TensorListShape<ndims>> &in_shapes,
     span<paste::MultiPasteSampleInput<ndims - 1>> samples) {
   static_assert(ndims == 3, "Only 2D data with channels supported");
 
@@ -174,8 +175,11 @@ void CreateSampleDescriptors(
           patch.patch_end[1] = scaled_x_to_x[x + 1];
           patch.in = nullptr;  // to be filled later
           patch.in_sample_idx = max_paste == -1 ? -1 : sample.inputs[max_paste].in_idx;
+          patch.in_batch_idx = max_paste == -1 ? -1 : sample.inputs[max_paste].batch_idx;
           patch.in_pitch[0] = 0;
-          patch.in_pitch[1] = max_paste == -1 ? -1 : in_shape[sample.inputs[max_paste].in_idx][1];
+          int mp_in_idx = sample.inputs[max_paste].in_idx;
+          int mp_batch_idx = sample.inputs[max_paste].batch_idx;
+          patch.in_pitch[1] = max_paste == -1 ? -1 : in_shapes[mp_batch_idx][mp_in_idx][1];
 
           if (max_paste != -1) {
             patch.in_anchor[0] = sample.inputs[max_paste].in_anchor[0] +
@@ -263,8 +267,8 @@ class PasteGPU {
       KernelContext &context,
       span<paste::MultiPasteSampleInput<spatial_dims>> samples,
       const TensorListShape<ndims> &out_shape,
-      const TensorListShape<ndims> &in_shape) {
-    paste::CreateSampleDescriptors(sample_descriptors_, patch_descriptors_, in_shape, samples);
+      const span<TensorListShape<ndims>> &in_shapes) {
+    paste::CreateSampleDescriptors(sample_descriptors_, patch_descriptors_, in_shapes, samples);
 
     KernelRequirements req;
     ScratchpadEstimator se;
@@ -283,8 +287,8 @@ class PasteGPU {
   void Run(
       KernelContext &context,
       const OutListGPU<OutputType, ndims> &out,
-      const InListGPU<InputType, ndims> &in) {
-    paste::FillPointers(make_span(sample_descriptors_), make_span(patch_descriptors_), out, in);
+      const span<InListGPU<InputType, ndims>> &ins) {
+    paste::FillPointers(make_span(sample_descriptors_), make_span(patch_descriptors_), out, ins);
 
     SampleDesc *samples_gpu;
     PatchDesc  *patches_gpu;

--- a/dali/kernels/imgproc/paste/paste_gpu.h
+++ b/dali/kernels/imgproc/paste/paste_gpu.h
@@ -174,14 +174,17 @@ void CreateSampleDescriptors(
           patch.patch_end[0] = scaled_y_to_y[y + 1];
           patch.patch_end[1] = scaled_x_to_x[x + 1];
           patch.in = nullptr;  // to be filled later
-          patch.in_sample_idx = max_paste == -1 ? -1 : sample.inputs[max_paste].in_idx;
-          patch.in_batch_idx = max_paste == -1 ? -1 : sample.inputs[max_paste].batch_idx;
           patch.in_pitch[0] = 0;
-          int mp_in_idx = sample.inputs[max_paste].in_idx;
-          int mp_batch_idx = sample.inputs[max_paste].batch_idx;
-          patch.in_pitch[1] = max_paste == -1 ? -1 : in_shapes[mp_batch_idx][mp_in_idx][1];
-
-          if (max_paste != -1) {
+          if (max_paste == -1) {
+            patch.in_sample_idx = -1;
+            patch.in_batch_idx = -1;
+            patch.in_pitch[1] = -1;
+          } else {
+            patch.in_sample_idx = sample.inputs[max_paste].in_idx;
+            patch.in_batch_idx = sample.inputs[max_paste].batch_idx;
+            int mp_in_idx = sample.inputs[max_paste].in_idx;
+            int mp_batch_idx = sample.inputs[max_paste].batch_idx;
+            patch.in_pitch[1] = in_shapes[mp_batch_idx][mp_in_idx][1];
             patch.in_anchor[0] = sample.inputs[max_paste].in_anchor[0] +
                               patch.patch_start[0] - sample.inputs[max_paste].out_anchor[0];
             patch.in_anchor[1] = sample.inputs[max_paste].in_anchor[1] +

--- a/dali/kernels/imgproc/paste/paste_gpu_input.h
+++ b/dali/kernels/imgproc/paste/paste_gpu_input.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,9 +25,10 @@ template <int ndims>
 struct MultiPasteSampleInput {
   struct InputPatch {
     ivec<ndims> out_anchor, in_anchor, size;
-    int in_idx;
+    int in_idx; // which sample in the batch
+    int batch_idx; // which batch
   };
-  vector<InputPatch> inputs;
+  std::vector<InputPatch> inputs;
   ivec<ndims> out_size;
   int channels;
 };

--- a/dali/kernels/imgproc/paste/paste_gpu_input.h
+++ b/dali/kernels/imgproc/paste/paste_gpu_input.h
@@ -25,8 +25,8 @@ template <int ndims>
 struct MultiPasteSampleInput {
   struct InputPatch {
     ivec<ndims> out_anchor, in_anchor, size;
-    int in_idx; // which sample in the batch
-    int batch_idx; // which batch
+    int in_idx;  // which sample in the batch
+    int batch_idx;  // which batch
   };
   std::vector<InputPatch> inputs;
   ivec<ndims> out_size;

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,44 +19,83 @@
 namespace dali {
 
 DALI_SCHEMA(MultiPaste)
-.DocStr(R"code(Performs multiple pastes from image batch to each of outputs
+    .DocStr(R"code(Performs multiple pastes from image batch to each of the outputs.
+
+If the `in_ids` is specified, the operator expects exactly one input batch.
+In that case, for each output sample, `in_ids` describe which samples
+from the input batch should be pasted to the corresponding sample
+in the output batch.
+
+If the `in_ids` argument is omitted, the operator accepts multiple inputs.
+In that case, the i-th sample from each input batch will be pasted to the
+i-th sample of the output batch. All the input batches must have the same
+type and device placement.
+
+If the input shapes are uniform and no explicit `output_size` is provided,
+the operator assumes the same output shape. Otherwise, the `output_size`
+must be specified.
 
 This operator can also change the type of data.)code")
-.NumInput(1)
-.InputDox(0, "images", "3D TensorList", R"code(Batch of input images.
+    .NumInput(1, 64)
+    .AllowSequences()
+    .InputLayout({"HWC", "FHWC"})
+    .AddOptionalArg<std::vector<int>>("in_ids", R"code(Indices of the inputs to paste data from.
 
-Assumes HWC layout.)code")
-.AddArg("in_ids", R"code(Indices of the inputs to paste data from.)code",
-        DALI_INT_VEC, true)
-.AddOptionalArg<int>("in_anchors", R"code(Absolute coordinates of LU corner
+If specified, the operator accepts exactly one batch as an input.)code",
+                                      {}, true)
+    .AddOptionalArg<int>("in_anchors", R"code(Absolute coordinates of LU corner
 of the source region.
 
 The anchors are represented as 2D tensors where the first dimension corresponds to the
-elements of ``in_ids`` and the second one is equal to the number of dimensions of the
+number of pasted regions and the second one is equal to the number of dimensions of the
 data, excluding channels.
 
-If not provided, all anchors are zero.)code", nullptr, true)
-.AddOptionalArg<int>("shapes", R"code(Shape of the paste regions.
+If neither `in_anchors` nor `in_anchors_rel` are provided, all anchors are zero.)code",
+                         nullptr, true, true)
+    .AddOptionalArg<float>("in_anchors_rel", R"code(Relative coordinates of LU corner
+of the source region.
+
+The argument works like `in_anchors`, but the values should be floats in `[0, 1]` range,
+describing the anchor placement relative to the input sample shape.)code",
+                           nullptr, true, true)
+    .AddOptionalArg<int>("shapes", R"code(Shape of the paste regions.
 
 The shapes are represented as 2D tensors where the first dimension corresponds to the
-elements of ``in_ids`` and the second one is equal to the number of dimensions of the
+number of pasted regions and the second one is equal to the number of dimensions of the
 data, excluding channels.
 
-If not provided, the shape is calculated so that the region goes from the region anchor
- in the input image until the end of the input image.)code", nullptr, true)
-.AddOptionalArg<int>("out_anchors", R"code(Absolute coordinates of LU corner
+If neither `shapes` nor `shapes_rel` are provided, the shape is calculated so that
+the region goes from the region anchor in the input image until the end
+of the input image.)code",
+                         nullptr, true, true)
+    .AddOptionalArg<float>("shapes_rel", R"code(Relative shape of the paste regions.
+
+Works like `shape` argument, but the values should be floats in `[0, 1]` range,
+describing the paste region shape relative to the input shape.)code",
+                           nullptr, true, true)
+    .AddOptionalArg<int>("out_anchors", R"code(Absolute coordinates of LU corner
 of the destination region.
 
 The anchors are represented as 2D tensors where the first dimension corresponds to the
-elements of ``in_ids`` and the second one is equal to the number of dimensions of the
+number of pasted regions and the second one is equal to the number of dimensions of the
 data, excluding channels.
 
-If not provided, all anchors are zero.)code", nullptr, true)
-.AddArg("output_size",
-R"code(Shape of the output.)code", DALI_INT_VEC, true)
-.AddOptionalTypeArg("dtype",
-R"code(Output data type. If not set, the input type is used.)code")
-.NumOutput(1);
+In neither `out_anchors` nor `out_anchors_rel` are provided, all anchors are zero.)code",
+                         nullptr, true, true)
+    .AddOptionalArg<float>("out_anchors_rel", R"code(Absolute coordinates of LU corner
+of the destination region.
+
+Works like `out_anchors` argument, but the values should be floats in `[0, 1]` range,
+describing the LU corner of the pasted region relative to the output shape.)code",
+                           nullptr, true, true)
+    .AddOptionalArg<std::vector<int>>("output_size",
+                                      R"code(A tuple (HW) describing the output shape.
+
+Can be omitted if the operator is run with inputs of uniform shape. In that case,
+the same shape is used as the output shape.)code",
+                                      {}, true)
+    .AddOptionalTypeArg("dtype", R"code(Output data type. If not set, the input type is used.)code")
+    .NumOutput(1);
 
 template <typename OutputType, typename InputType>
 void MultiPasteCPU::SetupTyped(const Workspace & /*ws*/,
@@ -68,10 +107,9 @@ void MultiPasteCPU::SetupTyped(const Workspace & /*ws*/,
 
 template <typename OutputType, typename InputType>
 void MultiPasteCPU::RunTyped(Workspace &ws) {
-  const auto &images = ws.Input<CPUBackend>(0);
   auto &output = ws.Output<CPUBackend>(0);
 
-  output.SetLayout(images.GetLayout());
+  output.SetLayout(ws.Input<CPUBackend>(0).GetLayout());
   auto out_shape = output.shape();
 
   auto& tp = ws.GetThreadPool();
@@ -79,53 +117,58 @@ void MultiPasteCPU::RunTyped(Workspace &ws) {
   auto batch_size = output.shape().num_samples();
 
   using Kernel = kernels::PasteCPU<OutputType, InputType>;
-  auto in_view = view<const InputType, 3>(images);
+
+  int num_inputs = ws.NumInput();
+  std::vector<TensorListView<StorageCPU, const InputType, 3>> in_views;
+  in_views.reserve(num_inputs);
+  for (int i = 0; i < num_inputs; i++) {
+    in_views.push_back(view<const InputType, 3>(ws.Input<CPUBackend>(i)));
+  }
   auto out_view = view<OutputType, 3>(output);
+
+  bool hasInIdx = in_idx_.HasExplicitValue();
   for (int i = 0; i < batch_size; i++) {
-    auto paste_count = in_idx_[i].shape[0];
+    auto paste_count = GetPasteCount(ws, i);
     memset(out_view[i].data, 0, out_view[i].num_elements() * sizeof(OutputType));
+    auto out_sample_shape = out_shape[i];
 
-    if (no_intersections_[i]) {
+    if (!HasIntersections(ws, i)) {
       for (int iter = 0; iter < paste_count; iter++) {
-        int from_sample = in_idx_[i].data[iter];
-        int to_sample = i;
-
         tp.AddWork(
-          [&, i, iter, from_sample, to_sample, in_view, out_view](int thread_id) {
+          [&, i, iter, out_sample_shape](int thread_id) {
             kernels::KernelContext ctx;
-            auto tvin = in_view[from_sample];
-            auto tvout = out_view[to_sample];
 
-            auto in_sh_view = GetInputShape(from_sample);
-            auto in_anchor_view = GetInAnchors(i, iter);
-            auto out_anchor_view = GetOutAnchors(i, iter);
-            auto region_shape = GetShape(i, iter, in_sh_view, in_anchor_view);
-            Coords region_shape_view{region_shape.data(), coords_sh_};
+            int sample_input = hasInIdx ? 0 : iter;
+            int sample_idx = hasInIdx ? in_idx_[i].data[iter] : i;
+            auto tvin = in_views[sample_input][sample_idx];
+            auto tvout = out_view[i];
+
+            Coords region_shape_view{&region_shapes_data_[i][iter][0], coords_sh_};
+            Coords in_anchor_view{&in_anchors_data_[i][iter][0], coords_sh_};
+            Coords out_anchor_view{&out_anchors_data_[i][iter][0], coords_sh_};
             kernel_manager_.Run<Kernel>(
-                    to_sample, ctx, tvout, tvin,
+                    i, ctx, tvout, tvin,
                     in_anchor_view, region_shape_view, out_anchor_view);
           },
-          out_shape.tensor_size(to_sample));
+          out_shape.tensor_size(i));
       }
     } else {
       tp.AddWork(
-        [&, i, paste_count, in_view, out_view](int thread_id) {
+        [&, i, paste_count, out_sample_shape](int thread_id) {
           for (int iter = 0; iter < paste_count; iter++) {
-            int from_sample = in_idx_[i].data[iter];
-            int to_sample = i;
 
             kernels::KernelContext ctx;
-            auto tvin = in_view[from_sample];
-            auto tvout = out_view[to_sample];
 
-            auto in_sh_view = GetInputShape(from_sample);
-            auto in_anchor_view = GetInAnchors(i, iter);
-            auto out_anchor_view = GetOutAnchors(i, iter);
-            auto region_shape = GetShape(i, iter, in_sh_view, in_anchor_view);
-            Coords region_shape_view{region_shape.data(), coords_sh_};
+            int sample_input = hasInIdx ? 0 : iter;
+            int sample_idx = hasInIdx ? in_idx_[i].data[iter] : i;
+            auto tvin = in_views[sample_input][sample_idx];
+            auto tvout = out_view[i];
 
+            Coords region_shape_view{&region_shapes_data_[i][iter][0], coords_sh_};
+            Coords in_anchor_view{&in_anchors_data_[i][iter][0], coords_sh_};
+            Coords out_anchor_view{&out_anchors_data_[i][iter][0], coords_sh_};
             kernel_manager_.Run<Kernel>(
-                    to_sample, ctx, tvout, tvin,
+                    i, ctx, tvout, tvin,
                     in_anchor_view, region_shape_view, out_anchor_view);
           }
         },

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -145,19 +145,18 @@ void MultiPasteCPU::RunTyped(Workspace &ws) {
   for (int i = 0; i < batch_size; i++) {
     auto paste_count = GetPasteCount(ws, i);
     memset(out_view[i].data, 0, out_view[i].num_elements() * sizeof(OutputType));
-    auto out_sample_shape = out_shape[i];
 
     if (!HasIntersections(ws, i)) {
       for (int iter = 0; iter < paste_count; iter++) {
         tp.AddWork(
-          [&, i, iter, out_sample_shape](int thread_id) {
+          [&, i, iter](int thread_id) {
             CopyPatch(out_view, in_views, i, iter);
           },
           out_shape.tensor_size(i));
       }
     } else {
       tp.AddWork(
-        [&, i, paste_count, out_sample_shape](int thread_id) {
+        [&, i, paste_count](int thread_id) {
           for (int iter = 0; iter < paste_count; iter++) {
             CopyPatch(out_view, in_views, i, iter);
           }

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -43,16 +43,15 @@ This operator can also change the type of data.)code")
 
 If specified, the operator accepts exactly one batch as an input.)code",
                                       {}, true)
-    .AddOptionalArg<int>("in_anchors", R"code(Absolute coordinates of LU corner
+    .AddOptionalArg<int>("in_anchors", R"code(Absolute coordinates of the top-left corner
 of the source region.
 
-The anchors are represented as 2D tensors where the first dimension corresponds to the
-number of pasted regions and the second one is equal to the number of dimensions of the
-data, excluding channels.
+The anchors are represented as 2D tensors where the first dimension is equal to the
+number of pasted regions and the second one is 2 (for the H and W extents).
 
 If neither `in_anchors` nor `in_anchors_rel` are provided, all anchors are zero.)code",
                          nullptr, true, true)
-    .AddOptionalArg<float>("in_anchors_rel", R"code(Relative coordinates of LU corner
+    .AddOptionalArg<float>("in_anchors_rel", R"code(Relative coordinates of the top-left corner
 of the source region.
 
 The argument works like `in_anchors`, but the values should be floats in `[0, 1]` range,
@@ -60,38 +59,35 @@ describing the anchor placement relative to the input sample shape.)code",
                            nullptr, true, true)
     .AddOptionalArg<int>("shapes", R"code(Shape of the paste regions.
 
-The shapes are represented as 2D tensors where the first dimension corresponds to the
-number of pasted regions and the second one is equal to the number of dimensions of the
-data, excluding channels.
+The shapes are represented as 2D tensors where the first dimension is equal to the
+number of pasted regions and the second one is 2 (for the H and W extents).
 
 If neither `shapes` nor `shapes_rel` are provided, the shape is calculated so that
-the region goes from the region anchor in the input image until the end
-of the input image.)code",
+the region spans from the input anchor until the end of the input image.)code",
                          nullptr, true, true)
     .AddOptionalArg<float>("shapes_rel", R"code(Relative shape of the paste regions.
 
 Works like `shape` argument, but the values should be floats in `[0, 1]` range,
 describing the paste region shape relative to the input shape.)code",
                            nullptr, true, true)
-    .AddOptionalArg<int>("out_anchors", R"code(Absolute coordinates of LU corner
+    .AddOptionalArg<int>("out_anchors", R"code(Absolute coordinates of the top-left corner
 of the pasted region in the output canvas.
 
-The anchors are represented as 2D tensors where the first dimension corresponds to the
-number of pasted regions and the second one is equal to the number of dimensions of the
-data, excluding channels.
+The anchors are represented as 2D tensors where the first dimension is equal to the
+number of pasted regions and the second one is 2 (for the H and W extents).
 
-In neither `out_anchors` nor `out_anchors_rel` are provided, all anchors are zero,
-making all the pasted region start at the top-left corner of the output canvas.)code",
+If neither `out_anchors` nor `out_anchors_rel` are provided, all anchors are zero,
+making all the pasted regions start at the top-left corner of the output canvas.)code",
                          nullptr, true, true)
-    .AddOptionalArg<float>("out_anchors_rel", R"code(Absolute coordinates of LU corner
+    .AddOptionalArg<float>("out_anchors_rel", R"code(Relative coordinates of the top-left corner
 of the pasted region in the output canvas.
 
 Works like `out_anchors` argument, but the values should be floats in `[0, 1]` range,
-describing the LU corner of the pasted region relative to the output canvas size.)code",
+describing the top-left corner of the pasted region relative to the output canvas size.)code",
                            nullptr, true, true)
     .AddOptionalArg<std::vector<int>>(
         "output_size",
-        R"code(A tuple (HW) describing the output shape
+        R"code(A tuple (H, W) describing the output shape
 (i.e. the size of the canvas for the output pastes).
 
 Can be omitted if the operator is run with inputs of uniform shape. In that case,

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -22,7 +22,7 @@ DALI_SCHEMA(MultiPaste)
     .DocStr(R"code(Performs multiple pastes from image batch to each of the outputs.
 
 If the `in_ids` is specified, the operator expects exactly one input batch.
-In that case, for each output sample, `in_ids` describe which samples
+In that case, for each output sample, `in_ids` describes which samples
 from the input batch should be pasted to the corresponding sample
 in the output batch.
 
@@ -156,7 +156,6 @@ void MultiPasteCPU::RunTyped(Workspace &ws) {
       tp.AddWork(
         [&, i, paste_count, out_sample_shape](int thread_id) {
           for (int iter = 0; iter < paste_count; iter++) {
-
             kernels::KernelContext ctx;
 
             int sample_input = hasInIdx ? 0 : iter;

--- a/dali/operators/image/paste/multipaste.cu
+++ b/dali/operators/image/paste/multipaste.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,29 +25,31 @@ inline void to_vec(vec<n, T> &out, Source &&src) {
     out[i] = src[i];
 }
 
-void MultiPasteGPU::InitSamples(const TensorListShape<> &out_shape) {
+void MultiPasteGPU::InitSamples(const Workspace &ws, const TensorListShape<> &out_shape) {
   assert(spatial_ndim_ == 2);
+  assert(out_shape.sample_dim() == 3);
   int batch_size = out_shape.num_samples();
   samples_.resize(batch_size);
+  bool hasInIdx = in_idx_.HasExplicitValue();
   for (int i = 0; i < batch_size; i++) {
     auto &sample = samples_[i];
-    int n = in_idx_[i].num_elements();
+    int n = GetPasteCount(ws, i);
 
     sample.inputs.resize(n);
-
-    sample.channels = 3;
+    sample.channels = out_shape[i][spatial_ndim_];
 
     to_vec(sample.out_size, out_shape[i]);
     for (int j = 0; j < n; j++) {
-      int from_sample = in_idx_[i].data[j];
-      auto in_anchor_view = GetInAnchors(i, j);
-      auto out_anchor_view = GetOutAnchors(i, j);
-      auto in_shape_view = GetInputShape(from_sample);
-      auto region_shape = GetShape(i, j, in_shape_view, in_anchor_view);
+      int batch_idx = hasInIdx ? 0 : j;
+      int in_idx = hasInIdx ? in_idx_[i].data[j] : i;
+      const auto &in_anchor = in_anchors_data_[i][j];
+      const auto &out_anchor = out_anchors_data_[i][j];
+      const auto &region_shape = region_shapes_data_[i][j];
       to_vec(sample.inputs[j].size,       region_shape);
-      to_vec(sample.inputs[j].in_anchor,  in_anchor_view.data);
-      to_vec(sample.inputs[j].out_anchor, out_anchor_view.data);
-      sample.inputs[j].in_idx = from_sample;
+      to_vec(sample.inputs[j].in_anchor,  in_anchor);
+      to_vec(sample.inputs[j].out_anchor, out_anchor);
+      sample.inputs[j].batch_idx = batch_idx;
+      sample.inputs[j].in_idx = in_idx;
     }
   }
 }
@@ -55,31 +57,38 @@ void MultiPasteGPU::InitSamples(const TensorListShape<> &out_shape) {
 template<typename OutputType, typename InputType>
 void MultiPasteGPU::SetupTyped(const Workspace &ws,
                                const TensorListShape<> &out_shape) {
-  const auto &images = ws.Input<GPUBackend>(0);
-  const auto &in = view<const InputType, 3>(images);
   using Kernel = kernels::PasteGPU<OutputType, InputType, 3>;
   kernels::KernelContext ctx;
   ctx.gpu.stream = ws.stream();
   kernel_manager_.Initialize<Kernel>();
-  InitSamples(out_shape);
+  InitSamples(ws, out_shape);
+  std::vector<TensorListShape<3>> in_shapes;
+  in_shapes.reserve(ws.NumInput());
+  for (int i = 0; i < ws.NumInput(); i++) {
+    in_shapes.push_back(ws.Input<GPUBackend>(0).shape().to_static<3>());
+  }
   const auto &reqs = kernel_manager_.Setup<Kernel>(
-        0, ctx, make_span(samples_), out_shape.to_static<3>(), in.shape);
+        0, ctx, make_span(samples_), out_shape.to_static<3>(), make_span(in_shapes));
 }
 
 template<typename OutputType, typename InputType>
 void MultiPasteGPU::RunTyped(Workspace &ws) {
-  const auto &images = ws.Input<GPUBackend>(0);
   auto &output = ws.Output<GPUBackend>(0);
 
-  output.SetLayout(images.GetLayout());
+  output.SetLayout(ws.Input<GPUBackend>(0).GetLayout());
   auto out_shape = output.shape();
   using Kernel = kernels::PasteGPU<OutputType, InputType, 3>;
-  auto in_view = view<const InputType, 3>(images);
+
+  std::vector<TensorListView<StorageGPU, const InputType, 3>> in_views;
+  in_views.reserve(ws.NumInput());
+  for (int i = 0; i < ws.NumInput(); i++) {
+    in_views.push_back(view<const InputType, 3>(ws.Input<GPUBackend>(i)));
+  }
   auto out_view = view<OutputType, 3>(output);
 
   kernels::KernelContext ctx;
   ctx.gpu.stream = ws.stream();
-  kernel_manager_.Run<Kernel>(0, ctx, out_view, in_view);
+  kernel_manager_.Run<Kernel>(0, ctx, out_view, make_span(in_views));
 }
 
 DALI_REGISTER_OPERATOR(MultiPaste, MultiPasteGPU, GPU)

--- a/dali/operators/image/paste/multipaste.h
+++ b/dali/operators/image/paste/multipaste.h
@@ -331,7 +331,8 @@ class MultiPasteOp : public SequenceOperator<Backend, StatelessOperator> {
     };
     for (int k = 0; k < spatial_ndim_; k++) {
       DALI_ENFORCE(
-          in_anchor[k] >= 0 && in_anchor[k] + region_shape[k] <= region_source_shape[k],
+          in_anchor[k] >= 0 && region_shape[k] >= 0 &&
+              in_anchor[k] + region_shape[k] <= region_source_shape[k],
           make_string("The pasted region must be within input sample. Got input anchor: ",
                       as_shape(in_anchor), ", pasted region shape: ", as_shape(region_shape),
                       ", input shape: ", as_shape(region_source_shape),

--- a/dali/test/python/operator_1/test_multipaste.py
+++ b/dali/test/python/operator_1/test_multipaste.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -339,7 +339,7 @@ def check_operator_multipaste(
             out_dtype,
         )
     except RuntimeError as e:
-        if "Paste in/out coords should be within input/output bounds" in str(e):
+        if "The pasted region must be within" in str(e):
             assert verify_out_of_bounds(
                 bs, in_idx_l, in_anchors_l, shapes_l, out_anchors_l, in_size, out_size
             )


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
**Bug fix** (*non-breaking change which fixes an issue*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
This PR reworks arguments and their parsing for fn.multi_paste to make it more flexible and easier to use (with cutmix augmentation in mind; namely ability to mix different batches and no need to use image shape explicitly if the inputs are uniformly shaped). It fixes a couple of bugs.

Fixes:
* There was no validation of in_ids leading to out-of-bound accesses for incorrect input
* The number of channels was handled incorrectly
  * GPU assumed 3 channels no matter the actual number of channels - leading to incorrect cuda mem accesses.
  * Both backends did not verify if all the pasted regions have the same number of channels (and if the output number of channels matches). The number of output channels was copied from the corresponding input sample. The PR changes that - the number of output channels is inferred from the actually pasted regions and uses the old behaviour only if there are none (to be compatible with the only case it could have worked previously).

New features:
* The in_anchors, region shapes and out_anchors have now relative counterparts - they can be specified as [0, 1] floats relative to input shape, input shape and output shape respectively.
* If all the input shapes are uniform and no output size is provided, the output shape is assumed to be the same.
* To allow mixing images of diffrent batches, the operator can accept multiple inputs - in that case the in_ids must not be specified and the regions are pasted elementwise.

The first two points are aimed to make it easier to use fn.multi_paste without explcitly handling the actual shapes of the samples. 
The multi-input mode should make it easier to use the operator in simple applications where the number of paste regions is uniform - with DALI implict batch you can think in terms of samples rather than indicies in the implicit batch. And it enables cases were you need to mix images from different sources.

Other changes:
* The args are parsed once and saved not to recompute them along the way
* No intersection check is moved to the CPU impl, it's outputs were ignored by the GPU impl anyway.
* Added video support.


<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:

![cutmix](https://github.com/NVIDIA/DALI/assets/11878086/9623a265-1add-485f-989a-6fe1b7df9148)

<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3496
<!--- DALI-XXXX or NA --->
