### PR TITLE
Emphasise the optical flow is calculated at input resolution.

### DIFF
--- a/dali/operators/sequence/optical_flow/optical_flow.cc
+++ b/dali/operators/sequence/optical_flow/optical_flow.cc
@@ -27,6 +27,12 @@ can be provided with external hints for the optical flow calculation. The output
 matches the output format of the optical flow driver API.
 Refer to https://developer.nvidia.com/opticalflow-sdk for more information about the
 Turing, Ampere and Hopper optical flow hardware that is used by DALI.
+
+.. note::
+  The calculated optical flow is always with respect to the resolution of the input image, however the
+  output optical flow image can be a lower resolution, dictated by `output_grid`. If instead you would like
+  the optical flow vectors be consistent with the resolution of the output of this operator, you must divide
+  the output vector field by `output_grid`.
 )code")
                 .NumInput(1, 2)
                 .NumOutput(1)
@@ -48,7 +54,9 @@ The lower the speed, the more additional pre- and postprocessing is used to enha
 
 This operator produces the motion vector field at a coarser resolution than the input pixels.
 This parameter specifies the size of the pixel grid cell corresponding to one motion vector.
-For example, a value of 4 will produce one motion vector for each 4x4 pixel block.
+For example, a value of 4 will produce one motion vector for each 4x4 pixel block. Hence, to
+use optical flow with an `output_grid` of 4 to resample a full resolution image, the flow field 
+is upsampled *without* scaling the vector quantities.
 
 .. note::
   Currently, only a 1, 2 and 4 are supported for Ampere and 4 for Turing.


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
Documentation

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
I personally have made a mistake in using this operator by misinterpreting the output vector quantities as the resolution of the output image. A common pattern pytorch to automate dealing with flow vectors is to autmatically scale the flow magnitude and resolution at the same time in the following code.

```python
scale = image.shape[-1] / flow.shape[-1]
flow_scale = torch.nn.functional.interpolate(flow * scale, scale_factor=scale, mode='bilinear')
```

By emphasising the output of this operator is always at the resolution of the input, but the resolution of the output may differ, I hope to prevent others from making this same mistake.

### Context

Original datapipe code...

```python
pipedata["flow_pn"] = fn.optical_flow(image_seq)
```

...was fixed with (since default output_grid=4)

```python
pipedata["flow_pn"] = fn.optical_flow(image_seq) / 4
```

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
