### PR TITLE
External context refactor

### DIFF
--- a/dali/pipeline/operator/checkpointing/checkpoint.cc
+++ b/dali/pipeline/operator/checkpointing/checkpoint.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,8 +60,7 @@ std::string Checkpoint::SerializeToProtobuf(const OpGraph &graph) const {
     op_cpt->set_operator_name(cpts_[i].OperatorName());
     op_cpt->set_operator_state(nodes[i].op->SerializeCheckpoint(cpts_[i]));
   }
-  checkpoint.mutable_external_ctx_cpt()->set_epoch_idx(external_ctx_cpt_.epoch_idx);
-  checkpoint.mutable_external_ctx_cpt()->set_iteration(external_ctx_cpt_.iter);
+  checkpoint.mutable_external_ctx_cpt()->set_pipeline_data(external_ctx_cpt_.pipeline_data);
   return checkpoint.SerializeAsString();
 }
 
@@ -84,8 +83,7 @@ void Checkpoint::DeserializeFromProtobuf(const OpGraph &graph,
                  "The checkpoint might come from another pipeline. ");
     nodes[i].op->DeserializeCheckpoint(op_cpt, data);
   }
-  external_ctx_cpt_.epoch_idx = checkpoint.external_ctx_cpt().epoch_idx();
-  external_ctx_cpt_.iter = checkpoint.external_ctx_cpt().iteration();
+  external_ctx_cpt_.pipeline_data = checkpoint.external_ctx_cpt().pipeline_data();
 }
 
 }  // namespace dali

--- a/dali/pipeline/operator/checkpointing/checkpoint.h
+++ b/dali/pipeline/operator/checkpointing/checkpoint.h
@@ -28,8 +28,7 @@ class OpGraph;
  * @brief Pipeline-wide state, passed from python side
 */
 struct ExternalContextCheckpoint {
-  int epoch_idx;  // Epoch index, as counted by python Pipeline
-  int iter;       // Iteration, as counted by python Pipeline
+  std::string pipeline_data;
 };
 
 /**

--- a/dali/pipeline/proto/dali.proto
+++ b/dali/pipeline/proto/dali.proto
@@ -84,8 +84,7 @@ message Checkpoint {
   }
 
   message ExternalContextCheckpoint {
-    optional int64 epoch_idx = 1;
-    optional int64 iteration = 2;
+    optional bytes pipeline_data = 1;
   }
 
   repeated OpCheckpoint cpts = 1;

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1832,8 +1832,7 @@ PYBIND11_MODULE(backend_impl, m) {
 
   py::class_<ExternalContextCheckpoint>(m, "ExternalContextCheckpoint")
     .def(py::init<>())
-    .def_readwrite("epoch_idx", &ExternalContextCheckpoint::epoch_idx)
-    .def_readwrite("iter", &ExternalContextCheckpoint::iter);
+    .def_readwrite("pipeline_data", &ExternalContextCheckpoint::pipeline_data);
 
   // Pipeline class
   py::class_<Pipeline, PyPipeline>(m, "Pipeline")

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1832,7 +1832,14 @@ PYBIND11_MODULE(backend_impl, m) {
 
   py::class_<ExternalContextCheckpoint>(m, "ExternalContextCheckpoint")
     .def(py::init<>())
-    .def_readwrite("pipeline_data", &ExternalContextCheckpoint::pipeline_data);
+    .def_property("pipeline_data",
+        [](const ExternalContextCheckpoint &self) {
+          return py::bytes(self.pipeline_data);
+        },
+        [](ExternalContextCheckpoint &self, const std::string &new_data) {
+          self.pipeline_data = new_data;
+        }
+    );
 
   // Pipeline class
   py::class_<Pipeline, PyPipeline>(m, "Pipeline")

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1523,10 +1523,9 @@ class Pipeline(object):
                 The file that the serialized pipeline will be written to.
         """
         external_ctx_cpt = b.ExternalContextCheckpoint()
-        external_ctx_cpt.pipeline_data = pickle.dumps({
-            "iter": self._consumer_iter,
-            "epoch_idx": self._epoch_idx
-        })
+        external_ctx_cpt.pipeline_data = pickle.dumps(
+            {"iter": self._consumer_iter, "epoch_idx": self._epoch_idx}
+        )
         ret = self._pipe.SerializedCheckpoint(external_ctx_cpt)
         if filename is not None:
             with open(filename, "wb") as checkpoint_file:

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -29,6 +29,7 @@ import atexit
 import ctypes
 import functools
 import inspect
+import pickle
 import sys
 import warnings
 import weakref
@@ -906,12 +907,13 @@ class Pipeline(object):
     def _restore_state_from_checkpoint(self):
         if self._checkpoint is not None:
             external_ctx_cpt = self._pipe.RestoreFromSerializedCheckpoint(self._checkpoint)
-            self._consumer_epoch_idx = self._epoch_idx = external_ctx_cpt.epoch_idx
-            self._consumer_iter = external_ctx_cpt.iter
+            pipeline_data = pickle.loads(external_ctx_cpt.pipeline_data)
+            self._consumer_epoch_idx = self._epoch_idx = pipeline_data["epoch_idx"]
+            self._consumer_iter = pipeline_data["iter"]
             if self._input_callbacks:
                 for group in self._input_callbacks:
-                    group.current_iter = external_ctx_cpt.iter
-                    group.current_sample = external_ctx_cpt.iter * self._max_batch_size
+                    group.current_iter = pipeline_data["iter"]
+                    group.current_sample = pipeline_data["iter"] * self._max_batch_size
             self._is_restored_from_checkpoint = True
 
     def build(self):
@@ -1521,8 +1523,10 @@ class Pipeline(object):
                 The file that the serialized pipeline will be written to.
         """
         external_ctx_cpt = b.ExternalContextCheckpoint()
-        external_ctx_cpt.epoch_idx = self._consumer_epoch_idx
-        external_ctx_cpt.iter = self._consumer_iter
+        external_ctx_cpt.pipeline_data = pickle.dumps({
+            "iter": self._consumer_iter,
+            "epoch_idx": self._epoch_idx
+        })
         ret = self._pipe.SerializedCheckpoint(external_ctx_cpt)
         if filename is not None:
             with open(filename, "wb") as checkpoint_file:

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -89,9 +89,13 @@ typedef struct {
 /*
  * Need to keep that in sync with ExternalContextCheckpoint from checkpoint.h
  */
+typedef struct daliExternalContextField {
+  char *data;
+  size_t size;
+} daliExternalContextField;
+
 typedef struct {
-  int epoch_idx;
-  int iter;
+  daliExternalContextField pipeline_data;
 } daliExternalContextCheckpoint;
 
 
@@ -756,12 +760,20 @@ DLL_PUBLIC void daliGetSerializedCheckpoint(
  * @param n Size of the checkpoint, in bytes.
  *
  * @param external_context Output buffer to which checkpoint's external context will be saved.
- *                         Ignored if null.
+ *                         Populated fields of the external context can be later freed with
+ *                         daliDestroyExternalContextCheckpoint. Ignored if null.
 */
 DLL_PUBLIC void daliRestoreFromSerializedCheckpoint(
   daliPipelineHandle *pipe_handle,
   const char *checkpoint, size_t n,
   daliExternalContextCheckpoint *external_context);
+
+/** @brief Frees all allocated fields of daliExternalContextCheckpoint */
+DLL_PUBLIC void daliDestroyExternalContextCheckpoint(daliExternalContextCheckpoint *external_context);
+
+DLL_PUBLIC void *daliAlloc(size_t n);
+
+DLL_PUBLIC void daliFree(void *ptr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
In this PR, I refactor `ExternalContext` to be more flexible. 

Instead of enforcing specific data format, just a bytes field for `pipeline_data` is there,  allowing `Pipeline` to populate it in any way. This is a preparation for allowing `ExternalContext` to keep arbitrary `iterator_data` alongside `pipeline_data`, which will improve and simplify iterator checkpointing.

## Additional information:

#### What is ExternalContext?
ExternalContext is a structure used to pass data from the frontend to be saved in a checkpoint. 
Currently, it's used to pass Pipeline's epoch and iteration, but it will be extended in the future to store other frontend data (in particular, iterator's counters).

### Affected modules and functionalities:

#### General changes
ExternalContext no longer stores `epoch_idx` and `iter` directly. Instead, a `bytes pipeline_data` is provided and the pipeline uses it this field to store its counters. Pipeline is responsible for encoding and decoding this data.

#### Changes in the pipeline
Pipeline now stores **a pickled dict** in `pipeline_data`, with two keys: `"epoch_idx"` and `"iter"`.

#### Changes in C API


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
