### PR TITLE
Optimize sanitizer operator tests

### DIFF
--- a/dali/test/python/operator_1/test_gaussian_blur.py
+++ b/dali/test/python/operator_1/test_gaussian_blur.py
@@ -320,6 +320,7 @@ def slow_test_generic_gaussian_blur():
                 yield from generate_generic_cases(dev, t_in, t_out)
 
 
+@attr("sanitizer_skip")
 def check_per_sample_gaussian_blur(
     batch_size, sigma_dim, window_size_dim, shape, layout, axes, op_type="cpu"
 ):
@@ -367,7 +368,6 @@ def check_per_sample_gaussian_blur(
 
 
 # TODO(klecki): consider checking mixed ArgumentInput/Scalar value cases
-@attr("sanitizer_skip")
 def test_per_sample_gaussian_blur():
     for dev in ["cpu", "gpu"]:
         for shape, layout, axes in shape_layout_axes_cases:

--- a/dali/test/python/operator_1/test_gaussian_blur.py
+++ b/dali/test/python/operator_1/test_gaussian_blur.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -367,6 +367,7 @@ def check_per_sample_gaussian_blur(
 
 
 # TODO(klecki): consider checking mixed ArgumentInput/Scalar value cases
+@attr("sanitizer_skip")
 def test_per_sample_gaussian_blur():
     for dev in ["cpu", "gpu"]:
         for shape, layout, axes in shape_layout_axes_cases:
@@ -524,6 +525,7 @@ def test_fail_gaussian_blur():
     )
 
 
+@attr("sanitizer_skip")
 def test_per_frame():
     def window_size(sample_desc):
         return np.array(2 * sample_desc.rng.randint(1, 15) + 1, dtype=np.int32)

--- a/dali/test/python/operator_1/test_numba_func.py
+++ b/dali/test/python/operator_1/test_numba_func.py
@@ -129,6 +129,7 @@ def get_data_zeros(shapes, dtype):
     return [np.zeros(shape, dtype=dtype) for shape in shapes]
 
 
+@attr("sanitizer_skip")
 def _testimpl_numba_func(
     device,
     shapes,
@@ -201,7 +202,6 @@ def _testimpl_numba_func(
             assert np.array_equal(out_arr, expected_out[i])
 
 
-@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_cpu)
 def test_numba_func():
     # shape, dtype, run_fn, out_types,
@@ -353,7 +353,6 @@ def test_numba_func_with_cond_do_not_convert():
     )
 
 
-@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_gpu)
 def test_numba_func_gpu():
     # shape, dtype, run_fn, out_types,
@@ -478,6 +477,7 @@ def numba_func_image_pipe(
     return images_in, images_out
 
 
+@attr("sanitizer_skip")
 def _testimpl_numba_func_image(
     device,
     run_fn,
@@ -565,7 +565,6 @@ def rot_image_setup(outs, ins):
         out0[sample_id][2] = in0[sample_id][2]
 
 
-@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_cpu)
 def test_numba_func_image():
     args = [
@@ -635,7 +634,6 @@ def test_numba_func_image():
         )
 
 
-@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_gpu)
 def test_numba_func_image_gpu():
     args = [

--- a/dali/test/python/operator_1/test_numba_func.py
+++ b/dali/test/python/operator_1/test_numba_func.py
@@ -28,6 +28,7 @@ from test_utils import (
 )
 from nvidia.dali.plugin.numba.fn.experimental import numba_function
 from numba import cuda
+from nose.plugins.attrib import attr
 
 test_data_root = get_dali_extra_path()
 lmdb_folder = os.path.join(test_data_root, "db", "lmdb")
@@ -200,6 +201,7 @@ def _testimpl_numba_func(
             assert np.array_equal(out_arr, expected_out[i])
 
 
+@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_cpu)
 def test_numba_func():
     # shape, dtype, run_fn, out_types,
@@ -309,6 +311,7 @@ def test_numba_func():
         )
 
 
+@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_cpu)
 def test_numba_func_with_cond():
     # When the function is not converted, the numba still works with no issues.
@@ -330,6 +333,7 @@ def test_numba_func_with_cond():
     )
 
 
+@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_cpu)
 def test_numba_func_with_cond_do_not_convert():
     # Test if do_not_convert decorated functions still work.
@@ -349,6 +353,7 @@ def test_numba_func_with_cond_do_not_convert():
     )
 
 
+@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_gpu)
 def test_numba_func_gpu():
     # shape, dtype, run_fn, out_types,
@@ -560,6 +565,7 @@ def rot_image_setup(outs, ins):
         out0[sample_id][2] = in0[sample_id][2]
 
 
+@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_cpu)
 def test_numba_func_image():
     args = [
@@ -629,6 +635,7 @@ def test_numba_func_image():
         )
 
 
+@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_gpu)
 def test_numba_func_image_gpu():
     args = [
@@ -746,6 +753,7 @@ def numba_func_split_image_pipe(
     return images_in, out0, out1, out2
 
 
+@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_cpu)
 def test_split_images_col():
     pipe = numba_func_split_image_pipe(
@@ -823,6 +831,7 @@ def multiple_ins_run_gpu(out0, in0, in1, in2):
             out0[y][x][2] = in2[y][x]
 
 
+@attr("sanitizer_skip")
 @pipeline_def
 def numba_multiple_ins_pipe(
     shapes,
@@ -969,6 +978,7 @@ def nonuniform_types_pipe(
     return images_in, out_img, out_shape
 
 
+@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_cpu)
 def test_nonuniform_types_cpu():
     pipe = nonuniform_types_pipe(
@@ -990,6 +1000,7 @@ def test_nonuniform_types_cpu():
             assert np.array_equal(images_out.at(i).shape, img_shape.at(i))
 
 
+@attr("sanitizer_skip")
 @with_setup(check_numba_compatibility_gpu)
 def test_nonuniform_types_gpu():
     blocks = [16, 16, 1]

--- a/qa/TL0_python-self-test-operators_1/test_body.sh
+++ b/qa/TL0_python-self-test-operators_1/test_body.sh
@@ -1,7 +1,11 @@
 #!/bin/bash -e
 
 test_py_with_framework() {
-    ${python_new_invoke_test} -A '!slow' -s operator_1
+    if [ -z "$DALI_ENABLE_SANITIZERS" ]; then
+        ${python_new_invoke_test} -A '!slow' -s operator_1
+    else
+        ${python_new_invoke_test} -A '!slow,!sanitizer_skip' -s operator_1
+    fi
 }
 
 test_no_fw() {


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
--->
**Other** (*e.g. Documentation, Tests, Configuration*)


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

Those two test suites are slowing down our sanitizer runs the most:
- `test_gaussian_blur` takes 80 minutes (27% of total time), with 831 tests, average 5s per test
- `test_numba_func` takes 65 minutes (21%), with 25 tests, average 160s per test

In this PR I disable most of `test_gaussian_blur` and `test_numba_func` when running under sanitizer, just keep a few tests from each suite.

## Additional information:

### Affected modules and functionalities:
Tests: `test_gaussian_blur`, `test_numba_func`

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3859
<!--- DALI-XXXX or NA --->
