### PR TITLE
Fix access to unitialized memory in RNG ops

### DIFF
--- a/dali/operators/random/choice.h
+++ b/dali/operators/random/choice.h
@@ -43,7 +43,7 @@ struct ChoiceSampleDist {
   using DistType =
       std::conditional_t<uniform, std::uniform_int_distribution<>, std::discrete_distribution<>>;
 
-  DALI_HOST_DEV explicit ChoiceSampleDist() {}
+  DALI_HOST_DEV ChoiceSampleDist() = default;
 
   template <bool uniform_ = uniform, typename = std::enable_if_t<!uniform_>>
   DALI_HOST_DEV ChoiceSampleDist(const T *elements, const float *p_first, const float *p_last)
@@ -76,14 +76,13 @@ struct ChoiceSampleDist<T, uniform, false> {
   using DistType =
       std::conditional_t<uniform, std::uniform_int_distribution<T>, std::discrete_distribution<T>>;
 
-  DALI_HOST_DEV explicit ChoiceSampleDist() {}
+  DALI_HOST_DEV ChoiceSampleDist() = default;
 
   template <bool uniform_ = uniform, typename = std::enable_if_t<!uniform_>>
   DALI_HOST_DEV ChoiceSampleDist(const float *p_first, const float *p_last)
       : dist_{p_first, p_last} {
     static_assert(!uniform_, "This is non-uniform variant");
   }
-
 
   template <bool uniform_ = uniform, typename = std::enable_if_t<uniform_>>
   DALI_HOST_DEV ChoiceSampleDist(int64_t element_count) : dist_(0, element_count - 1) {

--- a/dali/operators/random/rng_base_cpu.h
+++ b/dali/operators/random/rng_base_cpu.h
@@ -30,8 +30,6 @@ namespace rng {
 template<>
 struct OperatorWithRngFields<CPUBackend> {
   OperatorWithRngFields(int64_t seed, int nsamples) {}
-
-  std::vector<uint8_t> dists_cpu_;
 };
 
 template <bool IsNoiseGen>
@@ -125,10 +123,8 @@ void RNGBase<Backend, Impl, IsNoiseGen>::RunImplTyped(Workspace &ws, CPUBackend)
 
   // TODO(janton): set layout explicitly from the user for RNG
 
-  auto &dists_cpu = backend_data_.dists_cpu_;
-  dists_cpu.resize(sizeof(Dist) * nsamples);  // memory was already reserved in the constructor
-  Dist* dists = reinterpret_cast<Dist*>(dists_cpu.data());
-  bool use_default_dist = !This().template SetupDists<T>(dists, ws, nsamples);
+  std::vector<Dist> dists(nsamples);
+  bool use_default_dist = !This().template SetupDists<T>(dists.data(), ws, nsamples);
 
   int channel_dim = -1;
   auto layout = output.GetLayout();


### PR DESCRIPTION
## Category: **Bug fix**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Random operators used vector of reinterpreted bytes as a target of assignment when creating distribution objects.
The random choice uses non-trivial `std::discrete_distribution` carrying some state. Assigning to that memory caused a leak.
Switch to a proper `vector<distribution>`, so the copy/move assignments are not UB as the location that we assign to is now
properly constructed ahead of time.


## Additional information:

### Affected modules and functionalities:
RNG operators



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
The relevant fn.random.choice tests no longer report leak under ASAN.
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
