### PR TITLE
Extend fn.random.choice to support n-D inputs

### DIFF
--- a/dali/operators/random/choice.h
+++ b/dali/operators/random/choice.h
@@ -156,13 +156,13 @@ class Choice : public rng::RNGBase<Backend, Choice<Backend>, false> {
    * @brief Concatenate the requested output shape with the shape of the sampled element.
    */
   TensorListShape<> PostprocessShape(const OpSpec &spec, const Workspace &ws) {
-     const auto &input = ws.Input<CPUBackend>(0);
+    const auto &input = ws.Input<CPUBackend>(0);
     int element_dim = GetElementDim(input);
     TensorListShape<> shape(shape_.num_samples(), shape_.sample_dim() + element_dim);
     for (int sample_idx = 0; sample_idx < shape.num_samples(); sample_idx++) {
       auto result = shape_cat(shape_[sample_idx], input.tensor_shape(sample_idx).last(element_dim));
       shape.set_tensor_shape(sample_idx, result);
-     }
+    }
     return shape;
   }
 
@@ -243,7 +243,6 @@ class Choice : public rng::RNGBase<Backend, Choice<Backend>, false> {
   }
 
  protected:
-
   /**
    * @brief Returns the number of elements that will be sampled for given sample_idx within batch.
    *
@@ -321,7 +320,6 @@ class Choice : public rng::RNGBase<Backend, Choice<Backend>, false> {
     }
     tp.RunAll();
   }
-
 
 
   using Operator<Backend>::max_batch_size_;

--- a/dali/operators/random/choice.h
+++ b/dali/operators/random/choice.h
@@ -108,25 +108,6 @@ class Choice : public rng::RNGBase<Backend, Choice<Backend>, false> {
 
   explicit Choice(const OpSpec &spec) : BaseImpl(spec), p_dist_("p", spec) {}
 
-  /**
-   * @brief Returns the number of elements that will be sampled for given sample_idx within batch.
-   *
-   * If the input is scalar, it represents the number of elements, otherwise it's the outermost
-   * dimension (we treat the input as flat list of elements for sampling).
-   */
-  int64_t GetSampleNumElements(const TensorList<CPUBackend> &input, int sample_idx) const {
-    if (input.sample_dim() == 0) {
-      TYPE_SWITCH(dtype_, type2id, T, (DALI_CHOICE_0D_TYPES),
-      (
-        return input.tensor<T>(sample_idx)[0];
-      ),  // NOLINT
-      (
-        DALI_FAIL("Data type ", dtype_, " is not supported for 0D inputs. "
-                  "Supported types are: ", ListTypeNames<DALI_CHOICE_0D_TYPES>(), ".");
-      ));  // NOLINT
-    }
-    return input.tensor_shape_span(sample_idx)[0];
-  }
 
   void AcquireArgs(const OpSpec &spec, const Workspace &ws, int nsamples) {
     const auto &input = ws.Input<CPUBackend>(0);
@@ -169,6 +150,20 @@ class Choice : public rng::RNGBase<Backend, Choice<Backend>, false> {
                                ListTypeNames<DALI_CHOICE_0D_TYPES>(), "."));
     }
     return ws.Input<CPUBackend>(0).type();
+  }
+
+  /**
+   * @brief Concatenate the requested output shape with the shape of the sampled element.
+   */
+  TensorListShape<> PostprocessShape(const OpSpec &spec, const Workspace &ws) {
+     const auto &input = ws.Input<CPUBackend>(0);
+    int element_dim = GetElementDim(input);
+    TensorListShape<> shape(shape_.num_samples(), shape_.sample_dim() + element_dim);
+    for (int sample_idx = 0; sample_idx < shape.num_samples(); sample_idx++) {
+      auto result = shape_cat(shape_[sample_idx], input.tensor_shape(sample_idx).last(element_dim));
+      shape.set_tensor_shape(sample_idx, result);
+     }
+    return shape;
   }
 
   template <typename T>
@@ -234,8 +229,7 @@ class Choice : public rng::RNGBase<Backend, Choice<Backend>, false> {
                   "Supported types are: ", ListTypeNames<DALI_CHOICE_1D_TYPES>(), ".");
       ));  // NOLINT
     } else {
-      DALI_FAIL("The operator only supports sampling of 0D elements, got: ", input.sample_dim(),
-                "D input.");
+      ElementCopy(ws);
     }
     if (!input.GetLayout().empty()) {
       if (input.sample_dim() == output.sample_dim()) {
@@ -249,6 +243,87 @@ class Choice : public rng::RNGBase<Backend, Choice<Backend>, false> {
   }
 
  protected:
+
+  /**
+   * @brief Returns the number of elements that will be sampled for given sample_idx within batch.
+   *
+   * If the input is scalar, it represents the number of elements, otherwise it's the outermost
+   * dimension (we treat the input as flat list of elements for sampling).
+   */
+  int64_t GetSampleNumElements(const TensorList<CPUBackend> &input, int sample_idx) const {
+    if (input.sample_dim() == 0) {
+      TYPE_SWITCH(dtype_, type2id, T, (DALI_CHOICE_0D_TYPES),
+      (
+        return input.tensor<T>(sample_idx)[0];
+      ),  // NOLINT
+      (
+        DALI_FAIL("Data type ", dtype_, " is not supported for 0D inputs. "
+                  "Supported types are: ", ListTypeNames<DALI_CHOICE_0D_TYPES>(), ".");
+      ));  // NOLINT
+    }
+    return input.tensor_shape_span(sample_idx)[0];
+  }
+
+  /**
+   * @brief Get the dimension of the element to be sampled.
+   */
+  int GetElementDim(const TensorList<CPUBackend> &input) {
+    if (input.sample_dim() == 0) {
+      return 0;
+    }
+    return input.sample_dim() - 1;
+  }
+
+  /**
+   * @brief Implement sampling from input of dimensionality > 1.
+   *
+   * The sampling is done by configuring indirect distribution to generate indices in
+   * [0, num_elements), where `num_elements` is the outermost dimension of the input.
+   * Next the selected samples are memcopied to the output.
+   */
+  void ElementCopy(Workspace &ws) {
+    const auto &input = ws.Input<CPUBackend>(0);
+    auto &output = ws.Output<CPUBackend>(0);
+    int num_samples = input.num_samples();
+    auto &tp = ws.GetThreadPool();
+    for (int sample_idx = 0; sample_idx < num_samples; ++sample_idx) {
+      int element_dim = GetElementDim(input);
+      int64_t element_size = volume(input.tensor_shape(sample_idx).last(element_dim)) *
+                             TypeTable::GetTypeInfo(input.type()).size();
+      int64_t num_input_elements = input_list_shape_[sample_idx][0];
+      int64_t num_output_elements =
+          volume(output.tensor_shape(sample_idx).first(output.sample_dim() - element_dim));
+      uint8_t *output_data = static_cast<uint8_t *>(output.raw_mutable_tensor(sample_idx));
+      const uint8_t *input_data = static_cast<const uint8_t *>(input.raw_tensor(sample_idx));
+
+      tp.AddWork(
+          [=](int thread_id) {
+            auto &rng = rng_[sample_idx];
+            if (p_dist_.HasValue()) {
+              auto dist = ChoiceSampleDist<int64_t, false, false>(
+                  p_dist_[sample_idx].data,
+                  p_dist_[sample_idx].data + p_dist_[sample_idx].num_elements());
+              for (int64_t i = 0; i < num_output_elements; ++i) {
+                auto source_idx = dist.Generate(rng);
+                memcpy(output_data + i * element_size, input_data + source_idx * element_size,
+                       element_size);
+              }
+            } else {
+              auto dist = ChoiceSampleDist<int64_t, true, false>(num_input_elements);
+              for (int64_t i = 0; i < num_output_elements; ++i) {
+                auto source_idx = dist.Generate(rng);
+                memcpy(output_data + i * element_size, input_data + source_idx * element_size,
+                       element_size);
+              }
+            }
+          },
+          volume(output.tensor_shape(sample_idx)));
+    }
+    tp.RunAll();
+  }
+
+
+
   using Operator<Backend>::max_batch_size_;
   using BaseImpl::backend_data_;
   using BaseImpl::dtype_;

--- a/dali/operators/random/rng_base.h
+++ b/dali/operators/random/rng_base.h
@@ -122,6 +122,15 @@ class RNGBase : public OperatorWithRng<Backend> {
   void AcquireArgs(const OpSpec &spec, const Workspace &ws, int nsamples) {}
 
   /**
+   * @brief If the output shape is non copied from `shape` argument or `__shape_like` input,
+   * return new one that should be used instead. Called after basic shape parameter is obtained
+   * into `shape_`.
+   */
+  TensorListShape<> PostprocessShape(const OpSpec &spec, const Workspace &ws) {
+    return shape_;
+  }
+
+  /**
    * @brief The RNG implementation must provide SetupDist function, with `Dist` type
    * and call RunImplTyped<T, Dist>(ws) in its RunImpl, for given output type `T`.
    *
@@ -189,6 +198,7 @@ class RNGBase : public OperatorWithRng<Backend> {
       shape_ = uniform_list_shape(nsamples, TensorShape<0>{});
     }
     This().AcquireArgs(spec_, ws, shape_.size());
+    shape_ = This().PostprocessShape(spec_, ws);
 
     output_desc.resize(1);
     output_desc[0].shape = shape_;

--- a/dali/test/python/operator_2/test_random_choice.py
+++ b/dali/test/python/operator_2/test_random_choice.py
@@ -204,13 +204,16 @@ def test_choice_64_bit_type():
 
 
 @params(
-    ("N", 10),
-    ("", None),
+    (np.arange(3), "N", "N", 10),
+    (np.arange(3), "N", "", None),
+    (np.full((2, 3), 4), "NS", "S", None),
+    (np.full((2, 3), 4), "NS", "NS", 5),
+    (np.full((2, 3), 4), "NS", "", (1, 2)),
 )
-def test_layout(expected_layout, shape):
+def test_layout(input, input_layout, expected_layout, shape):
     @pipeline_def(batch_size=2, device_id=0, num_threads=4, seed=1234)
     def choice_pipe():
-        a = fn.external_source(lambda: np.array([1, 2, 3], dtype=np.int32), batch=False, layout="N")
+        a = fn.external_source(lambda: input, batch=False, layout=input_layout)
         return fn.random.choice(a, shape=shape)
 
     pipe = choice_pipe()


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **New feature**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Add support for sampling from inputs of higher dimensionality.
The sampling is done by obtaining the element index  from the distribution and than copying
it from input to output.


## Additional information:

### Affected modules and functionalities:
fn.random.choice



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
Tests were extended to cover the nd case
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
