### PR TITLE
Tasking module

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -177,7 +177,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If

--- a/dali/core/CMakeLists.txt
+++ b/dali/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ project(dali_core CUDA CXX C)
 
 add_subdirectory(mm)
 add_subdirectory(os)
+add_subdirectory(exec)
 
 # Get all the source files
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)

--- a/dali/core/exec/CMakeLists.txt
+++ b/dali/core/exec/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(tasking)
+
+# Get all the source files
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_CORE_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_CORE_TEST_SRCS PARENT_SCOPE)

--- a/dali/core/exec/tasking/CMakeLists.txt
+++ b/dali/core/exec/tasking/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Get all the source files
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_CORE_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_CORE_TEST_SRCS PARENT_SCOPE)

--- a/dali/core/exec/tasking/scheduler.cc
+++ b/dali/core/exec/tasking/scheduler.cc
@@ -20,7 +20,7 @@
 namespace dali::tasking {
 
 bool Scheduler::CheckTaskReady(SharedTask &task) noexcept {
-  assert(task->state <= TaskState::Pending);
+  assert(task->state_ <= TaskState::Pending);
 
   for (auto &w : task->preconditions_)
     if (!w->CheckComplete())
@@ -35,7 +35,7 @@ bool Scheduler::CheckTaskReady(SharedTask &task) noexcept {
     }
 
   task->preconditions_.clear();
-  task->state = TaskState::Ready;
+  task->state_ = TaskState::Ready;
   pending_.Remove(task);
   ready_.push(std::move(task));
   return true;
@@ -77,7 +77,7 @@ void Scheduler::Notify(Waitable *w) {
         task->preconditions_.erase(it);
         if (task->Ready()) {
           pending_.Remove(task);
-          task->state = TaskState::Ready;
+          task->state_ = TaskState::Ready;
           ready_.push(std::move(task));
           new_ready++;
           // OK, the task is ready, we're done with it

--- a/dali/core/exec/tasking/scheduler.cc
+++ b/dali/core/exec/tasking/scheduler.cc
@@ -1,0 +1,100 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <mutex>
+#include <iostream>
+#include "dali/core/exec/tasking/scheduler.h"
+
+namespace dali::tasking {
+
+bool Scheduler::CheckTaskReady(SharedTask &task) noexcept {
+  assert(task->state <= TaskState::Pending);
+
+  for (auto &w : task->preconditions_)
+    if (!w->CheckComplete())
+      return false;
+  for (auto &w : task->preconditions_)
+    if (!w->TryAcquire(task)) {
+      // this should be a fatal error, but terminate and abort don't have messages
+      std::cerr
+          << "Internal error - resource acquisition failed for a resource known to be available"
+          << std::endl;
+      std::abort();
+    }
+
+  task->preconditions_.clear();
+  task->state = TaskState::Ready;
+  pending_.Remove(task);
+  ready_.push(std::move(task));
+  return true;
+}
+
+void Scheduler::Notify(Waitable *w) {
+  bool is_completion_event = dynamic_cast<CompletionEvent *>(w) != nullptr;
+  bool is_task = is_completion_event && dynamic_cast<Task *>(w);
+
+  int new_ready = 0;
+  {
+    std::lock_guard g(mtx_);
+    if (is_task)
+      task_done_.notify_all();
+
+    SmallVector<SharedTask, 8> waiting;
+    int n = w->waiting_.size();
+    waiting.reserve(n);
+    for (int i = 0; i < n; i++)
+      waiting.emplace_back(w->waiting_[i]);
+
+    for (auto &task : waiting) {
+      if (task->Ready())
+        continue;
+
+      // If the task has only one precondition or the waitable is a completion event,
+      // then we can just try to acquire that waitable on behalf of the task.
+      if (is_completion_event ||
+          (task->preconditions_.size() == 1 && task->preconditions_.begin()->get() == w)) {
+        // try acquire - the only way this can fail is that the task was
+        // re-checked in another thread and marked as ready...
+        if (!w->TryAcquire(task)) {
+          assert(task->preconditions_.size() != 1 || task->preconditions_.begin()->get() != w);
+          continue;  // ... if so, nothing to do
+        }
+        auto it = std::find_if(task->preconditions_.begin(), task->preconditions_.end(),
+                               [w](auto &pre) { return pre.get() == w; });
+        assert(it != task->preconditions_.end());
+        task->preconditions_.erase(it);
+        if (task->Ready()) {
+          pending_.Remove(task);
+          task->state = TaskState::Ready;
+          ready_.push(std::move(task));
+          new_ready++;
+          // OK, the task is ready, we're done with it
+          continue;
+        }
+      }
+
+      if (CheckTaskReady(task))
+        new_ready++;
+    }
+  }
+
+
+  if (new_ready == 1)
+    this->task_ready_.notify_one();
+  else if (new_ready > 1)
+    this->task_ready_.notify_all();
+}
+
+}  // namespace dali::tasking

--- a/dali/core/exec/tasking/scheduler.cc
+++ b/dali/core/exec/tasking/scheduler.cc
@@ -19,7 +19,7 @@
 
 namespace dali::tasking {
 
-bool Scheduler::AcquireAllPreconditions(SharedTask &task) noexcept {
+bool Scheduler::AcquireAllAndMoveToReady(SharedTask &task) noexcept {
   assert(task->state_ <= TaskState::Pending);
 
   // All or nothing - first we check that all preconditions are met
@@ -90,7 +90,7 @@ void Scheduler::Notify(Waitable *w) {
         }
       }
 
-      if (AcquireAllPreconditions(task))
+      if (AcquireAllAndMoveToReady(task))
         new_ready++;
     }
   }

--- a/dali/core/exec/tasking/scheduler.cc
+++ b/dali/core/exec/tasking/scheduler.cc
@@ -59,6 +59,8 @@ void Scheduler::Notify(Waitable *w) {
       waiting.emplace_back(w->waiting_[i]);
 
     for (auto &task : waiting) {
+      if (!is_completion_event && !w->IsAcquirable())
+        break;
       if (task->Ready())
         continue;
 

--- a/dali/core/exec/tasking/scheduler.cc
+++ b/dali/core/exec/tasking/scheduler.cc
@@ -29,7 +29,6 @@ bool Scheduler::AcquireAllAndMoveToReady(SharedTask &task) noexcept {
   // If they are, we acquire them - this must succeed
   for (auto &w : task->preconditions_)
     if (!w->TryAcquire(task)) {
-      // this should be a fatal error, but terminate and abort don't have messages
       std::cerr
           << "Internal error - resource acquisition failed for a resource known to be available"
           << std::endl;

--- a/dali/core/exec/tasking/scheduler.cc
+++ b/dali/core/exec/tasking/scheduler.cc
@@ -24,7 +24,7 @@ bool Scheduler::AcquireAllPreconditions(SharedTask &task) noexcept {
 
   // All or nothing - first we check that all preconditions are met
   for (auto &w : task->preconditions_)
-    if (!w->CheckComplete())
+    if (!w->IsAcquirable())
       return false;  // at least one unmet
   // If they are, we acquire them - this must succeed
   for (auto &w : task->preconditions_)

--- a/dali/core/exec/tasking/scheduler.cc
+++ b/dali/core/exec/tasking/scheduler.cc
@@ -59,6 +59,8 @@ void Scheduler::Notify(Waitable *w) {
       waiting.emplace_back(w->waiting_[i]);
 
     for (auto &task : waiting) {
+      // If the waitable is a completion event, it will never become unacquirable again.
+      // Otherwise, we have to re-check it.
       if (!is_completion_event && !w->IsAcquirable())
         break;
       if (task->Ready())

--- a/dali/core/exec/tasking_test.cc
+++ b/dali/core/exec/tasking_test.cc
@@ -1,0 +1,248 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/core/exec/tasking.h"
+
+namespace dali::tasking::test {
+
+inline auto t_now() {
+  return std::chrono::high_resolution_clock::now();
+}
+
+template <typename T>
+inline auto t_plus(T delta) {
+  return std::chrono::high_resolution_clock::now() + std::chrono::duration<T>(delta);
+}
+
+TEST(TaskingTest, ExecutorShutdown) {
+  EXPECT_NO_THROW({
+    Executor ex(4);
+    ex.Start();
+  });
+}
+
+
+TEST(TaskingTest, IndependentTasksAreParallel) {
+  int num_threads = 4;
+  Executor ex(num_threads);
+  ex.Start();
+
+  std::atomic_int parallel;
+  std::atomic_bool done = false;
+  auto timeout = std::chrono::high_resolution_clock::now() + std::chrono::seconds(1);
+  auto complete = Task::Create([](){});
+  for (int i = 0; i < num_threads; i++) {
+    auto task = Task::Create([&]() {
+      if (++parallel)
+        done = true;
+      while (!done && std::chrono::high_resolution_clock::now() < timeout) {}
+      parallel--;
+    });
+    complete->Succeed(task);
+    ex.AddSilentTask(task);
+  }
+  ex.AddSilentTask(complete);
+  ex.Wait(complete);
+  EXPECT_TRUE(done);
+}
+
+TEST(TaskingTest, DependentTasksAreSequential) {
+  int num_threads = 4;
+  Executor ex(num_threads);
+  ex.Start();
+
+  int num_tasks = 10;
+
+  std::atomic_int parallel = 0;
+  std::atomic_int max_parallel = 0;
+  SharedTask last_task;
+  for (int i = 0; i < num_tasks; i++) {
+    auto task = Task::Create([&]() {
+      int p = ++parallel;
+      int expected = max_parallel.load();
+      while (!max_parallel.compare_exchange_strong(expected, std::max(p, expected))) {}
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+      --parallel;
+    });
+    if (last_task)
+      task->Succeed(last_task);
+    ex.AddSilentTask(task);
+    last_task = std::move(task);
+  }
+  ex.Wait(last_task);
+  EXPECT_EQ(max_parallel, 1)
+      << "The parallelism counter should not exceed 1 for a sequence of dependent tasks.";
+}
+
+TEST(TaskingTest, TaskArgumentValid) {
+  Executor ex(4);
+  ex.Start();
+  const int N = 10;
+  SharedTask tasks[N];
+  std::atomic_int tested = 0, valid = 0;
+  for (int i = 0; i < N; i++) {
+    tasks[i] = Task::Create([&, i](Task *task) {
+      ++tested;
+      if (task == tasks[i].get())
+        ++valid;
+    });
+    ex.AddSilentTask(tasks[i]);
+  }
+  auto timeout = t_plus(1.0);
+  while (tested != N && t_now() < timeout) {}
+  ASSERT_EQ(tested, N) << "Not all tasks finished - timeout expired.";
+  EXPECT_EQ(valid, N) << "Invalid task identity inside task job.";
+}
+
+
+TEST(TaskingTest, ArgumentPassing) {
+  Executor ex(4);
+  ex.Start();
+  auto producer1 = Task::Create([]() {
+    return 42;
+  });
+  auto producer2 = Task::Create([]() {
+    return 0.5;
+  });
+  auto consumer = Task::Create([&](Task *task) {
+    return 2 * task->GetInputValue<int>(0) + task->GetInputValue<double>(1);
+  });
+
+  consumer->Consume(producer1)->Consume(producer2);
+  ex.AddSilentTask(producer1);
+  ex.AddSilentTask(producer2);
+  double ret = ex.AddTask(consumer).Value<double>(ex);
+  EXPECT_EQ(ret, 84.5);
+}
+
+TEST(TaskingTest, MultiOutput) {
+  Executor ex(4);
+  ex.Start();
+  auto producer = Task::Create(2, []() {
+    return std::vector<int>{1, 42};
+  });
+
+  auto consumer1 = Task::Create([](Task *t) {
+    return t->GetInputValue<int>(0) + 3;
+  });
+  consumer1->Consume(producer, 0);
+
+  auto consumer2 = Task::Create([](Task *t) {
+    return t->GetInputValue<int>(0) + 5;
+  });
+  consumer2->Consume(producer, 1);
+
+  auto apex = Task::Create([](Task *t) {
+    return t->GetInputValue<int>(0) + t->GetInputValue<int>(1) + 10;
+  });
+  apex->Consume(consumer1)->Consume(consumer2);
+
+  ex.AddSilentTask(producer);
+  ex.AddSilentTask(consumer1);
+  ex.AddSilentTask(consumer2);
+  int ret = ex.AddTask(apex).Value<int>(ex);
+  EXPECT_EQ(ret, 1 + 3 + 42 + 5 + 10);
+}
+
+namespace {
+
+template <typename T>
+struct InstanceCounter {
+  T payload;
+  InstanceCounter() {
+    ++num_instances;
+  }
+  ~InstanceCounter() {
+    --num_instances;
+  }
+  InstanceCounter(T x) : payload(std::move(x)) {  // NOLINT
+    ++num_instances;
+  }
+  InstanceCounter(const InstanceCounter &other) : payload(other.payload) {
+    ++num_instances;
+  }
+  InstanceCounter(InstanceCounter &&other) : payload(std::move(other.payload)) {
+    ++num_instances;
+  }
+  static std::atomic_int num_instances;
+};
+
+}  // namespace
+
+template <typename T>
+std::atomic_int InstanceCounter<T>::num_instances = 0;
+
+/** This test makes sure that task results are disposed of as soon as possible */
+TEST(TaskingTest, MultiOutputLifespan) {
+  Executor ex(4);
+  ex.Start();
+
+  // These semaphores are used for delaying the launch of dependent tasks
+  auto sem1 = std::make_shared<Semaphore>(1, 0);
+  auto sem2 = std::make_shared<Semaphore>(1, 0);
+  auto sem3 = std::make_shared<Semaphore>(1, 0);
+
+  // This task creates 2 InstanceCounters - it has 2 separate outputs
+  auto producer = Task::Create(2, []() {
+    return std::vector<InstanceCounter<int>>{1, 42};
+  });
+
+  auto consumer1 = Task::Create([](Task *t) {
+    return t->GetInputValue<InstanceCounter<int>>(0).payload;
+  });
+  // This task consumes the 1st output of producer
+  consumer1->Consume(producer, 0)->Succeed(sem1);
+
+  auto consumer2 = Task::Create([](Task *t) {
+    return t->GetInputValue<InstanceCounter<int>>(0).payload;
+  });
+  // This task consumes the 2nd output of producer
+  consumer2->Consume(producer, 1)->Succeed(sem2);
+
+  auto consumer3 = Task::Create([](Task *t) {
+    return t->GetInputValue<InstanceCounter<int>>(0).payload;
+  });
+  // This task consumes the (again) 2nd output of producer
+  consumer3->Consume(producer, 1)->Succeed(sem3);
+
+
+  ex.AddSilentTask(producer);
+  ex.AddSilentTask(consumer1);
+  ex.AddSilentTask(consumer2);
+  ex.AddSilentTask(consumer3);
+  ex.Wait(producer);
+
+  // Once producer is finished we should still see both instances - they should be in the inputs
+  // of the consumers.
+  EXPECT_EQ(InstanceCounter<int>::num_instances, 2);
+
+  // We trigger 1st consumer
+  sem1->Release(ex);
+  ex.Wait(consumer1);
+  // After it's done, the 1st output of producer is no longer needed - it should be destroyed
+  EXPECT_EQ(InstanceCounter<int>::num_instances, 1);
+  sem2->Release(ex);
+  ex.Wait(consumer2);
+  // 2nd output is different - it has 2 consumers
+  EXPECT_EQ(InstanceCounter<int>::num_instances, 1);
+
+  sem3->Release(ex);
+  ex.Wait(consumer3);
+  // Both consumers are gone - the 2nd output should be gone now.
+  EXPECT_EQ(InstanceCounter<int>::num_instances, 0);
+}
+
+}  // namespace dali::tasking::test

--- a/dali/core/exec/tasking_test.cc
+++ b/dali/core/exec/tasking_test.cc
@@ -47,7 +47,7 @@ TEST(TaskingTest, IndependentTasksAreParallel) {
   auto complete = Task::Create([](){});
   for (int i = 0; i < num_threads; i++) {
     auto task = Task::Create([&]() {
-      if (++parallel)
+      if (++parallel == num_threads)
         done = true;
       while (!done && std::chrono::high_resolution_clock::now() < timeout) {}
       parallel--;
@@ -58,6 +58,7 @@ TEST(TaskingTest, IndependentTasksAreParallel) {
   ex.AddSilentTask(complete);
   ex.Wait(complete);
   EXPECT_TRUE(done);
+  EXPECT_EQ(parallel, 0) << "The tasks didn't finish cleanly";
 }
 
 TEST(TaskingTest, DependentTasksAreSequential) {
@@ -87,6 +88,7 @@ TEST(TaskingTest, DependentTasksAreSequential) {
   ex.Wait(last_task);
   EXPECT_EQ(max_parallel, 1)
       << "The parallelism counter should not exceed 1 for a sequence of dependent tasks.";
+  EXPECT_EQ(parallel, 0) << "The tasks didn't finish cleanly";
 }
 
 TEST(TaskingTest, TaskArgumentValid) {

--- a/dali/core/exec/tasking_test.cc
+++ b/dali/core/exec/tasking_test.cc
@@ -465,7 +465,7 @@ TEST(TaskFutureTest, IndexChecking) {
 TEST(TaskFutureTest, TypeChecking) {
   Scheduler sched;
   SharedTask task;
-  task = Task::Create(2, []() { return std::vector<int>{1, 2, 3 }; });
+  task = Task::Create(3, []() { return std::vector<int>{1, 2, 3 }; });
   auto fut = sched.AddTask(task);
   sched.Pop()->Run(sched);
   EXPECT_NO_THROW(fut.Value<int>(sched, 0));
@@ -475,7 +475,7 @@ TEST(TaskFutureTest, TypeChecking) {
 TEST(TaskInputTest, InvalidResultIndex) {
   Executor ex(4);
   ex.Start();
-  auto t1 = Task::Create(2, []() { return std::vector<int>{1, 2, 3 }; });
+  auto t1 = Task::Create(3, []() { return std::vector<int>{1, 2, 3 }; });
   auto t2 = Task::Create([](Task *t) { t->GetInputValue<int>(3); });
   t2->Subscribe(t1, 0);
   t2->Subscribe(t1, 1);

--- a/dali/core/exec/tasking_test.cc
+++ b/dali/core/exec/tasking_test.cc
@@ -302,7 +302,12 @@ double slowfunc(double x) {
   return std::sqrt(x + std::sqrt(x) + std::sqrt(x + std::sqrt(x)));
 }
 
-void GraphSubscribeTest(Executor &ex, int num_layers, int layer_size, int prev_layer_conn) {
+// This test creates a large graph with several layers and randomly placed connections
+// between nodes in the layers.
+// Each node produces a value that is then consumed by the dependent tasks.
+// Each task compares the value vs a reference computed at task creation.
+// In the event of failure, obtaining the future throws an exception.
+void GraphTest(Executor &ex, int num_layers, int layer_size, int prev_layer_conn) {
   std::vector<SharedTask> tasks;
   std::set<Task *> has_successor;
   std::mt19937_64 rng;
@@ -362,7 +367,7 @@ TEST(TaskingTest, HighLoad) {
   Executor ex(4);
   ex.Start();
   for (int i = 0; i < 10; i++)
-    GraphSubscribeTest(ex, 3, 1500, 50);
+    GraphTest(ex, 3, 1500, 50);
 }
 
 

--- a/dali/core/exec/tasking_test.cc
+++ b/dali/core/exec/tasking_test.cc
@@ -41,7 +41,7 @@ TEST(TaskingTest, IndependentTasksAreParallel) {
   Executor ex(num_threads);
   ex.Start();
 
-  std::atomic_int parallel;
+  std::atomic_int parallel = 0;
   std::atomic_bool done = false;
   auto timeout = std::chrono::high_resolution_clock::now() + std::chrono::seconds(1);
   auto complete = Task::Create([](){});
@@ -50,7 +50,7 @@ TEST(TaskingTest, IndependentTasksAreParallel) {
       if (++parallel == num_threads)
         done = true;
       while (!done && std::chrono::high_resolution_clock::now() < timeout) {}
-      parallel--;
+      --parallel;
     });
     complete->Succeed(task);
     ex.AddSilentTask(task);

--- a/dali/core/exec/tasking_test.cc
+++ b/dali/core/exec/tasking_test.cc
@@ -507,7 +507,7 @@ TEST(TaskingErrorTest, IncorrectTupleSize) {
   EXPECT_THROW(Task::Create(2, []() { return std::make_tuple(1, 2, 3); }), std::invalid_argument);
 }
 
-TEST(TaskingErrorTest, TaskRun_IncorrectResultCountAtRunTime) {
+TEST(TaskingErrorTest, IncorrectResultCountAtRunTime) {
   Scheduler sched;
   SharedTask task;
   EXPECT_NO_THROW(task = Task::Create(2, []() { return std::vector<int>{1, 2, 3 }; }));
@@ -539,7 +539,7 @@ TEST(TaskFutureTest, TypeChecking) {
   EXPECT_THROW(fut.Value<double>(0), std::bad_any_cast);
 }
 
-TEST(TaskInputTest, InvalidResultIndex) {
+TEST(TaskInputTest, InvalidInputIndex) {
   Executor ex(4);
   ex.Start();
   auto t1 = Task::Create(3, []() { return std::vector<int>{1, 2, 3 }; });
@@ -552,15 +552,15 @@ TEST(TaskInputTest, InvalidResultIndex) {
   EXPECT_THROW(fut.Value<void>(), std::out_of_range);
 }
 
-TEST(TaskInputTest, InvalidResultType) {
+TEST(TaskInputTest, InvalidInputType) {
   Executor ex(4);
   ex.Start();
   auto t1 = Task::Create([]() { return 42; });
-  auto t2 = Task::Create([](Task *t) { t->GetInputValue<double>(1); });
+  auto t2 = Task::Create([](Task *t) { t->GetInputValue<double>(0); });
   t2->Subscribe(t1);
   ex.AddSilentTask(t1);
   auto fut = ex.AddTask(t2);
-  EXPECT_THROW(fut.Value<void>(), std::out_of_range);
+  EXPECT_THROW(fut.Value<void>(), std::bad_any_cast);
 }
 
 }  // namespace dali::tasking::test

--- a/include/dali/core/exec/tasking.h
+++ b/include/dali/core/exec/tasking.h
@@ -20,4 +20,55 @@
 #include "dali/core/exec/tasking/sync.h"
 #include "dali/core/exec/tasking/executor.h"
 
+/**
+ * @brief DALI tasking module
+ *
+ * The tasking module provides an abstraction for scheduling dependent tasks and a simple
+ * thread-pool basd executor.
+ *
+ * The tasks can have temporal dependencies (for side-effects) and data dependencies.
+ * The tasks are single-use objects, passed around via shared pointer.
+ *
+ * Simple usage:
+ * ```
+ * Executor ex;
+ * ex.Start();
+ * auto task1 = Task::Create([]() {
+ *     cout << "Foo" << endl;
+ * });
+ * auto task2 = Task::Create([]() {
+ *     cout << "Bar" << endl;
+ * });
+ * auto task3 = Task::Create([]() {
+ *     cout << "Baz" << endl;
+ * });
+ * ex.AddSilentTask(task1);  // we're not interested in the result
+ * ex.AddSilentTask(task2);
+ * task3->Succeed(task1)->Succeed(task2);
+ * auto future = ex.AddTask(task3);
+ * future.Value<void>(ex);
+ * ```
+ *
+ * Data dependencies
+ * ```
+ * Executor ex;
+ * ex.Start();
+ * auto task1 = Task::Create([]() {
+ *     return 12;
+ * });
+ * auto task2 = Task::Create([]() {
+ *     return 30;
+ * });
+ * auto task3 = Task::Create([](Task *t) {
+ *     return t->GetInputValue<int>(0) + t->GetInputValue<int>(1);
+ * });
+ * task3->Subscribe(task1)->Subscribe(task2);
+ * ex.AddSilentTask(task1);
+ * ex.AddSilentTask(task2);
+ * auto future = ex.AddTask(task3);
+ * cout << future.Value<int>(ex) << endl;  // prints 42
+ * ```
+ */
+namespace dali::tasking {}
+
 #endif  // DALI_CORE_EXEC_TASKING_H_

--- a/include/dali/core/exec/tasking.h
+++ b/include/dali/core/exec/tasking.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_EXEC_TASKING_H_
+#define DALI_CORE_EXEC_TASKING_H_
+
+#include "dali/core/exec/tasking/scheduler.h"
+#include "dali/core/exec/tasking/task.h"
+#include "dali/core/exec/tasking/sync.h"
+#include "dali/core/exec/tasking/executor.h"
+
+#endif  // DALI_CORE_EXEC_TASKING_H_

--- a/include/dali/core/exec/tasking.h
+++ b/include/dali/core/exec/tasking.h
@@ -24,7 +24,7 @@
  * @brief DALI tasking module
  *
  * The tasking module provides an abstraction for scheduling dependent tasks and a simple
- * thread-pool basd executor.
+ * thread-pool based executor.
  *
  * The tasks can have temporal dependencies (for side-effects) and data dependencies.
  * The tasks are single-use objects, passed around via shared pointer.

--- a/include/dali/core/exec/tasking.h
+++ b/include/dali/core/exec/tasking.h
@@ -46,7 +46,7 @@
  * ex.AddSilentTask(task2);
  * task3->Succeed(task1)->Succeed(task2);
  * auto future = ex.AddTask(task3);
- * future.Value<void>(ex);
+ * future.Value<void>();
  * ```
  *
  * Data dependencies
@@ -66,7 +66,7 @@
  * ex.AddSilentTask(task1);
  * ex.AddSilentTask(task2);
  * auto future = ex.AddTask(task3);
- * cout << future.Value<int>(ex) << endl;  // prints 42
+ * cout << future.Value<int>() << endl;  // prints 42
  * ```
  */
 namespace dali::tasking {}

--- a/include/dali/core/exec/tasking/executor.h
+++ b/include/dali/core/exec/tasking/executor.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_EXEC_TASKING_EXECUTOR_H_
+#define DALI_CORE_EXEC_TASKING_EXECUTOR_H_
+
+#include "dali/core/exec/tasking/scheduler.h"
+
+
+#endif  // DALI_CORE_EXEC_TASKING_EXECUTOR_H_

--- a/include/dali/core/exec/tasking/executor.h
+++ b/include/dali/core/exec/tasking/executor.h
@@ -36,7 +36,8 @@ class Executor : public Scheduler {
       return;
     assert(workers_.empty());
     for (int i = 0; i < num_threads_; i++)
-      workers_.emplace_back([this, i]() { RunWorker(i); });
+      workers_.emplace_back([this]() { RunWorker(); });
+    started_ = true;
   }
 
   void Shutdown() {
@@ -49,7 +50,7 @@ class Executor : public Scheduler {
  private:
   bool started_ = false;
 
-  void RunWorker(int worker_idx) {
+  void RunWorker() {
     while (SharedTask task = Pop()) {
       task->Run(*this);
     }

--- a/include/dali/core/exec/tasking/executor.h
+++ b/include/dali/core/exec/tasking/executor.h
@@ -67,7 +67,7 @@ class Executor : public Scheduler {
 
   void RunWorker() {
     while (SharedTask task = Pop()) {
-      task->Run(*this);
+      task->Run();
     }
   }
 

--- a/include/dali/core/exec/tasking/executor.h
+++ b/include/dali/core/exec/tasking/executor.h
@@ -15,7 +15,50 @@
 #ifndef DALI_CORE_EXEC_TASKING_EXECUTOR_H_
 #define DALI_CORE_EXEC_TASKING_EXECUTOR_H_
 
+#include <memory>
+#include <thread>
+#include <vector>
 #include "dali/core/exec/tasking/scheduler.h"
 
+namespace dali::tasking {
+
+class Executor : public Scheduler {
+ public:
+  explicit Executor(int num_threads = std::thread::hardware_concurrency())
+      : num_threads_(num_threads) {}
+
+  ~Executor() {
+    Shutdown();
+  }
+
+  void Start() {
+    if (started_)
+      return;
+    assert(workers_.empty());
+    for (int i = 0; i < num_threads_; i++)
+      workers_.emplace_back([this, i]() { RunWorker(i); });
+  }
+
+  void Shutdown() {
+    Scheduler::Shutdown();
+    for (auto &w : workers_)
+      w.join();
+    workers_.clear();
+  }
+
+ private:
+  bool started_ = false;
+
+  void RunWorker(int worker_idx) {
+    while (SharedTask task = Pop()) {
+      task->Run(*this);
+    }
+  }
+
+  int num_threads_ = -1;
+  std::vector<std::thread> workers_;
+};
+
+}  // namespace dali::tasking
 
 #endif  // DALI_CORE_EXEC_TASKING_EXECUTOR_H_

--- a/include/dali/core/exec/tasking/executor.h
+++ b/include/dali/core/exec/tasking/executor.h
@@ -22,6 +22,10 @@
 
 namespace dali::tasking {
 
+/** A simple thread-pool-based executor based on the `Scheduler` class.
+ *
+ * The executor maintains a thread pool which `Pop` and `Run` tasks in a loop.
+ */
 class Executor : public Scheduler {
  public:
   explicit Executor(int num_threads = std::thread::hardware_concurrency())
@@ -31,6 +35,10 @@ class Executor : public Scheduler {
     Shutdown();
   }
 
+  /** Launches the worker threads.
+   *
+   * Multiple calls to Start have no effect. The function is not thread safe.
+   */
   void Start() {
     if (started_)
       return;
@@ -40,11 +48,18 @@ class Executor : public Scheduler {
     started_ = true;
   }
 
+  /** @brief Notifies the scheduler of the imminent shutdown and waits for the worker threads
+   *         to terminate.
+   */
   void Shutdown() {
     Scheduler::Shutdown();
     for (auto &w : workers_)
       w.join();
     workers_.clear();
+  }
+
+  bool IsRunning() const {
+    return started_ && !ShutdownRequested();
   }
 
  private:

--- a/include/dali/core/exec/tasking/scheduler.h
+++ b/include/dali/core/exec/tasking/scheduler.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_EXEC_TASKING_SCHEDULER_H_
+#define DALI_CORE_EXEC_TASKING_SCHEDULER_H_
+
+#include "dali/core/exec/tasking/task.h"
+#include "dali/core/exec/tasking/scheduler.h"
+#include "dali/core/exec/tasking/executor.h"
+
+
+#endif  // DALI_CORE_EXEC_TASKING_SCHEDULER_H_

--- a/include/dali/core/exec/tasking/scheduler.h
+++ b/include/dali/core/exec/tasking/scheduler.h
@@ -15,9 +15,286 @@
 #ifndef DALI_CORE_EXEC_TASKING_SCHEDULER_H_
 #define DALI_CORE_EXEC_TASKING_SCHEDULER_H_
 
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+#include <utility>
+#include <vector>
 #include "dali/core/exec/tasking/task.h"
-#include "dali/core/exec/tasking/scheduler.h"
-#include "dali/core/exec/tasking/executor.h"
+#include "dali/core/exec/tasking/sync.h"
+
+namespace dali::tasking {
+
+/** Represents a future result of a task.
+ *
+ * Like with std::future, this object can be used to wait for and obtain a result of a task.
+ * The difference is that it needs a Scheduler object which can be used to determine task's
+ * readiness.
+ * TaskFuture prolongs the life ot a task object and its result.
+ */
+class TaskFuture {
+ public:
+  TaskFuture(SharedTask task, SharedTaskResult result)
+      : task_(std::move(task)), result_(std::move(result)) {}
+
+  /** Waits for a result of type T
+   *
+   * If the task throws, the exception rethrown here.
+   * If the task returns a value of a different type, std::bad_any_cast is thrown.
+   */
+  template <typename T>
+  T Value(Scheduler &sched) & {
+    Wait(sched);
+    return result_->Value<T>();
+  }
+
+  /** Waits for a result of type T
+   *
+   * If the task throws, the exception rethrown here.
+   * If the task returns a value of a different type, std::bad_any_cast is thrown.
+   */
+  template <typename T>
+  T Value(Scheduler &sched) && {
+    static_assert(!std::is_reference_v<T>, "Returning a reference to a temporary");
+    Wait(sched);
+    return result_->Value<T>();
+  }
+
+  /** Waits for a result and returns it as `std::any`
+   *
+   * If the task throws, the exception rethrown here.
+   * If the task returns `void`, the returned `any` is empty.
+   */
+  decltype(auto) Value(Scheduler &sched) & {
+    Wait(sched);
+    return result_->Value();
+  }
+
+  /** Waits for a result and returns it as `std::any`
+   *
+   * If the task throws, the exception rethrown here.
+   * If the task returns `void`, the returned `any` is empty.
+   */
+  auto Value(Scheduler &sched) && {
+    Wait(sched);
+    return result_->Value();
+  }
+
+
+ private:
+  void Wait(Scheduler &sched);
+  SharedTask task_;
+  SharedTaskResult result_;
+};
+
+/** Determines the readiness and execution order of tasks.
+ *
+ * Task lifecycle:
+ * 1. New
+ *    - the task is created
+ *    - the data dependencies are added
+ * 2. Pending
+ *    - the task has been submitted to a Scheduler via AddTask or AddSilentTask
+ * 3. Ready
+ *    - the task has been submitted and all its preconditions are met
+ * 4. Running
+ *    - the task has been Popped from the scheduler and is being run
+ * 5. Complete
+ *    - the task's payload has finished running
+ *
+ * The Scheduler steps in at stage 2 and drives the lifecycle of a task until completion.
+ *
+ */
+class Scheduler {
+  struct TaskPriorityLess {
+    bool operator()(const SharedTask &a, const SharedTask &b) const {
+      return a->Priority() < b->Priority();
+    }
+  };
+
+ public:
+  SharedTask Pop() {
+    std::unique_lock lock(mtx_);
+    task_ready_.wait(lock, [&]() { return !ready_.empty() || shutdown_requested_; });
+    if (ready_.empty()) {
+      assert(shutdown_requested_);
+      return nullptr;
+    }
+    auto ret = std::move(ready_.top());
+    assert(ret->state == TaskState::Ready);
+    ready_.pop();
+    ret->state = TaskState::Running;
+    return ret;
+  }
+
+  void AddSilentTask(SharedTask task) {
+    if (task->state != TaskState::New)
+      throw std::logic_error("A task can be submitted only once.");
+    AddTaskImpl(std::move(task));
+  }
+
+  [[nodiscard("Use AddSilentTask if the result is not needed")]] TaskFuture AddTask(
+      SharedTask task) {
+    if (task->state != TaskState::New)
+      throw std::logic_error("A task can be submitted only once.");
+    auto res = task->result_;
+    assert(res);
+    AddTaskImpl(task);
+    return {std::move(task), std::move(res)};
+  }
+
+  void Notify(Waitable *w);
+
+  void Wait(Task *task);
+
+  void Shutdown() {
+    std::lock_guard g(mtx_);
+    shutdown_requested_ = true;
+    task_ready_.notify_all();
+  }
+
+ private:
+  bool CheckTaskReady(SharedTask &task) noexcept;
+
+  void AddTaskImpl(SharedTask task) {
+    if (task->state != TaskState::New)
+      throw std::logic_error("A task can be submitted only once.");
+    if (task->Ready()) {
+      std::lock_guard lock(mtx_);
+      {
+        task->state = TaskState::Ready;
+        ready_.push(task);
+      }
+    } else {
+      std::lock_guard lock(mtx_);
+      task->state = TaskState::Pending;
+      for (auto &pre : task->preconditions_) {
+        bool added = pre->AddToWaiting(task);
+        (void)added;
+        assert(added);
+      }
+      pending_.PushFront(task);
+      CheckTaskReady(task);
+    }
+    task_ready_.notify_one();
+  }
+
+  friend class Task;
+
+  std::mutex mtx_;
+  std::condition_variable task_ready_, task_done_;
+
+  detail::TaskList pending_;
+  std::priority_queue<SharedTask, std::vector<SharedTask>, TaskPriorityLess> ready_;
+  bool shutdown_requested_ = false;
+};
+
+inline void Waitable::Notify(Scheduler &sched) {
+  sched.Notify(this);
+}
+
+inline void Task::Run(Scheduler &sched) {
+  assert(state == TaskState::Running);
+  wrapped_(this);
+  result_.reset();
+  MarkAsComplete();
+  Notify(sched);
+  for (auto &r : release_) {
+    r->Release(sched);
+  }
+  release_.clear();
+  state = TaskState::Complete;
+}
+
+inline void TaskFuture::Wait(Scheduler &sched) {
+  sched.Wait(task_.get());
+}
+
+
+void Scheduler::Wait(Task *task) {
+  std::unique_lock lock(mtx_);
+  task_done_.wait(lock, [&]() { return task->CheckComplete() || shutdown_requested_; });
+}
+
+bool Scheduler::CheckTaskReady(SharedTask &task) noexcept {
+  assert(task->state <= TaskState::Pending);
+
+  for (auto &w : task->preconditions_)
+    if (!w->CheckComplete())
+      return false;
+  for (auto &w : task->preconditions_)
+    if (!w->TryAcquire(task)) {
+      // this should be a fatal error, but terminate and abort don't have messages
+      std::cerr
+          << "Internal error - resource acquisition failed for a resource known to be available"
+          << std::endl;
+      std::abort();
+    }
+
+  task->preconditions_.clear();
+  task->state = TaskState::Ready;
+  pending_.Remove(task);
+  ready_.push(std::move(task));
+  return true;
+}
+
+void Scheduler::Notify(Waitable *w) {
+  bool is_completion_event = dynamic_cast<CompletionEvent *>(w) != nullptr;
+  bool is_task = is_completion_event && dynamic_cast<Task *>(w);
+
+  int new_ready = 0;
+  {
+    std::lock_guard g(mtx_);
+    if (is_task)
+      task_done_.notify_all();
+
+    SmallVector<SharedTask, 8> waiting;
+    int n = w->waiting_.size();
+    waiting.reserve(n);
+    for (int i = 0; i < n; i++)
+      waiting.emplace_back(w->waiting_[i]);
+
+    for (auto &task : waiting) {
+      if (task->Ready())
+        continue;
+
+      // If the task has only one precondition or the waitable is a completion event,
+      // then we can just try to acquire that waitable on behalf of the task.
+      if (is_completion_event ||
+          (task->preconditions_.size() == 1 && task->preconditions_.begin()->get() == w)) {
+        // try acquire - the only way this can fail is that the task was
+        // re-checked in another thread and marked as ready...
+        if (!w->TryAcquire(task)) {
+          assert(task->preconditions_.size() != 1 || task->preconditions_.begin()->get() != w);
+          continue;  // ... if so, nothing to do
+        }
+        auto it = std::find_if(task->preconditions_.begin(), task->preconditions_.end(),
+                               [w](auto &pre) { return pre.get() == w; });
+        assert(it != task->preconditions_.end());
+        task->preconditions_.erase(it);
+        if (task->Ready()) {
+          pending_.Remove(task);
+          task->state = TaskState::Ready;
+          ready_.push(std::move(task));
+          new_ready++;
+          // OK, the task is ready, we're done with it
+          continue;
+        }
+      }
+
+      if (CheckTaskReady(task))
+        new_ready++;
+    }
+  }
+
+
+  if (new_ready == 1)
+    this->task_ready_.notify_one();
+  else if (new_ready > 1)
+    this->task_ready_.notify_all();
+}
+
+}  // namespace dali::tasking
 
 
 #endif  // DALI_CORE_EXEC_TASKING_SCHEDULER_H_

--- a/include/dali/core/exec/tasking/scheduler.h
+++ b/include/dali/core/exec/tasking/scheduler.h
@@ -220,7 +220,7 @@ class Scheduler {
   void DLL_PUBLIC Notify(Waitable *w);
 
   /** Waits for a task to complete. */
-  void Wait(Task *task);
+  void Wait(const Task *task);
 
   /** Waits for a task to complete. */
   void Wait(const SharedTask &task) {
@@ -293,7 +293,7 @@ inline void Waitable::Notify(Scheduler &sched) {
   sched.Notify(this);
 }
 
-inline void Task::Wait() {
+inline void Task::Wait() const {
   // Load the value of sched_ first....
   Scheduler *sched = sched_;
   // ...prevent the read of sched_ from being reordered
@@ -345,7 +345,7 @@ inline void TaskFuture::Wait() {
 }
 
 
-void Scheduler::Wait(Task *task) {
+void Scheduler::Wait(const Task *task) {
   std::unique_lock lock(mtx_);
   if (task->state_ < TaskState::Pending)
     throw std::logic_error("Cannot wait for a task that has not been submitted");

--- a/include/dali/core/exec/tasking/scheduler.h
+++ b/include/dali/core/exec/tasking/scheduler.h
@@ -236,8 +236,8 @@ class Scheduler {
   }
 
  private:
-  /** Checks if the task is ready and moves it from pending_ to ready_ list */
-  bool DLL_PUBLIC CheckTaskReady(SharedTask &task) noexcept;
+  /** Acquires all preconditions if they are ready or none if at least one isn't ready */
+  bool DLL_PUBLIC AcquireAllPreconditions(SharedTask &task) noexcept;
 
   void AddTaskImpl(SharedTask task) {
     assert(task->state_ == TaskState::New);
@@ -257,7 +257,7 @@ class Scheduler {
         assert(added);
       }
       pending_.PushFront(task);
-      if (CheckTaskReady(task))
+      if (AcquireAllPreconditions(task))
         task_ready_.notify_one();
     }
   }

--- a/include/dali/core/exec/tasking/scheduler.h
+++ b/include/dali/core/exec/tasking/scheduler.h
@@ -20,6 +20,7 @@
 #include <queue>
 #include <utility>
 #include <vector>
+#include "dali/core/api_helper.h"
 #include "dali/core/exec/tasking/task.h"
 #include "dali/core/exec/tasking/sync.h"
 
@@ -34,8 +35,8 @@ namespace dali::tasking {
  */
 class TaskFuture {
  public:
-  TaskFuture(SharedTask task, SharedTaskResult result)
-      : task_(std::move(task)), result_(std::move(result)) {}
+  TaskFuture(SharedTask task, TaskResults results)
+      : task_(std::move(task)), results_(std::move(results)) {}
 
   /** Waits for a result of type T
    *
@@ -45,7 +46,7 @@ class TaskFuture {
   template <typename T>
   T Value(Scheduler &sched) & {
     Wait(sched);
-    return result_->Value<T>();
+    return results_.Value<T>();
   }
 
   /** Waits for a result of type T
@@ -57,7 +58,7 @@ class TaskFuture {
   T Value(Scheduler &sched) && {
     static_assert(!std::is_reference_v<T>, "Returning a reference to a temporary");
     Wait(sched);
-    return result_->Value<T>();
+    return results_.Value<T>();
   }
 
   /** Waits for a result and returns it as `std::any`
@@ -67,7 +68,7 @@ class TaskFuture {
    */
   decltype(auto) Value(Scheduler &sched) & {
     Wait(sched);
-    return result_->Value();
+    return results_.Value();
   }
 
   /** Waits for a result and returns it as `std::any`
@@ -77,14 +78,57 @@ class TaskFuture {
    */
   auto Value(Scheduler &sched) && {
     Wait(sched);
-    return result_->Value();
+    return results_.Value();
+  }
+
+  /** Waits for a result of type T
+   *
+   * If the task throws, the exception rethrown here.
+   * If the task returns a value of a different type, std::bad_any_cast is thrown.
+   */
+  template <typename T>
+  T Value(Scheduler &sched, int index) & {
+    Wait(sched);
+    return results_.Value<T>(index);
+  }
+
+  /** Waits for a result of type T
+   *
+   * If the task throws, the exception rethrown here.
+   * If the task returns a value of a different type, std::bad_any_cast is thrown.
+   */
+  template <typename T>
+  T Value(Scheduler &sched, int index) && {
+    static_assert(!std::is_reference_v<T>, "Returning a reference to a temporary");
+    Wait(sched);
+    return results_.Value<T>(index);
+  }
+
+  /** Waits for a result and returns it as `std::any`
+   *
+   * If the task throws, the exception rethrown here.
+   * If the task returns `void`, the returned `any` is empty.
+   */
+  decltype(auto) Value(Scheduler &sched, int index) & {
+    Wait(sched);
+    return results_.Value(index);
+  }
+
+  /** Waits for a result and returns it as `std::any`
+   *
+   * If the task throws, the exception rethrown here.
+   * If the task returns `void`, the returned `any` is empty.
+   */
+  auto Value(Scheduler &sched, int index) && {
+    Wait(sched);
+    return results_.Value(index);
   }
 
 
  private:
   void Wait(Scheduler &sched);
   SharedTask task_;
-  SharedTaskResult result_;
+  TaskResults results_;
 };
 
 /** Determines the readiness and execution order of tasks.
@@ -137,15 +181,18 @@ class Scheduler {
       SharedTask task) {
     if (task->state != TaskState::New)
       throw std::logic_error("A task can be submitted only once.");
-    auto res = task->result_;
-    assert(res);
+    auto res = task->results_;
     AddTaskImpl(task);
     return {std::move(task), std::move(res)};
   }
 
-  void Notify(Waitable *w);
+  void DLL_PUBLIC Notify(Waitable *w);
 
   void Wait(Task *task);
+
+  void Wait(const SharedTask &task) {
+    Wait(task.get());
+  }
 
   void Shutdown() {
     std::lock_guard g(mtx_);
@@ -154,7 +201,7 @@ class Scheduler {
   }
 
  private:
-  bool CheckTaskReady(SharedTask &task) noexcept;
+  bool DLL_PUBLIC CheckTaskReady(SharedTask &task) noexcept;
 
   void AddTaskImpl(SharedTask task) {
     if (task->state != TaskState::New)
@@ -196,7 +243,8 @@ inline void Waitable::Notify(Scheduler &sched) {
 inline void Task::Run(Scheduler &sched) {
   assert(state == TaskState::Running);
   wrapped_(this);
-  result_.reset();
+  results_.clear();
+  inputs_.clear();
   MarkAsComplete();
   Notify(sched);
   for (auto &r : release_) {
@@ -213,85 +261,9 @@ inline void TaskFuture::Wait(Scheduler &sched) {
 
 void Scheduler::Wait(Task *task) {
   std::unique_lock lock(mtx_);
+  if (task->state < TaskState::Pending)
+    throw std::logic_error("Cannot wait for a task that has not been submitted");
   task_done_.wait(lock, [&]() { return task->CheckComplete() || shutdown_requested_; });
-}
-
-bool Scheduler::CheckTaskReady(SharedTask &task) noexcept {
-  assert(task->state <= TaskState::Pending);
-
-  for (auto &w : task->preconditions_)
-    if (!w->CheckComplete())
-      return false;
-  for (auto &w : task->preconditions_)
-    if (!w->TryAcquire(task)) {
-      // this should be a fatal error, but terminate and abort don't have messages
-      std::cerr
-          << "Internal error - resource acquisition failed for a resource known to be available"
-          << std::endl;
-      std::abort();
-    }
-
-  task->preconditions_.clear();
-  task->state = TaskState::Ready;
-  pending_.Remove(task);
-  ready_.push(std::move(task));
-  return true;
-}
-
-void Scheduler::Notify(Waitable *w) {
-  bool is_completion_event = dynamic_cast<CompletionEvent *>(w) != nullptr;
-  bool is_task = is_completion_event && dynamic_cast<Task *>(w);
-
-  int new_ready = 0;
-  {
-    std::lock_guard g(mtx_);
-    if (is_task)
-      task_done_.notify_all();
-
-    SmallVector<SharedTask, 8> waiting;
-    int n = w->waiting_.size();
-    waiting.reserve(n);
-    for (int i = 0; i < n; i++)
-      waiting.emplace_back(w->waiting_[i]);
-
-    for (auto &task : waiting) {
-      if (task->Ready())
-        continue;
-
-      // If the task has only one precondition or the waitable is a completion event,
-      // then we can just try to acquire that waitable on behalf of the task.
-      if (is_completion_event ||
-          (task->preconditions_.size() == 1 && task->preconditions_.begin()->get() == w)) {
-        // try acquire - the only way this can fail is that the task was
-        // re-checked in another thread and marked as ready...
-        if (!w->TryAcquire(task)) {
-          assert(task->preconditions_.size() != 1 || task->preconditions_.begin()->get() != w);
-          continue;  // ... if so, nothing to do
-        }
-        auto it = std::find_if(task->preconditions_.begin(), task->preconditions_.end(),
-                               [w](auto &pre) { return pre.get() == w; });
-        assert(it != task->preconditions_.end());
-        task->preconditions_.erase(it);
-        if (task->Ready()) {
-          pending_.Remove(task);
-          task->state = TaskState::Ready;
-          ready_.push(std::move(task));
-          new_ready++;
-          // OK, the task is ready, we're done with it
-          continue;
-        }
-      }
-
-      if (CheckTaskReady(task))
-        new_ready++;
-    }
-  }
-
-
-  if (new_ready == 1)
-    this->task_ready_.notify_one();
-  else if (new_ready > 1)
-    this->task_ready_.notify_all();
 }
 
 }  // namespace dali::tasking

--- a/include/dali/core/exec/tasking/scheduler.h
+++ b/include/dali/core/exec/tasking/scheduler.h
@@ -303,8 +303,8 @@ void Scheduler::Wait(Task *task) {
   std::unique_lock lock(mtx_);
   if (task->state_ < TaskState::Pending)
     throw std::logic_error("Cannot wait for a task that has not been submitted");
-  task_done_.wait(lock, [&]() { return task->CheckComplete() || shutdown_requested_; });
-  if (!task->CheckComplete())
+  task_done_.wait(lock, [&]() { return task->IsAcquirable() || shutdown_requested_; });
+  if (!task->IsAcquirable())
     throw std::runtime_error("The scheduler was shut down before the task was completed.");
 }
 

--- a/include/dali/core/exec/tasking/scheduler.h
+++ b/include/dali/core/exec/tasking/scheduler.h
@@ -205,7 +205,11 @@ class Scheduler {
 
   /** Submits a task for execution and gets a Future which can be used to get the output value
    */
+#if __cplusplus >= 201907L
   [[nodiscard("Use AddSilentTask if the result is not needed")]]
+#else
+  [[nodiscard]]
+#endif
   TaskFuture AddTask(SharedTask task) {
     if (task->state_ != TaskState::New)
       throw std::logic_error("A task can be submitted only once.");

--- a/include/dali/core/exec/tasking/scheduler.h
+++ b/include/dali/core/exec/tasking/scheduler.h
@@ -345,7 +345,7 @@ inline void TaskFuture::Wait() {
 }
 
 
-void Scheduler::Wait(const Task *task) {
+inline void Scheduler::Wait(const Task *task) {
   std::unique_lock lock(mtx_);
   if (task->state_ < TaskState::Pending)
     throw std::logic_error("Cannot wait for a task that has not been submitted");

--- a/include/dali/core/exec/tasking/sync.h
+++ b/include/dali/core/exec/tasking/sync.h
@@ -1,0 +1,151 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_EXEC_TASKING_SYNC_H_
+#define DALI_CORE_EXEC_TASKING_SYNC_H_
+
+#include <memory>
+#include <algorithm>
+#include "dali/core/small_vector.h"
+#include "dali/core/spinlock.h"
+
+namespace dali::tasking {
+
+
+class Waitable : public std::enable_shared_from_this<Waitable>
+{
+    friend class Scheduler;
+    friend class Task;
+protected:
+    SmallVector<std::weak_ptr<Task>, 8> waiting_;
+
+    virtual bool CheckComplete() const = 0;
+
+    virtual bool AcquireImpl() = 0;
+
+    void Notify(Scheduler &sched);
+
+    static bool task_owner_equal(const std::weak_ptr<Task> &w, const std::shared_ptr<Task> &t)
+    {
+        return !w.owner_before(t) && !t.owner_before(w);
+    }
+
+    bool IsWaitedForBy(const SharedTask &task) const
+    {
+        auto it = std::find_if(waiting_.begin(), waiting_.end(), [&](auto &t) { return task_owner_equal(t, task); });
+        return it != waiting_.end();
+    }
+
+    bool TryAcquire(const SharedTask &task)
+    {
+        PROFILE_FUNCTION();
+        auto it = std::find_if(waiting_.begin(), waiting_.end(), [&](auto &t) { return task_owner_equal(t, task); });
+        if (it == waiting_.end())
+            return false;
+        if (AcquireImpl())
+        {
+            waiting_.erase(it);
+            return true;
+        }
+        return false;
+    }
+
+    bool AddToWaiting(const SharedTask &task);
+
+public:
+    virtual ~Waitable() = default;
+};
+
+class CompletionEvent : public Waitable
+{
+protected:
+    virtual bool AcquireImpl()
+    {
+        // Nothing to acquire - just return true if the event is completed.
+        return CheckComplete();
+    }
+
+    void MarkAsComplete()
+    {
+        completed_ = true;
+    }
+
+    bool CheckComplete() const override
+    {
+        return completed_;
+    }
+
+private:
+    bool completed_ = false;
+};
+
+class Releasable : public Waitable
+{
+public:
+    bool Release(Scheduler &sched)
+    {
+        if (!ReleaseImpl())
+            return false;
+        Notify(sched);
+        return true;
+    }
+
+protected:
+    virtual bool ReleaseImpl() = 0;
+};
+
+class Semaphore : public Releasable
+{
+public:
+    explicit Semaphore(int max_count) : Semaphore(max_count, max_count) {}
+    Semaphore(int max_count, int initial_count) : max_count(max_count), count(initial_count) {}
+
+protected:
+    mutable spinlock lock_;
+
+    bool CheckComplete() const override
+    {
+        std::lock_guard g(lock_);
+        return count > 0;
+    }
+
+    bool AcquireImpl() override
+    {
+        std::lock_guard g(lock_);
+        if (count > 0)
+        {
+            count--;
+            return true;
+        }
+        return false;
+    }
+
+    bool ReleaseImpl() override
+    {
+        std::lock_guard g(lock_);
+        if (count >= max_count)
+            return false;
+        count++;
+        return true;
+    }
+
+private:
+    int count = 1;
+    int max_count = 1;
+};
+
+}  // namespace dali::tasking
+
+
+#endif  // DALI_CORE_EXEC_TASKING_SYNC_H_

--- a/include/dali/core/exec/tasking/sync.h
+++ b/include/dali/core/exec/tasking/sync.h
@@ -129,11 +129,9 @@ class CompletionEvent : public Waitable {
  */
 class Releasable : public Waitable {
  public:
-  bool Release(Scheduler &sched) {
-    if (!ReleaseImpl())
-      return false;
+  void Release(Scheduler &sched) {
+    ReleaseImpl();
     Notify(sched);
-    return true;
   }
 
  protected:
@@ -141,7 +139,7 @@ class Releasable : public Waitable {
    *
    * If IsAcquirable is called atomically after a successful ReleaseImpl, then it must return true.
    */
-  virtual bool ReleaseImpl() = 0;
+  virtual void ReleaseImpl() = 0;
 };
 
 /** A releasable object which counts how many times it can be acquired.
@@ -175,12 +173,11 @@ class Semaphore : public Releasable {
     return false;
   }
 
-  bool ReleaseImpl() override {
+  void ReleaseImpl() override {
     std::lock_guard g(lock_);
     if (count >= max_count)
-      return false;
+      throw std::out_of_range("The semaphore exceeded its maximum count.");
     count++;
-    return true;
   }
 
  private:

--- a/include/dali/core/exec/tasking/sync.h
+++ b/include/dali/core/exec/tasking/sync.h
@@ -85,7 +85,7 @@ class Waitable : public std::enable_shared_from_this<Waitable> {
 
 class CompletionEvent : public Waitable {
  protected:
-  virtual bool AcquireImpl() {
+  bool AcquireImpl() override {
     // Nothing to acquire - just return true if the event is completed.
     return CheckComplete();
   }
@@ -118,7 +118,7 @@ class Releasable : public Waitable {
 class Semaphore : public Releasable {
  public:
   explicit Semaphore(int max_count) : Semaphore(max_count, max_count) {}
-  Semaphore(int max_count, int initial_count) : max_count(max_count), count(initial_count) {}
+  Semaphore(int max_count, int initial_count) : count(initial_count), max_count(max_count) {}
 
  protected:
   mutable spinlock lock_;

--- a/include/dali/core/exec/tasking/sync.h
+++ b/include/dali/core/exec/tasking/sync.h
@@ -129,6 +129,7 @@ class CompletionEvent : public Waitable {
  */
 class Releasable : public Waitable {
  public:
+  /** Releases the object (see ReleaseImpl) and notifies the scheduler about the change. */
   void Release(Scheduler &sched) {
     ReleaseImpl();
     Notify(sched);
@@ -137,7 +138,7 @@ class Releasable : public Waitable {
  protected:
   /** Changes the internal state of the object.
    *
-   * If IsAcquirable is called atomically after a successful ReleaseImpl, then it must return true.
+   * The state of the object is changed such that the next call to TryAcquire must suceed.
    */
   virtual void ReleaseImpl() = 0;
 };

--- a/include/dali/core/exec/tasking/sync.h
+++ b/include/dali/core/exec/tasking/sync.h
@@ -16,6 +16,7 @@
 #define DALI_CORE_EXEC_TASKING_SYNC_H_
 
 #include <algorithm>
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include "dali/core/small_vector.h"
@@ -114,15 +115,15 @@ class CompletionEvent : public Waitable {
   }
 
   void MarkAsComplete() {
-    completed_ = true;
+    completed_.store(true, std::memory_order_release);
   }
 
   bool IsAcquirable() const override {
-    return completed_;
+    return completed_.load(std::memory_order_acquire);
   }
 
  private:
-  bool completed_ = false;
+  std::atomic_bool completed_{false};
 };
 
 /** A waitable object which has a Release method, which can be called from outside any task.

--- a/include/dali/core/exec/tasking/sync.h
+++ b/include/dali/core/exec/tasking/sync.h
@@ -15,134 +15,139 @@
 #ifndef DALI_CORE_EXEC_TASKING_SYNC_H_
 #define DALI_CORE_EXEC_TASKING_SYNC_H_
 
-#include <memory>
 #include <algorithm>
+#include <memory>
+#include <mutex>
 #include "dali/core/small_vector.h"
 #include "dali/core/spinlock.h"
 
 namespace dali::tasking {
 
+class Scheduler;
+class Task;
 
-class Waitable : public std::enable_shared_from_this<Waitable>
-{
-    friend class Scheduler;
-    friend class Task;
-protected:
-    SmallVector<std::weak_ptr<Task>, 8> waiting_;
+using SharedTask = std::shared_ptr<Task>;
+using WeakTask = std::weak_ptr<Task>;
 
-    virtual bool CheckComplete() const = 0;
+/** @brief Represents any object in the tasking framework that a task can wait for.
+ *
+ * A waitable object may be passed to Task::Succeed. This causes the execution of the task to
+ * be deferred until all of its preceding conditions are ready.
+ *
+ * NOTE: The tasking framework implements "wait all" semantics - that is, a task acquires the
+ *       waitable objects only after all of them are available, thus mitigating deadlocks.
+ */
+class Waitable : public std::enable_shared_from_this<Waitable> {
+  friend class Scheduler;
+  friend class Task;
 
-    virtual bool AcquireImpl() = 0;
+ protected:
+  SmallVector<WeakTask, 8> waiting_;
 
-    void Notify(Scheduler &sched);
+  virtual bool CheckComplete() const = 0;
 
-    static bool task_owner_equal(const std::weak_ptr<Task> &w, const std::shared_ptr<Task> &t)
-    {
-        return !w.owner_before(t) && !t.owner_before(w);
+  virtual bool AcquireImpl() = 0;
+
+  void Notify(Scheduler &sched);
+
+  static bool task_owner_equal(const WeakTask &w, const SharedTask &t) {
+    return !w.owner_before(t) && !t.owner_before(w);
+  }
+
+  bool IsWaitedForBy(const SharedTask &task) const {
+    auto it = std::find_if(waiting_.begin(), waiting_.end(),
+                           [&](auto &t) { return task_owner_equal(t, task); });
+    return it != waiting_.end();
+  }
+
+  bool TryAcquire(const SharedTask &task) {
+    auto it = std::find_if(waiting_.begin(), waiting_.end(),
+                           [&](auto &t) { return task_owner_equal(t, task); });
+    if (it == waiting_.end())
+      return false;
+    if (AcquireImpl()) {
+      waiting_.erase(it);
+      return true;
     }
+    return false;
+  }
 
-    bool IsWaitedForBy(const SharedTask &task) const
-    {
-        auto it = std::find_if(waiting_.begin(), waiting_.end(), [&](auto &t) { return task_owner_equal(t, task); });
-        return it != waiting_.end();
-    }
+  bool AddToWaiting(const SharedTask &task) {
+    if (IsWaitedForBy(task))
+      return false;
+    waiting_.push_back(task);
+    return true;
+  }
 
-    bool TryAcquire(const SharedTask &task)
-    {
-        PROFILE_FUNCTION();
-        auto it = std::find_if(waiting_.begin(), waiting_.end(), [&](auto &t) { return task_owner_equal(t, task); });
-        if (it == waiting_.end())
-            return false;
-        if (AcquireImpl())
-        {
-            waiting_.erase(it);
-            return true;
-        }
-        return false;
-    }
-
-    bool AddToWaiting(const SharedTask &task);
-
-public:
-    virtual ~Waitable() = default;
+ public:
+  virtual ~Waitable() = default;
 };
 
-class CompletionEvent : public Waitable
-{
-protected:
-    virtual bool AcquireImpl()
-    {
-        // Nothing to acquire - just return true if the event is completed.
-        return CheckComplete();
-    }
+class CompletionEvent : public Waitable {
+ protected:
+  virtual bool AcquireImpl() {
+    // Nothing to acquire - just return true if the event is completed.
+    return CheckComplete();
+  }
 
-    void MarkAsComplete()
-    {
-        completed_ = true;
-    }
+  void MarkAsComplete() {
+    completed_ = true;
+  }
 
-    bool CheckComplete() const override
-    {
-        return completed_;
-    }
+  bool CheckComplete() const override {
+    return completed_;
+  }
 
-private:
-    bool completed_ = false;
+ private:
+  bool completed_ = false;
 };
 
-class Releasable : public Waitable
-{
-public:
-    bool Release(Scheduler &sched)
-    {
-        if (!ReleaseImpl())
-            return false;
-        Notify(sched);
-        return true;
-    }
+class Releasable : public Waitable {
+ public:
+  bool Release(Scheduler &sched) {
+    if (!ReleaseImpl())
+      return false;
+    Notify(sched);
+    return true;
+  }
 
-protected:
-    virtual bool ReleaseImpl() = 0;
+ protected:
+  virtual bool ReleaseImpl() = 0;
 };
 
-class Semaphore : public Releasable
-{
-public:
-    explicit Semaphore(int max_count) : Semaphore(max_count, max_count) {}
-    Semaphore(int max_count, int initial_count) : max_count(max_count), count(initial_count) {}
+class Semaphore : public Releasable {
+ public:
+  explicit Semaphore(int max_count) : Semaphore(max_count, max_count) {}
+  Semaphore(int max_count, int initial_count) : max_count(max_count), count(initial_count) {}
 
-protected:
-    mutable spinlock lock_;
+ protected:
+  mutable spinlock lock_;
 
-    bool CheckComplete() const override
-    {
-        std::lock_guard g(lock_);
-        return count > 0;
+  bool CheckComplete() const override {
+    std::lock_guard g(lock_);
+    return count > 0;
+  }
+
+  bool AcquireImpl() override {
+    std::lock_guard g(lock_);
+    if (count > 0) {
+      count--;
+      return true;
     }
+    return false;
+  }
 
-    bool AcquireImpl() override
-    {
-        std::lock_guard g(lock_);
-        if (count > 0)
-        {
-            count--;
-            return true;
-        }
-        return false;
-    }
+  bool ReleaseImpl() override {
+    std::lock_guard g(lock_);
+    if (count >= max_count)
+      return false;
+    count++;
+    return true;
+  }
 
-    bool ReleaseImpl() override
-    {
-        std::lock_guard g(lock_);
-        if (count >= max_count)
-            return false;
-        count++;
-        return true;
-    }
-
-private:
-    int count = 1;
-    int max_count = 1;
+ private:
+  int count = 1;
+  int max_count = 1;
 };
 
 }  // namespace dali::tasking

--- a/include/dali/core/exec/tasking/task.h
+++ b/include/dali/core/exec/tasking/task.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_EXEC_TASKING_TASK_H_
+#define DALI_CORE_EXEC_TASKING_TASK_H_
+
+#include <cassert>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+
+#include "dali/core/small_vector.h"
+#include "dali/core/exec/tasking/sync.h"
+
+namespace dali::tasking {
+
+class Scheduler;
+
+
+}  // namespace dali::tasking
+
+#endif  // DALI_CORE_EXEC_TASKING_TASK_H_

--- a/include/dali/core/exec/tasking/task.h
+++ b/include/dali/core/exec/tasking/task.h
@@ -329,7 +329,7 @@ class Task : public CompletionEvent {
   explicit Task(F &&function, double priority = 0)
   : Task(ScalarResult, std::forward<F>(function), priority) {}
 
-  /** Creates a task with a scalar result
+  /** Creates a task with a scalar result.
    *
    * @param function    the callable object that defines the task; it can return any type
    * @param priority    the priority with which the task will be popped by the scheduler, once ready
@@ -339,7 +339,7 @@ class Task : public CompletionEvent {
     return std::make_shared<Task>(std::forward<F>(function), priority);
   }
 
-  /** Creates a task with a multiple results
+  /** Creates a task with a multiple results.
    *
    * @param num_results the number of results produced by the task function;
    *                    the special value `ScalarResult` changes the interpretation of the result.
@@ -364,17 +364,17 @@ class Task : public CompletionEvent {
 
   TaskState state_ = TaskState::New;
 
-  /** The priorirt of the task; the higher, ths sooner a task is picked */
+  /** The priority of the task; the higher, the sooner a task is picked. */
   double Priority() const {
     return priority_;
   }
 
-  /** If true, the task can be immediately moved to execution */
+  /** If true, the task can be immediately moved to execution. */
   bool Ready() {
     return preconditions_.empty();
   }
 
-  /** Adds a precondition
+  /** Adds a precondition.
    *
    * Calling Succeed adds the waitable `w` to the task's list of preconditions.
    * Duplicates are detected and ignored.
@@ -390,7 +390,7 @@ class Task : public CompletionEvent {
     return this;
   }
 
-  /** Subscribes to other task's output value
+  /** Subscribes to other task's output value.
    *
    * This function does two things:
    * - adds a dependency (Succeed) on the producer task
@@ -450,9 +450,9 @@ class Task : public CompletionEvent {
     return this;
   }
 
-  /**  Guards the execution of the task with a waitable/releasable object.
+  /** Guards the execution of the task with a waitable/releasable object.
    *
-   * Equivalent to Succeed + ReleaseAfterRun
+   * Equivalent to Succeed + ReleaseAfterRun.
    */
   Task *GuardWith(std::shared_ptr<Releasable> releasable) {
     Succeed(releasable);
@@ -460,7 +460,9 @@ class Task : public CompletionEvent {
     return this;
   }
 
-  /**  Executes the task. The task must have been submitted to the specified scheduler.
+  /** Executes the task.
+   *
+   * The task must have been submitted to and popped from the specified scheduler.
    */
   void Run(Scheduler &sched);
 

--- a/include/dali/core/exec/tasking/task.h
+++ b/include/dali/core/exec/tasking/task.h
@@ -17,17 +17,242 @@
 
 #include <cassert>
 #include <condition_variable>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
 
-#include "dali/core/small_vector.h"
 #include "dali/core/exec/tasking/sync.h"
+#include "dali/core/small_vector.h"
 
 namespace dali::tasking {
 
 class Scheduler;
 
+
+class TaskResult {
+ public:
+  template <typename F>
+  void SetResultOf(F &&f) {
+    Reset();
+    try {
+      if constexpr (std::is_void_v<decltype(f())>) {
+        f();
+        value_ = void_t();
+      } else {
+        value_ = f();
+      }
+    } catch (...) {
+      exception_ = std::exception_ptr();
+    }
+  }
+
+  void Reset() {
+    value_.reset();
+    exception_ = nullptr;
+  }
+
+  template <typename T>
+  void Set(T &&t) {
+    value_ = std::forward<T>(t);
+  }
+
+  void SetException(std::exception_ptr &&e) {
+    exception_ = std::move(e);
+  }
+
+  bool Empty() {
+    return !value_.has_value();
+  }
+
+  const std::any &Value() const {
+    if (exception_)
+      std::rethrow_exception(exception_);
+    return value_;
+  }
+
+  template <typename T>
+  T Value() const {
+    if constexpr (std::is_void_v<T>) {
+      (void)std::any_cast<void_t>(value_);
+    }
+  }
+
+  const bool HasException() const {
+    return exception_ != nullptr;
+  }
+
+ private:
+  struct void_t {};
+  std::any value_;
+  std::exception_ptr exception_;
+};
+
+using SharedTaskResult = std::shared_ptr<TaskResult>;
+
+
+enum class TaskState {
+  New,
+  Pending,
+  Ready,
+  Running,
+  Complete,
+  Destroyed
+};
+
+
+class Task : public CompletionEvent {
+  template <typename F, typename... Args>
+  void SetResult(F &&f, Args &&...args) {
+    assert(result_);
+    result_->SetResultOf([&]() { return f(std::forward<Args>(args)...); });
+  }
+
+ public:
+  template <typename F>
+  explicit Task(F &&function, double priority = 0) {
+    priority_ = priority;
+    wrapped_ = [f = std::forward<F>(function)](Task *t) {
+      using Func = std::remove_reference_t<F>;
+      if constexpr (std::is_invocable_v<Func, Task *>)
+        t->SetResult(f, t);
+      else if constexpr (std::is_invocable_v<Func>)
+        t->SetResult(f);
+    };
+  }
+
+  template <typename F>
+  static SharedTask Create(F &&function, double priority = 0) {
+    return std::make_shared<Task>(std::forward<F>(function), priority);
+  }
+
+  ~Task() {
+    assert(prev == nullptr);
+    assert(next == nullptr);
+    assert(state != TaskState::Running && state != TaskState::Destroyed);
+    state = TaskState::Destroyed;
+  }
+
+  TaskState state = TaskState::New;
+
+  double Priority() const {
+    return priority_;
+  }
+
+  bool Ready() {
+    return preconditions_.empty();
+  }
+
+  Task *Succeed(const std::shared_ptr<Waitable> &w) {
+    if (state != TaskState::New)
+      throw std::logic_error(
+          "Cannot add a new dependency to a task that has been submitted for execution.\n");
+    preconditions_.push_back(w);
+    return this;
+  }
+
+  Task *Consume(const SharedTask &producer) {
+    if (producer->state != TaskState::New)
+      throw std::logic_error(
+          "Cannot subscribe to a result of a task that's been already submitted for execution.\n"
+          "If only ordering is required, use Succeed instead.");
+    inputs_.push_back(producer->result_);
+    Succeed(producer);
+    return this;
+  }
+
+  const std::any &GetProducerResult(int index) const {
+    if (state != TaskState::Running)
+      throw std::logic_error(
+          "Obtaining a result of a producer task is only valid inside a task's payload function.");
+    if (index < 0 || index >= inputs_.size())
+      throw std::out_of_range("The specified producer index is out of range.");
+    return inputs_[index]->Value();
+  }
+
+  template <typename T>
+  T GetProducerResult(int index) const {
+    const std::any &result = GetProducerResult(index);
+    if constexpr (!std::is_void_v<T>)
+      return std::any_cast<T>(inputs_[index]->Value());
+  }
+
+  void Run(Scheduler &sched);
+
+  Task *ReleaseAfterRun(std::shared_ptr<Releasable> releasable) {
+    if (state != TaskState::New)
+      throw std::logic_error(
+          "Cannot add a new postcondition to a task that's been submitted to execution.\n"
+          "If you need to Release a releasable object after completion of an already "
+          "submitted task, create an auxiliary dependent task.");
+    release_.push_back(std::move(releasable));
+    return this;
+  }
+
+  Task *GuardWith(std::shared_ptr<Releasable> releasable) {
+    Succeed(releasable);
+    ReleaseAfterRun(std::move(releasable));
+    return this;
+  }
+
+ protected:
+  double priority_ = 0;
+  std::function<void(Task *)> wrapped_;
+  SmallVector<std::shared_ptr<Waitable>, 4> preconditions_;
+  SmallVector<SharedTaskResult, 4> inputs_;
+  SmallVector<std::shared_ptr<Releasable>, 4> release_;
+
+  friend class TaskList;
+  friend class Scheduler;
+
+  SharedTask next;        // pointer to the next task in an intrusive list
+  Task *prev = nullptr;   // pointer to the previous task in an intrusive list
+  SharedTaskResult result_ = std::make_shared<TaskResult>();
+};
+
+namespace detail {
+
+/** An intrusive list of tasks
+ *
+ * This list uses tasks' built-in next and prev fields.
+ */
+class TaskList {
+ public:
+  void PushFront(SharedTask task) {
+    assert(!task->next && !task->prev);
+    if (!head) {
+      assert(!tail);
+      head = std::move(task);
+      tail = head.get();
+    } else {
+      head->prev = task.get();
+      task->next = std::move(head);
+      head = std::move(task);
+    }
+  }
+
+  void Remove(const SharedTask &task) {
+    if (task == head)
+      head = task->next;
+    if (task.get() == tail)
+      tail = task->prev;
+
+    Task *p = task->prev;
+    if (task->next)
+      task->next->prev = p;
+    if (p)
+      p->next = std::move(task->next);
+    else
+      task->next.reset();
+    assert(!task->next);
+    task->prev = nullptr;
+  }
+
+ private:
+  SharedTask head;
+  Task *tail = nullptr;
+};
+}  // namespace detail
 
 }  // namespace dali::tasking
 

--- a/include/dali/core/exec/tasking/task.h
+++ b/include/dali/core/exec/tasking/task.h
@@ -403,8 +403,8 @@ class Task : public CompletionEvent {
       throw std::logic_error(
           "Cannot subscribe to a result of a task that's been already submitted for execution.\n"
           "If only ordering is required, use Succeed instead.");
-    inputs_.push_back(producer->results_.GetChecked(output_index));
     Succeed(producer);
+    inputs_.push_back(producer->results_.GetChecked(output_index));
     return this;
   }
 
@@ -538,7 +538,9 @@ class TaskList {
     task->prev_ = nullptr;
   }
 
+  /** Returns the head (front) of the list or null, if empty */
   SharedTask head() const { return head_; }
+  /** Returns the tail (back) of the list or nullptr, if empty */
   Task *tail() const { return tail_; }
 
  private:

--- a/include/dali/core/exec/tasking/task.h
+++ b/include/dali/core/exec/tasking/task.h
@@ -420,7 +420,7 @@ class Task : public CompletionEvent {
   Task *Succeed(const std::shared_ptr<Waitable> &w) {
     if (state_ != TaskState::New)
       throw std::logic_error(
-          "Cannot add a new dependency to a task that has been submitted for execution.\n");
+          "Cannot add a new dependency to a task that has been submitted for execution.");
     if (std::find(preconditions_.begin(), preconditions_.end(), w) == preconditions_.end())
       preconditions_.push_back(w);
     return this;

--- a/include/dali/core/exec/tasking/task.h
+++ b/include/dali/core/exec/tasking/task.h
@@ -496,16 +496,28 @@ class Task : public CompletionEvent {
     return this;
   }
 
-  /** Executes the task.
-   *
-   * The task must have been submitted to and popped from the specified scheduler.
-   */
-  void Run(Scheduler &sched);
+  /** Associates the task with a scheduler and sets the state to Pending. */
+  void Submit(Scheduler &sched) {
+    if (state_ != TaskState::New)
+      throw std::logic_error("The has already been submitted for execution.");
+    sched_ = &sched;
+    state_ = TaskState::Pending;
+  }
 
+  /** Executes the task. */
+  void Run();
+
+  /** Waits for the task to complete.
+   *
+   * The task must be already submitted for execution.
+   */
+  void Wait();
 
  private:
   SharedTask next_;       // pointer to the next task in an intrusive list
   Task *prev_ = nullptr;  // pointer to the previous task in an intrusive list
+
+  Scheduler *sched_ = nullptr;  // the scheduler to which the task was submitted
 
   friend class detail::TaskList;
   friend class Scheduler;

--- a/include/dali/core/exec/tasking/task.h
+++ b/include/dali/core/exec/tasking/task.h
@@ -275,7 +275,7 @@ class Task : public CompletionEvent {
         for (auto &&r : results) {
           if (n >= results_.size())
             throw std::logic_error("The function provided more results than "
-                                  "the task was declared to have.");
+                                   "the task was declared to have.");
           using T = std::remove_reference_t<decltype(r)>;
           results_[n]->Set(std::forward<T>(r));
           n++;
@@ -283,7 +283,7 @@ class Task : public CompletionEvent {
 
         if (n < results_.size())
           throw std::logic_error("The function provided fewer results than "
-                                  "the task was declared to have.");
+                                 "the task was declared to have.");
       } else if constexpr (detail::is_tuple_v<result_t>) {  // NOLINT
         assert(std::tuple_size_v<result_t> == results_.size() &&
                "Internal error - incorrect tuple size should have been detected earlier.");
@@ -314,8 +314,8 @@ class Task : public CompletionEvent {
       return;
     } else if constexpr (detail::is_tuple_v<Result>) {
       if (std::tuple_size_v<Result> != num_results)
-        throw std::logic_error("The output tuple has a different size than "
-                               "the declared number of task's ouputs.");
+        throw std::invalid_argument("The output tuple has a different size than "
+                                    "the declared number of task's ouputs.");
     } else {
       throw std::invalid_argument("The result of the function is neither iterable nor a tuple "
                                   "and cannot be used to obtain multiple output values.");

--- a/include/dali/core/exec/tasking/task.h
+++ b/include/dali/core/exec/tasking/task.h
@@ -520,7 +520,7 @@ class TaskList {
   /** Removes an element from the list.
    *
    * This function removes the element from the list by detaching it and reconnecting the
-   * previous and next elements. If the task coincides with head or tail, then the respecitve
+   * previous and next elements. If the task coincides with head or tail, then the respective
    * end is updated accordingly.
    */
   void Remove(const SharedTask &task) {

--- a/include/dali/core/exec/tasking/task.h
+++ b/include/dali/core/exec/tasking/task.h
@@ -432,7 +432,7 @@ class Task : public CompletionEvent {
    * - adds a dependency (Succeed) on the producer task
    * - creates a shared pointer to the producer task's output
    *
-   * The producer must not have been submitted to the scheruler when Subscribe is called.
+   * The producer must not have been submitted to the scheduler when Subscribe is called.
    */
   Task *Subscribe(const SharedTask &producer, int output_index = 0) {
     if (producer->state_ != TaskState::New)
@@ -496,14 +496,6 @@ class Task : public CompletionEvent {
     return this;
   }
 
-  /** Associates the task with a scheduler and sets the state to Pending. */
-  void Submit(Scheduler &sched) {
-    if (state_ != TaskState::New)
-      throw std::logic_error("The has already been submitted for execution.");
-    sched_ = &sched;
-    state_ = TaskState::Pending;
-  }
-
   /** Executes the task. */
   void Run();
 
@@ -518,6 +510,14 @@ class Task : public CompletionEvent {
   Task *prev_ = nullptr;  // pointer to the previous task in an intrusive list
 
   Scheduler *sched_ = nullptr;  // the scheduler to which the task was submitted
+
+  /** Associates the task with a scheduler and sets the state to Pending. */
+  void Submit(Scheduler &sched) {
+    if (state_ != TaskState::New)
+      throw std::logic_error("The has already been submitted for execution.");
+    sched_ = &sched;
+    state_ = TaskState::Pending;
+  }
 
   friend class detail::TaskList;
   friend class Scheduler;


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)


## Description:

# Tasking module
`dali::tasking` is a task execution engine which supports inter-task dependencies, semaphores and data passing.
Main concepts of the tasking API are:
* Task - a single-use object that encapsulates a function; it can depend on zero or more Waitable objects
* Waitable - an object for which a task can wait
* Scheduler - manages tasks and resolves their readiness state

## Main components
A `Task` is also `Waitable` - that is, a task can depend on the completion of other task(s).
There are two kinds of `Waitable` objects - completion events and releasable objects.
A `CompletionEvent` (e.g. Task) is an object which remains acquirable after it's "completed". Performing Acquire operation on it does not alter the state of the object.
A `Semaphore` can be externally released (it's `Releasable`), but `Acquire` lowers the semaphore count, so the number of tasks that can acquire a semaphore before it's released is limited.

Acquisition of `Waitable` objects on behalf of waiting tasks is the duty of the `Scheduler`. By contrast, `Release` operation on `Releasable` objects can be performed in any context.

## Data passing
Data can be passed between tasks. It's wrapped in a `TaskResult` type which stores either the value as `std::any` or the error as `std::exception_ptr`. An attempt to access the value with an exception present results in the exception being rethrown.
A `Task` wraps a function taking 0 or 1 argument (in the latter case it's this-like pointer to the `Task`) and returning a value of values.
Upon creation of the task, the caller defines the number of return values. There are two options:
- Scalar return value - in which case the return value can be any objects convertible to `std::any`. If the task returns `std::any`, it's stripped and the stored value is copied.
- Multiple return values - in this case the return value of the function must be either a collection or a `tuple`.
A `Task` can `Subscribe` to the result of a producer task (which has to be done before the producer is submitted to the scheduler). The result can be obtained by calling `task->GetInputValue<T>(index)`

## Obtaining results
When a task is added to the scheduler, a `TaskFuture` object can be obtained. `Scheduler::AddSilentTask` should be used if the result of the task is not needed. Calling `TaskFuture::Value` will wait for the task to complete and return the value produced by the task (or rethrow the exception).

## Error handling
All errors thrown by the task functions are stored in the task results. An attempt to obtain results of a task that threw an exception will result in the exception being rethrown.


## Additional information:

Usage with time dependencies only:
```C++
Executor ex;
ex.Start();
auto task1 = Task::Create([]() {
    cout << "Foo" << endl;
});
auto task2 = Task::Create([]() {
    cout << "Bar" << endl;
});
auto task3 = Task::Create([]() {
    cout << "Baz" << endl;
});
ex.AddSilentTask(task1);  // we're not interested in the result
ex.AddSilentTask(task2);
task3->Succeed(task1)->Succeed(task2);
auto future = ex.AddTask(task3);
future.Value<void>();
```

Usage with data dependencies
```C++
Executor ex;
ex.Start();
auto task1 = Task::Create([]() {
    return 12;
});
auto task2 = Task::Create([]() {
    return 30;
});
auto task3 = Task::Create([](Task *t) {
    return t->GetInputValue<int>(0) + t->GetInputValue<int>(1);
});
task3->Subscribe(task1)->Subscribe(task2);
ex.AddSilentTask(task1);
ex.AddSilentTask(task2);
auto future = ex.AddTask(task3);
cout << future.Value<int>() << endl;  // prints 42
```


### Affected modules and functionalities:
All new code.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3934
<!--- DALI-XXXX or NA --->
