### PR TITLE
Refactor custom ops classes to use python_op_factory as base class

### DIFF
--- a/dali/operators/reader/parser/tf_feature.h
+++ b/dali/operators/reader/parser/tf_feature.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ class Feature {
   };
 
   Feature() : has_shape_(false), type_(int64) {}
+
+  Feature(const Feature &other) = default;
 
   Feature(std::vector<Index> shape, FeatureType type, Value val) {
     has_shape_ = true;

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2237,7 +2237,8 @@ PYBIND11_MODULE(backend_impl, m) {
   tfrecord_m.attr("string") = static_cast<int>(TFFeatureType::string);
   tfrecord_m.attr("float32") = static_cast<int>(TFFeatureType::float32);
 
-  py::class_<TFFeature>(tfrecord_m, "Feature");
+  py::class_<TFFeature>(tfrecord_m, "Feature")
+    .def(py::init<const TFFeature&>());
 
   tfrecord_m.def("FixedLenFeature",
       [](vector<Index> converted_shape, int type, py::object default_value) {

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -517,10 +517,25 @@ def _check_arg_input(schema, op_name, name):
         )
 
 
-def python_op_factory(name, schema_name=None):
+def python_op_factory(name, schema_name, internal_schema_name=None):
+    """Generate the ops API class bindings for operator.
+
+    Parameters
+    ----------
+    name : str
+        The name of the operator (without the module) - this will be the name of the class
+    schema_name : str
+        Name of the schema, used for documentation lookups and schema/spec retrieval unless
+        internal_schema_name  is provided
+    internal_schema_name : str, optional
+        If provided, this will be the schema used to process the arguments, by default None
+    """
     class Operator(metaclass=_DaliOperatorMeta):
         def __init__(self, *, device="cpu", **kwargs):
-            schema_name = _schema_name(type(self))
+            if self._internal_schema_name is None:
+                schema_name = _schema_name(type(self))
+            else:
+                schema_name = self._internal_schema_name
             self._spec = _b.OpSpec(schema_name)
             self._schema = _b.GetSchema(schema_name)
 
@@ -611,7 +626,8 @@ def python_op_factory(name, schema_name=None):
             return result
 
     Operator.__name__ = str(name)
-    Operator.schema_name = schema_name or Operator.__name__
+    Operator.schema_name = schema_name
+    Operator._internal_schema_name = internal_schema_name
     Operator._generated = True  # The class was generated using python_op_factory
     Operator.__call__.__doc__ = _docs._docstring_generator_call(Operator.schema_name)
     return Operator
@@ -763,7 +779,6 @@ _internal._adjust_operator_module(ExternalSource, sys.modules[__name__], [])
 
 # Expose the PythonFunction family of classes and generate the fn bindings for them
 from nvidia.dali.ops._operators.python_function import (  # noqa: E402, F401
-    PythonFunctionBase,  # noqa: F401
     PythonFunction,
     DLTensorPythonFunction,
     _dlpack_to_array,  # noqa: F401

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -662,10 +662,6 @@ def _load_readers_tfrecord():
     if not tfrecord.tfrecord_enabled():
         return
 
-    tfrecord._TFRecordReaderImpl.__call__.__doc__ = _docs._docstring_generator_call(
-        "readers__TFRecord"
-    )
-
     _registry.register_cpu_op("readers__TFRecord")
     _registry.register_cpu_op("TFRecordReader")
 
@@ -675,7 +671,6 @@ def _load_readers_tfrecord():
         ("readers__TFRecord", tfrecord.TFRecord),
         ("TFRecordReader", tfrecord.TFRecordReader),
     ]:
-        op_class.schema_name = op_reg_name
         _, submodule, op_name = _process_op_name(op_reg_name)
         module = _internal.get_submodule(ops_module, submodule)
         if not hasattr(module, op_name):

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -517,7 +517,7 @@ def _check_arg_input(schema, op_name, name):
         )
 
 
-def python_op_factory(name, schema_name, internal_schema_name=None):
+def python_op_factory(name, schema_name, internal_schema_name=None, generated=True):
     """Generate the ops API class bindings for operator.
 
     Parameters
@@ -529,8 +529,9 @@ def python_op_factory(name, schema_name, internal_schema_name=None):
         internal_schema_name  is provided
     internal_schema_name : str, optional
         If provided, this will be the schema used to process the arguments, by default None
-        If it is not provided, the class is assumed to be `_generated=True`, otherwise, we mark
-        it as False - the user will provide a custom wrapper.
+    generated : bool, optional
+        Mark this class as fully generated API binding (True), or as a (base) class used for
+        manually extending the binding code (False), by default True.
     """
 
     class Operator(metaclass=_DaliOperatorMeta):
@@ -631,9 +632,7 @@ def python_op_factory(name, schema_name, internal_schema_name=None):
     Operator.__name__ = str(name)
     Operator.schema_name = schema_name
     Operator._internal_schema_name = internal_schema_name
-    # The class was generated using python_op_factory, and we don't expect custom wrapper.
-    # If needed, allow this tag to be overridden by an argument to this function
-    Operator._generated = internal_schema_name is None
+    Operator._generated = generated
     Operator.__call__.__doc__ = _docs._docstring_generator_call(Operator.schema_name)
     return Operator
 

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -633,7 +633,7 @@ def python_op_factory(name, schema_name, internal_schema_name=None):
     Operator._internal_schema_name = internal_schema_name
     # The class was generated using python_op_factory, and we don't expect custom wrapper.
     # If needed, allow this tag to be overridden by an argument to this function
-    Operator._generated = internal_schema_name is not None
+    Operator._generated = internal_schema_name is None
     Operator.__call__.__doc__ = _docs._docstring_generator_call(Operator.schema_name)
     return Operator
 

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -529,6 +529,8 @@ def python_op_factory(name, schema_name, internal_schema_name=None):
         internal_schema_name  is provided
     internal_schema_name : str, optional
         If provided, this will be the schema used to process the arguments, by default None
+        If it is not provided, the class is assumed to be `_generated=True`, otherwise, we mark
+        it as False - the user will provide a custom wrapper.
     """
 
     class Operator(metaclass=_DaliOperatorMeta):
@@ -629,7 +631,9 @@ def python_op_factory(name, schema_name, internal_schema_name=None):
     Operator.__name__ = str(name)
     Operator.schema_name = schema_name
     Operator._internal_schema_name = internal_schema_name
-    Operator._generated = True  # The class was generated using python_op_factory
+    # The class was generated using python_op_factory, and we don't expect custom wrapper.
+    # If needed, allow this tag to be overridden by an argument to this function
+    Operator._generated = internal_schema_name is not None
     Operator.__call__.__doc__ = _docs._docstring_generator_call(Operator.schema_name)
     return Operator
 

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -530,6 +530,7 @@ def python_op_factory(name, schema_name, internal_schema_name=None):
     internal_schema_name : str, optional
         If provided, this will be the schema used to process the arguments, by default None
     """
+
     class Operator(metaclass=_DaliOperatorMeta):
         def __init__(self, *, device="cpu", **kwargs):
             if self._internal_schema_name is None:

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -14,7 +14,6 @@
 
 
 import nvidia.dali.python_function_plugin
-from nvidia.dali import backend as _b
 from nvidia.dali import ops
 from nvidia.dali.ops import _registry
 from nvidia.dali.data_node import DataNode as _DataNode

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -19,7 +19,6 @@ from nvidia.dali.ops import _registry
 from nvidia.dali.data_node import DataNode as _DataNode
 from nvidia.dali.pipeline import Pipeline as _Pipeline
 from nvidia.dali.types import CUDAStream as _CUDAStream
-from nvidia.dali._utils import dali_trace as _dali_trace
 
 
 cupy = None

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -33,11 +33,11 @@ def _setup_cupy():
 
 def _get_base_impl(name, impl_name):
 
-    class PythonFunctionBase(ops.python_op_factory(impl_name, name, impl_name)):
+    class PythonFunctionBase(ops.python_op_factory(impl_name, name, impl_name, generated=False)):
 
         def __init__(self, function, num_outputs=1, **kwargs):
 
-            # The layout need to be handled manually due to implementation detail
+            # The layouts need to be handled manually due to an implementation detail
             # By calling spec.AddArg manually, we skip the promotion from a single string argument
             # to a 1-element list of strings that is done by the automation in the base class.
             # This way, the operator is able to differentiate between those cases.

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -14,7 +14,6 @@
 
 from nvidia.dali import backend as _b
 from nvidia.dali import ops
-from nvidia.dali._utils import dali_trace as _dali_trace
 
 _internal_schemas = ["_TFRecordReader", "readers___TFRecord"]
 

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -76,8 +76,6 @@ def _get_impl(name, schema_name, internal_schema_name):
 
             return outputs
 
-    # We provide manual type hints for this class
-    _TFRecordReaderImpl._generated = False
     return _TFRecordReaderImpl
 
 

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -30,8 +30,8 @@ def tfrecord_enabled():
     return False
 
 
-def _get_impl(name, schema_name):
-    class _TFRecordReaderImpl(ops.python_op_factory(name, schema_name)):
+def _get_impl(name, schema_name, internal_schema_name):
+    class _TFRecordReaderImpl(ops.python_op_factory(name, schema_name, internal_schema_name)):
         """custom wrappers around ops"""
 
         def __init__(self, path, index_path, features, **kwargs):
@@ -81,9 +81,9 @@ def _get_impl(name, schema_name):
     return _TFRecordReaderImpl
 
 
-class TFRecordReader(_get_impl("_TFRecordReader", "_TFRecordReader")):
+class TFRecordReader(_get_impl("_TFRecordReader", "TFRecordReader", "_TFRecordReader")):
     pass
 
 
-class TFRecord(_get_impl("_TFRecord", "readers___TFRecord")):
+class TFRecord(_get_impl("_TFRecord", "readers__TFRecord", "readers___TFRecord")):
     pass

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -31,7 +31,10 @@ def tfrecord_enabled():
 
 
 def _get_impl(name, schema_name, internal_schema_name):
-    class _TFRecordReaderImpl(ops.python_op_factory(name, schema_name, internal_schema_name)):
+
+    class _TFRecordReaderImpl(
+        ops.python_op_factory(name, schema_name, internal_schema_name, generated=False)
+    ):
         """custom wrappers around ops"""
 
         def __init__(self, path, index_path, features, **kwargs):

--- a/dali/python/nvidia/dali/plugin/numba/experimental/__init__.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental/__init__.py
@@ -85,7 +85,9 @@ def _get_shape_view(shapes_ptr, ndims_ptr, num_dims, num_samples):
     return ret
 
 
-class NumbaFunction(ops.python_op_factory("NumbaFunctionBase", "NumbaFunction", "NumbaFuncImpl")):
+class NumbaFunction(
+    ops.python_op_factory("NumbaFunctionBase", "NumbaFunction", "NumbaFuncImpl", generated=False)
+):
     _impl_module = "nvidia.dali.plugin.numba"
     ops.register_cpu_op("NumbaFunction")
     ops.register_gpu_op("NumbaFunction")

--- a/dali/python/nvidia/dali/plugin/numba/experimental/__init__.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental/__init__.py
@@ -14,7 +14,6 @@
 
 from distutils.version import LooseVersion
 
-from nvidia.dali import backend as _b
 from nvidia.dali.pipeline import Pipeline
 from nvidia.dali.data_node import DataNode as _DataNode
 from nvidia.dali import ops

--- a/dali/python/nvidia/dali/plugin/numba/experimental/__init__.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -86,8 +86,7 @@ def _get_shape_view(shapes_ptr, ndims_ptr, num_dims, num_samples):
     return ret
 
 
-class NumbaFunction(metaclass=ops._DaliOperatorMeta):
-    schema_name = "NumbaFunction"
+class NumbaFunction(ops.python_op_factory("NumbaFunctionBase", "NumbaFunction", "NumbaFuncImpl")):
     _impl_module = "nvidia.dali.plugin.numba"
     ops.register_cpu_op("NumbaFunction")
     ops.register_gpu_op("NumbaFunction")
@@ -386,11 +385,9 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
 
     def __call__(self, *inputs, **kwargs):
         pipeline = Pipeline.current()
+        inputs = ops._preprocess_inputs(inputs, self.__class__.__name__, self._device, None)
         if pipeline is None:
-            Pipeline._raise_no_current_pipeline("NumbaFunction")
-        inputs = ops._preprocess_inputs(inputs, self._impl_name, self._device, None)
-        if pipeline is None:
-            Pipeline._raise_pipeline_required("NumbaFunction operator")
+            Pipeline._raise_pipeline_required(self.__class__.__name__)
         for inp in inputs:
             if not isinstance(inp, _DataNode):
                 raise TypeError(
@@ -400,8 +397,7 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
                     ).format(type(inp).__name__)
                 )
 
-        args, arg_inputs = ops._separate_kwargs(kwargs)
-        args.update(
+        kwargs.update(
             {
                 "run_fn": self.run_fn,
                 "out_types": self.out_types,
@@ -412,23 +408,16 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
             }
         )
         if self.setup_fn is not None:
-            args.update({"setup_fn": self.setup_fn})
+            kwargs.update({"setup_fn": self.setup_fn})
         if self.device == "gpu":
-            args.update(
+            kwargs.update(
                 {
                     "blocks": self.blocks,
                     "threads_per_block": self.threads_per_block,
                 }
             )
 
-        args = ops._resolve_double_definitions(args, self._init_args, keep_old=False)
-        if self._name is not None:
-            args = ops._resolve_double_definitions(args, {"name": self._name})  # restore the name
-
-        op_instance = ops._OperatorInstance(inputs, arg_inputs, args, self._init_args, self)
-        op_instance.spec.AddArg("device", self.device)
-
-        return op_instance.unwrapped_outputs
+        return super().__call__(*inputs, **kwargs)
 
     def __init__(
         self,
@@ -496,16 +485,7 @@ class NumbaFunction(metaclass=ops._DaliOperatorMeta):
         if not isinstance(in_types, list):
             in_types = [in_types]
 
-        self._impl_name = "NumbaFuncImpl"
-        self._schema = _b.GetSchema(self._impl_name)
-        self._spec = _b.OpSpec(self._impl_name)
-        self._device = device
-
-        self._init_args, self._call_args = ops._separate_kwargs(kwargs)
-        self._name = self._init_args.pop("name", None)
-
-        for key, value in self._init_args.items():
-            self._spec.AddArg(key, value)
+        super().__init__(device=device, **kwargs)
 
         if device == "gpu":
             self.run_fn = self._get_run_fn_gpu(run_fn, out_types + in_types, outs_ndim + ins_ndim)

--- a/dali/python/nvidia/dali/plugin/pytorch/_torch_function.py
+++ b/dali/python/nvidia/dali/plugin/pytorch/_torch_function.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@ import torch.utils.dlpack as torch_dlpack
 
 from nvidia.dali import ops
 from nvidia.dali.pipeline import Pipeline
+from nvidia.dali.ops._operators import python_function
 
 
-class TorchPythonFunction(ops.PythonFunctionBase):
-    schema_name = "TorchPythonFunction"
+class TorchPythonFunction(
+    python_function._get_base_impl("TorchPythonFunction", "DLTensorPythonFunctionImpl")
+):
     ops.register_cpu_op("TorchPythonFunction")
     ops.register_gpu_op("TorchPythonFunction")
 
@@ -64,7 +66,6 @@ class TorchPythonFunction(ops.PythonFunctionBase):
     def __init__(self, function, num_outputs=1, device="cpu", batch_processing=False, **kwargs):
         self.stream = None
         super(TorchPythonFunction, self).__init__(
-            impl_name="DLTensorPythonFunctionImpl",
             function=lambda *ins: self.torch_wrapper(batch_processing, function, device, *ins),
             num_outputs=num_outputs,
             device=device,

--- a/dali/python/nvidia/dali/plugin/pytorch/_torch_function.py
+++ b/dali/python/nvidia/dali/plugin/pytorch/_torch_function.py
@@ -58,7 +58,7 @@ class TorchPythonFunction(
     def __call__(self, *inputs, **kwargs):
         pipeline = Pipeline.current()
         if pipeline is None:
-            Pipeline._raise_no_current_pipeline("TorchPythonFunction")
+            Pipeline._raise_pipeline_required("TorchPythonFunction")
         if self.stream is None:
             self.stream = torch.cuda.Stream(device=pipeline.device_id)
         return super(TorchPythonFunction, self).__call__(*inputs, **kwargs)

--- a/dali/python/nvidia/dali/plugin/pytorch/_torch_function.py
+++ b/dali/python/nvidia/dali/plugin/pytorch/_torch_function.py
@@ -61,11 +61,11 @@ class TorchPythonFunction(
             Pipeline._raise_pipeline_required("TorchPythonFunction")
         if self.stream is None:
             self.stream = torch.cuda.Stream(device=pipeline.device_id)
-        return super(TorchPythonFunction, self).__call__(*inputs, **kwargs)
+        return super().__call__(*inputs, **kwargs)
 
     def __init__(self, function, num_outputs=1, device="cpu", batch_processing=False, **kwargs):
         self.stream = None
-        super(TorchPythonFunction, self).__init__(
+        super().__init__(
             function=lambda *ins: self.torch_wrapper(batch_processing, function, device, *ins),
             num_outputs=num_outputs,
             device=device,

--- a/dali/test/python/reader/test_index.py
+++ b/dali/test/python/reader/test_index.py
@@ -367,7 +367,7 @@ def test_conditionals():
 
 @raises(
     TypeError,
-    glob="Expected `nvidia.dali.tfrecord.Feature` for the image/encoded, "
+    glob='Expected `nvidia.dali.tfrecord.Feature` for the "image/encoded", '
     "but got <class 'int'>. Use `nvidia.dali.tfrecord.FixedLenFeature` "
     "or `nvidia.dali.tfrecord.VarLenFeature` to define the features to extract.",
 )


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Refactoring** **Breaking change** 
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
 (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
`python_op_factory` was extended and documented. There is a new, optional `internal_schema_name` parameter, that will be used to retrieve schema and spec for argument handling on Python side, while allowing the original `schema` to be used for the purpose of exposing the documentation.

As both `TFRecordReader` and `PythonFunction` has several variants with different base implementation schemas, the base classes are converted into a class generator function. The new classes are marked as not generated, as the type hints are done manually for them.

This reduces the custom code to minimum, allowing the base class to handle all properties and some common arguments.
The argument handling is moved to base class by updating the kwargs before invoking the base class.

When a `tfrec.Feature` is encountered in the Python argument serialization layer, it is again processed by the `tfrec.Feature` constructor (as we do for other types, normalizing numbers with int() or float()). For this purpose a copy constructor is added and exposed in Pybind. An alternative would be to change the conversion to an identity function - that would keep the error in the spec.AddArg rather than moving it to constructor parameter matching.
Validation code is added to the operator, to check for matching type with better error message.

NumbaFunction was also reworked, inheriting directly from the python_op_factory.

Calls to `_raise_no_current_pipeline` were eliminated - this function doesn't exist!

Breaking change: There is no longer a `PythonFunctionBase` class in `nvidia.dali.ops`.

## Additional information:

### Affected modules and functionalities:
TFRecord, Python Function and Numba Function operators in Python


### Key points relevant for the review:
Does it has a potential to break something?
Does the documentation render correctly?
What would be a cleaner way to have schema and internal schema? - otherwise we would need to rewrite the operators to not use two schemas - one for presentation and one for implementation.
Should we keep implementation detail of `PythonFunctionBase` alive? 

As a followup a code that prohibits MIS would be a nice generalization for those custom implementations.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
   All TFRecord, Python function and Numba Function tests must pass
- [x] New tests added
  - [x] Python tests - new type error checking for TFRecord is tested.
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
