### PR TITLE
Remove the use of (soon deprecated) aligned_storage.

### DIFF
--- a/dali/core/mm/default_resources.cc
+++ b/dali/core/mm/default_resources.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -120,8 +120,8 @@ struct DefaultResources {
     // is allocated dynamically on stack and never destroyed.
     // This accomplishes the intentional leaking of the pointer.
     using Ptr = std::shared_ptr<T>;
-    std::aligned_storage_t<sizeof(Ptr), alignof(Ptr)> dump;
-    new (&dump) Ptr(std::move(p));
+    alignas(Ptr) std::byte dump[sizeof(Ptr)];
+    new (dump) Ptr(std::move(p));
   }
 };
 

--- a/dali/kernels/dynamic_scratchpad_test.cc
+++ b/dali/kernels/dynamic_scratchpad_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022, 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,8 +113,8 @@ TEST(DynamicScratchpad, Perf) {
 
   for (int attempt = 0; attempt < max_attempts; attempt++) {
     auto s = streams[attempt % 2];
-    std::aligned_storage_t<sizeof(DynamicScratchpad), alignof(DynamicScratchpad)> scratch_placement;
-    auto *scratch = new(&scratch_placement) DynamicScratchpad({}, AccessOrder(s));
+    alignas(DynamicScratchpad) std::byte scratch_placement[sizeof(DynamicScratchpad)];
+    auto *scratch = new(scratch_placement) DynamicScratchpad({}, AccessOrder(s));
     for (int k = 0; k < nkinds; k++) {
       auto kind = static_cast<mm::memory_kind_id>(k);
       if (kind == mm::memory_kind_id::managed)

--- a/dali/kernels/test/scratch_test.cc
+++ b/dali/kernels/test/scratch_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 - 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2021, 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,31 +81,31 @@ TEST(Scratch, Estimator) {
 }
 
 TEST(Scratch, BumpAllocator) {
-  const size_t size = 1024;
-  std::aligned_storage<size, 64>::type storage;
-  BumpAllocator allocator(reinterpret_cast<char*>(&storage), size);
+  const size_t kSize = 1024;
+  alignas(64) char storage[kSize];
+  BumpAllocator allocator(storage, kSize);
   size_t n0 = 10, n1 = 20, n2 = 33;
 
-  EXPECT_EQ(allocator.total(), size);
-  EXPECT_EQ(allocator.avail(), size);
+  EXPECT_EQ(allocator.total(), kSize);
+  EXPECT_EQ(allocator.avail(), kSize);
   EXPECT_EQ(allocator.used(), 0);
   auto *p0 = allocator.alloc(n0);
   auto *p1 = allocator.alloc(n1);
   auto *p2 = allocator.alloc(n2);
 
-  EXPECT_EQ(allocator.avail(), size-(n0+n1+n2));
+  EXPECT_EQ(allocator.avail(), kSize-(n0+n1+n2));
   EXPECT_EQ(allocator.used(), n0+n1+n2);
   EXPECT_EQ(p1-p0, n0);
   EXPECT_EQ(p2-p1, n1);
-  EXPECT_EQ(allocator.total(), size) << "Total size should remain constant";
+  EXPECT_EQ(allocator.total(), kSize) << "Total size should remain constant";
 
   BumpAllocator allocator2 = std::move(allocator);
   EXPECT_EQ(allocator.total(), 0) << "After move, allocator should be empty";
 
-  auto *p3 = allocator2.alloc(size-(n0+n1+n2));
+  auto *p3 = allocator2.alloc(kSize-(n0+n1+n2));
   EXPECT_EQ(p3-p0, n0+n1+n2);
-  EXPECT_EQ(allocator2.total(), size) << "Total size should remain constant";
-  EXPECT_EQ(allocator2.used(), size);
+  EXPECT_EQ(allocator2.total(), kSize) << "Total size should remain constant";
+  EXPECT_EQ(allocator2.used(), kSize);
   EXPECT_EQ(allocator2.avail(), 0);
 }
 

--- a/include/dali/core/mm/detail/aux_alloc.h
+++ b/include/dali/core/mm/detail/aux_alloc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020, 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,12 +77,12 @@ struct fixed_size_allocator {
       if (Block *blk = free_list_) {
         free_list_ = blk->next;
         blk->next = nullptr;
-        return reinterpret_cast<T*>(&blk->storage);
+        return reinterpret_cast<T*>(blk->storage);
       }
     }
     Block *blk = static_cast<Block*>(memalign(alignment, sizeof(Block)));
     blk->next = nullptr;
-    return reinterpret_cast<T*>(&blk->storage);
+    return reinterpret_cast<T*>(blk->storage);
   }
 
   /**
@@ -123,7 +123,7 @@ struct fixed_size_allocator {
   }
 
   struct Block {
-    std::aligned_storage_t<size, alignment> storage;
+    alignas(alignment) std::byte storage[size];  // NOLINT(runtime/arrays)
     Block *next;
   };
   Block *free_list_ = nullptr;

--- a/include/dali/core/small_vector.h
+++ b/include/dali/core/small_vector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -652,9 +652,8 @@ class SmallVector : SmallVectorAlloc<T, allocator>, SmallVectorBase<T> {
   template <typename U, size_t n, typename A>
   friend class SmallVector;
 
-  using storage_t = typename std::aligned_storage<sizeof(T) * static_size_, alignof(T)>::type;
   union {
-    storage_t storage;
+    alignas(T) std::byte storage[sizeof(T) * static_size];  // NOLINT(runtime/arrays)
     struct {
       T *data;
       size_t capacity;
@@ -708,10 +707,10 @@ class SmallVector : SmallVectorAlloc<T, allocator>, SmallVectorBase<T> {
   using Alloc::deallocate;
 
   DALI_HOST_DEV inline T *static_data() {
-    return reinterpret_cast<T *>(&storage);
+    return reinterpret_cast<T *>(storage);
   }
   DALI_HOST_DEV inline const T *static_data() const {
-    return reinterpret_cast<const T *>(&storage);
+    return reinterpret_cast<const T *>(storage);
   }
 
   DALI_HOST_DEV inline T *dynamic_data() {


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** C++ standard update


## Description:
According to C++ 17 standard, type-punning pointers to `std::aligned_storage_t` is UB and in C++23 `std::aligned_*` is deprecated. The recommended way is to use an appropriately aligned array of bytes.



## Additional information:

### Affected modules and functionalities:
aux_alloc
small_vector
"leaker" in default_resources (that's a hack anyway)
some tests

### Key points relevant for the review:
alignment syntax?

### Tests:
small_vector_test and everything that uses SmallVector
allocator tests indirectly test aux_alloc
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3036
<!--- DALI-XXXX or NA --->
