### PR TITLE
Extend context and name propagation in errors

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include "dali/core/tensor_shape_print.h"
 #include "dali/operators/generic/reshape.h"
 #include "dali/pipeline/data/views.h"
+#include "dali/pipeline/operator/name_utils.h"
 
 namespace dali {
 
@@ -135,11 +136,11 @@ Reshape<Backend>::Reshape(const OpSpec &spec) : Base(spec) {
       && !has_src_dims_arg) {
     bool can_have_dtype = spec.GetSchema().HasArgument("dtype");
     if (can_have_dtype) {
-      DALI_ENFORCE(output_type_arg_ != DALI_NO_TYPE, make_string(OpName(),
-                   " is no-op: arguments specify neither new shape, layout nor type."));
+      DALI_ENFORCE(output_type_arg_ != DALI_NO_TYPE, make_string("`", GetOpDisplayName(spec, true),
+                   "` is no-op: arguments specify neither new shape, layout nor type."));
     } else {
-      DALI_FAIL(make_string(OpName(),
-                " is no-op: arguments specify neither new shape nor layout."));
+      DALI_FAIL(make_string("`", GetOpDisplayName(spec, true),
+                "` is no-op: arguments specify neither new shape nor layout."));
     }
   }
   use_layout_ = has_layout_arg;

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -63,10 +63,6 @@ class Reshape : public StatelessOperator<Backend> {
   TensorLayout layout_;
 
  private:
-  inline const std::string &OpName() const {
-    return this->spec_.SchemaName();
-  }
-
   TensorListShape<> input_shape_;
   TensorShape<> uniform_shape_;
   std::vector<float> rel_uniform_shape_;

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -29,6 +29,7 @@
 #include "dali/operators/reader/loader/loader.h"
 #include "dali/operators/reader/parser/parser.h"
 #include "dali/pipeline/operator/checkpointing/snapshot_serializer.h"
+#include "dali/pipeline/operator/name_utils.h"
 #include "dali/pipeline/operator/operator.h"
 
 namespace dali {
@@ -104,7 +105,7 @@ class DataReader : public Operator<Backend> {
 
   void SaveState(OpCheckpoint &cpt, AccessOrder order) override {
     if constexpr (!supports_checkpointing) {
-      DALI_FAIL("The reader ", spec_.SchemaName(), " does not support checkpointing.");
+      DALI_FAIL("The reader `", GetOpDisplayName(spec_, true), "` does not support checkpointing.");
     } else {
       DALI_ENFORCE(checkpointing_,
                    "Cannot save the checkpoint, because "
@@ -116,7 +117,7 @@ class DataReader : public Operator<Backend> {
 
   void RestoreState(const OpCheckpoint &cpt) override {
     if constexpr (!supports_checkpointing) {
-      DALI_FAIL("The reader ", spec_.SchemaName(), " does not support checkpointing.");
+      DALI_FAIL("The reader `", GetOpDisplayName(spec_, true), "` does not support checkpointing.");
     } else {
       DALI_ENFORCE(checkpointing_,
                    "Cannot restore the checkpoint, because "

--- a/dali/pipeline/graph/graph_descr.cc
+++ b/dali/pipeline/graph/graph_descr.cc
@@ -19,6 +19,7 @@
 #include "dali/pipeline/graph/op_graph.h"
 
 #include "dali/pipeline/operator/error_reporting.h"
+#include "dali/pipeline/operator/name_utils.h"
 #include "dali/pipeline/operator/op_schema.h"
 
 #include "dali/pipeline/operator/builtin/make_contiguous.h"
@@ -55,17 +56,17 @@ void CheckOpConstraints(const OpSpec &spec) {
   const int additional_outputs = schema.CalculateAdditionalOutputs(spec);
 
   DALI_ENFORCE(schema.SupportsInPlace(spec) || !spec.GetArgument<bool>("inplace"),
-      "Op '" + spec.SchemaName() + "' does not support in-place execution.");
+      "Operator `" + GetOpDisplayName(spec, true) + "` does not support in-place execution.");
   DALI_ENFORCE(spec.NumRegularInput() <= schema.MaxNumInput(),
-      "Operator '" + spec.SchemaName() +
-      "' supports a maximum of " + std::to_string(schema.MaxNumInput()) + " inputs, "
+      "Operator `" + GetOpDisplayName(spec, true) +
+      "` supports a maximum of " + std::to_string(schema.MaxNumInput()) + " inputs, "
       "but was passed " + std::to_string(spec.NumRegularInput()) + ".");
   DALI_ENFORCE(spec.NumRegularInput() >= schema.MinNumInput(),
-      "Operator '" + spec.SchemaName() +
-      "' supports a minimum of " + std::to_string(schema.MinNumInput()) + " inputs, "
+      "Operator `" + GetOpDisplayName(spec, true) +
+      "` supports a minimum of " + std::to_string(schema.MinNumInput()) + " inputs, "
       "but was passed " + std::to_string(spec.NumRegularInput()) + ".");
   DALI_ENFORCE(spec.NumOutput() == schema.CalculateOutputs(spec) + additional_outputs,
-      "Operator '" + spec.SchemaName() + "' supports "
+      "Operator `" + GetOpDisplayName(spec, true) + "` supports "
       + std::to_string(schema.CalculateOutputs(spec) + additional_outputs)
       + " outputs, but was passed " + std::to_string(spec.NumOutput()) + ".");
 }

--- a/dali/pipeline/graph/graph_descr.cc
+++ b/dali/pipeline/graph/graph_descr.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <exception>
 #include <string>
 
 #include "dali/core/error_handling.h"
@@ -208,17 +209,14 @@ void OpGraph::InstantiateOperators() {
 
   for (auto op_type : order) {
     for (auto op_id : op_partitions_[static_cast<int>(op_type)]) {
-      std::exception_ptr eptr;
       try {
         op_nodes_[op_id].InstantiateOperator();
       } catch (...) {
-        eptr = std::current_exception();
+        PropagateError({std::current_exception(),
+                        "Critical error when building pipeline:\n" +
+                            GetErrorContextMessage(op_nodes_[op_id].spec),
+                        "\nCurrent pipeline object is no longer valid."});
       }
-
-      PropagateError({eptr,
-                      "Critical error when building pipeline:\n" +
-                          GetErrorContextMessage(op_nodes_[op_id].spec),
-                      "\nCurrent pipeline object is no longer valid."});
     }
   }
 }

--- a/dali/pipeline/graph/graph_descr.cc
+++ b/dali/pipeline/graph/graph_descr.cc
@@ -57,19 +57,20 @@ void CheckOpConstraints(const OpSpec &spec) {
   const int additional_outputs = schema.CalculateAdditionalOutputs(spec);
 
   DALI_ENFORCE(schema.SupportsInPlace(spec) || !spec.GetArgument<bool>("inplace"),
-      "Operator `" + GetOpDisplayName(spec, true) + "` does not support in-place execution.");
-  DALI_ENFORCE(spec.NumRegularInput() <= schema.MaxNumInput(),
-      "Operator `" + GetOpDisplayName(spec, true) +
-      "` supports a maximum of " + std::to_string(schema.MaxNumInput()) + " inputs, "
-      "but was passed " + std::to_string(spec.NumRegularInput()) + ".");
-  DALI_ENFORCE(spec.NumRegularInput() >= schema.MinNumInput(),
-      "Operator `" + GetOpDisplayName(spec, true) +
-      "` supports a minimum of " + std::to_string(schema.MinNumInput()) + " inputs, "
-      "but was passed " + std::to_string(spec.NumRegularInput()) + ".");
+               make_string("Operator `", GetOpDisplayName(spec, true),
+                           "` does not support in-place execution."));
+  DALI_ENFORCE(
+      spec.NumRegularInput() <= schema.MaxNumInput(),
+      make_string("Operator `", GetOpDisplayName(spec, true), "` supports a maximum of ",
+                  schema.MaxNumInput(), " inputs, but was passed ", spec.NumRegularInput(), "."));
+  DALI_ENFORCE(
+      spec.NumRegularInput() >= schema.MinNumInput(),
+      make_string("Operator `", GetOpDisplayName(spec, true), "` supports a minimum of ",
+                  schema.MinNumInput(), " inputs, but was passed ", spec.NumRegularInput(), "."));
   DALI_ENFORCE(spec.NumOutput() == schema.CalculateOutputs(spec) + additional_outputs,
-      "Operator `" + GetOpDisplayName(spec, true) + "` supports "
-      + std::to_string(schema.CalculateOutputs(spec) + additional_outputs)
-      + " outputs, but was passed " + std::to_string(spec.NumOutput()) + ".");
+               make_string("Operator `", GetOpDisplayName(spec, true), "` supports ",
+                           schema.CalculateOutputs(spec) + additional_outputs,
+                           " outputs, but was passed ", spec.NumOutput(), "."));
 }
 
 OpType ParseOpType(const std::string &device) {

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,10 +63,6 @@ class ExternalSource : public InputOperator<Backend> {
   }
 
   virtual ~ExternalSource() = default;
-
-  inline string name() const override {
-    return "ExternalSource (" + output_name_ + ")";
-  }
 
   const TensorLayout& in_layout() const override {
     return layout_;

--- a/dali/pipeline/operator/error_reporting.cc
+++ b/dali/pipeline/operator/error_reporting.cc
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -96,7 +97,7 @@ void PropagateError(ErrorInfo error) {
   }
 }
 
-std::string GetErrorContextMessage(const OpSpec &spec, const std::string &message_name) {
+std::string GetErrorContextMessage(const OpSpec &spec, std::string_view message_name) {
   auto device = spec.GetArgument<std::string>("device");
   auto op_name = GetOpDisplayName(spec, true);
   std::transform(device.begin(), device.end(), device.begin(), ::toupper);

--- a/dali/pipeline/operator/error_reporting.cc
+++ b/dali/pipeline/operator/error_reporting.cc
@@ -96,7 +96,7 @@ void PropagateError(ErrorInfo error) {
   }
 }
 
-std::string GetErrorContextMessage(const OpSpec &spec) {
+std::string GetErrorContextMessage(const OpSpec &spec, const std::string &message_name) {
   auto device = spec.GetArgument<std::string>("device");
   auto op_name = GetOpDisplayName(spec, true);
   std::transform(device.begin(), device.end(), device.begin(), ::toupper);
@@ -109,7 +109,7 @@ std::string GetErrorContextMessage(const OpSpec &spec) {
            formatted_origin_stack + "\n") :
           " ";  // we need space before "encountered"
 
-  return make_string("Error in ", device, " operator `", op_name, "`",
+  return make_string(message_name, " in ", device, " operator `", op_name, "`",
                      optional_stack_mention, "encountered:\n\n");
 }
 

--- a/dali/pipeline/operator/error_reporting.h
+++ b/dali/pipeline/operator/error_reporting.h
@@ -19,6 +19,7 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -186,7 +187,7 @@ class DaliStopIteration : public DaliError {
  * @param message_name Will be used as the prefix of the error message, for example:
  * "Error in <device> operator <op_name>" or "Warning in <device> operator <op_name>"
  */
-std::string GetErrorContextMessage(const OpSpec &spec, const std::string &message_name = "Error");
+std::string GetErrorContextMessage(const OpSpec &spec, std::string_view message_name = "Error");
 
 }  // namespace dali
 

--- a/dali/pipeline/operator/error_reporting.h
+++ b/dali/pipeline/operator/error_reporting.h
@@ -183,8 +183,10 @@ class DaliStopIteration : public DaliError {
  * * the origin stack trace of the operator within pipeline definition.
  *
  * It can be prepended to the original error message.
+ * @param message_name Will be used as the prefix of the error message, for example:
+ * "Error in <device> operator <op_name>" or "Warning in <device> operator <op_name>"
  */
-std::string GetErrorContextMessage(const OpSpec &spec);
+std::string GetErrorContextMessage(const OpSpec &spec, const std::string &message_name = "Error");
 
 }  // namespace dali
 

--- a/dali/pipeline/operator/name_utils.cc
+++ b/dali/pipeline/operator/name_utils.cc
@@ -39,4 +39,20 @@ std::string GetOpDisplayName(const OpSpec &spec, bool include_module_path) {
   }
 }
 
+std::string FormatInput(const OpSpec &spec, int input_idx, bool capitalize) {
+  if (spec.GetSchema().HasInputDox()) {
+    return make_string(capitalize ? "I" : "i", "nput `", input_idx, "` ('__",
+                       spec.GetSchema().GetInputName(input_idx), "')");
+  }
+  return make_string(capitalize ? "I" : "i", "nput `", input_idx, "`");
+}
+
+std::string FormatOutput(const OpSpec &spec, int output_idx, bool capitalize) {
+  return make_string(capitalize ? "O" : "o", "utput `", output_idx, "`");
+}
+
+std::string FormatArgument(const OpSpec &spec, const std::string &argument, bool capitalize) {
+  return make_string(capitalize ? "A" : "a", "rgument '", argument, "'");
+}
+
 }  // namespace dali

--- a/dali/pipeline/operator/name_utils.cc
+++ b/dali/pipeline/operator/name_utils.cc
@@ -23,7 +23,7 @@
 namespace dali {
 
 std::string GetOpModule(const OpSpec &spec) {
-  return spec.GetArgument<std::string>("_module");;
+  return spec.GetArgument<std::string>("_module");
 }
 
 std::string GetOpDisplayName(const OpSpec &spec, bool include_module_path) {

--- a/dali/pipeline/operator/name_utils.h
+++ b/dali/pipeline/operator/name_utils.h
@@ -42,6 +42,35 @@ DLL_PUBLIC std::string GetOpModule(const OpSpec &spec);
  */
 DLL_PUBLIC std::string GetOpDisplayName(const OpSpec &spec, bool include_module_path = false);
 
+/**
+ * @brief Uniformly format the display of the operator input index, optionally including the name
+ * if provided in schema doc.
+ *
+ * @param input_idx Index of the input
+ * @param capitalize should be true if the output should start with capital letter (used at the
+ * start of the sentence)
+ */
+DLL_PUBLIC std::string FormatInput(const OpSpec &spec, int input_idx, bool capitalize = false);
+
+/**
+ * @brief Uniformly format the display of the operator output index.
+ *
+ * @param input_idx Index of the output
+ * @param capitalize should be true if the output should start with capital letter (used at the
+ * start of the sentence)
+ */
+DLL_PUBLIC std::string FormatOutput(const OpSpec &spec, int output_idx, bool capitalize = false);
+
+/**
+ * @brief Uniformly format the display of the operator argument name
+ *
+ * @param argument string representing the name of the argument (without additional quotes)
+ * @param capitalize should be true if the output should start with capital letter (used at the
+ * start of the sentence)
+ */
+DLL_PUBLIC std::string FormatArgument(const OpSpec &spec, const std::string &argument,
+                                      bool capitalize = false);
+
 }  // namespace dali
 
 #endif  // DALI_PIPELINE_OPERATOR_NAME_UTILS_H_

--- a/dali/pipeline/operator/op_spec.cc
+++ b/dali/pipeline/operator/op_spec.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "dali/pipeline/operator/op_spec.h"
-
 #include "dali/pipeline/data/types.h"
+#include "dali/pipeline/operator/name_utils.h"
 
 namespace dali {
 
@@ -26,7 +26,7 @@ OpSpec& OpSpec::AddInput(const string &name, const string &device, bool regular_
     // We rely on the fact that regular inputs are first in inputs_ vector
     DALI_ENFORCE(NumArgumentInput() == 0,
         "All regular inputs (particularly, `" + name + "`) need to be added to the op `" +
-        this->SchemaName() + "` before argument inputs.");
+        GetOpDisplayName(*this, true) + "` before argument inputs.");
   }
 
   inputs_.push_back({name, device});
@@ -50,17 +50,64 @@ OpSpec& OpSpec::AddOutput(const string &name, const string &device) {
 
 OpSpec& OpSpec::AddArgumentInput(const string &arg_name, const string &inp_name) {
   DALI_ENFORCE(!this->HasArgument(arg_name), make_string(
-      "Argument ", arg_name, " is already specified."));
+      "Argument '", arg_name, "' is already specified."));
   const OpSchema& schema = GetSchema();
-  DALI_ENFORCE(schema.HasArgument(arg_name), make_string(
-      "Argument '", arg_name, "' is not part of the op schema '", schema.name(), "'"));
-  DALI_ENFORCE(schema.IsTensorArgument(arg_name), make_string(
-      "Argument `", arg_name, "` in operator `", schema.name(), "` is not a a tensor argument."));
+  DALI_ENFORCE(schema.HasArgument(arg_name),
+               make_string("Argument '", arg_name, "' is not supported by operator `",
+                           GetOpDisplayName(*this, true), "`."));
+  DALI_ENFORCE(schema.IsTensorArgument(arg_name),
+               make_string("Argument '", arg_name, "' in operator `", GetOpDisplayName(*this, true),
+                           "` is not an argument input."));
   int idx = inputs_.size();
   argument_inputs_.push_back({ arg_name, idx });
   argument_input_idxs_[arg_name] = idx;
   AddInput(inp_name, "cpu", false);
   return *this;
 }
+
+OpSpec& OpSpec::SetInitializedArg(const string& arg_name, std::shared_ptr<Argument> arg) {
+  if (schema_ && schema_->IsDeprecatedArg(arg_name)) {
+    const auto& deprecation_meta = schema_->DeprecatedArgMeta(arg_name);
+    // Argument was removed, and we can discard it
+    if (deprecation_meta.removed) {
+      return *this;
+    }
+    if (!deprecation_meta.renamed_to.empty()) {
+      const auto& new_arg_name = deprecation_meta.renamed_to;
+      DALI_ENFORCE(argument_idxs_.find(new_arg_name) == argument_idxs_.end(),
+                   make_string("Operator `", GetOpDisplayName(*this, true), "` got an unexpected '",
+                               arg_name, "' deprecated argument when '", new_arg_name,
+                               "' was already provided."));
+
+      set_through_deprecated_arguments_[new_arg_name] = arg_name;
+      // Adjust the arg so it carries the proper name for serialization
+      if (arg->has_name()) {
+        arg->set_name(new_arg_name);
+      }
+      auto [it, inserted] = argument_idxs_.insert({new_arg_name, arguments_.size()});
+      if (inserted)
+        arguments_.push_back(std::move(arg));
+      else
+        arguments_[it->second] = std::move(arg);
+      return *this;
+    }
+  }
+  EnforceNoAliasWithDeprecated(arg_name);
+  auto [it, inserted] = argument_idxs_.insert({arg_name, arguments_.size()});
+  if (inserted)
+    arguments_.push_back(std::move(arg));
+  else
+    arguments_[it->second] = std::move(arg);
+  return *this;
+}
+
+void OpSpec::EnforceNoAliasWithDeprecated(const string& arg_name) {
+  auto set_through = set_through_deprecated_arguments_.find(arg_name);
+  DALI_ENFORCE(set_through == set_through_deprecated_arguments_.end(),
+               make_string("Operator `", GetOpDisplayName(*this, true), "` got an unexpected '",
+                           set_through->second, "' deprecated argument when '", arg_name,
+                           "' was already provided."));
+}
+
 
 }  // namespace dali

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -146,53 +146,12 @@ class DLL_PUBLIC OpSpec {
    *
    * @remarks Deprecated arguments are renamed (or dropped, if no longer used).
    */
-  DLL_PUBLIC inline OpSpec& SetInitializedArg(const string& arg_name,
-                                              std::shared_ptr<Argument> arg) {
-    if (schema_ && schema_->IsDeprecatedArg(arg_name)) {
-      const auto& deprecation_meta = schema_->DeprecatedArgMeta(arg_name);
-      // Argument was removed, and we can discard it
-      if (deprecation_meta.removed) {
-        return *this;
-      }
-      if (!deprecation_meta.renamed_to.empty()) {
-        const auto& new_arg_name = deprecation_meta.renamed_to;
-        DALI_ENFORCE(
-            argument_idxs_.find(new_arg_name) == argument_idxs_.end(),
-            make_string("Operator ", SchemaName(), " got an unexpected '", arg_name,
-                        "' deprecated argument when '", new_arg_name, "' was already provided."));
-
-        set_through_deprecated_arguments_[new_arg_name] = arg_name;
-        // Adjust the arg so it carries the proper name for serialization
-        if (arg->has_name()) {
-          arg->set_name(new_arg_name);
-        }
-        auto [it, inserted] = argument_idxs_.insert({ new_arg_name, arguments_.size() });
-        if (inserted)
-          arguments_.push_back(std::move(arg));
-        else
-          arguments_[it->second] = std::move(arg);
-        return *this;
-      }
-    }
-    EnforceNoAliasWithDeprecated(arg_name);
-    auto [it, inserted] = argument_idxs_.insert({ arg_name, arguments_.size() });
-    if (inserted)
-      arguments_.push_back(std::move(arg));
-    else
-      arguments_[it->second] = std::move(arg);
-    return *this;
-  }
+  DLL_PUBLIC OpSpec& SetInitializedArg(const string& arg_name, std::shared_ptr<Argument> arg);
 
   /**
    * @brief Check if the `arg_name` was already set through a deprecated argument
    */
-  DLL_PUBLIC inline void EnforceNoAliasWithDeprecated(const string& arg_name) {
-    auto set_through = set_through_deprecated_arguments_.find(arg_name);
-    DALI_ENFORCE(
-        set_through == set_through_deprecated_arguments_.end(),
-        make_string("Operator ", SchemaName(), " got an unexpected '", set_through->second,
-                    "' deprecated argument when '", arg_name, "' was already provided."));
-  }
+  DLL_PUBLIC void EnforceNoAliasWithDeprecated(const string& arg_name);
 
   // Forward to string implementation
   template <unsigned N>

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -30,6 +30,7 @@
 #include "dali/core/tensor_shape_print.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/operator/common.h"
+#include "dali/pipeline/operator/name_utils.h"
 #include "dali/pipeline/operator/op_schema.h"
 #include "dali/pipeline/operator/op_spec.h"
 #include "dali/pipeline/operator/operator_factory.h"
@@ -96,15 +97,6 @@ class DLL_PUBLIC OperatorBase {
    * @brief Executes the operator on a batch of samples.
    */
   DLL_PUBLIC virtual void Run(Workspace &ws) = 0;
-
-  /**
-   * @brief returns the name of the operator. By default returns
-   * the name of the op as specified by the OpSpec it was constructed
-   * from.
-   */
-  DLL_PUBLIC virtual string name() const {
-    return spec_.SchemaName();
-  }
 
   /**
    * @brief For reader Ops, returns the metadata of the reader and dataset,
@@ -211,8 +203,8 @@ class DLL_PUBLIC OperatorBase {
   }
 
   [[noreturn]] void CheckpointingUnsupportedError() const {
-    DALI_FAIL(
-        make_string("Checkpointing is not implemented for this operator: ", spec_.SchemaName()));
+    DALI_FAIL(make_string("Checkpointing is not implemented for this operator: `",
+                          GetOpDisplayName(spec_, true), "`."));
   }
 
   // TODO(mszolucha): remove these two to allow i2i variable batch size, when all ops are ready

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -22,13 +22,10 @@
 #include <functional>
 #include <memory>
 
-#include "dali/pipeline/executor/executor_factory.h"
-#include "dali/pipeline/operator/argument.h"
-#include "dali/pipeline/operator/common.h"
-#include "dali/pipeline/operator/error_reporting.h"
 #include "dali/core/device_guard.h"
 #include "dali/core/mm/default_resources.h"
 #include "dali/pipeline/dali.pb.h"
+#include "dali/pipeline/executor/executor_factory.h"
 #include "dali/pipeline/operator/argument.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/error_reporting.h"

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -365,7 +365,7 @@ int Pipeline::AddOperatorImpl(const OpSpec &const_spec, const std::string &inst_
     if (!it->second.has_cpu) {
       assert(it->second.has_gpu);
       DALI_FAIL(make_string("Error while specifying ", FormatArgument(spec, arg_name),
-                            ". Named arguments inputs to operators must be CPU data nodes. "
+                            ". Named argument inputs to operators must be CPU data nodes. "
                             "However, a GPU data node was provided."));
     }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -596,6 +596,14 @@ class DLL_PUBLIC Pipeline {
     return base_ptr_offset;
   }
 
+  /**
+   * @brief See Pipeline::AddOperator for details.
+   *
+   * Does the internal processing allowing the errors to be processed once.
+   * Assumes that Build() has not been called.
+   */
+  DLL_PUBLIC int AddOperatorImpl(const OpSpec &spec, const std::string& inst_name, int logical_id);
+
   void SetupCPUInput(std::map<string, EdgeMeta>::iterator it, int input_idx, OpSpec *spec);
 
   void SetupGPUInput(std::map<string, EdgeMeta>::iterator it);

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -691,7 +691,8 @@ class DLL_PUBLIC Pipeline {
   void DiscoverInputOperators();
 
   /**
-   * @brief Process exception that was thrown when executing DALI.
+   * @brief Process exception that was thrown when executing DALI. Executor already provided context
+   * for operator if possible.
    */
   void ProcessException(std::exception_ptr eptr);
 

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -147,7 +147,7 @@ class PipelineTest : public DALITest {
     ASSERT_EQ(graph.NumOp(OpType::MIXED), 1);
     ASSERT_EQ(graph.NumOp(OpType::GPU), 2);
 
-    ASSERT_EQ(graph.Node(OpType::MIXED, 0).op->name(), "MakeContiguous");
+    ASSERT_EQ(graph.Node(OpType::MIXED, 0).op->GetSpec().GetSchema().name(), "MakeContiguous");
 
     // Validate the source op
     auto &node = graph.Node(0);

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -573,7 +573,13 @@ def python_op_factory(name, schema_name, internal_schema_name=None, generated=Tr
                 self._init_args.update({"_module": Operator.__module__.replace(".hidden", "")})
             if "_display_name" not in self._init_args:
                 self._init_args.update({"_display_name": type(self).__name__})
+            # Make sure that the internal name arguments are added first in case backend
+            # needs them to report errors.
+            name_internal_keys = ["_display_name", "_module"]
+            name_args = {key: self._init_args.pop(key) for key in name_internal_keys}
+            _process_arguments(self._schema, self._spec, name_args, type(self).__name__)
             _process_arguments(self._schema, self._spec, self._init_args, type(self).__name__)
+            self._init_args.update(name_args)
 
         @property
         def spec(self):

--- a/dali/test/python/conditionals/test_logical_expressions.py
+++ b/dali/test/python/conditionals/test_logical_expressions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -242,7 +242,7 @@ def test_error_input(expression):
             "Logical expression `.*` is restricted to scalar \\(0-d tensors\\)"
             " inputs of `bool` type, that are placed on CPU."
             " Got a GPU input .*in logical expression.*|"
-            "Named arguments inputs to operators must be CPU data nodes."
+            "Named argument inputs to operators must be CPU data nodes."
             " However, a GPU data node was provided"
         ),
     ):

--- a/dali/test/python/conditionals/test_pipeline_conditionals.py
+++ b/dali/test/python/conditionals/test_pipeline_conditionals.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -983,7 +983,7 @@ def test_error_condition():
     with assert_raises(
         RuntimeError,
         glob=(
-            "Named arguments inputs to operators must be CPU data nodes."
+            "Named argument inputs to operators must be CPU data nodes."
             " However, a GPU data node was provided"
         ),
     ):

--- a/dali/test/python/operator_1/test_operator_exception.py
+++ b/dali/test/python/operator_1/test_operator_exception.py
@@ -284,7 +284,8 @@ which was used in the pipeline definition with the following traceback:
 
 encountered:
 
-Error for argument 'probability'. Named arguments inputs to operators must be CPU data nodes.*"""
+Error while specifying argument 'probability'. Named argument inputs to operators must be CPU data nodes.*
+"""  # noqa(E501)
         ),
     ):
         p = pipe()

--- a/dali/test/python/operator_1/test_operator_exception.py
+++ b/dali/test/python/operator_1/test_operator_exception.py
@@ -284,8 +284,7 @@ which was used in the pipeline definition with the following traceback:
 
 encountered:
 
-Error for argument 'probability'. Named arguments inputs to operators must be CPU data nodes.*
-"""
+Error for argument 'probability'. Named arguments inputs to operators must be CPU data nodes.*"""
         ),
     ):
         p = pipe()

--- a/dali/test/python/operator_1/test_slice.py
+++ b/dali/test/python/operator_1/test_slice.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1191,7 +1191,7 @@ def test_wrong_backend_named_args():
         return sliced
 
     with assert_raises(
-        RuntimeError, glob="Named arguments inputs to operators must be CPU data nodes"
+        RuntimeError, glob="Named argument inputs to operators must be CPU data nodes"
     ):
         p = make_pipe()
         p.build()

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -94,8 +94,8 @@ def test_move_to_device_end():
         RuntimeError,
         pipe.build,
         glob="Cannot move the data node __ExternalSource_* to the GPU in a CPU-only pipeline. "
-        "The `device_id` parameter is set to `CPU_ONLY_DEVICE_ID`. "
-        "Set `device_id` to a valid GPU identifier to enable GPU features in the pipeline.",
+        "The 'device_id' parameter is set to `CPU_ONLY_DEVICE_ID`. "
+        "Set 'device_id' to a valid GPU identifier to enable GPU features in the pipeline.",
     )
 
 
@@ -113,7 +113,11 @@ def test_move_to_device_middle():
     assert_raises(
         RuntimeError,
         pipe.build,
-        glob="Cannot add a GPU operator Rotate, device_id should not be equal CPU_ONLY_DEVICE_ID.",
+        glob=(
+            "Error in GPU operator `nvidia.dali.fn.rotate`*"
+            "Cannot add a GPU operator. "
+            "Pipeline 'device_id' should not be equal to `CPU_ONLY_DEVICE_ID`."
+        ),
     )
 
 
@@ -133,7 +137,11 @@ def check_bad_device(device_id, error_msg):
 def test_gpu_op_bad_device():
     device_ids = [None, 0]
     error_msgs = [
-        "Cannot add a GPU operator ExternalSource, device_id should not be equal CPU_ONLY_DEVICE_ID.",  # noqa: E501
+        (
+            "Error in GPU operator `nvidia.dali.fn.external_source`*"
+            "Cannot add a GPU operator."
+            " Pipeline 'device_id' should not be equal to `CPU_ONLY_DEVICE_ID`."
+        ),
         "You are trying to create a GPU DALI pipeline, while CUDA is not available.*",
     ]
 
@@ -152,7 +160,11 @@ def check_mixed_op_bad_device(device_id, error_msg):
 def test_mixed_op_bad_device():
     device_ids = [None, 0]
     error_msgs = [
-        "Cannot add a mixed operator decoders__Image with a GPU output, device_id should not be CPU_ONLY_DEVICE_ID.",  # noqa: E501
+        (
+            "Error in MIXED operator `nvidia.dali.fn.decoders.image`*"
+            "Cannot add a Mixed operator with a GPU output,"
+            " 'device_id' should not be `CPU_ONLY_DEVICE_ID`"
+        ),
         "You are trying to create a GPU DALI pipeline, while CUDA is not available.*",
     ]
 
@@ -1150,8 +1162,9 @@ def test_arithm_ops_cpu_gpu():
         RuntimeError,
         pipe.build,
         glob=(
-            "Cannot add a GPU operator ArithmeticGenericOp,"
-            " device_id should not be equal CPU_ONLY_DEVICE_ID."
+            "Error in GPU operator `nvidia.dali.math.*`*"
+            "Cannot add a GPU operator."
+            " Pipeline 'device_id' should not be equal to `CPU_ONLY_DEVICE_ID`."
         ),
     )
 


### PR DESCRIPTION
## Category: **Refactoring**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Add error context related to particular operator during graph construction and pipeline build:
* error propagation in Pipeline::Build() is adjusted
* Python calls to backend: Pipeline::AddOperator now augment errors with context.
* OpSpec building errors propagate the proper operator name.

Replace most of the SchemaName() occurrences that were used to indicate the name operator
with the fully formatted operator name in the correct API.

Make sure that the naming information is added as soon as possible, so it can be accessed in partially
constructed schema with the correct values present.

Note: This PR mostly adds the context like:
```
Error in <device> operator `nvidia.dali.fn.operator_name`,
which was used in the pipeline definition with the following traceback:
<traceback>
encountered:
<Original error message>
```
to places where it was not previously used, but we are processing a single operator.

Error messages are adjusted to show the user-facing input/output/argument name (in uniform way) rather than the internal one. 
Otherwise the checks and messages are preserved.
The types of error messages are not adjusted.

## Additional information:

### Affected modules and functionalities:
Pipeline and spec building

### Key points relevant for the review:
Typos, broken formatting or conditions.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
Some of those error conditions are behind double or triple layer of error checks and are not observable by the Python user.
Will use CI to determine how much adjusting the wording affects the tests.
- [x] New tests added
The context added in AddOperator is verified to work, not all conditions are easily verified from Python tests. I won't build loads of broken GTest pipelines just to match the exact error messages.
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
