### PR TITLE
Use C++17 standard in nodeps test.

### DIFF
--- a/qa/TL1_nodeps_build/CMakeLists_submodule.txt
+++ b/qa/TL1_nodeps_build/CMakeLists_submodule.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 project(nodeps_test CUDA CXX)
+set(CMAKE_CXX_STANDARD 17)
 
 set(BUILD_DALI_NODEPS ON)
 set(STATIC_LIBS ON)

--- a/qa/TL1_nodeps_build/CMakeLists_system.txt
+++ b/qa/TL1_nodeps_build/CMakeLists_system.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 project(nodeps_test CUDA CXX)
+set(CMAKE_CXX_STANDARD 17)
 
 add_executable(nodeps_test main.cc)
 target_link_libraries(nodeps_test dali_core dali_kernels)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)



## Description:
We build DALI with C++17, but a test target used the compiler's default (which happened to be c++14). This PR explicitly sets the standard in the test target.

## Additional information:

### Affected modules and functionalities:
Nodeps test.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
qa/TL1_nodeps_build
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [X] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
