### PR TITLE
Propagate module and display name of the operator to backend

### DIFF
--- a/dali/operators/generic/cast.h
+++ b/dali/operators/generic/cast.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,13 +32,13 @@ class Cast : public StatelessOperator<Backend> {
  public:
   explicit inline Cast(const OpSpec &spec)
       : StatelessOperator<Backend>(spec) {
-    if (spec.name() == "Cast") {
+    if (spec.SchemaName() == "Cast") {
       dtype_arg_ = spec.GetArgument<DALIDataType>("dtype");
       if (dtype_arg_ == DALI_NO_TYPE) {
         DALI_FAIL(make_string("Unexpected data type argument", dtype_arg_));
       }
     } else {
-      assert(spec.name() == "CastLike");
+      assert(spec.SchemaName() == "CastLike");
       is_cast_like_ = true;
     }
   }

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ class Reshape : public StatelessOperator<Backend> {
 
  private:
   inline const std::string &OpName() const {
-    return this->spec_.name();
+    return this->spec_.SchemaName();
   }
 
   TensorListShape<> input_shape_;

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -104,7 +104,8 @@ class DataReader : public Operator<Backend> {
 
   void SaveState(OpCheckpoint &cpt, AccessOrder order) override {
     if constexpr (!supports_checkpointing) {
-      DALI_FAIL(make_string("The reader ", spec_.name(), " does not support checkpointing."));
+      DALI_FAIL(
+          make_string("The reader ", spec_.SchemaName(), " does not support checkpointing."));
     } else {
       DALI_ENFORCE(checkpointing_,
                    "Cannot save the checkpoint, because "
@@ -116,7 +117,8 @@ class DataReader : public Operator<Backend> {
 
   void RestoreState(const OpCheckpoint &cpt) override {
     if constexpr (!supports_checkpointing) {
-      DALI_FAIL(make_string("The reader ", spec_.name(), " does not support checkpointing."));
+      DALI_FAIL(
+          make_string("The reader ", spec_.SchemaName(), " does not support checkpointing."));
     } else {
       DALI_ENFORCE(checkpointing_,
                    "Cannot restore the checkpoint, because "
@@ -138,7 +140,7 @@ class DataReader : public Operator<Backend> {
 
   // Main prefetch work loop
   void PrefetchWorker() {
-    SetThreadName(make_string("PrefetchWorker ", spec_.name()).c_str());
+    SetThreadName(make_string("PrefetchWorker ", spec_.SchemaName()).c_str());
     DeviceGuard g(device_id_);
     ProducerWait();
     while (!finished_) {

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -248,12 +248,14 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
 
   void HandleError(const std::string &stage, const OpNode &op_node) {
       // handle internal Operator names that start with underscore
-      const auto &op_name =
-          op_node.spec.name()[0] == '_' ? op_node.spec.name().substr(1) : op_node.spec.name();
+      const auto &op_name = op_node.spec.SchemaName()[0] == '_' ?
+                                op_node.spec.SchemaName().substr(1) :
+                                op_node.spec.SchemaName();
 
       bool need_instance_name = false;
       for (int op_id = 0; op_id < graph_->NumOp(); op_id++) {
-        if (op_id != op_node.id && graph_->Node(op_id).spec.name() == op_node.spec.name()) {
+        if (op_id != op_node.id &&
+            graph_->Node(op_id).spec.SchemaName() == op_node.spec.SchemaName()) {
           need_instance_name = true;
           break;
         }

--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -660,7 +660,7 @@ void TestOnlyExternalSource(Pipeline &pipe, const std::string &name, const std::
   auto *op = pipe.GetOperatorNode(name);
   ASSERT_EQ(op->parents.size(), 0);
   ASSERT_EQ(op->id, 0);
-  ASSERT_EQ(op->spec.name(), "ExternalSource");
+  ASSERT_EQ(op->spec.SchemaName(), "ExternalSource");
   ASSERT_EQ(pipe.num_outputs(), 1);
   ASSERT_EQ(pipe.output_device(0), dev);
   ASSERT_EQ(pipe.output_name(0), name);

--- a/dali/pipeline/operator/checkpointing/checkpoint_test.cc
+++ b/dali/pipeline/operator/checkpointing/checkpoint_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -182,7 +182,7 @@ class CheckpointTest : public DALITest {
     OpGraph new_graph = make_graph_instance(ZERO_STATE);
 
     for (OpNodeId i = 0; i < nodes_cnt; i++) {
-      ASSERT_EQ(original_graph.Node(i).spec.name(),
+      ASSERT_EQ(original_graph.Node(i).spec.SchemaName(),
                 checkpoint.GetOpCheckpoint(i).OperatorName());
       original_graph.Node(i).op->SaveState(checkpoint.GetOpCheckpoint(i),
                                            AccessOrder(this->stream_.get()));
@@ -190,7 +190,7 @@ class CheckpointTest : public DALITest {
 
     ASSERT_EQ(new_graph.NumOp(), nodes_cnt);
     for (OpNodeId i = 0; i < nodes_cnt; i++) {
-      ASSERT_EQ(new_graph.Node(i).spec.name(),
+      ASSERT_EQ(new_graph.Node(i).spec.SchemaName(),
                 checkpoint.GetOpCheckpoint(i).OperatorName());
       checkpoint.GetOpCheckpoint(i).SetOrder(AccessOrder::host());
       new_graph.Node(i).op->RestoreState(checkpoint.GetOpCheckpoint(i));

--- a/dali/pipeline/operator/checkpointing/op_checkpoint.cc
+++ b/dali/pipeline/operator/checkpointing/op_checkpoint.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 namespace dali {
 
 OpCheckpoint::OpCheckpoint(const OpSpec &spec)
-  : operator_name_(spec.name())
+  : operator_name_(spec.SchemaName())
   , order_(AccessOrder::host()) {}
 
 const std::string &OpCheckpoint::OperatorName() const {

--- a/dali/pipeline/operator/eager_operator.h
+++ b/dali/pipeline/operator/eager_operator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ class DLL_PUBLIC EagerOperator {
   using WSOutputType = typename Backend2Types<Backend>::WSOutputType;
 
  public:
-  DLL_PUBLIC inline EagerOperator(const OpSpec &spec) : EagerOperator(spec, spec.name()) {}
+  DLL_PUBLIC inline EagerOperator(const OpSpec &spec) : EagerOperator(spec, spec.SchemaName()) {}
 
   DLL_PUBLIC inline EagerOperator(const OpSpec &spec, std::string name)
       : EagerOperator(spec, std::move(name), GetSharedThreadPool()->NumThreads()) {}
@@ -160,7 +160,7 @@ class DLL_PUBLIC EagerOperator {
       int batch_size = -1);
 
   inline std::string ExtendErrorMsg(const std::string &backend, const char *what) {
-    return make_string("Error when executing ", backend, " operator ", op_spec_.name(),
+    return make_string("Error when executing ", backend, " operator ", op_spec_.SchemaName(),
                        ", instance name: \"", name_, "\", encountered:\n", what);
   }
 

--- a/dali/pipeline/operator/false_gpu_operator.h
+++ b/dali/pipeline/operator/false_gpu_operator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class FalseGPUOperator : public Operator<GPUBackend> {
       : Operator<GPUBackend>(spec),
         cpu_impl_(spec),
         thread_pool_(num_threads_, spec.GetArgument<int>("device_id"), true,
-                     "FalseGPUOperator " + spec.name()) {
+                     "FalseGPUOperator " + spec.SchemaName()) {
     cpu_ws_.SetThreadPool(&thread_pool_);
   }
   ~FalseGPUOperator() override = default;

--- a/dali/pipeline/operator/name_utils.cc
+++ b/dali/pipeline/operator/name_utils.cc
@@ -22,38 +22,16 @@
 
 namespace dali {
 
-std::string GetOpApi(const OpSpec &spec) {
-  return spec.GetArgument<std::string>("_api");
+std::string GetOpModule(const OpSpec &spec) {
+  return spec.GetArgument<std::string>("_module");;
 }
 
-std::string GetOpModule(const OpSpec &spec, ModuleSpecKind kind) {
-  DALI_ENFORCE(kind != ModuleSpecKind::OpOnly, "This function can be only queried about module");
-  std::string result;
-  if (kind == ModuleSpecKind::LibApiModule) {
-    result += "nvidia.dali.";
-    result += GetOpApi(spec);
-  } else if (kind == ModuleSpecKind::ApiModule) {
-    result += GetOpApi(spec);
-  }
-  auto path = spec.GetSchema().ModulePath();
-  if (result.size() && path.size()) {
-    result += ".";
-  }
-  for (size_t i = 0; i < path.size(); i++) {
-    result += path[i];
-    if (i + 1 < path.size()) {
-      result += ".";
-    }
-  }
-  return result;
-}
-
-std::string GetOpDisplayName(const OpSpec &spec, ModuleSpecKind kind) {
+std::string GetOpDisplayName(const OpSpec &spec, bool include_module_path) {
   auto display_name = spec.GetArgument<std::string>("_display_name");
-  if (kind == ModuleSpecKind::OpOnly) {
+  if (!include_module_path) {
     return display_name;
   }
-  auto module = GetOpModule(spec, kind);
+  auto module = GetOpModule(spec);
   if (module.size()) {
     return module + "." + display_name;
   } else {

--- a/dali/pipeline/operator/name_utils.cc
+++ b/dali/pipeline/operator/name_utils.cc
@@ -1,0 +1,64 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <string>
+#include <vector>
+
+#include "dali/core/error_handling.h"
+#include "dali/pipeline/operator/name_utils.h"
+#include "dali/pipeline/operator/op_spec.h"
+
+namespace dali {
+
+std::string GetOpApi(const OpSpec &spec) {
+  return spec.GetArgument<std::string>("_api");
+}
+
+std::string GetOpModule(const OpSpec &spec, ModuleSpecKind kind) {
+  DALI_ENFORCE(kind != ModuleSpecKind::OpOnly, "This function can be only queried about module");
+  std::string result;
+  if (kind == ModuleSpecKind::LibApiModule) {
+    result += "nvidia.dali.";
+    result += GetOpApi(spec);
+  } else if (kind == ModuleSpecKind::ApiModule) {
+    result += GetOpApi(spec);
+  }
+  auto path = spec.GetSchema().ModulePath();
+  if (result.size() && path.size()) {
+    result += ".";
+  }
+  for (size_t i = 0; i < path.size(); i++) {
+    result += path[i];
+    if (i + 1 < path.size()) {
+      result += ".";
+    }
+  }
+  return result;
+}
+
+std::string GetOpDisplayName(const OpSpec &spec, ModuleSpecKind kind) {
+  auto display_name = spec.GetArgument<std::string>("_display_name");
+  if (kind == ModuleSpecKind::OpOnly) {
+    return display_name;
+  }
+  auto module = GetOpModule(spec, kind);
+  if (module.size()) {
+    return module + "." + display_name;
+  } else {
+    return display_name;
+  }
+}
+
+}  // namespace dali

--- a/dali/pipeline/operator/name_utils.h
+++ b/dali/pipeline/operator/name_utils.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef DALI_PIPELINE_OPERATOR_NAME_UTILS_H_
+#define DALI_PIPELINE_OPERATOR_NAME_UTILS_H_
+
+#include <string>
+#include <vector>
+
+#include "dali/pipeline/operator/op_spec.h"
+
+namespace dali {
+
+/** @brief Enum representing how module path can be formatted for given operator */
+enum class ModuleSpecKind {
+  /** @brief Only show operator display name */
+  OpOnly,
+  /** @brief Include the module path specified in schema, for example `experimental.random` */
+  Module,
+  /** Include the API distinction and module path, for example: `fn.experimental.random` */
+  ApiModule,
+  /** Include library, api and module path, for example: `nvidia.dali.fn.experimental.random` */
+  LibApiModule,
+};
+
+/**
+ * @brief Get the name of the API this operator was instantiated for.
+ */
+std::string GetOpApi(const OpSpec &spec);
+
+// /**
+//  * @brief Get the module path of the operator
+//  */
+// std::vector<std::string> GetOpModulePath(const OpSpec &spec, );
+
+/**
+ * @brief Get the module path of the operator as a dot separated string.
+ *
+ * Doesn't include the operator name, ModuleSpecKind::OpOnly is invalid.
+ * @param spec OpSpec definition of the operator
+ * @param kind Controls which portion of module path should be returned.
+ */
+std::string GetOpModule(const OpSpec &spec, ModuleSpecKind kind = ModuleSpecKind::Module);
+
+
+/**
+ * @brief Get the display name of the operator, optionally including the module path as a dot
+ * separated string.
+ *
+ * @param spec OpSpec definition of the operator
+ * @param kind Controls which portion of module path should be returned.
+ */
+std::string GetOpDisplayName(const OpSpec &spec, ModuleSpecKind kind = ModuleSpecKind::OpOnly);
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATOR_NAME_UTILS_H_

--- a/dali/pipeline/operator/name_utils.h
+++ b/dali/pipeline/operator/name_utils.h
@@ -41,11 +41,6 @@ enum class ModuleSpecKind {
  */
 DLL_PUBLIC std::string GetOpApi(const OpSpec &spec);
 
-// /**
-//  * @brief Get the module path of the operator
-//  */
-// std::vector<std::string> GetOpModulePath(const OpSpec &spec, );
-
 /**
  * @brief Get the module path of the operator as a dot separated string.
  *

--- a/dali/pipeline/operator/name_utils.h
+++ b/dali/pipeline/operator/name_utils.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "dali/core/api_helper.h"
 #include "dali/pipeline/operator/op_spec.h"
 
 namespace dali {
@@ -38,7 +39,7 @@ enum class ModuleSpecKind {
 /**
  * @brief Get the name of the API this operator was instantiated for.
  */
-std::string GetOpApi(const OpSpec &spec);
+DLL_PUBLIC std::string GetOpApi(const OpSpec &spec);
 
 // /**
 //  * @brief Get the module path of the operator
@@ -52,7 +53,8 @@ std::string GetOpApi(const OpSpec &spec);
  * @param spec OpSpec definition of the operator
  * @param kind Controls which portion of module path should be returned.
  */
-std::string GetOpModule(const OpSpec &spec, ModuleSpecKind kind = ModuleSpecKind::Module);
+DLL_PUBLIC std::string GetOpModule(const OpSpec &spec,
+                                   ModuleSpecKind kind = ModuleSpecKind::Module);
 
 
 /**
@@ -62,7 +64,8 @@ std::string GetOpModule(const OpSpec &spec, ModuleSpecKind kind = ModuleSpecKind
  * @param spec OpSpec definition of the operator
  * @param kind Controls which portion of module path should be returned.
  */
-std::string GetOpDisplayName(const OpSpec &spec, ModuleSpecKind kind = ModuleSpecKind::OpOnly);
+DLL_PUBLIC std::string GetOpDisplayName(const OpSpec &spec,
+                                        ModuleSpecKind kind = ModuleSpecKind::OpOnly);
 
 }  // namespace dali
 

--- a/dali/pipeline/operator/name_utils.h
+++ b/dali/pipeline/operator/name_utils.h
@@ -24,32 +24,13 @@
 
 namespace dali {
 
-/** @brief Enum representing how module path can be formatted for given operator */
-enum class ModuleSpecKind {
-  /** @brief Only show operator display name */
-  OpOnly,
-  /** @brief Include the module path specified in schema, for example `experimental.random` */
-  Module,
-  /** Include the API distinction and module path, for example: `fn.experimental.random` */
-  ApiModule,
-  /** Include library, api and module path, for example: `nvidia.dali.fn.experimental.random` */
-  LibApiModule,
-};
-
-/**
- * @brief Get the name of the API this operator was instantiated for.
- */
-DLL_PUBLIC std::string GetOpApi(const OpSpec &spec);
-
 /**
  * @brief Get the module path of the operator as a dot separated string.
  *
- * Doesn't include the operator name, ModuleSpecKind::OpOnly is invalid.
+ * Doesn't include the operator name, fully qualified name is used, like `nvidia.dali.fn.uniform`.
  * @param spec OpSpec definition of the operator
- * @param kind Controls which portion of module path should be returned.
  */
-DLL_PUBLIC std::string GetOpModule(const OpSpec &spec,
-                                   ModuleSpecKind kind = ModuleSpecKind::Module);
+DLL_PUBLIC std::string GetOpModule(const OpSpec &spec);
 
 
 /**
@@ -57,10 +38,9 @@ DLL_PUBLIC std::string GetOpModule(const OpSpec &spec,
  * separated string.
  *
  * @param spec OpSpec definition of the operator
- * @param kind Controls which portion of module path should be returned.
+ * @param include_module_path if true, the module path is included in the display name
  */
-DLL_PUBLIC std::string GetOpDisplayName(const OpSpec &spec,
-                                        ModuleSpecKind kind = ModuleSpecKind::OpOnly);
+DLL_PUBLIC std::string GetOpDisplayName(const OpSpec &spec, bool include_module_path = false);
 
 }  // namespace dali
 

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -83,7 +83,6 @@ to accommodate a batch of samples of this size.)code",
 graph even if its outputs are not used.)code",
                  false);
 
-
   // For simplicity we pass StackSummary as 4 separate arguments so we don't need to extend DALI
   // with support for special FrameSummary type.
   // List of FrameSummaries can be reconstructed using utility functions.
@@ -113,6 +112,15 @@ _origin_stack_filename for more information.)code",
   AddOptionalArg("_pipeline_internal", R"code(Boolean specifying if this operator was defined within
 a pipeline scope. False if it was defined without pipeline being set as current.)code",
                  true);
+  AddOptionalArg("_api",
+                 "String identifying the Python API used to instantiate operator: "
+                 "\"ops\" or \"fn\".",
+                 "ops");
+
+  AddOptionalArg("_display_name",
+                 "Operator name as presented in the API it was instantiated in (without the module "
+                 "path), for example: cast_like or CastLike.",
+                 OperatorName());
 }
 
 

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -20,6 +20,8 @@
 #include "dali/pipeline/operator/op_schema.h"
 #include "dali/pipeline/operator/op_spec.h"
 
+#include <dbg.h>
+
 namespace dali {
 
 std::map<string, OpSchema> &SchemaRegistry::registry() {
@@ -56,6 +58,8 @@ const OpSchema *SchemaRegistry::TryGetSchema(const std::string &name) {
 
 
 OpSchema::OpSchema(const std::string &name) : name_(name) {
+  // Process the module path and operator name
+  InitNames();
   // Fill internal arguments
   AddInternalArg("num_threads", "Number of CPU threads in a thread pool", -1);
   AddInternalArg("max_batch_size", "Max batch size", -1);
@@ -116,6 +120,25 @@ const std::string &OpSchema::name() const {
   return name_;
 }
 
+const std::vector<std::string> &OpSchema::ModulePath() const {
+  return module_path_;
+}
+
+const std::string &OpSchema::OperatorName() const {
+  return operator_name_;
+}
+
+void OpSchema::InitNames() {
+  static std::string kDelim = "__";
+  std::string::size_type start_pos = 0;
+  auto end_pos = name_.find(kDelim);
+  while (end_pos != std::string::npos) {
+    module_path_.push_back(name_.substr(start_pos, end_pos - start_pos));
+    start_pos = end_pos + kDelim.size();
+    end_pos = name_.find(kDelim, start_pos);
+  }
+  operator_name_ = name_.substr(start_pos);
+}
 
 OpSchema &OpSchema::DocStr(const string &dox) {
   dox_ = dox;

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -20,8 +20,6 @@
 #include "dali/pipeline/operator/op_schema.h"
 #include "dali/pipeline/operator/op_spec.h"
 
-#include <dbg.h>
-
 namespace dali {
 
 std::map<string, OpSchema> &SchemaRegistry::registry() {

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -110,10 +110,16 @@ _origin_stack_filename for more information.)code",
   AddOptionalArg("_pipeline_internal", R"code(Boolean specifying if this operator was defined within
 a pipeline scope. False if it was defined without pipeline being set as current.)code",
                  true);
-  AddOptionalArg("_api",
-                 "String identifying the Python API used to instantiate operator: "
-                 "\"ops\" or \"fn\".",
-                 "ops");
+
+  std::string default_module = "nvidia.dali.ops";
+  for (const auto &submodule : ModulePath()) {
+    default_module += "." + submodule;
+  }
+
+  AddOptionalArg("_module",
+                 "String identifying the module in which the operator is defined. "
+                 "Most of the time it is `__module__` of the API function/class.",
+                 default_module);
 
   AddOptionalArg("_display_name",
                  "Operator name as presented in the API it was instantiated in (without the module "

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -82,9 +82,19 @@ class DLL_PUBLIC OpSchema {
   DLL_PUBLIC inline ~OpSchema() = default;
 
   /**
-   * @brief Returns the name of this operator.
+   * @brief Returns the schema name of this operator.
    */
   DLL_PUBLIC const std::string &name() const;
+
+  /**
+   * @brief Returns the module path of this operator.
+   */
+   DLL_PUBLIC const std::vector<std::string> &ModulePath() const;
+
+  /**
+   * @brief Returns the camel case name of the operator (without the module path)
+   */
+   DLL_PUBLIC const std::string &OperatorName() const;
 
   /**
    * @brief Sets the doc string for this operator.
@@ -738,8 +748,16 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   std::map<std::string, DefaultedArgumentDef> GetOptionalArguments() const;
   std::map<std::string, DeprecatedArgDef> GetDeprecatedArguments() const;
 
-  string dox_;
-  string name_;
+
+  void InitNames();
+
+  std::string dox_;
+  /** @brief The name of the schema */
+  std::string name_;
+  /** @brief The module path for the operator */
+  std::vector<std::string> module_path_;
+  /** @brief The camel case name of the operator (without the module path) */
+  std::string operator_name_;
 
   bool disable_auto_input_dox_ = false;
 

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -89,12 +89,12 @@ class DLL_PUBLIC OpSchema {
   /**
    * @brief Returns the module path of this operator.
    */
-   DLL_PUBLIC const std::vector<std::string> &ModulePath() const;
+  DLL_PUBLIC const std::vector<std::string> &ModulePath() const;
 
   /**
    * @brief Returns the camel case name of the operator (without the module path)
    */
-   DLL_PUBLIC const std::string &OperatorName() const;
+  DLL_PUBLIC const std::string &OperatorName() const;
 
   /**
    * @brief Sets the doc string for this operator.

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -748,7 +748,9 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   std::map<std::string, DefaultedArgumentDef> GetOptionalArguments() const;
   std::map<std::string, DeprecatedArgDef> GetDeprecatedArguments() const;
 
-
+  /**
+   * @brief Initialize the module_path_ and operator_name_ fields based on the schema name.
+   */
   void InitNames();
 
   std::string dox_;

--- a/dali/pipeline/operator/op_spec.cc
+++ b/dali/pipeline/operator/op_spec.cc
@@ -26,7 +26,7 @@ OpSpec& OpSpec::AddInput(const string &name, const string &device, bool regular_
     // We rely on the fact that regular inputs are first in inputs_ vector
     DALI_ENFORCE(NumArgumentInput() == 0,
         "All regular inputs (particularly, `" + name + "`) need to be added to the op `" +
-        this->name() + "` before argument inputs.");
+        this->SchemaName() + "` before argument inputs.");
   }
 
   inputs_.push_back({name, device});

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -56,35 +56,34 @@ class DLL_PUBLIC OpSpec {
   DLL_PUBLIC inline OpSpec() = default;
 
   /**
-   * @brief Returns a full tensor name
-   * given its name and device
+   * @brief Returns a full tensor name given its name and device
    */
   DLL_PUBLIC static std::string TensorName(const std::string &name, const std::string &device) {
     return name + "_" + device;
   }
 
   /**
-   * @brief Constructs a specification for an op with the given name.
+   * @brief Constructs a specification for an op with the given schema name.
    */
-  DLL_PUBLIC explicit inline OpSpec(const string &name) {
-    set_name(name);
+  DLL_PUBLIC explicit inline OpSpec(const string &schema_name) {
+    SetName(schema_name);
   }
 
   /**
-   * @brief Getter for the name of the Operator.
+   * @brief Getter for the schema name of the Operator.
    */
-  DLL_PUBLIC inline const string& name() const { return name_; }
+  DLL_PUBLIC inline const string& SchemaName() const { return schema_name_; }
 
   /**
-   * @brief Sets the name of the Operator.
+   * @brief Sets the schema name of the Operator.
    */
-  DLL_PUBLIC inline void set_name(const string &name) {
-    name_ = name;
-    schema_ = name_.empty() ? nullptr : SchemaRegistry::TryGetSchema(name_);
+  DLL_PUBLIC inline void SetName(const string &schema_name) {
+    schema_name_ = schema_name;
+    schema_ = schema_name_.empty() ? nullptr : SchemaRegistry::TryGetSchema(schema_name_);
   }
 
   DLL_PUBLIC inline const OpSchema &GetSchema() const {
-    DALI_ENFORCE(schema_ != nullptr, "No schema found for operator \"" + name() + "\"");
+    DALI_ENFORCE(schema_ != nullptr, "No schema found for operator \"" + SchemaName() + "\"");
     return *schema_;
   }
 
@@ -159,7 +158,7 @@ class DLL_PUBLIC OpSpec {
         const auto& new_arg_name = deprecation_meta.renamed_to;
         DALI_ENFORCE(
             argument_idxs_.find(new_arg_name) == argument_idxs_.end(),
-            make_string("Operator ", name(), " got an unexpected '", arg_name,
+            make_string("Operator ", SchemaName(), " got an unexpected '", arg_name,
                         "' deprecated argument when '", new_arg_name, "' was already provided."));
 
         set_through_deprecated_arguments_[new_arg_name] = arg_name;
@@ -189,9 +188,10 @@ class DLL_PUBLIC OpSpec {
    */
   DLL_PUBLIC inline void EnforceNoAliasWithDeprecated(const string& arg_name) {
     auto set_through = set_through_deprecated_arguments_.find(arg_name);
-    DALI_ENFORCE(set_through == set_through_deprecated_arguments_.end(),
-                 make_string("Operator ", name(), " got an unexpected '", set_through->second,
-                             "' deprecated argument when '", arg_name, "' was already provided."));
+    DALI_ENFORCE(
+        set_through == set_through_deprecated_arguments_.end(),
+        make_string("Operator ", SchemaName(), " got an unexpected '", set_through->second,
+                    "' deprecated argument when '", arg_name, "' was already provided."));
   }
 
   // Forward to string implementation
@@ -403,7 +403,7 @@ class DLL_PUBLIC OpSpec {
 
   DLL_PUBLIC string ToString() const {
     string ret;
-    ret += "OpSpec for " + name() + ":\n  Inputs:\n";
+    ret += "OpSpec for " + SchemaName() + ":\n  Inputs:\n";
     for (size_t i = 0; i < inputs_.size(); ++i) {
       ret += "    " + Input(i) + "\n";
     }
@@ -465,7 +465,7 @@ class DLL_PUBLIC OpSpec {
   template <typename S, typename C>
   inline bool TryGetRepeatedArgumentImpl(C &result, const string &name) const;
 
-  string name_;
+  string schema_name_;
   const OpSchema *schema_ = nullptr;
 
   // the list of arguments, in addition order

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -66,7 +66,7 @@ class DLL_PUBLIC OpSpec {
    * @brief Constructs a specification for an op with the given schema name.
    */
   DLL_PUBLIC explicit inline OpSpec(const string &schema_name) {
-    SetName(schema_name);
+    SetSchema(schema_name);
   }
 
   /**
@@ -75,9 +75,9 @@ class DLL_PUBLIC OpSpec {
   DLL_PUBLIC inline const string& SchemaName() const { return schema_name_; }
 
   /**
-   * @brief Sets the schema name of the Operator.
+   * @brief Sets the schema of the Operator.
    */
-  DLL_PUBLIC inline void SetName(const string &schema_name) {
+  DLL_PUBLIC inline void SetSchema(const string &schema_name) {
     schema_name_ = schema_name;
     schema_ = schema_name_.empty() ? nullptr : SchemaRegistry::TryGetSchema(schema_name_);
   }

--- a/dali/pipeline/operator/operator.cc
+++ b/dali/pipeline/operator/operator.cc
@@ -100,11 +100,11 @@ std::unique_ptr<OperatorBase> InstantiateOperator(const OpSpec &spec) {
   string device = spec.GetArgument<string>("device");
   // traverse devices by likelihood (gpu, cpu, mixed, support)
   if (device == "gpu") {
-    return GPUOperatorRegistry::Registry().Create(spec.name(), spec, &device);
+    return GPUOperatorRegistry::Registry().Create(spec.SchemaName(), spec, &device);
   } else if (device == "cpu") {
-    return CPUOperatorRegistry::Registry().Create(spec.name(), spec, &device);
+    return CPUOperatorRegistry::Registry().Create(spec.SchemaName(), spec, &device);
   } else if (device == "mixed") {
-    return MixedOperatorRegistry::Registry().Create(spec.name(), spec, &device);
+    return MixedOperatorRegistry::Registry().Create(spec.SchemaName(), spec, &device);
   } else {
     DALI_FAIL("Unknown device: " + device);
   }

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -103,7 +103,7 @@ class DLL_PUBLIC OperatorBase {
    * from.
    */
   DLL_PUBLIC virtual string name() const {
-    return spec_.name();
+    return spec_.SchemaName();
   }
 
   /**
@@ -211,7 +211,8 @@ class DLL_PUBLIC OperatorBase {
   }
 
   [[noreturn]] void CheckpointingUnsupportedError() const {
-    DALI_FAIL(make_string("Checkpointing is not implemented for this operator: ", spec_.name()));
+    DALI_FAIL(
+        make_string("Checkpointing is not implemented for this operator: ", spec_.SchemaName()));
   }
 
   // TODO(mszolucha): remove these two to allow i2i variable batch size, when all ops are ready

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -62,7 +62,7 @@ void DeserializeOpSpec(const dali_proto::OpDef &def, OpSpec *spec) {
     name = "ExternalSource";
   }
 
-  spec->SetName(name);
+  spec->SetSchema(name);
 
   // Extract all the arguments with correct types
   for (auto &arg : def.args()) {

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -62,7 +62,7 @@ void DeserializeOpSpec(const dali_proto::OpDef &def, OpSpec *spec) {
     name = "ExternalSource";
   }
 
-  spec->set_name(name);
+  spec->SetName(name);
 
   // Extract all the arguments with correct types
   for (auto &arg : def.args()) {
@@ -239,7 +239,7 @@ int Pipeline::AddOperator(const OpSpec &spec, const std::string& inst_name) {
 }
 
 int Pipeline::AddOperator(const OpSpec &spec, int logical_id) {
-  return AddOperator(spec, make_string("__", spec.name(), "_", logical_id), logical_id);
+  return AddOperator(spec, make_string("__", spec.SchemaName(), "_", logical_id), logical_id);
 }
 
 int Pipeline::AddOperator(const OpSpec &spec) {
@@ -259,7 +259,7 @@ int Pipeline::AddOperator(const OpSpec &const_spec, const std::string& inst_name
 
   // we modify spec so copy it
   OpSpec spec = const_spec;
-  auto operator_name = spec.name();
+  auto operator_name = spec.SchemaName();
   // Take a copy of the passed OpSpec for serialization purposes before any modification
   this->op_specs_for_serialization_.push_back({inst_name, spec, logical_id});
 
@@ -292,7 +292,7 @@ int Pipeline::AddOperator(const OpSpec &const_spec, const std::string& inst_name
     auto it = edge_names_.find(input_name);
 
     DALI_ENFORCE(it != edge_names_.end(), "Input '" + input_name +
-        "' to op '" + spec.name() + "' is not known to the pipeline.");
+        "' to op '" + spec.SchemaName() + "' is not known to the pipeline.");
 
     // Table of possible scenarios:
     // Op location / requested input type / data location
@@ -308,7 +308,7 @@ int Pipeline::AddOperator(const OpSpec &const_spec, const std::string& inst_name
     // mixed / cpu / gpu -> error, data does not exist on cpu
     // mixed / gpu / cpu -> error, mixed op not allowed to have gpu inputs
     // mixed / gpu / gpu -> both of above errors
-    string error_str = "(op: '" + spec.name() + "', input: '" +
+    string error_str = "(op: '" + spec.SchemaName() + "', input: '" +
       input_name + "')";
 
     if (device == "cpu" || device == "mixed") {
@@ -335,15 +335,15 @@ int Pipeline::AddOperator(const OpSpec &const_spec, const std::string& inst_name
     auto it = edge_names_.find(input_name);
 
     DALI_ENFORCE(it != edge_names_.end(), "Input '" + input_name +
-        "' to op '" + spec.name() + "' is not known to the pipeline.");
+        "' to op '" + spec.SchemaName() + "' is not known to the pipeline.");
 
-    string error_str = "(op: '" + spec.name() + "', input: '" +
+    string error_str = "(op: '" + spec.SchemaName() + "', input: '" +
       input_name + "')";
 
     if (!it->second.has_cpu) {
       DALI_FAIL(make_string(
           "Named arguments inputs to operators must be CPU data nodes. However, a GPU ",
-          "data node was provided (op: '", spec.name(), "', input: '", input_name, "')"));
+          "data node was provided (op: '", spec.SchemaName(), "', input: '", input_name, "')"));
     }
 
     if (device == "gpu" && separated_execution_)
@@ -354,7 +354,7 @@ int Pipeline::AddOperator(const OpSpec &const_spec, const std::string& inst_name
   for (int i = 0; i < spec.NumOutput(); ++i) {
     string output_name = spec.OutputName(i);
     string output_device = spec.OutputDevice(i);
-    string error_str = "(op: '" + spec.name() + "', output: '" +
+    string error_str = "(op: '" + spec.SchemaName() + "', output: '" +
       output_name + "')";
 
     auto it = edge_names_.find(output_name);
@@ -402,16 +402,17 @@ bool Pipeline::IsLogicalIdUsed(int logical_id) const {
 void Pipeline::AddToOpSpecs(const std::string &inst_name, const OpSpec &spec, int logical_id) {
   auto& logical_group = logical_ids_[logical_id];
   if (logical_group.size() > 0) {
-    const auto &group_name = op_specs_[logical_group.front()].spec.name();
+    const auto &group_name = op_specs_[logical_group.front()].spec.SchemaName();
     DALI_ENFORCE(
-        group_name == spec.name(),
+        group_name == spec.SchemaName(),
         "Different Operator types cannot be groupped with the same logical id. Tried to group " +
-            spec.name() + " using logical_id=" + std::to_string(logical_id) +
+            spec.SchemaName() + " using logical_id=" + std::to_string(logical_id) +
             " which is already assigned to " + group_name + ".");
-    const OpSchema &schema = SchemaRegistry::GetSchema(spec.name());
+    const OpSchema &schema = SchemaRegistry::GetSchema(spec.SchemaName());
     DALI_ENFORCE(schema.AllowsInstanceGrouping(),
-                 "Operator " + spec.name() + " does not support synced random execution required "
-                      "for multiple input sets processing.");
+                 "Operator " + spec.SchemaName() +
+                     " does not support synced random execution required "
+                     "for multiple input sets processing.");
   }
   op_specs_.push_back({inst_name, spec, logical_id});
   logical_ids_[logical_id].push_back(op_specs_.size() - 1);
@@ -490,7 +491,7 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
     } catch (std::exception &e) {
       int same_op_count = 0;
       for (const auto& elem : op_specs_) {
-        if (elem.spec.name() == op_spec.name()) {
+        if (elem.spec.SchemaName() == op_spec.SchemaName()) {
           same_op_count++;
         }
         if (same_op_count > 1) {
@@ -499,14 +500,14 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
       }
       if (same_op_count > 1) {
         throw std::runtime_error(make_string(
-            "Critical error when building pipeline:\nError when adding operator: ", op_spec.name(),
-            ", instance name: \"", inst_name, "\", encountered:\n", e.what(),
+            "Critical error when building pipeline:\nError when adding operator: ",
+            op_spec.SchemaName(), ", instance name: \"", inst_name, "\", encountered:\n", e.what(),
             "\nCurrent pipeline object is no longer valid."));
       } else {
-        throw std::runtime_error(make_string(
-            "Critical error when building pipeline:\nError when adding operator: ", op_spec.name(),
-            "\" encountered:\n", e.what(),
-            "\nCurrent pipeline object is no longer valid."));
+        throw std::runtime_error(
+            make_string("Critical error when building pipeline:\nError when adding operator: ",
+                        op_spec.SchemaName(), "\" encountered:\n", e.what(),
+                        "\nCurrent pipeline object is no longer valid."));
       }
     } catch (...) {
       throw std::runtime_error("Unknown critical error when building pipeline.");
@@ -559,7 +560,7 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
 
   for (int i = 0; i < graph_.NumOp(OpType::MIXED); i++) {
     OpNode &node = graph_.Node(OpType::MIXED, i);
-    if (node.spec.name() == "MakeContiguous") {
+    if (node.spec.SchemaName() == "MakeContiguous") {
       PropagateMemoryHint(node);
     }
   }
@@ -713,7 +714,7 @@ void Pipeline::PrepareOpSpec(OpSpec *spec, int logical_id) {
  */
 void SerializeToProtobuf(dali_proto::OpDef *op, const string &inst_name, const OpSpec &spec,
                          int logical_id) {
-  op->set_name(spec.name());
+  op->set_name(spec.SchemaName());
   op->set_inst_name(inst_name);
   op->set_logical_id(logical_id);
 
@@ -767,7 +768,7 @@ string Pipeline::SerializeToProtobuf() const {
     const OpSpec& spec = p.spec;
 
     DALI_ENFORCE(spec.GetSchema().IsSerializable(), "Could not serialize the operator: "
-                                                    + spec.name());
+                                                    + spec.SchemaName());
 
     dali::SerializeToProtobuf(op_def, p.instance_name, spec, p.logical_id);
   }
@@ -1098,7 +1099,7 @@ void Pipeline::ProcessException(std::exception_ptr eptr) {
 
 void Pipeline::RepeatLastInputs::FindNodes(const OpGraph &graph) {
   for (const auto &node : graph.GetOpNodes()) {
-    if (node.spec.name() != "ExternalSource")
+    if (node.spec.SchemaName() != "ExternalSource")
       continue;
 
     bool repeat_last = false;

--- a/dali/pipeline/pipeline_debug.h
+++ b/dali/pipeline/pipeline_debug.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ class DLL_PUBLIC PipelineDebug {
   }
 
   void AddOperatorImpl(OpSpec &spec, int logical_id) {
-    std::string name = "__debug__" + spec.name() + "_" + std::to_string(logical_id);
+    std::string name = "__debug__" + spec.SchemaName() + "_" + std::to_string(logical_id);
     std::string device = spec.GetArgument<std::string>("device");
 
     if (device == "gpu") {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1830,7 +1830,7 @@ PYBIND11_MODULE(backend_impl, m) {
         })
     .def("name",
         [](OpNode* node) {
-          return node->spec.name();
+          return node->spec.SchemaName();
         });
 
   py::class_<ExternalContextCheckpoint>(m, "ExternalContextCheckpoint")

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2157,6 +2157,8 @@ PYBIND11_MODULE(backend_impl, m) {
   m.def("TryGetSchema", &TryGetSchema, py::return_value_policy::reference);
 
   py::class_<OpSchema>(m, "OpSchema")
+    .def("OperatorName", &OpSchema::OperatorName)
+    .def("ModulePath", &OpSchema::ModulePath)
     .def("Dox", &OpSchema::Dox)
     .def("CanUseAutoInputDox", &OpSchema::CanUseAutoInputDox)
     .def("AppendKwargsSection", &OpSchema::AppendKwargsSection)

--- a/dali/python/nvidia/dali/fn/__init__.py
+++ b/dali/python/nvidia/dali/fn/__init__.py
@@ -82,6 +82,8 @@ def _wrap_op_fn(op_class, wrapper_name, wrapper_doc):
     def fn_wrapper(*inputs, **kwargs):
         from nvidia.dali._debug_mode import _PipelineDebug
 
+        kwargs.update({"_api": "fn", "_display_name": wrapper_name})
+
         current_pipeline = _PipelineDebug.current()
         if getattr(current_pipeline, "_debug_on", False):
             return current_pipeline._wrap_op_call(op_class, wrapper_name, *inputs, **kwargs)

--- a/dali/python/nvidia/dali/fn/__init__.py
+++ b/dali/python/nvidia/dali/fn/__init__.py
@@ -82,7 +82,8 @@ def _wrap_op_fn(op_class, wrapper_name, wrapper_doc):
     def fn_wrapper(*inputs, **kwargs):
         from nvidia.dali._debug_mode import _PipelineDebug
 
-        kwargs.update({"_api": "fn", "_display_name": wrapper_name})
+        # This is executed after the APIs are populated and the module is updated
+        kwargs.update({"_module": fn_wrapper.__module__, "_display_name": wrapper_name})
 
         current_pipeline = _PipelineDebug.current()
         if getattr(current_pipeline, "_debug_on", False):

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -566,6 +566,11 @@ def python_op_factory(name, schema_name, internal_schema_name=None, generated=Tr
             # before it is validated against Schema.
             if _dali_trace.is_tracing_enabled():
                 self._definition_frame_end = self._init_args.pop("_definition_frame_end", None)
+            # Capture the ops API display name if it didn't arrive from fn API.
+            if "_module" not in self._init_args:
+                self._init_args.update({"_module": Operator.__module__})
+            if "_display_name" not in self._init_args:
+                self._init_args.update({"_display_name": type(self).__name__})
             _process_arguments(self._schema, self._spec, self._init_args, type(self).__name__)
 
         @property

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -796,12 +796,10 @@ _wrap_op(PythonFunction)
 _wrap_op(DLTensorPythonFunction)
 
 # Compose is only exposed for ops API, no fn bindings are generated
-from nvidia.dali.ops._operators.compose import Compose  # noqa: E402, F401
+from nvidia.dali.ops._operators.compose import Compose as Compose  # noqa: E402, F401
 
 _internal._adjust_operator_module(Compose, sys.modules[__name__], [])
 
-_registry.register_cpu_op("Compose")
-_registry.register_gpu_op("Compose")
 
 from nvidia.dali.ops._operators.math import (  # noqa: F401, E402
     _arithm_op,

--- a/dali/python/nvidia/dali/ops/_names.py
+++ b/dali/python/nvidia/dali/ops/_names.py
@@ -15,6 +15,7 @@
 from nvidia.dali import fn as _functional
 from nvidia.dali import backend as _b
 
+
 def _schema_name(cls):
     """Extract the name of the schema from Operator class."""
     return getattr(cls, "schema_name", cls.__name__)

--- a/dali/python/nvidia/dali/ops/_names.py
+++ b/dali/python/nvidia/dali/ops/_names.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from nvidia.dali import fn as _functional
-
+from nvidia.dali import backend as _b
 
 def _schema_name(cls):
     """Extract the name of the schema from Operator class."""
@@ -42,16 +42,15 @@ def _process_op_name(op_schema_name, make_hidden=False, api="ops"):
             ("Resize", [], "Resize") or
             ("experimental.readers.Video", ["experimental", "readers"], "Video")
     """
-    # Two underscores (reasoning: we might want to have single underscores in the namespace itself)
-    namespace_delim = "__"
-    op_full_name = op_schema_name.replace(namespace_delim, ".")
-    *submodule, op_name = op_full_name.split(".")
+    schema = _b.GetSchema(op_schema_name)
+    submodule_path = schema.ModulePath()
+    op_name = schema.OperatorName()
     if make_hidden:
-        submodule = [*submodule, "hidden"]
-    if api == "ops":
-        return op_full_name, submodule, op_name
-    else:
-        return op_full_name, submodule, _functional._to_snake_case(op_name)
+        submodule_path = [*submodule_path, "hidden"]
+    if api == "fn":
+        op_name = _functional._to_snake_case(op_name)
+    op_full_name = ".".join(submodule_path + [op_name])
+    return op_full_name, submodule_path, op_name
 
 
 def _op_name(op_schema_name, api="fn"):
@@ -72,13 +71,8 @@ def _op_name(op_schema_name, api="fn"):
     str
         The fully qualified name in given API
     """
-    full_name, submodule, op_name = _process_op_name(op_schema_name)
-    if api == "fn":
-        return ".".join([*submodule, _functional._to_snake_case(op_name)])
-    elif api == "ops":
-        return full_name
-    else:
-        raise ValueError(f'{api} is not a valid DALI api name, try one of {"fn", "ops"}')
+    full_name, _, _ = _process_op_name(op_schema_name, api=api)
+    return full_name
 
 
 def _get_input_name(schema, input_idx):

--- a/dali/test/dali_test_single_op.h
+++ b/dali/test/dali_test_single_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -235,7 +235,7 @@ class DALISingleOpTest : public DALITest {
     for (int i = 0; i < spec.NumOutput(); ++i)
       outputs_.push_back(std::make_pair(spec.OutputName(i), spec.OutputDevice(i)));
 
-    pipeline_->AddOperator(spec, spec.name());
+    pipeline_->AddOperator(spec, spec.SchemaName());
   }
 
   virtual void AddDefaultArgs(OpSpec& spec) {

--- a/dali/test/operators/name_dump.cc
+++ b/dali/test/operators/name_dump.cc
@@ -21,8 +21,8 @@ DALI_REGISTER_OPERATOR(NameDump, NameDump, CPU);
 
 DALI_SCHEMA(NameDump)
     .DocStr("Operator for testing naming utilities and propagation of API information to backend.")
-    .AddOptionalArg("target", "\"api\", \"module\" or \"op_name\"", "op_name")
-    .AddOptionalArg("kind", "Kind parameter to relevant function as a string", "OpOnly")
+    .AddOptionalArg("target", "\"module\" or \"op_name\"", "op_name")
+    .AddOptionalArg("include_module", "If module should be included in the \"op_name\"", false)
     .NumInput(0)
     .NumOutput(1);
 

--- a/dali/test/operators/name_dump.cc
+++ b/dali/test/operators/name_dump.cc
@@ -1,0 +1,49 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/data/types.h"
+#include "dali/test/operators/origin_trace_dump.h"
+
+#include <cstdlib>
+#include <string>
+
+namespace dali {
+
+DALI_REGISTER_OPERATOR(NameDump, NameDump, CPU);
+
+DALI_SCHEMA(NameDump)
+    .DocStr("Operator for testing naming utilities and propagation of API information to backend.")
+    .AddOptionalArg("target", "\"api\", \"module\" or \"op_name\"", "op_name")
+    .AddOptionalArg("kind", "Kind parameter to relevant function as a string", "OpOnly")
+    .NumInput(0)
+    .NumOutput(1);
+
+
+DALI_REGISTER_OPERATOR(sub__NameDump, NameDump, CPU);
+
+DALI_SCHEMA(sub__NameDump)
+    .DocStr("Operator for testing naming utilities and propagation of API information to backend.")
+    .NumInput(0)
+    .NumOutput(1)
+    .AddParent("NameDump");
+
+DALI_REGISTER_OPERATOR(sub__sub__NameDump, NameDump, CPU);
+
+DALI_SCHEMA(sub__sub__NameDump)
+    .DocStr("Operator for testing naming utilities and propagation of API information to backend.")
+    .NumInput(0)
+    .NumOutput(1)
+    .AddParent("NameDump");
+
+}  // namespace dali

--- a/dali/test/operators/name_dump.cc
+++ b/dali/test/operators/name_dump.cc
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 #include "dali/pipeline/data/types.h"
-#include "dali/test/operators/origin_trace_dump.h"
-
-#include <cstdlib>
-#include <string>
+#include "dali/test/operators/name_dump.h"
 
 namespace dali {
 

--- a/dali/test/operators/name_dump.h
+++ b/dali/test/operators/name_dump.h
@@ -38,24 +38,12 @@ class NameDump : public StringMsgHelper {
  protected:
   std::string GetMessage(const OpSpec &spec, const Workspace &ws) override {
     auto target_function = spec.GetArgument<std::string>("target");
-    auto kind = spec.GetArgument<std::string>("kind");
+    auto include_module = spec.GetArgument<bool>("include_module");
 
-    ModuleSpecKind kind_enum = ModuleSpecKind::OpOnly;
-    if (kind == "OpOnly") {
-      kind_enum = ModuleSpecKind::OpOnly;
-    } else if (kind == "Module") {
-      kind_enum = ModuleSpecKind::Module;
-    } else if (kind == "ApiModule") {
-      kind_enum = ModuleSpecKind::ApiModule;
-    } else if (kind == "LibApiModule") {
-      kind_enum = ModuleSpecKind::LibApiModule;
-    }
-    if (target_function == "api") {
-      return GetOpApi(spec);
-    } else if (target_function == "module") {
-      return GetOpModule(spec, kind_enum);
+    if (target_function == "module") {
+      return GetOpModule(spec);
     } else if (target_function == "op_name") {
-      return GetOpDisplayName(spec, kind_enum);
+      return GetOpDisplayName(spec, include_module);
     }
     DALI_FAIL("Should not get here");
   }

--- a/dali/test/operators/name_dump.h
+++ b/dali/test/operators/name_dump.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_TEST_OPERATORS_NAME_DUMP_H_
+#define DALI_TEST_OPERATORS_NAME_DUMP_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "dali/pipeline/data/types.h"
+#include "dali/pipeline/operator/name_utils.h"
+#include "dali/pipeline/operator/operator.h"
+#include "dali/test/operators/string_msg_helper.h"
+
+namespace dali {
+
+class NameDump : public StringMsgHelper {
+ public:
+  inline explicit NameDump(const OpSpec &spec) : StringMsgHelper(spec) {}
+
+  inline ~NameDump() override = default;
+
+  DISABLE_COPY_MOVE_ASSIGN(NameDump);
+  USE_OPERATOR_MEMBERS();
+
+ protected:
+  std::string GetMessage(const OpSpec &spec, const Workspace &ws) override {
+    auto target_function = spec.GetArgument<std::string>("target");
+    auto kind = spec.GetArgument<std::string>("kind");
+
+    ModuleSpecKind kind_enum = ModuleSpecKind::OpOnly;
+    if (kind == "OpOnly") {
+      kind_enum = ModuleSpecKind::OpOnly;
+    } else if (kind == "Module") {
+      kind_enum = ModuleSpecKind::Module;
+    } else if (kind == "ApiModule") {
+      kind_enum = ModuleSpecKind::ApiModule;
+    } else if (kind == "LibApiModule") {
+      kind_enum = ModuleSpecKind::LibApiModule;
+    }
+    if (target_function == "api") {
+      return GetOpApi(spec);
+    } else if (target_function == "module") {
+      return GetOpModule(spec, kind_enum);
+    } else if (target_function == "op_name") {
+      return GetOpDisplayName(spec, kind_enum);
+    }
+    DALI_FAIL("Should not get here");
+  }
+};
+
+
+}  // namespace dali
+
+#endif  // DALI_TEST_OPERATORS_NAME_DUMP_H_

--- a/dali/test/operators/origin_trace_dump.cc
+++ b/dali/test/operators/origin_trace_dump.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/test/operators/origin_trace_dump.cc
+++ b/dali/test/operators/origin_trace_dump.cc
@@ -19,7 +19,7 @@
 
 namespace dali {
 
-DALI_REGISTER_OPERATOR(OriginTraceDump, OriginTraceDump<CPUBackend>, CPU);
+DALI_REGISTER_OPERATOR(OriginTraceDump, OriginTraceDump, CPU);
 
 DALI_SCHEMA(OriginTraceDump)
     .DocStr("Operator for testing origin stack trace from Python.")

--- a/dali/test/operators/origin_trace_dump.h
+++ b/dali/test/operators/origin_trace_dump.h
@@ -22,7 +22,6 @@
 #include "dali/pipeline/data/types.h"
 #include "dali/pipeline/operator/error_reporting.h"
 #include "dali/pipeline/operator/operator.h"
-#include "dali/test/operators/name_dump.h"
 #include "dali/test/operators/string_msg_helper.h"
 
 namespace dali {

--- a/dali/test/operators/string_msg_helper.h
+++ b/dali/test/operators/string_msg_helper.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_TEST_OPERATORS_STRING_MSG_HELPER_H_
+#define DALI_TEST_OPERATORS_STRING_MSG_HELPER_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "dali/pipeline/data/types.h"
+#include "dali/pipeline/operator/operator.h"
+
+namespace dali {
+
+/**
+ * @brief Operator class that returns a precomputed string as an only sample.
+ */
+class StringMsgHelper : public Operator<CPUBackend> {
+ public:
+  inline explicit StringMsgHelper(const OpSpec &spec) : Operator<CPUBackend>(spec) {
+  }
+
+  inline ~StringMsgHelper() override = default;
+
+  DISABLE_COPY_MOVE_ASSIGN(StringMsgHelper);
+  USE_OPERATOR_MEMBERS();
+
+ protected:
+  virtual std::string GetMessage(const OpSpec &spec, const Workspace &ws) = 0;
+
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
+    returned_message_ = GetMessage(spec_, ws);
+    output_desc.resize(1);
+    int bs = ws.GetRequestedBatchSize(0);
+    TensorListShape<1> shape(bs);
+    shape.set_tensor_shape(0, {static_cast<int64_t>(returned_message_.size())});
+    output_desc[0].type = DALI_UINT8;
+    output_desc[0].shape = shape;
+    return true;
+  }
+
+  void RunImpl(Workspace &ws) override {
+    auto &out = ws.Output<CPUBackend>(0);
+    auto *dst = out.template mutable_tensor<uint8_t>(0);
+    memcpy(dst, returned_message_.data(), returned_message_.size());
+  }
+  std::string returned_message_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_TEST_OPERATORS_STRING_MSG_HELPER_H_

--- a/dali/test/python/operator_1/test_operator_name_dump.py
+++ b/dali/test/python/operator_1/test_operator_name_dump.py
@@ -20,6 +20,7 @@ from test_utils import load_test_operator_plugin
 
 load_test_operator_plugin()
 
+
 def extract_str_from_tl(out):
     """Extract string from the test operator that returns it as u8 tensor."""
     # Extract data from first sample
@@ -68,6 +69,7 @@ def baseline_module_path(api, module, kind):
     elif kind == "LibApiModule":
         dot = "." if module else ""
         return f"nvidia.dali.{api}{dot}{module}"
+    raise ValueError(f"Wrong kind: {kind}")
 
 
 def baseline_display_name(api, module, kind):

--- a/dali/test/python/operator_1/test_operator_name_dump.py
+++ b/dali/test/python/operator_1/test_operator_name_dump.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import traceback
+import re
+import fnmatch
+
+from nvidia.dali import pipeline_def, fn, ops, Pipeline
+from nose2.tools import params
+from test_utils import load_test_operator_plugin
+
+
+def setUpModule():
+    load_test_operator_plugin()
+
+
+def extract_str_from_tl(out):
+    """Extract string from the test operator that returns it as u8 tensor."""
+    # Extract data from first sample
+    arr = np.array(out[0])
+    # View it as list of characters and decode to string
+    return arr.view(f"S{arr.shape[0]}")[0].decode("utf-8")
+
+
+api_variants = [("fn", fn.name_dump), ("ops", ops.NameDump)]
+
+
+@params(*api_variants)
+def test_api_name(api, op):
+
+    @pipeline_def(batch_size=1, num_threads=1, device_id=0)
+    def pipe():
+        return op(target="api")
+
+    p = pipe()
+    p.build()
+    (out,) = p.run()
+    out_str = extract_str_from_tl(out)
+    assert out_str == "api"

--- a/docs/operations_table.py
+++ b/docs/operations_table.py
@@ -1,6 +1,5 @@
 from nvidia.dali import backend as b
 import nvidia.dali.ops as ops
-import nvidia.dali.fn as fn
 import nvidia.dali.plugin.pytorch
 import nvidia.dali.plugin.numba.experimental
 import sys

--- a/docs/supported_ops_legacy.rst
+++ b/docs/supported_ops_legacy.rst
@@ -84,3 +84,8 @@ nvidia.dali.plugin.pytorch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: nvidia.dali.plugin.pytorch.TorchPythonFunction
    :members:
+
+Compose
+^^^^^^^
+.. autoclass:: nvidia.dali.ops.Compose
+   :members:


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **New feature**, **Refactoring**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Move module and op name partitioning to backend.
The "__" delimiter splitting of schema name into a module path and operator name is moved to backend.

Python APIs are switched over to query the schema.

ops.Compose is removed from registry of operators - it is mainly used to generate documentation and stubs, Compose is not really an operator but a special Python wrapper. It will be a standalone entity in the ops module and the documentation for it is now listed separately.

Add new `_module` and `_display_name` arguments that are updated by the `fn` and `ops` API bindings.

OpSpec name() is adjusted to SchemaName() to differentiate that from the name/display name
of the operator and avoid the confusion.

New module that formats module path and operator display name is added in the backend.

Tests are added on Python level, to see if the bindings correctly propagate the snake_case
and CamelCase names (with the proper API specified).

The tests is based on the origin stack trace tests, both are generalized into simple common utility.

In a followup those utilities will be used to report better error messages.

## Additional information:

### Affected modules and functionalities:
API bindings generation - schema processing,
OpSpec and OpSchema APIs are adjusted and extended
New module for processing names in backend.
ops.Compose.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
