### PR TITLE
Make shared IterationData a first class member of Workspace.

### DIFF
--- a/dali/pipeline/executor/executor_impl.h
+++ b/dali/pipeline/executor/executor_impl.h
@@ -34,6 +34,7 @@
 #include "dali/pipeline/executor/queue_metadata.h"
 #include "dali/pipeline/executor/queue_policy.h"
 #include "dali/pipeline/executor/workspace_policy.h"
+#include "dali/pipeline/executor/iteration_data.h"
 #include "dali/pipeline/graph/op_graph.h"
 #include "dali/pipeline/graph/op_graph_storage.h"
 #include "dali/pipeline/graph/op_graph_verifier.h"
@@ -327,7 +328,7 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
 
   WorkspacePolicy ws_policy_;
 
-  std::vector<IterationData> iteration_data_;
+  std::vector<ExecIterData> iteration_data_;
   size_t cpu_iteration_id_ = 0, mixed_iteration_id_ = 0, gpu_iteration_id_ = 0;
   size_t output_iteration_id_ = 0;
 
@@ -438,7 +439,7 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
   /**
    * Returns the iteration data for given iteration ID and stage.
    */
-  virtual IterationData& GetCurrentIterationData(size_t iteration_id);
+  virtual ExecIterData& GetCurrentIterationData(size_t iteration_id);
 };
 
 template <typename WorkspacePolicy, typename QueuePolicy>

--- a/dali/pipeline/executor/iteration_data.h
+++ b/dali/pipeline/executor/iteration_data.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,36 +18,13 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-
+#include "dali/pipeline/workspace/iteration_data.h"
 #include "dali/pipeline/operator/checkpointing/checkpoint.h"
 
 namespace dali {
 
-/**
- * Operator Traces is a mechanism, where an Operator can provide any arbitrary information to
- * the end user. Under `trace_name` key, the Operator assigns `trace_value` as the information
- * mentioned above. Using the provided API, user will be able to retrieve this information after
- * the iteration ends - at the same time when he's able to access outputs from the pipeline.
- *
- * @see daliGetOperatorTrace, daliGetNumOperatorTraces
- *
- * Here are few examples of these traces, but essentially sky is the limit:
- *   - "execution_time" -> "432 sec"
- *   - "number_of_unprocessed_samples" -> "100"
- *   - "next_batch_ready" -> "true"
- */
-using operator_trace_map_t = std::unordered_map<
-        std::string /* op_name */,
-        std::unordered_map<std::string /* trace_name */, std::string /* trace_value */>
->;
-
-
-/**
- * Contains the data of an iteration. This data is shared across all Workspaces, that belong to
- * a single iteration.
- */
-struct IterationData {
-  std::shared_ptr<operator_trace_map_t> operator_traces;
+struct ExecIterData {
+  std::shared_ptr<IterationData> iter_data;
   Checkpoint checkpoint;
 };
 

--- a/dali/pipeline/workspace/iteration_data.h
+++ b/dali/pipeline/workspace/iteration_data.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_WORKSPACE_ITERATION_DATA_H_
+#define DALI_PIPELINE_WORKSPACE_ITERATION_DATA_H_
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace dali {
+
+/**
+ * Operator Traces is a mechanism, where an Operator can provide any arbitrary information to
+ * the end user. Under `trace_name` key, the Operator assigns `trace_value` as the information
+ * mentioned above. Using the provided API, user will be able to retrieve this information after
+ * the iteration ends - at the same time when he's able to access outputs from the pipeline.
+ *
+ * @see daliGetOperatorTrace, daliGetNumOperatorTraces
+ *
+ * Here are few examples of these traces, but essentially sky is the limit:
+ *   - "execution_time" -> "432 sec"
+ *   - "number_of_unprocessed_samples" -> "100"
+ *   - "next_batch_ready" -> "true"
+ */
+using operator_trace_map_t = std::unordered_map<
+  std::string /* trace_name */, std::string /* trace_value */>;
+
+class OperatorTraces {
+ public:
+  /** Gets operator traces for a single operator.
+   *
+   * This function is thread safe, however, the map returned by it is not.
+   * The operator must ensure that it does not attempt to modify the map from multiple threads.
+   */
+  operator_trace_map_t &Get(const std::string &operator_name) {
+    std::lock_guard g(mtx_);
+    return map_[operator_name];
+  }
+
+  /** Obtains a copy of trace maps for all operators.
+   *
+   * This function is thread safe.
+   */
+  auto GetCopy() const {
+    std::lock_guard g(mtx_);
+    return map_;
+  }
+
+ private:
+  mutable std::mutex mtx_;
+  std::unordered_map<
+        std::string /* op_name */,
+        operator_trace_map_t /* per-operator traces */
+  > map_;
+};
+
+/**
+ * Contains the data of an iteration. This data is shared across all Workspaces that belong to
+ * a single iteration.
+ */
+struct IterationData {
+  int64_t iteration_index = 0;
+  OperatorTraces operator_traces;
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_WORKSPACE_ITERATION_DATA_H_
+


### PR DESCRIPTION
Make operator traces thread-safe.


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:
This change does 2 things:
- it generalizes the mechanism of iteration data beyond operator traces
- it makes operator traces thread-safe

## Additional information:

### Affected modules and functionalities:
Executor, Workspace, operator traces


### Key points relevant for the review:
N/A

### Tests:
- C API operator trace tests 
- Executor tests

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
