### PR TITLE
Remove usage of THRUST host&device vector

### DIFF
--- a/dali/operators/input/video_input.h
+++ b/dali/operators/input/video_input.h
@@ -15,8 +15,6 @@
 #ifndef DALI_OPERATORS_INPUT_VIDEO_INPUT_H_
 #define DALI_OPERATORS_INPUT_VIDEO_INPUT_H_
 
-#include <thrust/host_vector.h>
-#include <thrust/device_vector.h>
 #include <deque>
 #include <string>
 #include <utility>
@@ -84,10 +82,6 @@ inline auto DetermineBatchOutline(int num_frames, int frames_per_sequence, int b
 template<typename OutBackend, typename PadType>
 struct PadFrameCreator {
   static constexpr bool is_cpu = std::is_same_v<OutBackend, CPUBackend>;
-
-  template<typename T>
-  using container_type =
-          std::conditional_t<is_cpu, thrust::host_vector<T>, thrust::device_vector<T>>;
 
   PadFrameCreator() = default;
 


### PR DESCRIPTION
- as there is no guarantee that THRUST host and device
  vectors can be used in host-only programs this PR removes
  their usage from DALI

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- as there is no guarantee that THRUST host and device
  vectors can be used in host-only programs this PR removes
  their usage from DALI
- see https://github.com/NVIDIA/cccl/issues/1374
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- mostly tests
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
