### PR TITLE
Use host sync allocation for nvImageCodec <= 0.2

### DIFF
--- a/dali/test/python/decoder/test_imgcodec.py
+++ b/dali/test/python/decoder/test_imgcodec.py
@@ -99,78 +99,66 @@ def test_image_decoder():
 
 
 @pipeline_def
-def create_decoder_slice_pipeline(data_path, device, is_roi_dec):
+def create_decoder_slice_pipeline(data_path, device):
     jpegs, _ = fn.readers.file(file_root=data_path, shard_id=0, num_shards=1, name="Reader")
-    seed0 = 1234
-    seed1 = 2345
-    anchor = fn.random.uniform(range=[0.05, 0.15], shape=(2,), seed=seed0)
-    shape = fn.random.uniform(range=[0.5, 0.7], shape=(2,), seed=seed1)
-    if is_roi_dec:
-        images_sliced = fn.experimental.decoders.image_slice(
-            jpegs, anchor, shape, axes=(0, 1), device=device, hw_decoder_load=0.7
-        )
-    else:
-        images = fn.experimental.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
-        images_sliced = fn.slice(images, anchor, shape, axes=(0, 1))
 
-    return images_sliced
+    anchor = fn.random.uniform(range=[0.05, 0.15], shape=(2,))
+    shape = fn.random.uniform(range=[0.5, 0.7], shape=(2,))
+    images_sliced_1 = fn.experimental.decoders.image_slice(
+        jpegs, anchor, shape, axes=(0, 1), device=device, hw_decoder_load=0.7
+    )
+
+    images = fn.experimental.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
+    images_sliced_2 = fn.slice(images, anchor, shape, axes=(0, 1))
+
+    return images_sliced_1, images_sliced_2
 
 
 @pipeline_def
-def create_decoder_crop_pipeline(data_path, device, is_roi_dec):
+def create_decoder_crop_pipeline(data_path, device):
     jpegs, _ = fn.readers.file(file_root=data_path, shard_id=0, num_shards=1, name="Reader")
 
-    crop_pos_x = fn.random.uniform(range=[0.1, 0.9], seed=1234)
-    crop_pos_y = fn.random.uniform(range=[0.1, 0.9], seed=2345)
+    crop_pos_x = fn.random.uniform(range=[0.1, 0.9])
+    crop_pos_y = fn.random.uniform(range=[0.1, 0.9])
     w = 242
     h = 230
 
-    if is_roi_dec:
-        images_crop = fn.experimental.decoders.image_crop(
-            jpegs,
-            crop=(w, h),
-            crop_pos_x=crop_pos_x,
-            crop_pos_y=crop_pos_y,
-            device=device,
-            hw_decoder_load=0.7,
-        )
-    else:
-        images = fn.experimental.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
-        images_crop = fn.crop(images, crop=(w, h), crop_pos_x=crop_pos_x, crop_pos_y=crop_pos_y)
+    images_crop_1 = fn.experimental.decoders.image_crop(
+        jpegs,
+        crop=(w, h),
+        crop_pos_x=crop_pos_x,
+        crop_pos_y=crop_pos_y,
+        device=device,
+        hw_decoder_load=0.7,
+    )
 
-    return images_crop
+    images = fn.experimental.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
+
+    images_crop_2 = fn.crop(images, crop=(w, h), crop_pos_x=crop_pos_x, crop_pos_y=crop_pos_y)
+
+    return images_crop_1, images_crop_2
 
 
 @pipeline_def
-def create_decoder_random_crop_pipeline(data_path, device, is_roi_dec):
+def create_decoder_random_crop_pipeline(data_path, device):
     seed = 1234
     jpegs, _ = fn.readers.file(file_root=data_path, shard_id=0, num_shards=1, name="Reader")
 
     w = 242
     h = 230
-    if is_roi_dec:
-        images_random_crop = fn.experimental.decoders.image_random_crop(
-            jpegs, device=device, output_type=types.RGB, hw_decoder_load=0.7, seed=seed
-        )
-        images_random_crop = fn.resize(images_random_crop, size=(w, h))
-    else:
-        images = fn.experimental.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
-        images_random_crop = fn.random_resized_crop(images, size=(w, h), seed=seed)
+    images_random_crop_1 = fn.experimental.decoders.image_random_crop(
+        jpegs, device=device, output_type=types.RGB, hw_decoder_load=0.7, seed=seed
+    )
+    images_random_crop_1 = fn.resize(images_random_crop_1, size=(w, h))
 
-    return images_random_crop
+    images = fn.experimental.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
+    images_random_crop_2 = fn.random_resized_crop(images, size=(w, h), seed=seed)
+
+    return images_random_crop_1, images_random_crop_2
 
 
 def run_decode_fused(test_fun, path, img_type, batch, device, threads, validation_fun):
     data_path = os.path.join(test_data_root, path, img_type)
-    pipe_roi = test_fun(
-        data_path=data_path,
-        batch_size=batch,
-        num_threads=threads,
-        device_id=0,
-        device=device,
-        prefetch_queue_depth=1,
-        is_roi_dec=True,
-    )
     pipe = test_fun(
         data_path=data_path,
         batch_size=batch,
@@ -178,15 +166,12 @@ def run_decode_fused(test_fun, path, img_type, batch, device, threads, validatio
         device_id=0,
         device=device,
         prefetch_queue_depth=1,
-        is_roi_dec=False,
     )
-    pipe_roi.build()
     pipe.build()
     idxs = [i for i in range(batch)]
     iters = math.ceil(pipe.epoch_size("Reader") / batch)
     for it in range(iters):
-        (out_1,) = pipe_roi.run()
-        (out_2,) = pipe.run()
+        out_1, out_2 = pipe.run()
         for sample_idx, img_1, img_2 in zip(idxs, out_1, out_2):
             arr_1 = to_array(img_1)
             arr_2 = to_array(img_2)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Bug fix**

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
nvImageCodec 0.2 doesn't sync with user stream before decoding, meaning that the buffer provided needs to be ready immediately before we call decode. This limitation shall be lifted on the following version.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
experimental image decoders


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
N/A

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
