### PR TITLE
Resize: Optimize block sizes, use dynamic amount of shared mem.

### DIFF
--- a/dali/kernels/imgproc/resample/resampling_batch.cu
+++ b/dali/kernels/imgproc/resample/resampling_batch.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@
 namespace dali {
 namespace kernels {
 namespace resampling {
-
 
 template <int spatial_ndim, typename Output, typename Input>
 __global__ void BatchedSeparableResampleKernel(
@@ -97,6 +96,7 @@ void BatchedSeparableResample(
     const SampleDesc<spatial_ndim> *samples,
     const BlockDesc<spatial_ndim> *block2sample, int num_blocks,
     ivec3 block_size,
+    int shm_size,
     cudaStream_t stream) {
   if (num_blocks <= 0)
     return;
@@ -104,7 +104,7 @@ void BatchedSeparableResample(
   dim3 block(block_size.x, block_size.y, block_size.z);
 
   BatchedSeparableResampleKernel<spatial_ndim, Output, Input>
-  <<<num_blocks, block, ResampleSharedMemSize, stream>>>(which_pass, samples, block2sample);
+  <<<num_blocks, block, shm_size, stream>>>(which_pass, samples, block2sample);
   CUDA_CALL(cudaGetLastError());
 }
 
@@ -114,7 +114,7 @@ template DLL_PUBLIC void BatchedSeparableResample<spatial_ndim, Output, Input>( 
   int which_pass,                                                               \
   const SampleDesc<spatial_ndim> *samples,                                      \
   const BlockDesc<spatial_ndim> *block2sample, int num_blocks,                  \
-  ivec3 block_size, cudaStream_t stream)
+  ivec3 block_size, int shm_size, cudaStream_t stream)
 
 // Instantiate the resampling functions.
 // The resampling always goes through intermediate image of float type.

--- a/dali/kernels/imgproc/resample/resampling_batch.h
+++ b/dali/kernels/imgproc/resample/resampling_batch.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ void BatchedSeparableResample(
   const SampleDesc<spatial_ndim> *samples,
   const BlockDesc<spatial_ndim> *block2sample, int num_blocks,
   ivec3 block_size,
+  int shm_size,
   cudaStream_t stream);
 
 }  // namespace resampling

--- a/dali/kernels/imgproc/resample/resampling_impl.cuh
+++ b/dali/kernels/imgproc/resample/resampling_impl.cuh
@@ -24,8 +24,6 @@
 namespace dali {
 namespace kernels {
 
-constexpr int ResampleSharedMemSize = 32<<10;
-
 namespace {  // NOLINT
 
 template <int n>

--- a/dali/kernels/imgproc/resample/resampling_setup.cc
+++ b/dali/kernels/imgproc/resample/resampling_setup.cc
@@ -200,61 +200,13 @@ ProcessingOrder<ndim> GetProcessingOrder(
   return poc();
 }
 
-inline int GetMaxElementsPerBlockEnv() {
-  char *env = getenv("DALI_RESIZE_MAX_ELEMENTS_PER_BLOCK");
-  if (env) {
-    int ret = atoi(env);
-    if (ret < 1024)
-      DALI_FAIL(make_string("DALI_RESIZE_MAX_ELEMENTS_PER_BLOCK must be at least 1024, got ", ret));
-    return ret;
-  } else {
-    return 1<<18;  // 256k
-  }
-}
-
-inline int GetMaxElementsPerBlock() {
-  static int ret = GetMaxElementsPerBlockEnv();
-  return ret;
-}
-
-
-inline int GetBlockSizeEnv(int ndim) {
-  char *env = getenv("DALI_RESIZE_CUDA_BLOCK");
-  if (env) {
-    int ret = atoi(env);
-    if (ret > 1024 || (ret & 31)) {
-      DALI_FAIL(make_string(
-        "DALI_RESIZE_CUDA_BLOCK must be a multiple of 32 between 32 and 1024, got ", ret));
-    }
-    return ret;
-  } else {
-    return ndim == 2 ? 24*32 : 8*32;
-  }
-}
-
-template <int ndim>
-inline int GetBlockSize() {
-  static int ret = GetBlockSizeEnv(ndim);
-  return ret;
-}
-
-
-template <>
-SeparableResamplingSetup<2>::SeparableResamplingSetup() {
-  block_dim = { 32, GetBlockSize<2>() / 32, 1 };
-}
-
-template <>
-SeparableResamplingSetup<3>::SeparableResamplingSetup() {
-  block_dim = { 32, GetBlockSize<3>() / 32, 1 };
-}
+static constexpr int kMaxElementsPerBlock = 2048;
 
 /**
  * @brief Calculates block layout for a 2D sample
  */
 template <>
 void SeparableResamplingSetup<2>::ComputeBlockLayout(SampleDesc &sample) const {
-  int64_t max_elements_per_block = GetMaxElementsPerBlock();
   for (int pass = 0; pass < 2; pass++) {
     int axis = sample.order[pass];
     // Horizontal pass (axis == 0) is processed in vertical slices
@@ -265,8 +217,8 @@ void SeparableResamplingSetup<2>::ComputeBlockLayout(SampleDesc &sample) const {
     ivec2 blk = sample.shapes[pass+1];
     blk[axis] = block_dim[axis];
     int64_t block_vol = volume(blk);
-    if (block_vol > max_elements_per_block) {
-      int den = div_ceil(block_vol, max_elements_per_block);
+    if (block_vol > kMaxElementsPerBlock) {
+      int den = div_ceil(block_vol, static_cast<uint64_t>(kMaxElementsPerBlock));
       blk[1 - axis] = align_up(blk[1 - axis] / den, 32);
     }
     sample.logical_block_shape[pass] = blk;
@@ -286,8 +238,6 @@ void SeparableResamplingSetup<3>::ComputeBlockLayout(SampleDesc &sample) const {
   for (int pass = 0; pass < 3; pass++) {
     int axis = sample.order[pass];
 
-    int max_elements_per_block = GetMaxElementsPerBlock();
-
     // Horizontal pass (axis == 0) is processed in vertical slices
     // the width of block_dim and extending down the entire image.
     // Depth of the slice is calculated so that it contains no more than
@@ -300,10 +250,10 @@ void SeparableResamplingSetup<3>::ComputeBlockLayout(SampleDesc &sample) const {
     ivec3 blk = pass_output_shape;
     if (axis < 2) {
       blk[axis] = block_dim[axis];
-      blk.z = max_elements_per_block / (blk[0] * blk[1] * sample.channels);
+      blk.z = kMaxElementsPerBlock / (blk[0] * blk[1] * sample.channels);
     } else {
       blk.z = block_dim.y;  // (yes, .y)
-      blk.y = max_elements_per_block / (blk[0] * blk[2] * sample.channels);
+      blk.y = kMaxElementsPerBlock / (blk[0] * blk[2] * sample.channels);
     }
     blk = clamp(blk, ivec3(1, 1, 1), pass_output_shape);
     sample.logical_block_shape[pass] = blk;
@@ -400,6 +350,9 @@ void BatchResamplingSetup<spatial_ndim>::SetupBatch(
   if (!this->filters)
     this->Initialize();
 
+  for (int &s : shm_size_for_pass)
+    s = 0;
+
   int N = in.num_samples();
   assert(params.size() == static_cast<span_extent_t>(N));
 
@@ -438,6 +391,28 @@ void BatchResamplingSetup<spatial_ndim>::SetupBatch(
         blocks[d] = div_ceil(desc.shapes[pass+1][d], desc.logical_block_shape[pass][d]);
       }
       total_blocks[pass] += volume(blocks);
+    }
+
+    // compute shared memory requirements for this sample
+    for (int pass = 0; pass < spatial_ndim; pass++) {
+      auto &filter = desc.filter[desc.order[pass]];
+      int shm_size = 0;
+      if (filter.num_coeffs > 0) {
+        int sup = filter.support();
+
+        // above 256 we go the "huge kernel" route - the kernel is the same for all threads
+        if (sup > 256) {
+          shm_size = sup * sizeof(float);
+        } else {
+          // The coefficients are calculated separately for each:
+          // - threadIdx.x, when resampling horizontally
+          // - threadIdx.y, when resampling vertically or depthwise
+          int block_extent = desc.order[pass] == 0 ? block_dim.x : block_dim.y;
+          shm_size = sup * block_extent * sizeof(float);
+        }
+      }
+      if (shm_size > shm_size_for_pass[pass])
+        shm_size_for_pass[pass] = shm_size;
     }
   }
 }

--- a/dali/kernels/imgproc/resample/resampling_setup.h
+++ b/dali/kernels/imgproc/resample/resampling_setup.h
@@ -45,7 +45,7 @@ struct SampleDesc {
   DeviceArray<uintptr_t, num_buffers> pointers;
   DeviceArray<ptrdiff_t, num_buffers> offsets;
   DeviceArray<Strides, num_buffers>   strides;
-  DeviceArray<Shape, num_buffers>  shapes;
+  DeviceArray<Shape, num_buffers>     shapes;
 
   template <typename Input, typename Tmp, typename Output, int D = spatial_ndim>
   void set_base_pointers(Input *in, Tmp *tmp, Output *out) {
@@ -109,7 +109,9 @@ ResamplingFilter GetResamplingFilter(const ResamplingFilters *filters, const Fil
 template <int _spatial_ndim>
 class SeparableResamplingSetup {
  public:
-  DLL_PUBLIC SeparableResamplingSetup();
+  inline SeparableResamplingSetup() {
+    block_dim = { 32, 8, 1 };
+  }
 
   static constexpr int channel_dim = _spatial_ndim;  // assumes interleaved channel data
   static constexpr int spatial_ndim = _spatial_ndim;
@@ -140,6 +142,7 @@ class SeparableResamplingSetup {
   }
 
   ivec3 block_dim;
+  int shm_size_for_pass[spatial_ndim] = {};
 
  protected:
   using ROI = Roi<spatial_ndim>;
@@ -161,6 +164,8 @@ class BatchResamplingSetup : public SeparableResamplingSetup<_spatial_ndim> {
   using Base::spatial_ndim;
   using Base::tensor_ndim;
   using Base::num_tmp_buffers;
+  using Base::block_dim;
+  using Base::shm_size_for_pass;
   using Params = span<const ResamplingParamsND<spatial_ndim>>;
   using SampleDesc = resampling::SampleDesc<spatial_ndim>;
   using BlockDesc = kernels::BlockDesc<spatial_ndim>;

--- a/dali/kernels/imgproc/resample/resampling_setup.h
+++ b/dali/kernels/imgproc/resample/resampling_setup.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,9 +109,8 @@ ResamplingFilter GetResamplingFilter(const ResamplingFilters *filters, const Fil
 template <int _spatial_ndim>
 class SeparableResamplingSetup {
  public:
-  SeparableResamplingSetup() {
-    block_dim = { 32, _spatial_ndim == 2 ? 24 : 8, 1 };
-  }
+  DLL_PUBLIC SeparableResamplingSetup();
+
   static constexpr int channel_dim = _spatial_ndim;  // assumes interleaved channel data
   static constexpr int spatial_ndim = _spatial_ndim;
   static constexpr int tensor_ndim = spatial_ndim + (channel_dim >= 0 ? 1 : 0);

--- a/dali/kernels/imgproc/resample/separable_impl.h
+++ b/dali/kernels/imgproc/resample/separable_impl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,7 @@ struct SeparableResamplingGPUImpl : Interface {
         which_pass,
         descs_gpu, block2sample.data, block2sample.shape[0],
         setup.block_dim,
+        setup.shm_size_for_pass[which_pass],
         stream);
   }
 

--- a/dali/kernels/test/resampling_test/resampling_internal_test.cu
+++ b/dali/kernels/test/resampling_test/resampling_internal_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@
 
 namespace dali {
 namespace kernels {
+
+constexpr int ResampleSharedMemSize = 32<<10;
 
 template <typename Dst, typename Src>
 __global__ void ResampleHorzTestKernel(


### PR DESCRIPTION
## Category:
**Other** Optimization


## Description:
This PR fixes the low GPU utilization issue in resize kernel.
It does 3 things:
- reduces the size of the logical block (more blocks = better occupancy)
- reduces the size of the physical block
- computes the amount of shared memory required dynamically instead of always requiring 32kB

## Additional information:

### Affected modules and functionalities:
Resize, operators derived from ResizeBase.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
`python/operator_2/resize_test.py`
resampling kernel tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3813
<!--- DALI-XXXX or NA --->
