### PR TITLE
Bump up NUMBA version used in tests to 0.59.1

### DIFF
--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -947,9 +947,10 @@ def check_numba_compatibility_cpu(if_skip=True):
     #
     # TODO(michalz): Update the Numba version range when there's a fix - or possibly check
     # llvmlite directly (if still applicable)
-    if platform.processor().lower() in ("arm64", "aarch64", "armv8") and LooseVersion(
-        numba.__version__
-    ) >= LooseVersion("0.57.0"):
+    if platform.processor().lower() in ("arm64", "aarch64", "armv8") and (
+        LooseVersion(numba.__version__) >= LooseVersion("0.57.0")
+        and LooseVersion(numba.__version__) < LooseVersion("0.59.0")
+    ):
         if if_skip:
             raise SkipTest()
         else:

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -939,14 +939,11 @@ def check_numba_compatibility_cpu(if_skip=True):
     import numba
     from nose import SkipTest
 
-    # At present (as of Numba 0.57) there's a bug in LLVM JIT linker that makes the tests fail
-    # randomly on 64-bit ARM platform.
+    # There's a bug in LLVM JIT linker that makes the tests fail
+    # randomly on 64-bit ARM platform for some NUMBA versions.
     #
     # Numba bug:
     # https://github.com/numba/numba/issues/8567
-    #
-    # TODO(michalz): Update the Numba version range when there's a fix - or possibly check
-    # llvmlite directly (if still applicable)
     if platform.processor().lower() in ("arm64", "aarch64", "armv8") and (
         LooseVersion(numba.__version__) >= LooseVersion("0.57.0")
         and LooseVersion(numba.__version__) < LooseVersion("0.59.0")

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -575,7 +575,19 @@ all_packages = [
         links_index=("https://storage.googleapis.com/" "jax-releases/jax_cuda_releases.html"),
     ),
     CudaPackage(
-        "numba", {"110": [PckgVer("0.57.0", python_min_ver="3.8", dependencies=["numpy<1.24"])]}
+        "numba",
+        {
+            "110": [
+                # the more recent NUMBA doesn't support python 3.8 so keep it for this version here
+                PckgVer(
+                    "0.57.0",
+                    python_min_ver="3.8",
+                    python_max_ver="3.8",
+                    dependencies=["numpy<1.24"],
+                ),
+                PckgVer("0.59.1", python_min_ver="3.9", dependencies=["numpy<1.24"]),
+            ]
+        },
     ),
 ]
 


### PR DESCRIPTION
- bumps up NUMBA version used in tests to 0.59.1
- reenables NUMBA CPU tests on aarch64 for >=0.59.0
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- bumps up NUMBA version used in tests to 0.59.1
- reenables NUMBA CPU tests on aarch64 for >=0.59.0
- related to https://github.com/NVIDIA/DALI/issues/5450
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- setup packages script
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_numba_func
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
