### PR TITLE
Make the video reader use cudaVideoDeinterlaceMode_Adaptive only for non-progressive videos

### DIFF
--- a/dali/operators/reader/nvdecoder/cuvideodecoder.cc
+++ b/dali/operators/reader/nvdecoder/cuvideodecoder.cc
@@ -245,7 +245,11 @@ int CUVideoDecoder::initialize(CUVIDEOFORMAT* format) {
     decoder_info_.ChromaFormat = format->chroma_format;
     decoder_info_.OutputFormat = cudaVideoSurfaceFormat_NV12;
     decoder_info_.bitDepthMinus8 = format->bit_depth_luma_minus8;
-    decoder_info_.DeinterlaceMode = cudaVideoDeinterlaceMode_Adaptive;
+    if (format->progressive_sequence) {
+        decoder_info_.DeinterlaceMode = cudaVideoDeinterlaceMode_Weave;
+    } else {
+        decoder_info_.DeinterlaceMode = cudaVideoDeinterlaceMode_Adaptive;
+    }
     decoder_info_.ulTargetWidth = format->display_area.right - format->display_area.left;
     decoder_info_.ulTargetHeight = format->display_area.bottom - format->display_area.top;
     decoder_info_.ulMaxWidth = static_cast<unsigned long>(max_width_);  // NOLINT


### PR DESCRIPTION
- removes the default usage of cudaVideoDeinterlaceMode_Adaptive
  for all videos in the video reader. Makes it conditional only
  for videos with progressive_sequence set to true

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- removes the default usage of cudaVideoDeinterlaceMode_Adaptive
  for all videos in the video reader. Makes it conditional only
  for videos with progressive_sequence set to true
- relates to nv4564021 and nv4566756
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- video reader
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- the change is based on the VideoSDK sample
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - VideoReaderTest
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3895
<!--- DALI-XXXX or NA --->
