### PR TITLE
Process TFRecord reader binding classes only when it is enabled

### DIFF
--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -64,7 +64,8 @@ if tfrecord_enabled():
                             "Expected `nvidia.dali.tfrecord.Feature` for the "
                             f'"{feature_name}", but got {type(feature)}. '
                             "Use `nvidia.dali.tfrecord.FixedLenFeature` or "
-                            "`nvidia.dali.tfrecord.VarLenFeature` to define the features to extract."
+                            "`nvidia.dali.tfrecord.VarLenFeature` "
+                            "to define the features to extract."
                         )
 
                 kwargs.update({"feature_names": feature_names, "features": features})

--- a/dali/python/nvidia/dali/ops/_operators/tfrecord.py
+++ b/dali/python/nvidia/dali/ops/_operators/tfrecord.py
@@ -29,61 +29,61 @@ def tfrecord_enabled():
     return False
 
 
-def _get_impl(name, schema_name, internal_schema_name):
+if tfrecord_enabled():
 
-    class _TFRecordReaderImpl(
-        ops.python_op_factory(name, schema_name, internal_schema_name, generated=False)
-    ):
-        """custom wrappers around ops"""
+    def _get_impl(name, schema_name, internal_schema_name):
 
-        def __init__(self, path, index_path, features, **kwargs):
-            if isinstance(path, list):
-                self._path = path
-            else:
-                self._path = [path]
-            if isinstance(index_path, list):
-                self._index_path = index_path
-            else:
-                self._index_path = [index_path]
+        class _TFRecordReaderImpl(
+            ops.python_op_factory(name, schema_name, internal_schema_name, generated=False)
+        ):
+            """custom wrappers around ops"""
 
-            kwargs.update({"path": self._path, "index_path": self._index_path})
-            self._features = features
+            def __init__(self, path, index_path, features, **kwargs):
+                if isinstance(path, list):
+                    self._path = path
+                else:
+                    self._path = [path]
+                if isinstance(index_path, list):
+                    self._index_path = index_path
+                else:
+                    self._index_path = [index_path]
 
-            super().__init__(**kwargs)
+                kwargs.update({"path": self._path, "index_path": self._index_path})
+                self._features = features
 
-        def __call__(self, *inputs, **kwargs):
-            feature_names = []
-            features = []
-            for feature_name, feature in self._features.items():
-                feature_names.append(feature_name)
-                features.append(feature)
-                if not isinstance(feature, _b.tfrecord.Feature):
-                    raise TypeError(
-                        "Expected `nvidia.dali.tfrecord.Feature` for the "
-                        f'"{feature_name}", but got {type(feature)}. '
-                        "Use `nvidia.dali.tfrecord.FixedLenFeature` or "
-                        "`nvidia.dali.tfrecord.VarLenFeature` to define the features to extract."
-                    )
+                super().__init__(**kwargs)
 
-            kwargs.update({"feature_names": feature_names, "features": features})
+            def __call__(self, *inputs, **kwargs):
+                feature_names = []
+                features = []
+                for feature_name, feature in self._features.items():
+                    feature_names.append(feature_name)
+                    features.append(feature)
+                    if not isinstance(feature, _b.tfrecord.Feature):
+                        raise TypeError(
+                            "Expected `nvidia.dali.tfrecord.Feature` for the "
+                            f'"{feature_name}", but got {type(feature)}. '
+                            "Use `nvidia.dali.tfrecord.FixedLenFeature` or "
+                            "`nvidia.dali.tfrecord.VarLenFeature` to define the features to extract."
+                        )
 
-            # We won't have MIS as this op doesn't have any inputs (Reader)
-            linear_outputs = super().__call__(*inputs, **kwargs)
-            # We may have single, flattened output
-            if not isinstance(linear_outputs, list):
-                linear_outputs = [linear_outputs]
-            outputs = {}
-            for feature_name, output in zip(feature_names, linear_outputs):
-                outputs[feature_name] = output
+                kwargs.update({"feature_names": feature_names, "features": features})
 
-            return outputs
+                # We won't have MIS as this op doesn't have any inputs (Reader)
+                linear_outputs = super().__call__(*inputs, **kwargs)
+                # We may have single, flattened output
+                if not isinstance(linear_outputs, list):
+                    linear_outputs = [linear_outputs]
+                outputs = {}
+                for feature_name, output in zip(feature_names, linear_outputs):
+                    outputs[feature_name] = output
 
-    return _TFRecordReaderImpl
+                return outputs
 
+        return _TFRecordReaderImpl
 
-class TFRecordReader(_get_impl("_TFRecordReader", "TFRecordReader", "_TFRecordReader")):
-    pass
+    class TFRecordReader(_get_impl("_TFRecordReader", "TFRecordReader", "_TFRecordReader")):
+        pass
 
-
-class TFRecord(_get_impl("_TFRecord", "readers__TFRecord", "readers___TFRecord")):
-    pass
+    class TFRecord(_get_impl("_TFRecord", "readers__TFRecord", "readers___TFRecord")):
+        pass


### PR DESCRIPTION
## Category: **Bug fix** 
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Only parse the code and create the TFRecord reader API bindings/classes when the feature is enabled.

## Additional information:

### Affected modules and functionalities:
TFRecord Python bidnings



### Key points relevant for the review:
It just adds the if statement and indents the implementation.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
Should fix the custom src pattern test and work as is in the rest of DALI
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
