### PR TITLE
Handle arguments more strictly

### DIFF
--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -88,7 +88,7 @@ class _DaliBaseIterator(object):
                 * ``"no"``, ``False`` or ``None`` - at the end of epoch StopIteration is raised and
                   reset() needs to be called. Calling ``iter()`` on the iterator would reset
                   it as well.
-                * ``"yes"`` or ``"True"``- at the end of epoch StopIteration is raised but reset()
+                * ``"yes"`` or ``True``- at the end of epoch StopIteration is raised but reset()
                   is called internally automatically
 
     fill_last_batch : bool, optional, default = None
@@ -162,9 +162,9 @@ class _DaliBaseIterator(object):
         ), "All pipelines should have the same batch size set"
 
         self._size = int(size)
-        if not auto_reset or auto_reset is None or auto_reset == "no":
+        if auto_reset is False or auto_reset is None or auto_reset == "no":
             self._auto_reset = "no"
-        elif auto_reset or auto_reset == "yes":
+        elif auto_reset is True or auto_reset == "yes":
             self._auto_reset = "yes"
         else:
             raise ValueError(f"Unsupported value for `auto_reset` {auto_reset}")


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

This code looks like it validates that the `auto_reset` argument is `True`, `False`, `"yes"`, `"no"`, or `None`:
```python
        if not auto_reset or auto_reset is None or auto_reset == "no":
            self._auto_reset = "no"
        elif auto_reset or auto_reset == "yes":
            self._auto_reset = "yes"
        else:
            raise ValueError(f"Unsupported value for `auto_reset` {auto_reset}")
```
But in fact the `else` clause will never trigger, because all falsy values will trigger the first branch, and all truthy values (except `"no"`) will trigger the second branch. So the `else` clause is dead code.

And if the user provides `"False"` or `"No"`, the code will silently set `self._auto_reset` to `"yes"`

This PR limits acceptable values to `True`, `False`, `"yes"`, `"no"`, or `None`

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
