### PR TITLE
Disable type annotation tests in sanitizer build

### DIFF
--- a/qa/TL0_python-self-test-core/test_body.sh
+++ b/qa/TL0_python-self-test-core/test_body.sh
@@ -17,7 +17,9 @@ test_py_with_framework() {
                             test_external_source_impl_utils.py); do
         ${python_invoke_test} --attr '!slow,!pytorch,!mxnet,!cupy' ${test_script}
     done
-    ${python_new_invoke_test} -A 'numba' -s type_annotations
+    if [ -z "$DALI_ENABLE_SANITIZERS" ]; then
+        ${python_new_invoke_test} -A 'numba' -s type_annotations
+    fi
     ${python_new_invoke_test} -A '!slow,numba' checkpointing.test_dali_checkpointing
     ${python_new_invoke_test} -A '!slow,numba' checkpointing.test_dali_stateless_operators
 }
@@ -39,13 +41,15 @@ test_autograph() {
 }
 
 test_type_annotations() {
-    ${python_new_invoke_test} -A '!pytorch,!numba' -s type_annotations
+    if [ -z "$DALI_ENABLE_SANITIZERS" ]; then
+        ${python_new_invoke_test} -A '!pytorch,!numba' -s type_annotations
+    fi
 }
 
 test_pytorch() {
     ${python_invoke_test} --attr '!slow,pytorch' test_dali_variable_batch_size.py
-    ${python_new_invoke_test} -A 'pytorch' -s type_annotations
     if [ -z "$DALI_ENABLE_SANITIZERS" ]; then
+        ${python_new_invoke_test} -A 'pytorch' -s type_annotations
         ${python_new_invoke_test} -A '!slow' checkpointing.test_dali_checkpointing_fw_iterators.TestPytorch
         ${python_new_invoke_test} -A '!slow' checkpointing.test_dali_checkpointing_fw_iterators.TestPytorchRagged
     fi


### PR DESCRIPTION

## Category: **Bug fix**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
The type annotation generation is disabled in sanitizer build so the test should be disabled as well.



## Additional information:

### Affected modules and functionalities:
tests



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
The test should not run in sanitizer build
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
