### PR TITLE
Checkpoint refactoring - recognize checkpoints by operator instance name.

### DIFF
--- a/dali/operators/decoder/host/fused/host_decoder_random_crop.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_random_crop.cc
@@ -21,6 +21,7 @@
 #include "dali/operators/decoder/host/fused/host_decoder_random_crop.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/checkpointing/snapshot_serializer.h"
+#include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 
 namespace dali {
 

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.cc
@@ -17,6 +17,7 @@
 #include "dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.h"
 #include "dali/pipeline/operator/checkpointing/snapshot_serializer.h"
 #include "dali/util/random_crop_generator.h"
+#include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 
 namespace dali {
 

--- a/dali/operators/image/crop/random_crop_generator.h
+++ b/dali/operators/image/crop/random_crop_generator.h
@@ -28,6 +28,7 @@
 #include "dali/pipeline/operator/common.h"
 #include "dali/operators/image/crop/random_crop_attr.h"
 #include "dali/pipeline/operator/checkpointing/snapshot_serializer.h"
+#include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 
 namespace dali {
 

--- a/dali/operators/image/resize/random_resized_crop.h
+++ b/dali/operators/image/resize/random_resized_crop.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@
 #include "dali/operators/image/crop/random_crop_attr.h"
 #include "dali/kernels/imgproc/resample/params.h"
 #include "dali/pipeline/operator/checkpointing/snapshot_serializer.h"
+#include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 
 namespace dali {
 

--- a/dali/operators/imgcodec/roi_image_decoder.h
+++ b/dali/operators/imgcodec/roi_image_decoder.h
@@ -21,6 +21,7 @@
 #include "dali/operators/image/crop/random_crop_attr.h"
 #include "dali/operators/imgcodec/imgcodec.h"
 #include "dali/pipeline/operator/checkpointing/snapshot_serializer.h"
+#include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
 #include "dali/util/crop_window.h"

--- a/dali/operators/random/rng_base_cpu_test.cc
+++ b/dali/operators/random/rng_base_cpu_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ class RNGCheckpointingTest : public ::testing::Test {
 
     // save and restore the pipeline
     auto node = original_pipe.GetOperatorNode("rng_op");
-    OpCheckpoint cpt(node->spec);
+    OpCheckpoint cpt("rng_op");
     node->op->SaveState(cpt, {});
     restored_pipe.GetOperatorNode("rng_op")->op->RestoreState(cpt);
 

--- a/dali/operators/random/rng_checkpointing_utils.h
+++ b/dali/operators/random/rng_checkpointing_utils.h
@@ -23,6 +23,7 @@
 #include "dali/pipeline/operator/checkpointing/snapshot_serializer.h"
 #include "dali/pipeline/util/batch_rng.h"
 #include "dali/operators/util/randomizer.cuh"
+#include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 
 namespace dali {
 namespace rng {

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -29,6 +29,7 @@
 #include "dali/operators/reader/loader/loader.h"
 #include "dali/operators/reader/parser/parser.h"
 #include "dali/pipeline/operator/checkpointing/snapshot_serializer.h"
+#include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 #include "dali/pipeline/operator/name_utils.h"
 #include "dali/pipeline/operator/operator.h"
 

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -37,6 +37,8 @@ struct DLL_PUBLIC ExecutorMeta {
 
 using ExecutorMetaMap = std::unordered_map<std::string, std::vector<ExecutorMeta>>;
 
+class OpGraph;
+
 class DLL_PUBLIC ExecutorBase {
  public:
   DLL_PUBLIC virtual ~ExecutorBase() {}

--- a/dali/pipeline/executor/executor_impl.cc
+++ b/dali/pipeline/executor/executor_impl.cc
@@ -709,6 +709,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::CreateCheckpoint(const OpNode &op_n
                                                               AccessOrder order) {
   auto &cpt = GetCurrentIterationData(iteration_id).checkpoint;
   auto &op_cpt = cpt.GetOpCheckpoint(op_node.id);
+  assert(op_cpt.OperatorName() == op_node.instance_name);
   cpt.SetIterationId(iteration_id);
   op_node.op->SaveState(op_cpt, order);
 }
@@ -750,8 +751,15 @@ Checkpoint &Executor<WorkspacePolicy, QueuePolicy>::GetCurrentCheckpoint() {
 template<typename WorkspacePolicy, typename QueuePolicy>
 void Executor<WorkspacePolicy, QueuePolicy>::RestoreStateFromCheckpoint(const Checkpoint &cpt) {
   DALI_ENFORCE(cpu_iteration_id_ == 0, "Cannot restore state of a running executor. ");
-  for (int i = 0; i < graph_->NumOp(); ++i)
-    graph_->Node(i).op->RestoreState(cpt.GetOpCheckpoint(i));
+
+  for (int i = 0, n = cpt.NumOp(); i < n; i++) {
+    const auto &op_cpt = cpt.GetOpCheckpoint(i);
+    auto *op = GetOperator(op_cpt.OperatorName());
+    DALI_ENFORCE(op != nullptr, make_string(
+        "Operator with name \"", op_cpt.OperatorName(), "\" "
+        "from the checkpoint not found in the graph."));
+    op->RestoreState(op_cpt);
+  }
 
   // Overwrite the initial checkpoints after the state was restored.
   CreateInitialCheckpoints();

--- a/dali/pipeline/executor/executor_impl.cc
+++ b/dali/pipeline/executor/executor_impl.cc
@@ -665,8 +665,10 @@ void Executor<WorkspacePolicy, QueuePolicy>::InitIterationData() {
   iteration_data_.resize(iteration_data_size);
   for (auto& id : iteration_data_) {
     id.iter_data = std::make_shared<IterationData>();
-    if (checkpointing_)
-      id.checkpoint.Build(*graph_);
+    if (checkpointing_) {
+      for (auto &node : graph_->GetOpNodes())
+        id.checkpoint.AddOperator(node.instance_name);
+    }
   }
 }
 

--- a/dali/pipeline/executor/executor_impl.cc
+++ b/dali/pipeline/executor/executor_impl.cc
@@ -751,7 +751,8 @@ Checkpoint &Executor<WorkspacePolicy, QueuePolicy>::GetCurrentCheckpoint() {
 template<typename WorkspacePolicy, typename QueuePolicy>
 void Executor<WorkspacePolicy, QueuePolicy>::RestoreStateFromCheckpoint(const Checkpoint &cpt) {
   DALI_ENFORCE(cpu_iteration_id_ == 0, "Cannot restore state of a running executor. ");
-
+  DALI_ENFORCE(graph_->NumOp() == cpt.NumOp(),
+               "The number of operators in the checkpoint doesn't match the graph structure.");
   for (int i = 0, n = cpt.NumOp(); i < n; i++) {
     const auto &op_cpt = cpt.GetOpCheckpoint(i);
     auto *op = GetOperator(op_cpt.OperatorName());

--- a/dali/pipeline/executor/lowered_graph.h
+++ b/dali/pipeline/executor/lowered_graph.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <memory>
 #include <fstream>
+#include <optional>
 #include <set>
 
 #include "dali/core/common.h"

--- a/dali/pipeline/operator/checkpointing/checkpoint.cc
+++ b/dali/pipeline/operator/checkpointing/checkpoint.cc
@@ -85,7 +85,8 @@ void Checkpoint::DeserializeFromProtobuf(ExecutorBase &exec, const std::string &
     DALI_ENFORCE(op, make_string(
                  "The executor doesn't recognize \"", name, "\" as a name of an operator.\n"
                  "The checkpoint might come from another pipeline."));
-    auto &op_cpt = cpts_[AddOperator(name)];
+    auto idx = AddOperator(name);  // this extends the `cpts_` vector
+    auto &op_cpt = cpts_[idx];
     op->DeserializeCheckpoint(op_cpt, data);
   }
   external_ctx_cpt_.pipeline_data = checkpoint.external_ctx_cpt().pipeline_data();

--- a/dali/pipeline/operator/checkpointing/checkpoint.cc
+++ b/dali/pipeline/operator/checkpointing/checkpoint.cc
@@ -23,12 +23,29 @@ namespace dali {
 
 void Checkpoint::Clear() {
   cpts_.clear();
+  name2id_.clear();
   iteration_id_ = 0;
 }
 
 int Checkpoint::AddOperator(std::string instance_name) {
+  if (!name2id_.emplace(instance_name, cpts_.size()).second)
+    DALI_FAIL("The checkpoint already contains an operator with name \"", instance_name, "\".");
   cpts_.emplace_back(std::move(instance_name));
   return cpts_.size() - 1;
+}
+
+std::optional<int> Checkpoint::OperatorIdx(std::string_view instance_name) const {
+  auto it = name2id_.find(instance_name);
+  if (it == name2id_.end())
+    return std::nullopt;
+  return it->second;
+}
+
+const OpCheckpoint &Checkpoint::GetOpCheckpoint(std::string_view instance_name) const {
+  auto idx = OperatorIdx(instance_name);
+  if (!idx)
+    DALI_FAIL("There's no checkpoint for operator \"", instance_name, "\".");
+  return GetOpCheckpoint(*idx);
 }
 
 OpCheckpoint &Checkpoint::GetOpCheckpoint(int idx) {

--- a/dali/pipeline/operator/checkpointing/checkpoint.cc
+++ b/dali/pipeline/operator/checkpointing/checkpoint.cc
@@ -12,28 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/pipeline/operator/checkpointing/checkpoint.h"
-// TODO(michalz): Use OpGraph2
-#include "dali/pipeline/executor/lowered_graph.h"
+#include <utility>
 
+#include "dali/pipeline/operator/checkpointing/checkpoint.h"
+#include "dali/pipeline/executor/executor.h"
+#include "dali/pipeline/operator/operator.h"
 #include "dali/pipeline/dali.pb.h"
 
 namespace dali {
 
-void Checkpoint::Build(const OpGraph &graph) {
-  cpts_.reserve(graph.GetOpNodes().size());
-  for (const auto &node : graph.GetOpNodes())
-    cpts_.emplace_back(node.spec);
+void Checkpoint::Clear() {
+  cpts_.clear();
+  iteration_id_ = 0;
 }
 
-OpCheckpoint &Checkpoint::GetOpCheckpoint(OpNodeId id) {
-  DALI_ENFORCE_VALID_INDEX(id, cpts_.size());
-  return cpts_[id];
+int Checkpoint::AddOperator(std::string instance_name) {
+  cpts_.emplace_back(std::move(instance_name));
+  return cpts_.size() - 1;
 }
 
-const OpCheckpoint &Checkpoint::GetOpCheckpoint(OpNodeId id) const {
-  DALI_ENFORCE_VALID_INDEX(id, cpts_.size());
-  return cpts_[id];
+OpCheckpoint &Checkpoint::GetOpCheckpoint(int idx) {
+  DALI_ENFORCE_VALID_INDEX(idx, cpts_.size());
+  return cpts_[idx];
+}
+
+const OpCheckpoint &Checkpoint::GetOpCheckpoint(int idx) const {
+  DALI_ENFORCE_VALID_INDEX(idx, cpts_.size());
+  return cpts_[idx];
 }
 
 void Checkpoint::SetIterationId(size_t iteration_id) {
@@ -53,37 +58,35 @@ Index Checkpoint::NumOp() const {
   return cpts_.size();
 }
 
-std::string Checkpoint::SerializeToProtobuf(const OpGraph &graph) const {
+std::string Checkpoint::SerializeToProtobuf(ExecutorBase &exec) const {
   dali_proto::Checkpoint checkpoint;
-  const auto &nodes = graph.GetOpNodes();
-  for (size_t i = 0; i < nodes.size(); i++) {
+  for (const OpCheckpoint &cpt : cpts_) {
     auto op_cpt = checkpoint.add_cpts();
-    op_cpt->set_operator_name(cpts_[i].OperatorName());
-    op_cpt->set_operator_state(nodes[i].op->SerializeCheckpoint(cpts_[i]));
+    const auto &name = cpt.OperatorName();
+    op_cpt->set_operator_name(name);
+    auto *op = exec.GetOperator(name);
+    assert(op);
+    op_cpt->set_operator_state(op->SerializeCheckpoint(cpt));
   }
   checkpoint.mutable_external_ctx_cpt()->set_pipeline_data(external_ctx_cpt_.pipeline_data);
   checkpoint.mutable_external_ctx_cpt()->set_iterator_data(external_ctx_cpt_.iterator_data);
   return checkpoint.SerializeAsString();
 }
 
-void Checkpoint::DeserializeFromProtobuf(const OpGraph &graph,
-                                         const std::string &serialized_data) {
-  Build(graph);
+void Checkpoint::DeserializeFromProtobuf(ExecutorBase &exec, const std::string &serialized_data) {
+  Clear();
   dali_proto::Checkpoint checkpoint;
   checkpoint.ParseFromString(serialized_data);
-  DALI_ENFORCE(checkpoint.cpts_size() == static_cast<int>(cpts_.size()),
-               "The number of operators in the checkpoint differs from the number "
-               "of operators in the pipeline. ");
 
-  const auto &nodes = graph.GetOpNodes();
   for (int i = 0; i < checkpoint.cpts_size(); i++) {
-    auto &op_cpt = cpts_[i];
     const auto &name = checkpoint.cpts(i).operator_name();
     const auto &data = checkpoint.cpts(i).operator_state();
-    DALI_ENFORCE(name == op_cpt.OperatorName(),
-                 "Attempted to restore state from checkpoint of another operator. "
-                 "The checkpoint might come from another pipeline. ");
-    nodes[i].op->DeserializeCheckpoint(op_cpt, data);
+    auto *op = exec.GetOperator(name);
+    DALI_ENFORCE(op, make_string(
+                 "The executor doesn't recognize \"", name, "\" as a name of an operator.\n"
+                 "The checkpoint might come from another pipeline."));
+    auto &op_cpt = cpts_[AddOperator(name)];
+    op->DeserializeCheckpoint(op_cpt, data);
   }
   external_ctx_cpt_.pipeline_data = checkpoint.external_ctx_cpt().pipeline_data();
   external_ctx_cpt_.iterator_data = checkpoint.external_ctx_cpt().iterator_data();

--- a/dali/pipeline/operator/checkpointing/checkpoint.h
+++ b/dali/pipeline/operator/checkpointing/checkpoint.h
@@ -22,7 +22,7 @@
 
 namespace dali {
 
-class OpGraph;
+class ExecutorBase;
 
 /**
  * @brief Pipeline-wide state, passed from python side
@@ -39,16 +39,13 @@ class DLL_PUBLIC Checkpoint {
  public:
   DLL_PUBLIC Checkpoint() {}
 
-  /**
-   * @brief Builds a checkpoint that can be used to store state of operators in a given graph.
-  */
-  DLL_PUBLIC void Build(const OpGraph &graph);
+  DLL_PUBLIC void Clear();
 
-  using OpNodeId = int64_t;
+  DLL_PUBLIC int AddOperator(std::string instance_name);
 
-  DLL_PUBLIC OpCheckpoint &GetOpCheckpoint(OpNodeId id);
+  DLL_PUBLIC OpCheckpoint &GetOpCheckpoint(int index);
 
-  DLL_PUBLIC const OpCheckpoint &GetOpCheckpoint(OpNodeId id) const;
+  DLL_PUBLIC const OpCheckpoint &GetOpCheckpoint(int index) const;
 
   DLL_PUBLIC void SetIterationId(size_t iteration_id);
 
@@ -71,12 +68,13 @@ class DLL_PUBLIC Checkpoint {
   /**
    * @brief Serializes this entire object into a serialized protobuf message.
   */
-  DLL_PUBLIC std::string SerializeToProtobuf(const OpGraph &graph) const;
+  DLL_PUBLIC std::string SerializeToProtobuf(ExecutorBase &exec) const;
 
   /**
    * @brief Deserializes a protobuf message and builds this object.
   */
-  DLL_PUBLIC void DeserializeFromProtobuf(const OpGraph &graph, const std::string &serialized_data);
+  DLL_PUBLIC void DeserializeFromProtobuf(ExecutorBase &exec,
+                                          const std::string &serialized_data);
 
   ExternalContextCheckpoint external_ctx_cpt_{};
 

--- a/dali/pipeline/operator/checkpointing/checkpoint.h
+++ b/dali/pipeline/operator/checkpointing/checkpoint.h
@@ -86,8 +86,7 @@ class DLL_PUBLIC Checkpoint {
   /**
    * @brief Deserializes a protobuf message and builds this object.
   */
-  void DeserializeFromProtobuf(ExecutorBase &exec,
-                                          const std::string &serialized_data);
+  void DeserializeFromProtobuf(ExecutorBase &exec, const std::string &serialized_data);
 
   ExternalContextCheckpoint external_ctx_cpt_{};
 

--- a/dali/pipeline/operator/checkpointing/checkpoint.h
+++ b/dali/pipeline/operator/checkpointing/checkpoint.h
@@ -15,8 +15,12 @@
 #ifndef DALI_PIPELINE_OPERATOR_CHECKPOINTING_CHECKPOINT_H_
 #define DALI_PIPELINE_OPERATOR_CHECKPOINTING_CHECKPOINT_H_
 
-#include <vector>
+#include <functional>
+#include <map>
+#include <optional>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 
@@ -37,49 +41,59 @@ struct ExternalContextCheckpoint {
  */
 class DLL_PUBLIC Checkpoint {
  public:
-  DLL_PUBLIC Checkpoint() {}
+  Checkpoint() {}
 
-  DLL_PUBLIC void Clear();
+  void Clear();
 
-  DLL_PUBLIC int AddOperator(std::string instance_name);
+  int AddOperator(std::string instance_name);
 
-  DLL_PUBLIC OpCheckpoint &GetOpCheckpoint(int index);
+  std::optional<int> OperatorIdx(std::string_view instance_name) const;
 
-  DLL_PUBLIC const OpCheckpoint &GetOpCheckpoint(int index) const;
+  OpCheckpoint &GetOpCheckpoint(int index);
 
-  DLL_PUBLIC void SetIterationId(size_t iteration_id);
+  const OpCheckpoint &GetOpCheckpoint(int index) const;
 
-  DLL_PUBLIC size_t GetIterationId() const;
+  inline OpCheckpoint &GetOpCheckpoint(std::string_view instance_name) {
+    const Checkpoint *cthis = this;
+    return const_cast<OpCheckpoint &>(cthis->GetOpCheckpoint(instance_name));
+  }
+
+  const OpCheckpoint &GetOpCheckpoint(std::string_view instance_name) const;
+
+  void SetIterationId(size_t iteration_id);
+
+  size_t GetIterationId() const;
 
   /**
    * @brief Sets the given order on all the OpCheckpoints.
    *
    * Can be used to synchronize the checkpoints.
   */
-  DLL_PUBLIC void SetOrder(AccessOrder order);
+  void SetOrder(AccessOrder order);
 
   /**
    * @brief Returns the number of OpCheckpoints kept.
    *
    * It's equivalent to the number of operators in the related pipeline.
   */
-  DLL_PUBLIC Index NumOp() const;
+  Index NumOp() const;
 
   /**
    * @brief Serializes this entire object into a serialized protobuf message.
   */
-  DLL_PUBLIC std::string SerializeToProtobuf(ExecutorBase &exec) const;
+  std::string SerializeToProtobuf(ExecutorBase &exec) const;
 
   /**
    * @brief Deserializes a protobuf message and builds this object.
   */
-  DLL_PUBLIC void DeserializeFromProtobuf(ExecutorBase &exec,
+  void DeserializeFromProtobuf(ExecutorBase &exec,
                                           const std::string &serialized_data);
 
   ExternalContextCheckpoint external_ctx_cpt_{};
 
  private:
   std::vector<OpCheckpoint> cpts_;
+  std::map<std::string, int, std::less<>> name2id_;
   size_t iteration_id_ = 0;
 };
 

--- a/dali/pipeline/operator/checkpointing/checkpoint_test.cc
+++ b/dali/pipeline/operator/checkpointing/checkpoint_test.cc
@@ -198,8 +198,10 @@ class CheckpointTest : public DALITest {
     OpGraph new_graph = make_graph_instance(ZERO_STATE);
 
     for (OpNodeId i = 0; i < nodes_cnt; i++) {
-      ASSERT_EQ(original_graph.Node(i).instance_name,
+      const auto &name = original_graph.Node(i).instance_name;
+      ASSERT_EQ(name,
                 checkpoint.GetOpCheckpoint(i).OperatorName());
+      EXPECT_EQ(&checkpoint.GetOpCheckpoint(i), &checkpoint.GetOpCheckpoint(name));
       original_graph.Node(i).op->SaveState(checkpoint.GetOpCheckpoint(i),
                                            AccessOrder(this->stream_.get()));
     }
@@ -248,21 +250,21 @@ TEST_F(CheckpointTest, CPUOnly) {
             .AddArg("device", "cpu")
             .AddArg("dummy_state", this->NextState(policy))
             .AddOutput("data_node_1", "cpu")
-            .AddOutput("data_node_2", "cpu")), "");
+            .AddOutput("data_node_2", "cpu")), "source");
 
     graph.AddOp(this->PrepareSpec(
             OpSpec("DummyInnerLayer")
             .AddArg("device", "cpu")
             .AddArg("dummy_state", this->NextState(policy))
             .AddInput("data_node_1", "cpu")
-            .AddOutput("data_node_3", "cpu")), "");
+            .AddOutput("data_node_3", "cpu")), "inner1");
 
     graph.AddOp(this->PrepareSpec(
             OpSpec("DummyInnerLayer")
             .AddArg("device", "cpu")
             .AddArg("dummy_state", this->NextState(policy))
             .AddInput("data_node_2", "cpu")
-            .AddOutput("data_node_4", "cpu")), "");
+            .AddOutput("data_node_4", "cpu")), "inner2");
 
     graph.AddOp(this->PrepareSpec(
             OpSpec("DummyOutput")
@@ -270,7 +272,7 @@ TEST_F(CheckpointTest, CPUOnly) {
             .AddArg("dummy_state", this->NextState(policy))
             .AddInput("data_node_3", "cpu")
             .AddInput("data_node_4", "cpu")
-            .AddOutput("data_output", "cpu")), "");
+            .AddOutput("data_output", "cpu")), "output");
 
     graph.InstantiateOperators();
     return graph;
@@ -286,21 +288,21 @@ TEST_F(CheckpointTest, GPUOnly) {
             .AddArg("device", "gpu")
             .AddArg("dummy_state", this->NextState(policy))
             .AddOutput("data_node_1", "gpu")
-            .AddOutput("data_node_2", "gpu")), "");
+            .AddOutput("data_node_2", "gpu")), "source");
 
     graph.AddOp(this->PrepareSpec(
             OpSpec("DummyInnerLayer")
             .AddArg("device", "gpu")
             .AddArg("dummy_state", this->NextState(policy))
             .AddInput("data_node_1", "gpu")
-            .AddOutput("data_node_3", "gpu")), "");
+            .AddOutput("data_node_3", "gpu")), "inner1");
 
     graph.AddOp(this->PrepareSpec(
             OpSpec("DummyInnerLayer")
             .AddArg("device", "gpu")
             .AddArg("dummy_state", this->NextState(policy))
             .AddInput("data_node_2", "gpu")
-            .AddOutput("data_node_4", "gpu")), "");
+            .AddOutput("data_node_4", "gpu")), "inner2");
 
     graph.AddOp(this->PrepareSpec(
             OpSpec("DummyOutput")
@@ -308,7 +310,7 @@ TEST_F(CheckpointTest, GPUOnly) {
             .AddArg("dummy_state", this->NextState(policy))
             .AddInput("data_node_3", "gpu")
             .AddInput("data_node_4", "gpu")
-            .AddOutput("data_output", "gpu")), "");
+            .AddOutput("data_output", "gpu")), "output");
 
     graph.InstantiateOperators();
     return graph;

--- a/dali/pipeline/operator/checkpointing/op_checkpoint.cc
+++ b/dali/pipeline/operator/checkpointing/op_checkpoint.cc
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <utility>
+
 #include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 #include "dali/pipeline/operator/op_spec.h"
 
 namespace dali {
 
-OpCheckpoint::OpCheckpoint(const OpSpec &spec)
-  : operator_name_(spec.SchemaName())
+OpCheckpoint::OpCheckpoint(std::string instance_name)
+  : operator_name_(std::move(instance_name))
   , order_(AccessOrder::host()) {}
 
 const std::string &OpCheckpoint::OperatorName() const {

--- a/dali/pipeline/operator/checkpointing/op_checkpoint.h
+++ b/dali/pipeline/operator/checkpointing/op_checkpoint.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ class OpSpec;
  */
 class OpCheckpoint {
  public:
-  DLL_PUBLIC explicit OpCheckpoint(const OpSpec &spec);
+  DLL_PUBLIC explicit OpCheckpoint(std::string instance_name);
 
   /**
    * @brief Returns name of the corresponding operator. Can be used for validation.

--- a/dali/pipeline/operator/checkpointing/op_checkpoint.h
+++ b/dali/pipeline/operator/checkpointing/op_checkpoint.h
@@ -36,7 +36,7 @@ class OpCheckpoint {
   DLL_PUBLIC explicit OpCheckpoint(std::string instance_name);
 
   /**
-   * @brief Returns name of the corresponding operator. Can be used for validation.
+   * @brief Returns the unique name of the corresponding operator.
    */
   DLL_PUBLIC const std::string &OperatorName() const;
 

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -34,13 +34,14 @@
 #include "dali/pipeline/operator/op_schema.h"
 #include "dali/pipeline/operator/op_spec.h"
 #include "dali/pipeline/operator/operator_factory.h"
-#include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 #include "dali/pipeline/util/batch_utils.h"
 #include "dali/pipeline/workspace/workspace.h"
 #include "dali/pipeline/workspace/sample_workspace.h"
 #include "dali/pipeline/util/thread_pool.h"
 
 namespace dali {
+
+class OpCheckpoint;
 
 struct DLL_PUBLIC ReaderMeta {
   Index epoch_size = -1;          // raw epoch size

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -319,7 +319,7 @@ class DLL_PUBLIC Pipeline {
   DLL_PUBLIC string SerializedCheckpoint(const ExternalContextCheckpoint &external_ctx_cpt) const {
     auto cpt = GetCheckpoint();
     cpt.external_ctx_cpt_ = external_ctx_cpt;
-    return cpt.SerializeToProtobuf(graph_);
+    return cpt.SerializeToProtobuf(*executor_);
   }
 
   /**
@@ -349,7 +349,7 @@ class DLL_PUBLIC Pipeline {
                  "Cannot restore checkpoint. The `enable_checkpointing` was not "
                  "specified when creating the pipeline");
     Checkpoint cpt;
-    cpt.DeserializeFromProtobuf(graph_, serialized_checkpoint);
+    cpt.DeserializeFromProtobuf(*executor_, serialized_checkpoint);
     RestoreFromCheckpoint(cpt);
     return cpt.external_ctx_cpt_;
   }

--- a/dali/test/dali_test_checkpointing.h
+++ b/dali/test/dali_test_checkpointing.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ class PipelineWrapper {
     clone.Build();
 
     for (const auto &[spec, id] : ops_) {
-      OpCheckpoint cpt(spec);
+      OpCheckpoint cpt(id);
       // TODO(mstaniewski): provide a stream, so operators with state kept
       // in device memory can be tested.
       GetOperator(id)->SaveState(cpt, {});

--- a/dali/test/operators/dummy_op.h
+++ b/dali/test/operators/dummy_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 
 namespace dali {
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)



## Description:
Use operator names rather than incidental order in checkpoints.
Get operator instances from executor (by name) rather than from lowered graph (by index).
Rationale:
- new graph doesn't store operator instances - that's the job of the executor
- order of operators in the graph is incidental and brittle

Additionally, OpCheckpoint is now only forward-declared in operator.h, because most operators are stateless and don't need to depend on OpCheckpoint definition.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Tests **adjusted** (not added)
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3979
<!--- DALI-XXXX or NA --->
