### PR TITLE
Add default schema and use it in OpSpec argument queries.

### DIFF
--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -54,6 +54,10 @@ const OpSchema *SchemaRegistry::TryGetSchema(const std::string &name) {
   return it != schema_map.end() ? &it->second : nullptr;
 }
 
+const OpSchema &OpSchema::Default() {
+  static OpSchema default_schema("");
+  return default_schema;
+}
 
 OpSchema::OpSchema(const std::string &name) : name_(name) {
   // Process the module path and operator name

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -82,6 +82,11 @@ class DLL_PUBLIC OpSchema {
   DLL_PUBLIC inline ~OpSchema() = default;
 
   /**
+   * @brief Returns an empty schema, with only internal arguments
+   */
+  DLL_PUBLIC static const OpSchema &Default();
+
+  /**
    * @brief Returns the schema name of this operator.
    */
   DLL_PUBLIC const std::string &name() const;

--- a/dali/pipeline/operator/op_spec.cc
+++ b/dali/pipeline/operator/op_spec.cc
@@ -51,7 +51,7 @@ OpSpec& OpSpec::AddOutput(const string &name, const string &device) {
 OpSpec& OpSpec::AddArgumentInput(const string &arg_name, const string &inp_name) {
   DALI_ENFORCE(!this->HasArgument(arg_name), make_string(
       "Argument '", arg_name, "' is already specified."));
-  const OpSchema& schema = GetSchema();
+  const OpSchema& schema = GetSchemaOrDefault();
   DALI_ENFORCE(schema.HasArgument(arg_name),
                make_string("Argument '", arg_name, "' is not supported by operator `",
                            GetOpDisplayName(*this, true), "`."));

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -82,9 +82,24 @@ class DLL_PUBLIC OpSpec {
     schema_ = schema_name_.empty() ? nullptr : SchemaRegistry::TryGetSchema(schema_name_);
   }
 
+  /**
+   * @brief Sets the schema of the Operator.
+   */
+  DLL_PUBLIC inline void SetSchema(OpSchema *schema) {
+    schema_ = schema;
+    if (schema)
+      schema_name_ = schema->name();
+    else
+      schema_name_ = {};
+  }
+
   DLL_PUBLIC inline const OpSchema &GetSchema() const {
     DALI_ENFORCE(schema_ != nullptr, "No schema found for operator \"" + SchemaName() + "\"");
     return *schema_;
+  }
+
+  DLL_PUBLIC inline const OpSchema &GetSchemaOrDefault() const {
+    return schema_ ? *schema_ : OpSchema::Default();
   }
 
   /**
@@ -469,7 +484,7 @@ inline T OpSpec::GetArgumentImpl(
     return static_cast<T>(arg.Get<S>());
   } else {
     // Argument wasn't present locally, get the default from the associated schema
-    const OpSchema& schema = GetSchema();
+    const OpSchema& schema = GetSchemaOrDefault();
     return static_cast<T>(schema.GetDefaultValueForArgument<S>(name));
   }
 }
@@ -495,7 +510,7 @@ inline bool OpSpec::TryGetArgumentImpl(
   }
   // Search for the argument locally
   auto arg_it = argument_idxs_.find(name);
-  const OpSchema& schema = GetSchema();
+  const OpSchema& schema = GetSchemaOrDefault();
   if (arg_it != argument_idxs_.end()) {
     // Found locally - return
     Argument &arg = *arguments_[arg_it->second];
@@ -527,7 +542,7 @@ inline std::vector<T> OpSpec::GetRepeatedArgumentImpl(const string &name) const 
     return detail::convert_vector<T>(arg.Get<V>());
   } else {
     // Argument wasn't present locally, get the default from the associated schema
-    const OpSchema& schema = GetSchema();
+    const OpSchema& schema = GetSchemaOrDefault();
     return detail::convert_vector<T>(schema.GetDefaultValueForArgument<V>(name));
   }
 }
@@ -537,7 +552,7 @@ inline bool OpSpec::TryGetRepeatedArgumentImpl(C &result, const string &name) co
   using V = std::vector<S>;
   // Search for the argument locally
   auto arg_it = argument_idxs_.find(name);
-  const OpSchema& schema = GetSchema();
+  const OpSchema& schema = GetSchemaOrDefault();
   if (arg_it != argument_idxs_.end()) {
     // Found locally - return
     Argument &arg = *arguments_[arg_it->second];

--- a/dali/pipeline/operator/op_spec_test.cc
+++ b/dali/pipeline/operator/op_spec_test.cc
@@ -468,7 +468,8 @@ TEST(TestOpSpec, Lookup) {
 }
 
 TEST(TestOpSpec, EmptySchema) {
-  OpSpec spec("dummy");
+  OpSpec spec("nonexistent_schema");
+  EXPECT_THROW(spec.GetSchema(), std::runtime_error);
   EXPECT_EQ(spec.GetArgument<std::string>("device"), "cpu");
   EXPECT_EQ(spec.GetArgument<std::string>("_module"), "nvidia.dali.ops");
 }

--- a/dali/pipeline/operator/op_spec_test.cc
+++ b/dali/pipeline/operator/op_spec_test.cc
@@ -467,5 +467,10 @@ TEST(TestOpSpec, Lookup) {
   EXPECT_EQ(spec.ArgumentInputName(2), "zero");
 }
 
+TEST(TestOpSpec, EmptySchema) {
+  OpSpec spec("dummy");
+  EXPECT_EQ(spec.GetArgument<std::string>("device"), "cpu");
+  EXPECT_EQ(spec.GetArgument<std::string>("_module"), "nvidia.dali.ops");
+}
 
 }  // namespace dali


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)


## Description:
Prior to this change it was possible to construct an OpSpec with a name of a nonexistent schema, but it was impossible to query it for arguments - even ones that were present in the OpSpec.
This change introduces a default schema which is used in argument queries in absence of a proper schema. This gives consistent results when querying for default values of built-in arguments.

## Additional information:

### Affected modules and functionalities:
`OpSpec::[Try]Get[Repeated]Argument`


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
`OpSpecTest.EmptySchema`
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
