### PR TITLE
Fix Loader checkpointing bug

### DIFF
--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -198,6 +198,9 @@ class Loader {
     }
 
     DALI_ENFORCE(GetMissingSamples().empty(), "Internal error: reading missing samples failed");
+
+    // current_snapshot_.age was increased by `ReadOne` calls, reset it to correct value
+    current_snapshot_.age = state.age;
   }
 
   bool ShouldPadBatch(bool is_new_batch) {

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -1140,7 +1140,7 @@ def test_multiple_restores(warmup_epochs, warmup_iters, run_epochs, run_iters):
     pipe = pipeline()
     pipe.build()
 
-    iters_in_epoch = pipe.reader_meta()['Reader']['epoch_size'] // batch_size
+    iters_in_epoch = pipe.reader_meta()["Reader"]["epoch_size"] // batch_size
     warmup_iters += warmup_epochs * iters_in_epoch
     run_iters += run_epochs * iters_in_epoch
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:

#### Context
`Loader` checkpointing works the following way:
- Every full epoch, a new snapshot of Loader state is taken and kept (as `current_snapshot_`)
- Every iteration, `age` counter of the current snapshot is incremented.

When restoring from checkpoint, Loader first restores its state from the snapshot provided, and then fast-forwards `age` iterations.

#### Bug & fix
On restore, during fast-forwarding phase, the `age` counter is increased by `ReadOne`, resulting in incorrect value of `age` being kept in `current_snapshot_`. In this PR I fix the restore function to set `age` to a correct value.

#### Impact
For the first epoch after restoring from checkpoint, Loader's `current_snapshot_` will have invalid `age`. As a result, checkpoints of the Loader saved during this first epoch will be incorrect. After the first epoch, `age` will be reset and the checkpoints will be correct again.

## Additional information:

### Affected modules and functionalities:

Loader checkpointing.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
