### PR TITLE
Add option to prune bboxes based on % area in Crop ROI

### DIFF
--- a/dali/operators/image/crop/bbox_crop.cc
+++ b/dali/operators/image/crop/bbox_crop.cc
@@ -356,14 +356,14 @@ the original indices of the bounding boxes that passed the centroid filter and a
 the output bounding boxes.)code",
         false)
     .AddOptionalArg<float>("bbox_prune",
-        R"code(Controls how bboxes are pruned from the ROI. Valid values of `bbox_prune` are `-1.f`
-(to flag centroid pruning) or in the range `[0,1]` for the threshold algorithm.
+        R"code(Controls how bboxes are pruned from the ROI. Valid values of `bbox_prune` are `-1.f` 
+(to flag centroid pruning) or in the range `[0.0,1.0)` for the threshold algorithm.
 
 - `bbox_prune=-1.0` prune boxes if their centroid is outside of the ROI.
 
-- `bbox_prune=(0.0,1.0]` this is a threshold where boxes are removed if the fraction of their
-original area within the ROI is less than this value. For example when `bbox_prune=0.2` bboxes that
-have more than 20% of their area within the ROI are kept, bboxes under this threshold are pruned.
+- `bbox_prune=(0.0,1.0)` this is a threshold where boxes are only kept if the fraction of their 
+area within the ROI is greater than this value. For example when `bbox_prune=0.2` bboxes that have 
+more than 20% of their original area within the ROI are kept, bboxes less than or equal to are pruned.
 
 - `bbox_prune=0.0` all boxes that have some presence in the ROI are kept.)code",
         -1.f);
@@ -408,8 +408,8 @@ class RandomBBoxCropImpl : public OpImplBase<CPUBackend> {
                     ", ", scale_range_.max));
 
     if (bbox_prune_threshold_ != -1.f) {
-      DALI_ENFORCE(0 <= bbox_prune_threshold_ && bbox_prune_threshold_ <= 1,
-        make_string("`bbox_prune` must be `-1` or in range `[0,1]`. Got: ", bbox_prune_threshold_));
+      DALI_ENFORCE(0 <= bbox_prune_threshold_ && bbox_prune_threshold_ < 1.f,
+        make_string("`bbox_prune` must be `-1` or in range `[0,1)`. Got: ", bbox_prune_threshold_));
     }
 
     auto aspect_ratio_arg = spec_.GetRepeatedArgument<float>("aspect_ratio");


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** 

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
Following on #5366, I made some modifications to RandomBBoxCropImpl to enable pruning bboxes based on their remaining area within the ROI, while leaving the option to use the original centroid algorithm (which is currently default). This simply finds the intersection between the crop and bbox and divides this by the bbox area. The bbox is kept if this result is above a threshold.

Some results of this change are also shown in the aforementioned thread.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
Added new argument to `random_bbox_crop`, namely `bbox_prune`, which is a float that signals to use the old algorithm (by default), or the new algorithm.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
Naming things is a difficult part of CS, I just copied my original "one new parameter" implementation that has overloaded functionality. We can change it to a string to signal which algoirthm, and add another parameter for the threshold tolerance. Always better to have more than one opinion on API design.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->

I intend to add some more tests to `operator_2/test_random_bbox_crop.py`.

- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
