### PR TITLE
Use synchronous copy to framework array in the absence of a stream

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -72,12 +72,13 @@ def feed_ndarray(dali_tensor, arr, cuda_stream=None):
     ptr = ctypes.c_void_p()
     mx.base._LIB.MXNDArrayGetData(arr.handle, ctypes.byref(ptr))
 
+    non_blocking = cuda_stream is not None
     cuda_stream = types._raw_cuda_stream(cuda_stream)
 
     # Copy data from DALI tensor to ptr
     if isinstance(dali_tensor, (TensorGPU, TensorListGPU)):
         stream = None if cuda_stream is None else ctypes.c_void_p(cuda_stream)
-        dali_tensor.copy_to_external(ptr, stream, non_blocking=True)
+        dali_tensor.copy_to_external(ptr, stream, non_blocking=non_blocking)
     else:
         dali_tensor.copy_to_external(ptr)
 

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -73,12 +73,13 @@ def feed_ndarray(dali_tensor, ptr, cuda_stream=None):
                     (if not provided, an internal user stream will be selected)
     """
 
+    non_blocking = cuda_stream is not None
     cuda_stream = types._raw_cuda_stream(cuda_stream)
 
     c_type_pointer = ctypes.c_void_p(ptr)
     if isinstance(dali_tensor, (TensorGPU, TensorListGPU)):
         stream = None if cuda_stream is None else ctypes.c_void_p(cuda_stream)
-        dali_tensor.copy_to_external(c_type_pointer, stream, non_blocking=True)
+        dali_tensor.copy_to_external(c_type_pointer, stream, non_blocking=non_blocking)
     else:
         dali_tensor.copy_to_external(c_type_pointer)
     return ptr

--- a/dali/python/nvidia/dali/plugin/pytorch/__init__.py
+++ b/dali/python/nvidia/dali/plugin/pytorch/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,13 +85,15 @@ def feed_ndarray(
     ), "Shapes do not match: DALI tensor has size {0}, but PyTorch Tensor has size {1}".format(
         dali_tensor.shape(), list(arr.size())
     )
+
+    non_blocking = cuda_stream is not None
     cuda_stream = types._raw_cuda_stream(cuda_stream)
 
     # turn raw int to a c void pointer
     c_type_pointer = ctypes.c_void_p(arr.data_ptr())
     if isinstance(dali_tensor, (TensorGPU, TensorListGPU)):
         stream = None if cuda_stream is None else ctypes.c_void_p(cuda_stream)
-        dali_tensor.copy_to_external(c_type_pointer, stream, non_blocking=True)
+        dali_tensor.copy_to_external(c_type_pointer, stream, non_blocking=non_blocking)
     else:
         dali_tensor.copy_to_external(c_type_pointer)
     return arr


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:

The mxnet does not provide stream to make the copy, in that case the `copy_to_external` should not be run in non-blocking mode (as it ends up doing the copy on a random stream).
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply  (mxnet/gluon checkpointing tests)
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
