### PR TITLE
Support checkpointing in JAX peekable iterator

### DIFF
--- a/dali/python/nvidia/dali/plugin/jax/clu.py
+++ b/dali/python/nvidia/dali/plugin/jax/clu.py
@@ -228,7 +228,8 @@ class DALIGenericPeekableIterator(DALIGenericIterator):
         if self._peek is not None:
             raise RuntimeError(
                 "Checkpointing is not supported for peekable iterators with peeked data. "
-                "Consume the peeked data completely using next() before saving a checkpoint.")
+                "Consume the peeked data completely using next() before saving a checkpoint."
+            )
         return super().checkpoints()
 
     @property

--- a/dali/python/nvidia/dali/plugin/jax/clu.py
+++ b/dali/python/nvidia/dali/plugin/jax/clu.py
@@ -150,13 +150,16 @@ class DALIGenericPeekableIterator(DALIGenericIterator):
 
         self._element_spec = None
 
+    def _set_element_spec(self, output):
+        self._element_spec = {
+            output_name: get_spec_for_array(output[output_name])
+            for output_name in self._output_categories
+        }
+
     def _assert_output_shape_and_type(self, output):
         if self._element_spec is None:
             # Set element spec based on the first seen element
-            self._element_spec = {
-                output_name: get_spec_for_array(output[output_name])
-                for output_name in self._output_categories
-            }
+            self._set_element_spec(output)
 
         for key in output:
             if get_spec_for_array(output[key]) != self._element_spec[key]:
@@ -241,6 +244,8 @@ class DALIGenericPeekableIterator(DALIGenericIterator):
         Returns:
             ElementSpec: Element spec for the elements returned by the iterator.
         """
+        if self._element_spec is None:
+            self._set_element_spec(self.peek())
         return self._element_spec
 
     @property

--- a/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing_fw_iterators.py
@@ -451,12 +451,9 @@ class TestJaxPeekable(FwTestBase):
             device_id=0,
         )
         def pipeline():
-            data, _ = fn.readers.file(
-                file_root=images_dir,
-                name="Reader"
-            )
+            data, _ = fn.readers.file(file_root=images_dir, name="Reader")
             data = fn.decoders.image(data)
-            data = fn.resize(data, size=(200,200))
+            data = fn.resize(data, size=(200, 200))
             return data
 
         p = pipeline()
@@ -472,9 +469,11 @@ class TestJaxPeekable(FwTestBase):
         it.checkpoints()  # This is OK, we've consumed the peeked batch
 
         it.peek()
-        with assert_raises(RuntimeError, glob="Checkpointing is not supported for peekable iterators with peeked data."):
+        with assert_raises(
+            RuntimeError,
+            glob="Checkpointing is not supported for peekable iterators with peeked data.",
+        ):
             it.checkpoints()
-
 
 
 class TestPaddle(FwTestBase):


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** (*non-breaking change which adds functionality*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
This PR adds checkpointing support to JAX/CLU peekable iterator. It's an iterator that allows you to look at the data (_peek_) multiple times without actually consuming it. This peeking is implemented by simply keeping the _peeked_ batch inside the iterator and returning it multiple times on multiple calls to `peek`, until it's properly consumed with `next`.

This approach makes checkpointing hard for iterators which have already `peek`ed at the data but didn't consume it. In this PR I raise an error in this case, allowing checkpointing only if no peeked data is kept in the iterator.

Also, I removed `peek` from `__init__`. The `peek` was used there to learn about data type and shape to ensure its consistency. It made the code clean, but put freshly created iterators in non-checkpointable state. I moved the code obtaining data type and shape to the place where the data is actually seen.

## Additional information:

### Affected modules and functionalities:

Peekable iterator

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3871
<!--- DALI-XXXX or NA --->
