### PR TITLE
Revert "Move old ImageDecoder to legacy module and make the nvImageCodec based ImageDecoder the default (#5445)"

### DIFF
--- a/dali/operators/decoder/host/fused/host_decoder_crop.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_crop.cc
@@ -29,6 +29,7 @@ HostDecoderCrop::HostDecoderCrop(const OpSpec &spec)
   , CropAttr(spec) {
 }
 
-DALI_REGISTER_OPERATOR(legacy__decoders__ImageCrop, HostDecoderCrop, CPU);
+DALI_REGISTER_OPERATOR(decoders__ImageCrop, HostDecoderCrop, CPU);
+DALI_REGISTER_OPERATOR(ImageDecoderCrop, HostDecoderCrop, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/host/fused/host_decoder_random_crop.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_random_crop.cc
@@ -44,6 +44,7 @@ HostDecoderRandomCrop::DeserializeCheckpoint(OpCheckpoint &cpt, const std::strin
     SnapshotSerializer().Deserialize<std::vector<std::mt19937>>(data);
 }
 
-DALI_REGISTER_OPERATOR(legacy__decoders__ImageRandomCrop, HostDecoderRandomCrop, CPU);
+DALI_REGISTER_OPERATOR(decoders__ImageRandomCrop, HostDecoderRandomCrop, CPU);
+DALI_REGISTER_OPERATOR(ImageDecoderRandomCrop, HostDecoderRandomCrop, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/host/fused/host_decoder_random_crop_test.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_random_crop_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019 NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ TEST_F(ImageRandomCropCheckpointingTest_CPU, Simple) {
       .AddArg("files", std::vector{filepath}));
 
   pipe.AddOperator(
-    OpSpec("legacy__decoders__ImageRandomCrop")
+    OpSpec("decoders__ImageRandomCrop")
       .AddInput("file", "cpu")
       .AddOutput("decoded", "cpu"));
 

--- a/dali/operators/decoder/host/fused/host_decoder_slice.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_slice.cc
@@ -28,6 +28,7 @@ HostDecoderSlice::HostDecoderSlice(const OpSpec &spec)
   , slice_attr_(spec) {
 }
 
-DALI_REGISTER_OPERATOR(legacy__decoders__ImageSlice, HostDecoderSlice, CPU);
+DALI_REGISTER_OPERATOR(decoders__ImageSlice, HostDecoderSlice, CPU);
+DALI_REGISTER_OPERATOR(ImageDecoderSlice, HostDecoderSlice, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/host/host_decoder.cc
+++ b/dali/operators/decoder/host/host_decoder.cc
@@ -50,6 +50,7 @@ void HostDecoder::RunImpl(SampleWorkspace &ws) {
   std::memcpy(out_data, decoded.get(), volume(shape));
 }
 
-DALI_REGISTER_OPERATOR(legacy__decoders__Image, HostDecoder, CPU);
+DALI_REGISTER_OPERATOR(decoders__Image, HostDecoder, CPU);
+DALI_REGISTER_OPERATOR(ImageDecoder, HostDecoder, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -163,11 +163,8 @@ allocation might be useful to determine suitable values for ``device_memory_padd
 )code",
       false);
 
-DALI_SCHEMA(legacy__decoders__Image)
+DALI_SCHEMA(decoders__Image)
   .DocStr(R"code(Decodes images.
-
-.. warning::
-  This is a legacy implementation of the image decoder. Use the  ``decoders`` module instead.
 
 For jpeg images, depending on the backend selected ("mixed" and "cpu"), the implementation uses
 the *nvJPEG* library or *libjpeg-turbo*, respectively. Other image formats are decoded
@@ -198,12 +195,9 @@ Please note that GPU acceleration for JPEG 2000 decoding is only available for C
 
 // Fused
 
-DALI_SCHEMA(legacy__decoders__ImageCrop)
+DALI_SCHEMA(decoders__ImageCrop)
   .DocStr(R"code(Decodes images and extracts regions-of-interest (ROI) that are specified
 by fixed window dimensions and variable anchors.
-
-.. warning::
-  This is a legacy implementation of the image decoder. Use the  ``decoders`` module instead.
 
 When possible, the argument uses the ROI decoding APIs (for example, *libjpeg-turbo* and *nvJPEG*)
 to reduce the decoding time and memory usage. When the ROI decoding is not supported for a given
@@ -225,11 +219,8 @@ Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000, WebP.
   .AddParent("ImageDecoderAttr")
   .AddParent("CropAttr");
 
-DALI_SCHEMA(legacy__decoders__ImageRandomCrop)
+DALI_SCHEMA(decoders__ImageRandomCrop)
   .DocStr(R"code(Decodes images and randomly crops them.
-
-.. warning::
-  This is a legacy implementation of the image decoder. Use the  ``decoders`` module instead.
 
 The cropping window's area (relative to the entire image) and aspect ratio can be restricted to
 a range of values specified by ``area`` and ``aspect_ratio`` arguments, respectively.
@@ -255,11 +246,8 @@ Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000, WebP.
   .AddParent("RandomCropAttr");
 
 
-DALI_SCHEMA(legacy__decoders__ImageSlice)
+DALI_SCHEMA(decoders__ImageSlice)
   .DocStr(R"code(Decodes images and extracts regions of interest.
-
-.. warning::
-  This is a legacy implementation of the image decoder. Use the  ``decoders`` module instead.
 
 The slice can be specified by proving the start and end coordinates, or start coordinates
 and shape of the slice. Both coordinates and shapes can be provided in absolute or relative terms.
@@ -322,5 +310,59 @@ of the slice (s0, s1, s2, …).
 Integer coordinates are interpreted as absolute coordinates, while float coordinates can be
 interpreted as absolute or relative coordinates, depending on the value of
 ``normalized_shape``.)code");
+
+
+// Deprecated aliases
+
+DALI_SCHEMA(ImageDecoder)
+    .DocStr("Legacy alias for :meth:`decoders.image`.")
+    .NumInput(1)
+    .NumOutput(1)
+    .AddParent("decoders__Image")
+    .MakeDocPartiallyHidden()
+    .Deprecate(
+        "decoders__Image",
+        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
+submodule and renamed to follow a common pattern. This is a placeholder operator with identical
+functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
+
+// Fused
+
+DALI_SCHEMA(ImageDecoderCrop)
+    .DocStr("Legacy alias for :meth:`decoders.image_crop`.")
+    .NumInput(1)
+    .NumOutput(1)
+    .AddParent("decoders__ImageCrop")
+    .MakeDocPartiallyHidden()
+    .Deprecate(
+        "decoders__ImageCrop",
+        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
+submodule and renamed to follow a common pattern. This is a placeholder operator with identical
+functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
+
+DALI_SCHEMA(ImageDecoderRandomCrop)
+    .DocStr("Legacy alias for :meth:`decoders.image_random_crop`.")
+    .NumInput(1)
+    .NumOutput(1)
+    .AddParent("decoders__ImageRandomCrop")
+    .MakeDocPartiallyHidden()
+    .Deprecate(
+        "decoders__ImageRandomCrop",
+        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
+submodule and renamed to follow a common pattern. This is a placeholder operator with identical
+functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
+
+
+DALI_SCHEMA(ImageDecoderSlice)
+    .DocStr("Legacy alias for :meth:`decoders.image_slice`.")
+    .NumInput(1, 3)
+    .NumOutput(1)
+    .AddParent("decoders__ImageSlice")
+    .MakeDocPartiallyHidden()
+    .Deprecate(
+        "decoders__ImageSlice",
+        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
+submodule and renamed to follow a common pattern. This is a placeholder operator with identical
+functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_crop.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_crop.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 namespace dali {
 
-DALI_REGISTER_OPERATOR(legacy__decoders__ImageCrop, nvJPEGDecoderCrop, Mixed);
+DALI_REGISTER_OPERATOR(decoders__ImageCrop, nvJPEGDecoderCrop, Mixed);
+DALI_REGISTER_OPERATOR(ImageDecoderCrop, nvJPEGDecoderCrop, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ nvJPEGDecoderRandomCrop::DeserializeCheckpoint(OpCheckpoint &cpt, const std::str
     SnapshotSerializer().Deserialize<std::vector<std::mt19937>>(data);
 }
 
-DALI_REGISTER_OPERATOR(legacy__decoders__ImageRandomCrop, nvJPEGDecoderRandomCrop, Mixed);
+DALI_REGISTER_OPERATOR(decoders__ImageRandomCrop, nvJPEGDecoderRandomCrop, Mixed);
+DALI_REGISTER_OPERATOR(ImageDecoderRandomCrop, nvJPEGDecoderRandomCrop, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop_test.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ TEST_F(ImageRandomCropCheckpointingTest_GPU, Simple) {
       .AddArg("files", std::vector{filepath}));
 
   pipe.AddOperator(
-    OpSpec("legacy__decoders__ImageRandomCrop")
+    OpSpec("decoders__ImageRandomCrop")
       .AddInput("file", "cpu")
       .AddOutput("decoded", "gpu")
       .AddArg("device", "mixed"));

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_slice.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_slice.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 namespace dali {
 
-DALI_REGISTER_OPERATOR(legacy__decoders__ImageSlice, nvJPEGDecoderSlice, Mixed);
+DALI_REGISTER_OPERATOR(decoders__ImageSlice, nvJPEGDecoderSlice, Mixed);
+DALI_REGISTER_OPERATOR(ImageDecoderSlice, nvJPEGDecoderSlice, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.cc
@@ -24,6 +24,7 @@ bool nvjpegIsSymbolAvailable(const char *name) {
 
 namespace dali {
 
-DALI_REGISTER_OPERATOR(legacy__decoders__Image, nvJPEGDecoder, Mixed);
+DALI_REGISTER_OPERATOR(decoders__Image, nvJPEGDecoder, Mixed);
+DALI_REGISTER_OPERATOR(ImageDecoder, nvJPEGDecoder, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/peek_shape/peek_image_shape.cc
+++ b/dali/operators/decoder/peek_shape/peek_image_shape.cc
@@ -16,7 +16,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(legacy__PeekImageShape)
+DALI_SCHEMA(PeekImageShape)
   .DocStr(R"code(Obtains the shape of the encoded image.)code")
   .NumInput(1)
   .NumOutput(1)
@@ -24,6 +24,6 @@ DALI_SCHEMA(legacy__PeekImageShape)
     R"code(Data type, to which the sizes are converted.)code", DALI_INT64)
   .DeprecateArgInFavorOf("type", "dtype");  // deprecated since 1.16dev
 
-DALI_REGISTER_OPERATOR(legacy__PeekImageShape, PeekImageShape, CPU);
+DALI_REGISTER_OPERATOR(PeekImageShape, PeekImageShape, CPU);
 
 }  // namespace dali

--- a/dali/operators/imgcodec/decoder_schema.cc
+++ b/dali/operators/imgcodec/decoder_schema.cc
@@ -48,8 +48,16 @@ requested size per thread. If the value is correctly selected, no additional all
 will occur during the pipeline execution.)code",
       16*1024*1024)
   .AddOptionalArg("device_memory_padding_jpeg2k",
-      R"code(Deprecated argument. Use `device_memory_padding`)code", 0)
-  .DeprecateArg("device_memory_padding_jpeg2k", false)  // deprecated since 1.38dev
+      R"code(Applies **only** to the ``mixed`` backend type.
+
+The padding for nvJPEG2k's device memory allocations, in bytes. This parameter helps to avoid
+reallocation in nvJPEG2k when a larger image is encountered, and the internal buffer needs to be
+reallocated to decode the image.
+
+If a value greater than 0 is provided, the operator preallocates the necessary number of buffers
+according to the hint provided. If the value is correctly selected, no additional allocations
+will occur during the pipeline execution.)code",
+      0)
   .AddOptionalArg("host_memory_padding",
       R"code(Applies **only** to the ``mixed`` backend type.
 
@@ -62,8 +70,16 @@ host-pinned buffers of the requested size per thread. If selected correctly, no 
 allocations will occur during the pipeline execution.)code",
       8*1024*1024)  // based on ImageNet heuristics (8MB)
   .AddOptionalArg("host_memory_padding_jpeg2k",
-      R"code(Deprecated argument. Use `host_memory_padding`.)code", 0)
-  .DeprecateArg("host_memory_padding_jpeg2k", false)
+      R"code(Applies **only** to the ``mixed`` backend type.
+
+The padding for nvJPEG2k's host memory allocations, in bytes. This parameter helps to prevent
+the reallocation in nvJPEG2k when a larger image is encountered, and the internal buffer needs
+to be reallocated to decode the image.
+
+If a value greater than 0 is provided, the operator preallocates the necessary number of buffers
+according to the hint provided. If the value is correctly selected, no additional
+allocations will occur during the pipeline execution.)code",
+      0)
   .AddOptionalArg("hw_decoder_load",
       R"code(The percentage of the image data to be processed by the HW JPEG decoder.
 
@@ -125,7 +141,7 @@ Values will be converted to the dynamic range of the requested type.)code",
   .DeprecateArg("memory_stats", false);  // deprecated since in Nov 2022
 
 
-DALI_SCHEMA(decoders__Image)
+DALI_SCHEMA(experimental__decoders__Image)
   .DocStr(R"code(Decodes images.
 
 Supported formats: JPEG, JPEG 2000, TIFF, PNG, BMP, PNM, PPM, PGM, PBM, WebP.
@@ -151,7 +167,7 @@ CUDA_MAJOR_VERSION is your CUDA major version (e.g. 12).
   .AddParent("ImgcodecDecoderAttr")
   .AddParent("CachedDecoderAttr");
 
-DALI_SCHEMA(decoders__ImageCrop)
+DALI_SCHEMA(experimental__decoders__ImageCrop)
   .DocStr(R"code(Decodes images and extracts regions-of-interest (ROI) that are specified
 by fixed window dimensions and variable anchors.
 
@@ -183,7 +199,7 @@ When possible, the operator uses the ROI decoding, reducing the decoding time an
   .AddParent("CropAttr");
 
 
-DALI_SCHEMA(decoders__ImageSlice)
+DALI_SCHEMA(experimental__decoders__ImageSlice)
   .DocStr(R"code(Decodes images and extracts regions of interest.
 
 Supported formats: JPEG, JPEG 2000, TIFF, PNG, BMP, PNM, PPM, PGM, PBM, WebP.
@@ -256,7 +272,7 @@ interpreted as absolute or relative coordinates, depending on the value of
 ``normalized_shape``.)code");
 
 
-DALI_SCHEMA(decoders__ImageRandomCrop)
+DALI_SCHEMA(experimental__decoders__ImageRandomCrop)
   .DocStr(R"code(Decodes images and randomly crops them.
 
 Supported formats: JPEG, JPEG 2000, TIFF, PNG, BMP, PNM, PPM, PGM, PBM, WebP.
@@ -287,101 +303,6 @@ When possible, the operator uses the ROI decoding, reducing the decoding time an
   .NumOutput(1)
   .AddParent("ImgcodecDecoderAttr")
   .AddParent("RandomCropAttr");
-
-
-DALI_SCHEMA(ImageDecoder)
-    .DocStr("Alias for :meth:`decoders.image`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .AddParent("decoders__Image")
-    .MakeDocPartiallyHidden()
-    .Deprecate(
-        "decoders__Image",
-        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
-submodule and renamed to follow a common pattern. This is a placeholder operator with identical
-functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
-
-DALI_SCHEMA(experimental__decoders__Image)
-    .DocStr("Alias for :meth:`decoders.image`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .AddParent("decoders__Image")
-    .MakeDocPartiallyHidden()
-    .Deprecate(
-        "decoders__Image",
-        R"code(Experimental features of the decoders have been moved to the main decoder module
-:mod:`~nvidia.dali.fn.decoders`, this is just an alias maintained for backward compatibility.)code");  // Deprecated in 1.38
-
-// Fused
-
-DALI_SCHEMA(ImageDecoderCrop)
-    .DocStr("Alias for :meth:`decoders.image_crop`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .AddParent("decoders__ImageCrop")
-    .MakeDocPartiallyHidden()
-    .Deprecate(
-        "decoders__ImageCrop",
-        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
-submodule and renamed to follow a common pattern. This is a placeholder operator with identical
-functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
-
-DALI_SCHEMA(experimental__decoders__ImageCrop)
-    .DocStr("Alias for :meth:`decoders.image_crop`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .AddParent("decoders__ImageCrop")
-    .MakeDocPartiallyHidden()
-    .Deprecate(
-        "decoders__ImageCrop",
-        R"code(Experimental features of the decoders have been moved to the main decoder module
-:mod:`~nvidia.dali.fn.decoders`, this is just an alias maintained for backward compatibility.)code");  // Deprecated in 1.38
-
-DALI_SCHEMA(ImageDecoderRandomCrop)
-    .DocStr("Alias for :meth:`decoders.image_random_crop`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .AddParent("decoders__ImageRandomCrop")
-    .MakeDocPartiallyHidden()
-    .Deprecate(
-        "decoders__ImageRandomCrop",
-        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
-submodule and renamed to follow a common pattern. This is a placeholder operator with identical
-functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
-
-DALI_SCHEMA(experimental__decoders__ImageRandomCrop)
-    .DocStr("Alias for :meth:`decoders.image_random_crop`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .AddParent("decoders__ImageRandomCrop")
-    .MakeDocPartiallyHidden()
-    .Deprecate(
-        "decoders__ImageRandomCrop",
-        R"code(Experimental features of the decoders have been moved to the main decoder module
-:mod:`~nvidia.dali.fn.decoders`, this is just an alias maintained for backward compatibility.)code");  // Deprecated in 1.38
-
-DALI_SCHEMA(ImageDecoderSlice)
-    .DocStr("Alias for :meth:`decoders.image_slice`.")
-    .NumInput(1, 3)
-    .NumOutput(1)
-    .AddParent("decoders__ImageSlice")
-    .MakeDocPartiallyHidden()
-    .Deprecate(
-        "decoders__ImageSlice",
-        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
-submodule and renamed to follow a common pattern. This is a placeholder operator with identical
-functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
-
-DALI_SCHEMA(experimental__decoders__ImageSlice)
-    .DocStr("Alias for :meth:`decoders.image_slice`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .AddParent("decoders__ImageSlice")
-    .MakeDocPartiallyHidden()
-    .Deprecate(
-        "decoders__ImageSlice",
-        R"code(Experimental features of the decoders have been moved to the main decoder module
-:mod:`~nvidia.dali.fn.decoders`, this is just an alias maintained for backward compatibility.)code");  // Deprecated in 1.38
 
 }  // namespace imgcodec
 }  // namespace dali

--- a/dali/operators/imgcodec/host_decoder.cc
+++ b/dali/operators/imgcodec/host_decoder.cc
@@ -32,18 +32,6 @@ using HostDecoderCrop = WithCropAttr<HostDecoder, CPUBackend>;
 using HostDecoderSlice = WithSliceAttr<HostDecoder, CPUBackend>;
 using HostDecoderRandomCrop = WithRandomCropAttr<HostDecoder, CPUBackend>;
 
-DALI_REGISTER_OPERATOR(decoders__Image, HostDecoder, CPU);
-DALI_REGISTER_OPERATOR(decoders__ImageCrop, HostDecoderCrop, CPU);
-DALI_REGISTER_OPERATOR(decoders__ImageSlice, HostDecoderSlice, CPU);
-DALI_REGISTER_OPERATOR(decoders__ImageRandomCrop, HostDecoderRandomCrop, CPU);
-
-// Deprecated aliases: fn.image*_decoder
-DALI_REGISTER_OPERATOR(ImageDecoder, HostDecoder, CPU);
-DALI_REGISTER_OPERATOR(ImageDecoderCrop, HostDecoderCrop, CPU);
-DALI_REGISTER_OPERATOR(ImageDecoderSlice, HostDecoderSlice, CPU);
-DALI_REGISTER_OPERATOR(ImageDecoderRandomCrop, HostDecoderRandomCrop, CPU);
-
-// Deprecated aliases: fn.experimental.decoders.image*_decoder
 DALI_REGISTER_OPERATOR(experimental__decoders__Image, HostDecoder, CPU);
 DALI_REGISTER_OPERATOR(experimental__decoders__ImageCrop, HostDecoderCrop, CPU);
 DALI_REGISTER_OPERATOR(experimental__decoders__ImageSlice, HostDecoderSlice, CPU);

--- a/dali/operators/imgcodec/mixed_decoder.cc
+++ b/dali/operators/imgcodec/mixed_decoder.cc
@@ -33,22 +33,11 @@ using MixedDecoderCrop = WithCropAttr<MixedDecoder, MixedBackend>;
 using MixedDecoderSlice = WithSliceAttr<MixedDecoder, MixedBackend>;
 using MixedDecoderRandomCrop = WithRandomCropAttr<MixedDecoder, MixedBackend>;
 
-DALI_REGISTER_OPERATOR(decoders__Image, MixedDecoder, Mixed);
-DALI_REGISTER_OPERATOR(decoders__ImageCrop, MixedDecoderCrop, Mixed);
-DALI_REGISTER_OPERATOR(decoders__ImageSlice, MixedDecoderSlice, Mixed);
-DALI_REGISTER_OPERATOR(decoders__ImageRandomCrop, MixedDecoderRandomCrop, Mixed);
-
-// Deprecated aliases: fn.image*_decoder
-DALI_REGISTER_OPERATOR(ImageDecoder, MixedDecoder, Mixed);
-DALI_REGISTER_OPERATOR(ImageDecoderCrop, MixedDecoderCrop, Mixed);
-DALI_REGISTER_OPERATOR(ImageDecoderSlice, MixedDecoderSlice, Mixed);
-DALI_REGISTER_OPERATOR(ImageDecoderRandomCrop, MixedDecoderRandomCrop, Mixed);
-
-// Deprecated aliases: fn.experimental.decoders.image*
 DALI_REGISTER_OPERATOR(experimental__decoders__Image, MixedDecoder, Mixed);
 DALI_REGISTER_OPERATOR(experimental__decoders__ImageCrop, MixedDecoderCrop, Mixed);
 DALI_REGISTER_OPERATOR(experimental__decoders__ImageSlice, MixedDecoderSlice, Mixed);
-DALI_REGISTER_OPERATOR(experimental__decoders__ImageRandomCrop, MixedDecoderRandomCrop, Mixed);
+DALI_REGISTER_OPERATOR(experimental__decoders__ImageRandomCrop,
+                       MixedDecoderRandomCrop, Mixed);
 
 }  // namespace imgcodec
 }  // namespace dali

--- a/dali/operators/imgcodec/peek_image_shape.cc
+++ b/dali/operators/imgcodec/peek_image_shape.cc
@@ -19,7 +19,7 @@
 namespace dali {
 namespace imgcodec {
 
-DALI_SCHEMA(PeekImageShape)
+DALI_SCHEMA(experimental__PeekImageShape)
   .DocStr(R"code(Obtains the shape of the encoded image.)code")
   .NumInput(1)
   .NumOutput(1)
@@ -29,17 +29,6 @@ DALI_SCHEMA(PeekImageShape)
     R"code(Use the EXIF orientation metadata when calculating the shape.)code", true)
   .AddOptionalArg("image_type",
     R"code(Color format of the image.)code", DALI_RGB);
-
-DALI_SCHEMA(experimental__PeekImageShape)
-    .DocStr("Alias for :meth:`peek_image_shape`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .AddParent("PeekImageShape")
-    .MakeDocPartiallyHidden()
-    .Deprecate(
-        "PeekImageShape",
-        R"code(Experimental features of the decoders have been moved to the main decoder module
-:mod:`~nvidia.dali.fn`, this is just an alias maintained for backward compatibility.)code");  // Deprecated in 1.38
 
 ImgcodecPeekImageShape::ImgcodecPeekImageShape(const OpSpec &spec)
     : StatelessOperator<CPUBackend>(spec) {
@@ -126,7 +115,6 @@ void ImgcodecPeekImageShape::RunImpl(Workspace &ws) {
 }
 
 
-DALI_REGISTER_OPERATOR(PeekImageShape, ImgcodecPeekImageShape, CPU);
 DALI_REGISTER_OPERATOR(experimental__PeekImageShape, ImgcodecPeekImageShape, CPU);
 
 }  // namespace imgcodec

--- a/dali/python/nvidia/dali/_utils/eager_utils.py
+++ b/dali/python/nvidia/dali/_utils/eager_utils.py
@@ -29,7 +29,7 @@ from nvidia.dali.external_source import _prep_data_for_feed_input
 # Stateful operators - rely on the internal state (return different outputs across iterations).
 _stateful_operators = {
     "decoders__ImageRandomCrop",
-    "legacy__decoders__ImageRandomCrop",
+    "experimental__decoders__ImageRandomCrop",
     "noise__Gaussian",
     "noise__SaltAndPepper",
     "noise__Shot",

--- a/dali/test/python/checkpointing/test_dali_checkpointing.py
+++ b/dali/test/python/checkpointing/test_dali_checkpointing.py
@@ -973,28 +973,12 @@ def test_noise_shot(device):
 
 
 @params("cpu", "mixed")
-@random_signed_off(
-    "image_decoder_random_crop",
-    "decoders.image_random_crop",
-    "experimental.decoders.image_random_crop",
-)
+@random_signed_off("image_decoder_random_crop", "decoders.image_random_crop")
 def test_image_random_crop(device):
     @pipeline_def
     def pipeline():
         data, _ = fn.readers.file(name="Reader", file_root=images_dir)
         image = fn.decoders.image_random_crop(data, device=device)
-        return image
-
-    check_pipeline_checkpointing_native(pipeline)
-
-
-@params("cpu", "mixed")
-@random_signed_off("legacy.decoders.image_random_crop")
-def test_legacy_image_random_crop(device):
-    @pipeline_def
-    def pipeline():
-        data, _ = fn.readers.file(name="Reader", file_root=images_dir)
-        image = fn.legacy.decoders.image_random_crop(data, device=device)
         return image
 
     check_pipeline_checkpointing_native(pipeline)
@@ -1192,6 +1176,7 @@ unsupported_readers = [
 unsupported_ops = [
     "experimental.decoders.video",
     "experimental.inputs.video",
+    "experimental.decoders.image_random_crop",
 ]
 
 

--- a/dali/test/python/checkpointing/test_dali_stateless_operators.py
+++ b/dali/test/python/checkpointing/test_dali_stateless_operators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -809,14 +809,14 @@ def test_inflate_stateless():
     check_is_pipeline_stateless(pipeline)
 
 
-@stateless_signed_off("peek_image_shape", "experimental.peek_image_shape")
+@stateless_signed_off("peek_image_shape")
 def test_peek_image_shape_stateless():
     check_single_encoded_jpeg_input(fn.peek_image_shape, "cpu")
 
 
-@stateless_signed_off("legacy.peek_image_shape")
+@stateless_signed_off("experimental.peek_image_shape")
 def test_imgcodec_peek_image_shape_stateless():
-    check_single_encoded_jpeg_input(fn.legacy.peek_image_shape, "cpu")
+    check_single_encoded_jpeg_input(fn.experimental.peek_image_shape, "cpu")
 
 
 @stateless_signed_off("decoders.audio", "audio_decoder")
@@ -828,46 +828,40 @@ def test_audio_decoder_stateless():
 
 
 @params("cpu", "mixed")
-@stateless_signed_off("decoders.image", "image_decoder", "experimental.decoders.image")
+@stateless_signed_off("decoders.image", "image_decoder")
 def test_image_decoder_stateless(device):
     check_single_encoded_jpeg_input(fn.decoders.image, device)
 
 
 @params("cpu", "mixed")
-@stateless_signed_off("legacy.decoders.image")
-def test_legacy_image_decoder_stateless(device):
-    check_single_encoded_jpeg_input(fn.legacy.decoders.image, device)
+@stateless_signed_off("experimental.decoders.image")
+def test_experimental_image_decoder_stateless(device):
+    check_single_encoded_jpeg_input(fn.experimental.decoders.image, device)
 
 
 @params("cpu", "mixed")
-@stateless_signed_off(
-    "decoders.image_crop", "image_decoder_crop", "experimental.decoders.image_crop"
-)
+@stateless_signed_off("decoders.image_crop", "image_decoder_crop")
 def test_image_decoder_crop_stateless(device):
     check_single_encoded_jpeg_input(fn.decoders.image_crop, device, crop=(20, 50))
 
 
 @params("cpu", "mixed")
-@stateless_signed_off("legacy.decoders.image_crop")
-def test_legacy_image_decoder_crop_stateless(device):
-    check_single_encoded_jpeg_input(fn.legacy.decoders.image_crop, device, crop=(20, 50))
+@stateless_signed_off("experimental.decoders.image_crop")
+def test_experimental_image_decoder_crop_stateless(device):
+    check_single_encoded_jpeg_input(fn.experimental.decoders.image_crop, device, crop=(20, 50))
 
 
 @params("cpu", "mixed")
-@stateless_signed_off(
-    "decoders.image_slice",
-    "image_decoder_slice",
-    "experimental.decoders.image_slice",
-)
+@stateless_signed_off("decoders.image_slice", "image_decoder_slice")
 def test_image_decoder_slice_stateless(device):
     check_single_encoded_jpeg_input(fn.decoders.image_slice, device, start=(5, 5), end=(45, 45))
 
 
 @params("cpu", "mixed")
-@stateless_signed_off("legacy.decoders.image_slice")
-def test_legacy_image_decoder_slice_stateless(device):
+@stateless_signed_off("experimental.decoders.image_slice")
+def test_experimental_image_decoder_slice_stateless(device):
     check_single_encoded_jpeg_input(
-        fn.legacy.decoders.image_slice, device, start=(5, 5), end=(45, 45)
+        fn.experimental.decoders.image_slice, device, start=(5, 5), end=(45, 45)
     )
 
 

--- a/dali/test/python/decoder/test_image.py
+++ b/dali/test/python/decoder/test_image.py
@@ -24,6 +24,7 @@ from nvidia.dali import pipeline_def
 
 from nose2.tools import params
 from nose_utils import assert_raises
+from test_utils import check_output_pattern
 from test_utils import compare_pipelines
 from test_utils import get_dali_extra_path
 from test_utils import to_array
@@ -298,6 +299,26 @@ def test_fancy_upsampling(batch_size):
         N_iterations=3,
         eps=1,
     )
+
+
+def test_image_decoder_memory_stats():
+    device = "mixed"
+    img_type = "jpeg"
+
+    def check(img_type, size, device, threads):
+        data_path = os.path.join(test_data_root, good_path, img_type)
+        # largest allocation should match our (in this case) memory padding settings
+        # (assuming no reallocation was needed here as the hint is big enough)
+        pattern = (
+            r"Device memory: \d+ allocations, largest = 16777216 bytes\n.*"
+            r"Host \(pinned|regular\) memory: \d+ allocations, largest = 8388608 bytes\n"
+        )
+        with check_output_pattern(pattern):
+            run_decode(img_type, data_path, size, device, threads, memory_stats=True)
+
+    for size in [1, 10]:
+        for threads in [1, random.choice([2, 3, 4])]:
+            yield check, img_type, size, device, threads
 
 
 batch_size_test = 16

--- a/dali/test/python/decoder/test_imgcodec.py
+++ b/dali/test/python/decoder/test_imgcodec.py
@@ -52,7 +52,7 @@ def get_img_files(data_path, subdir="*", ext=None):
 @pipeline_def
 def decoder_pipe(data_path, device, use_fast_idct=False, jpeg_fancy_upsampling=False):
     inputs, labels = fn.readers.file(file_root=data_path, shard_id=0, num_shards=1, name="Reader")
-    decoded = fn.decoders.image(
+    decoded = fn.experimental.decoders.image(
         inputs,
         device=device,
         output_type=types.RGB,
@@ -104,11 +104,11 @@ def create_decoder_slice_pipeline(data_path, device):
 
     anchor = fn.random.uniform(range=[0.05, 0.15], shape=(2,))
     shape = fn.random.uniform(range=[0.5, 0.7], shape=(2,))
-    images_sliced_1 = fn.decoders.image_slice(
+    images_sliced_1 = fn.experimental.decoders.image_slice(
         jpegs, anchor, shape, axes=(0, 1), device=device, hw_decoder_load=0.7
     )
 
-    images = fn.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
+    images = fn.experimental.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
     images_sliced_2 = fn.slice(images, anchor, shape, axes=(0, 1))
 
     return images_sliced_1, images_sliced_2
@@ -123,7 +123,7 @@ def create_decoder_crop_pipeline(data_path, device):
     w = 242
     h = 230
 
-    images_crop_1 = fn.decoders.image_crop(
+    images_crop_1 = fn.experimental.decoders.image_crop(
         jpegs,
         crop=(w, h),
         crop_pos_x=crop_pos_x,
@@ -132,7 +132,7 @@ def create_decoder_crop_pipeline(data_path, device):
         hw_decoder_load=0.7,
     )
 
-    images = fn.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
+    images = fn.experimental.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
 
     images_crop_2 = fn.crop(images, crop=(w, h), crop_pos_x=crop_pos_x, crop_pos_y=crop_pos_y)
 
@@ -146,12 +146,12 @@ def create_decoder_random_crop_pipeline(data_path, device):
 
     w = 242
     h = 230
-    images_random_crop_1 = fn.decoders.image_random_crop(
+    images_random_crop_1 = fn.experimental.decoders.image_random_crop(
         jpegs, device=device, output_type=types.RGB, hw_decoder_load=0.7, seed=seed
     )
     images_random_crop_1 = fn.resize(images_random_crop_1, size=(w, h))
 
-    images = fn.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
+    images = fn.experimental.decoders.image(jpegs, device=device, hw_decoder_load=0.7)
     images_random_crop_2 = fn.random_resized_crop(images, size=(w, h), seed=seed)
 
     return images_random_crop_1, images_random_crop_2
@@ -308,7 +308,7 @@ batch_size_test = 16
 @pipeline_def(batch_size=batch_size_test, device_id=0, num_threads=4)
 def img_decoder_pipe(device, out_type, files):
     encoded, _ = fn.readers.file(files=files)
-    decoded = fn.decoders.image(encoded, device=device, output_type=out_type)
+    decoded = fn.experimental.decoders.image(encoded, device=device, output_type=out_type)
     return decoded
 
 
@@ -347,8 +347,8 @@ def _testimpl_image_decoder_tiff_with_alpha_16bit(device, out_type, path, ext):
     @pipeline_def(batch_size=1, device_id=0, num_threads=1)
     def pipe(device, out_type, files):
         encoded, _ = fn.readers.file(files=files)
-        decoded = fn.decoders.image(encoded, device=device, output_type=out_type)
-        peeked_shape = fn.peek_image_shape(encoded)
+        decoded = fn.experimental.decoders.image(encoded, device=device, output_type=out_type)
+        peeked_shape = fn.experimental.peek_image_shape(encoded)
         return decoded, peeked_shape
 
     files = get_img_files(os.path.join(test_data_root, path), ext=ext, subdir=None)
@@ -377,7 +377,9 @@ def _testimpl_image_decoder_crop_error_oob(device):
     @pipeline_def(batch_size=batch_size_test, device_id=0, num_threads=4)
     def pipe(device):
         encoded, _ = fn.readers.file(file_root=file_root)
-        decoded = fn.decoders.image_crop(encoded, crop_w=10000, crop_h=100, device=device)
+        decoded = fn.experimental.decoders.image_crop(
+            encoded, crop_w=10000, crop_h=100, device=device
+        )
         return decoded
 
     p = pipe(device)
@@ -398,7 +400,9 @@ def _testimpl_image_decoder_slice_error_oob(device):
     @pipeline_def(batch_size=batch_size_test, device_id=0, num_threads=4)
     def pipe(device):
         encoded, _ = fn.readers.file(file_root=file_root)
-        decoded = fn.decoders.image_slice(encoded, device=device, end=[10000], axes=[1])
+        decoded = fn.experimental.decoders.image_slice(
+            encoded, device=device, end=[10000], axes=[1]
+        )
         return decoded
 
     p = pipe(device)
@@ -420,8 +424,8 @@ def test_tiff_palette():
     @pipeline_def(batch_size=2, device_id=0, num_threads=1)
     def pipe():
         encoded, _ = fn.readers.file(files=[normal, palette])
-        peeked_shapes = fn.peek_image_shape(encoded)
-        decoded = fn.decoders.image(encoded, device="cpu")
+        peeked_shapes = fn.experimental.peek_image_shape(encoded)
+        decoded = fn.experimental.decoders.image(encoded, device="cpu")
         return decoded, peeked_shapes
 
     p = pipe()
@@ -443,7 +447,7 @@ def _testimpl_image_decoder_peek_shape(
     @pipeline_def(batch_size=1, device_id=0, num_threads=1)
     def peek_shape_pipeline(file):
         encoded, _ = fn.readers.file(files=[file])
-        return fn.peek_image_shape(
+        return fn.experimental.peek_image_shape(
             encoded, image_type=image_type, adjust_orientation=adjust_orientation
         )
 
@@ -510,7 +514,9 @@ def test_image_decoder_lossless_jpeg(img_name, output_type, dtype, precision):
     @pipeline_def(batch_size=1, device_id=device_id, num_threads=1)
     def pipe(file):
         encoded, _ = fn.readers.file(files=[file])
-        decoded = fn.decoders.image(encoded, device="mixed", dtype=dtype, output_type=output_type)
+        decoded = fn.experimental.decoders.image(
+            encoded, device="mixed", dtype=dtype, output_type=output_type
+        )
         return decoded
 
     p = pipe(data_dir + f"/{img_name}.jpg")
@@ -535,7 +541,7 @@ def test_image_decoder_lossless_jpeg_cpu_not_supported():
     @pipeline_def(batch_size=1, device_id=0, num_threads=1)
     def pipe(file):
         encoded, _ = fn.readers.file(files=[file])
-        decoded = fn.decoders.image(
+        decoded = fn.experimental.decoders.image(
             encoded, device="cpu", dtype=types.UINT16, output_type=types.ANY_DATA
         )
         return decoded

--- a/dali/test/python/decoder/test_jpeg_scan_limit.py
+++ b/dali/test/python/decoder/test_jpeg_scan_limit.py
@@ -157,8 +157,7 @@ class ProgressiveJpeg(unittest.TestCase):
         @pipeline_def(batch_size=1, device_id=0, num_threads=4)
         def pipeline():
             data, _ = fn.readers.file(files=self.files[(decoding_method, decoding_step)].name)
-            # TODO(janton): Implement max jpeg scans in nvImageCodecs
-            return fn.legacy.decoders.image(data, device=decoding_device)
+            return fn.decoders.image(data, device=decoding_device)
 
         pretty_decoding_dev = "CPU" if decoding_device == "cpu" else "MIXED"
         with assert_raises(

--- a/dali/test/python/operator_2/test_filter.py
+++ b/dali/test/python/operator_2/test_filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ def images_pipeline(dev, shapes, border, in_dtype, mode):
     images, _ = fn.readers.file(
         name="Reader", file_root=images_dir, prefetch_queue_depth=2, random_shuffle=True, seed=42
     )
-    images = fn.decoders.image(
+    images = fn.experimental.decoders.image(
         images, device="cpu", output_type=types.RGB, dtype=np_type_to_dali(in_dtype)
     )
     if dev == "gpu":

--- a/dali/test/python/test_RN50_data_pipeline.py
+++ b/dali/test/python/test_RN50_data_pipeline.py
@@ -45,8 +45,8 @@ class CommonPipeline(Pipeline):
             batch_size, num_threads, device_id, random_shuffle, prefetch_queue_depth=prefetch
         )
         print(f"decoder type: {decoder_type}")
-        if "legacy" in decoder_type:
-            decoders_module = ops.legacy.decoders
+        if "experimental" in decoder_type:
+            decoders_module = ops.experimental.decoders
         else:
             decoders_module = ops.decoders
 
@@ -338,7 +338,7 @@ parser.add_argument(
     default="",
     type=str,
     metavar="N",
-    help="roi, cached, (default: regular nvjpeg). Also admit +legacy",
+    help="roi, cached, (default: regular nvjpeg). Also admit +experimental",
 )
 parser.add_argument("--cache_size", default=0, type=int, metavar="N", help="Cache size (in MB)")
 parser.add_argument("--cache_threshold", default=0, type=int, metavar="N", help="Cache threshold")

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -330,24 +330,24 @@ def test_image_decoder_cpu():
     _test_image_decoder_args_cpu(fn.decoders.image)
 
 
-def test_legacy_image_decoder_cpu():
-    _test_image_decoder_args_cpu(fn.legacy.decoders.image)
+def test_experimental_image_decoder_cpu():
+    _test_image_decoder_args_cpu(fn.experimental.decoders.image)
 
 
 def test_image_decoder_crop_cpu():
     _test_image_decoder_args_cpu(fn.decoders.image_crop, crop=(10, 10))
 
 
-def test_legacy_image_decoder_crop_cpu():
-    _test_image_decoder_args_cpu(fn.legacy.decoders.image_crop, crop=(10, 10))
+def test_experimental_image_decoder_crop_cpu():
+    _test_image_decoder_args_cpu(fn.experimental.decoders.image_crop, crop=(10, 10))
 
 
 def test_image_decoder_random_crop_cpu():
     _test_image_decoder_args_cpu(fn.decoders.image_random_crop)
 
 
-def test_legacy_image_decoder_random_crop_cpu():
-    _test_image_decoder_args_cpu(fn.legacy.decoders.image_random_crop)
+def test_experimental_image_decoder_random_crop_cpu():
+    _test_image_decoder_args_cpu(fn.experimental.decoders.image_random_crop)
 
 
 def test_coin_flip_cpu():
@@ -733,8 +733,8 @@ def test_image_decoder_slice_cpu():
     _test_image_decoder_slice_cpu(fn.decoders.image_slice)
 
 
-def test_legacy_image_decoder_slice_cpu():
-    _test_image_decoder_slice_cpu(fn.legacy.decoders.image_slice)
+def test_experimental_image_decoder_slice_cpu():
+    _test_image_decoder_slice_cpu(fn.experimental.decoders.image_slice)
 
 
 def test_pad_cpu():
@@ -1243,8 +1243,8 @@ def test_peek_image_shape_cpu():
     _test_peek_image_shape_cpu(fn.peek_image_shape)
 
 
-def test_legacy_peek_image_shape_cpu():
-    _test_peek_image_shape_cpu(fn.legacy.peek_image_shape)
+def test_experimental_peek_image_shape_cpu():
+    _test_peek_image_shape_cpu(fn.experimental.peek_image_shape)
 
 
 def test_separated_exec_setup():
@@ -1394,10 +1394,6 @@ tested_methods = [
     "experimental.decoders.image_crop",
     "experimental.decoders.image_slice",
     "experimental.decoders.image_random_crop",
-    "legacy.decoders.image",
-    "legacy.decoders.image_crop",
-    "legacy.decoders.image_slice",
-    "legacy.decoders.image_random_crop",
     "experimental.inputs.video",
     "decoders.audio",
     "external_source",
@@ -1514,7 +1510,6 @@ tested_methods = [
     "squeeze",
     "peek_image_shape",
     "experimental.peek_image_shape",
-    "legacy.peek_image_shape",
     "expand_dims",
     "coord_transform",
     "grid_mask",

--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -1151,16 +1151,16 @@ def test_image_decoders():
         for pipe_template in image_decoder_pipes:
             pipe = partial(pipe_template, fn.decoders)
             yield test_decoders_check, pipe, data_path, ext, ["cpu", "mixed"], exclude_subdirs
-            pipe = partial(pipe_template, fn.legacy.decoders)
+            pipe = partial(pipe_template, fn.experimental.decoders)
             yield test_decoders_check, pipe, data_path, ext, ["cpu", "mixed"], exclude_subdirs
         pipe = partial(image_decoder_rcrop_pipe, fn.decoders)
         yield test_decoders_run, pipe, data_path, ext, ["cpu", "mixed"], exclude_subdirs
-        pipe = partial(image_decoder_rcrop_pipe, fn.legacy.decoders)
+        pipe = partial(image_decoder_rcrop_pipe, fn.experimental.decoders)
         yield test_decoders_run, pipe, data_path, ext, ["cpu", "mixed"], exclude_subdirs
 
     pipe = partial(peek_image_shape_pipe, fn)
     yield test_decoders_check, pipe, data_path, ".jpg", ["cpu"], exclude_subdirs
-    pipe = partial(peek_image_shape_pipe, fn.legacy)
+    pipe = partial(peek_image_shape_pipe, fn.experimental)
     yield test_decoders_check, pipe, data_path, ".jpg", ["cpu"], exclude_subdirs
 
 
@@ -1593,6 +1593,7 @@ tested_methods = [
     "experimental.filter",
     "experimental.inflate",
     "experimental.median_blur",
+    "experimental.peek_image_shape",
     "experimental.remap",
     "external_source",
     "fast_resize_crop_mirror",
@@ -1609,10 +1610,6 @@ tested_methods = [
     "jitter",
     "jpeg_compression_distortion",
     "laplacian",
-    "legacy.decoders.image",
-    "legacy.decoders.image_crop",
-    "legacy.decoders.image_slice",
-    "legacy.decoders.image_random_crop",
     "lookup_table",
     "math.abs",
     "math.acos",
@@ -1657,8 +1654,6 @@ tested_methods = [
     "pad",
     "paste",
     "peek_image_shape",
-    "experimental.peek_image_shape",
-    "legacy.peek_image_shape",
     "per_frame",
     "permute_batch",
     "power_spectrum",

--- a/dali/test/python/test_eager_coverage.py
+++ b/dali/test/python/test_eager_coverage.py
@@ -365,9 +365,9 @@ def test_decoders_image():
     )
 
 
-def test_legacy_decoders_image():
+def test_experimental_decoders_image():
     check_single_input(
-        "legacy.decoders.image",
+        "experimental.decoders.image",
         pipe_fun=reader_op_pipeline,
         fn_source=images_dir,
         eager_source=PipelineInput(file_reader_pipeline, file_root=images_dir),
@@ -386,9 +386,9 @@ def test_decoders_image_crop():
     )
 
 
-def test_legacy_decoders_image_crop():
+def test_experimental_decoders_image_crop():
     check_single_input(
-        "legacy.decoders.image_crop",
+        "experimental.decoders.image_crop",
         pipe_fun=reader_op_pipeline,
         fn_source=images_dir,
         eager_source=PipelineInput(file_reader_pipeline, file_root=images_dir),
@@ -407,9 +407,9 @@ def test_decoders_image_random_crop():
     )
 
 
-def test_legacy_decoders_image_random_crop():
+def test_experimental_decoders_image_random_crop():
     check_single_input_stateful(
-        "legacy.decoders.image_random_crop",
+        "experimental.decoders.image_random_crop",
         pipe_fun=reader_op_pipeline,
         fn_source=images_dir,
         eager_source=PipelineInput(file_reader_pipeline, file_root=images_dir),
@@ -1225,9 +1225,9 @@ def test_peek_image_shape():
     )
 
 
-def test_legacy_peek_image_shape():
+def test_experimental_peek_image_shape():
     check_single_input(
-        "legacy.peek_image_shape",
+        "experimental.peek_image_shape",
         pipe_fun=reader_op_pipeline,
         fn_source=images_dir,
         eager_source=PipelineInput(file_reader_pipeline, file_root=images_dir),
@@ -1498,10 +1498,6 @@ tested_methods = [
     "experimental.decoders.image_crop",
     "experimental.decoders.image_slice",
     "experimental.decoders.image_random_crop",
-    "legacy.decoders.image",
-    "legacy.decoders.image_crop",
-    "legacy.decoders.image_slice",
-    "legacy.decoders.image_random_crop",
     "rotate",
     "brightness_contrast",
     "hue",
@@ -1588,7 +1584,6 @@ tested_methods = [
     "squeeze",
     "peek_image_shape",
     "experimental.peek_image_shape",
-    "legacy.peek_image_shape",
     "subscript_dim_check",
     "get_property",
     "tensor_subscript",

--- a/dali/test/python/test_nvjpeg_cache.py
+++ b/dali/test/python/test_nvjpeg_cache.py
@@ -44,7 +44,9 @@ class HybridDecoderPipeline(Pipeline):
         if cache_size > 0:
             policy = "threshold"
         print("Decoder type:", decoder_type)
-        decoder_module = ops.legacy.decoders if "legacy" in decoder_type else ops.decoders
+        decoder_module = (
+            ops.experimental.decoders if "experimental" in decoder_type else ops.decoders
+        )
         self.decode = decoder_module.Image(
             device="mixed",
             output_type=types.RGB,
@@ -60,7 +62,7 @@ class HybridDecoderPipeline(Pipeline):
         return (images, labels)
 
 
-@params(("legacy",), ("default",))
+@params(("legacy",), ("experimental",))
 def test_nvjpeg_cached(decoder_type):
     ref_pipe = HybridDecoderPipeline(batch_size, 1, 0, 0, decoder_type)
     ref_pipe.build()
@@ -83,7 +85,7 @@ def test_nvjpeg_cached(decoder_type):
 
 def main():
     test_nvjpeg_cached("legacy")
-    test_nvjpeg_cached("default")
+    test_nvjpeg_cached("experimental")
 
 
 if __name__ == "__main__":

--- a/dali/test/python/test_utils_tensorflow.py
+++ b/dali/test/python/test_utils_tensorflow.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -104,11 +104,7 @@ def get_mix_size_image_pipeline(
             image_ids=True,
         )
         images = fn.decoders.image(
-            jpegs,
-            device=("mixed" if device == "gpu" else "cpu"),
-            output_type=types.RGB,
-            device_memory_padding=0,
-            host_memory_padding=0,
+            jpegs, device=("mixed" if device == "gpu" else "cpu"), output_type=types.RGB
         )
 
         pipe.set_outputs(images)
@@ -137,11 +133,7 @@ def get_image_pipeline(
             image_ids=True,
         )
         images = fn.decoders.image(
-            jpegs,
-            device=("mixed" if device == "gpu" else "cpu"),
-            output_type=types.RGB,
-            device_memory_padding=0,
-            host_memory_padding=0,
+            jpegs, device=("mixed" if device == "gpu" else "cpu"), output_type=types.RGB
         )
         images = fn.resize(images, resize_x=224, resize_y=224, interp_type=types.INTERP_LINEAR)
         images = fn.crop_mirror_normalize(


### PR DESCRIPTION
This reverts commit da8204c00eb12eacb285414733f3b53d99a6f9cd.

Temporarily revert this commit so that we can investigate some issues that showed up after the change

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Other**

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
Revert the change of default image decoder


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
