### PR TITLE
Fix pixelwise_masks support when the ratio is on in the coco reader

### DIFF
--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -260,6 +260,7 @@ void COCOReader::RunImpl(SampleWorkspace &ws) {
 }
 
 void COCOReader::PixelwiseMasks(int image_idx, int* mask) {
+  bool ratio = spec_.GetArgument<bool>("ratio");
   auto &loader_impl = LoaderImpl();
   auto pol = loader_impl.polygons(image_idx);
   auto ver = loader_impl.vertices(image_idx);
@@ -290,8 +291,8 @@ void COCOReader::PixelwiseMasks(int image_idx, int* mask) {
     auto pol_ver = span<const vec2>{ver.data() + start_idx, nver};
     in.resize(pol_ver.size() * 2);
     for (int i = 0, k = 0; i < pol_ver.size(); i++) {
-      in[k++] = static_cast<double>(pol_ver[i].x);
-      in[k++] = static_cast<double>(pol_ver[i].y);
+      in[k++] = static_cast<double>(ratio ? pol_ver[i].x * w : pol_ver[i].x);
+      in[k++] = static_cast<double>(ratio ? pol_ver[i].y * h : pol_ver[i].y);
     }
     RLE M;
     rleInit(&M, 0, 0, 0, 0);

--- a/dali/test/python/reader/test_coco.py
+++ b/dali/test/python/reader/test_coco.py
@@ -367,3 +367,24 @@ def test_coco_empty_annotations_poly():
         assert (poly != 0 and image_ids in anno_mapping and anno_mapping[image_ids]) or (
             vert == 0 and not (image_ids in anno_mapping and anno_mapping[image_ids])
         )
+
+
+def test_coco_pix_mask_ratio():
+    file_root = os.path.join(test_data_root, "db", "coco_dummy", "images")
+    train_annotations = os.path.join(test_data_root, "db", "coco_dummy", "instances.json")
+
+    batch_size = 2
+
+    @pipeline_def(batch_size=1, device_id=0, num_threads=4)
+    def coco_pipe(ratio=False):
+        _, _, _, masks = fn.readers.coco(
+            file_root=file_root,
+            annotations_file=train_annotations,
+            pixelwise_masks=True,
+            ratio=ratio,
+        )
+        return masks
+
+    pipe_ref = coco_pipe(batch_size=batch_size, ratio=False)
+    pipe_test = coco_pipe(batch_size=batch_size, ratio=True)
+    compare_pipelines(pipe_ref, pipe_test, batch_size, 5)


### PR DESCRIPTION
- when the ratio option is on the pixelwise_masks calculation
  uses relative coordinates instead of the real one which leads
  to creating a 1-pixel map in the corner of the tensor. This PR
  fixes the math.
- adds relevant test

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- when the ratio option is on the pixelwise_masks calculation
  uses relative coordinates instead of the real one which leads
  to creating a 1-pixel map in the corner of the tensor. This PR
  fixes the math.
- adds relevant test
- relates to https://github.com/NVIDIA/DALI/issues/5404
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- coco reader
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_coco.test_coco_pix_mask_ratio
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
