### PR TITLE
Don't initialize NVML in ThreadPool when not setting affinity.

### DIFF
--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -30,8 +30,8 @@ ThreadPool::ThreadPool(int num_thread, int device_id, bool set_affinity, const c
     , active_threads_(0) {
   DALI_ENFORCE(num_thread > 0, "Thread pool must have non-zero size");
 #if NVML_ENABLED
-  // only for the CPU pipeline
-  if (device_id != CPU_ONLY_DEVICE_ID) {
+  // We use NVML only for setting thread affinity
+  if (device_id != CPU_ONLY_DEVICE_ID && set_affinity) {
     nvml_handle_ = nvml::NvmlInstance::CreateNvmlInstance();
   }
 #endif


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** Optimization


## Description:
NVML initialization takes considerable time. This PR skips the NVML initialization in ThreadPool when not setting thread affinity (which is the only situation when we need NVML). This change enables small tests using ThreadPool to take much less time.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
