### PR TITLE
Use "device" and "preserve" built-in arguments in OpGraph2.

### DIFF
--- a/dali/pipeline/graph/op_graph2.h
+++ b/dali/pipeline/graph/op_graph2.h
@@ -46,8 +46,8 @@ struct OpNode {
  public:
   friend class OpGraph;
 
-  OpNode(std::string instance_name, OpSpec spec)
-  : instance_name(std::move(instance_name)), spec(std::move(spec)) {}
+  OpNode(std::string instance_name, OpType type, OpSpec spec)
+  : instance_name(std::move(instance_name)), spec(std::move(spec)), op_type(type) {}
 
   /** A visit marker for various graph processing algorithms. */
   mutable bool visited = false;

--- a/dali/pipeline/graph/op_graph2_test.cc
+++ b/dali/pipeline/graph/op_graph2_test.cc
@@ -285,15 +285,9 @@ TEST(NewOpGraphBuilderTest, SortAndPrune) {
   OpGraph g = std::move(b).GetGraph();
 
   auto &nodes = g.OpNodes();
-  ASSERT_EQ(nodes.size(), 3_uz) << "The nodes were not added properly - abandoning test";
+  ASSERT_EQ(nodes.size(), 4_uz) << "The nodes were not added properly - abandoning test";
   g.Sort(true);
-  EXPECT_EQ(nodes.size(), 2_uz);
-  ASSERT_GE(nodes.size(), 2_uz) << "Graph overpruned.";
-  auto it = g.OpNodes().begin();
-  EXPECT_EQ(it->instance_name, "op1");
-  ++it;
-  EXPECT_EQ(it->instance_name, "op2");
-
+  EXPECT_EQ(nodes.size(), 3_uz);
 
   auto *op1 = g.GetOp("op1");
   auto *op2 = g.GetOp("op2");

--- a/dali/pipeline/graph/op_graph2_test.cc
+++ b/dali/pipeline/graph/op_graph2_test.cc
@@ -243,7 +243,7 @@ TEST(NewOpGraphBuilderTest, SortAndPrune) {
      /     /
     / \   / \
    (   ) /   \
-    op2      op3
+    op2      op3      op4 (preserved)
    /   \      |
   o0    o1    o2
   |     |     |
@@ -272,10 +272,14 @@ TEST(NewOpGraphBuilderTest, SortAndPrune) {
   spec3.AddInput("i1",  "gpu");
   spec3.AddOutput("o2", "gpu");
 
+  OpSpec spec4("dummy");
+  spec4.AddArg("preserve", true);
+
   OpGraph::Builder b;
   b.Add("op2", spec2);
   b.Add("op3", spec3);
   b.Add("op1", spec1);
+  b.Add("op4", spec4);
   b.AddOutput("o0_gpu");
   b.AddOutput("o1_cpu");
   OpGraph g = std::move(b).GetGraph();
@@ -294,7 +298,9 @@ TEST(NewOpGraphBuilderTest, SortAndPrune) {
   auto *op1 = g.GetOp("op1");
   auto *op2 = g.GetOp("op2");
   auto *op3 = g.GetOp("op3");
+  auto *op4 = g.GetOp("op4");
   EXPECT_EQ(op3, nullptr) << "The operator op3 should have been pruned";
+  EXPECT_NE(op4, nullptr) << "The operator op4 should NOT have been pruned";
 
   ASSERT_NE(op1, nullptr) << "Operator op1 not found in the pruned graph";
   EXPECT_EQ(op1->op_type, OpType::CPU);

--- a/dali/pipeline/graph/op_graph2_test.cc
+++ b/dali/pipeline/graph/op_graph2_test.cc
@@ -282,7 +282,7 @@ TEST(NewOpGraphBuilderTest, SortAndPrune) {
   b.Add("op4", spec4);
   b.AddOutput("o0_gpu");
   b.AddOutput("o1_cpu");
-  OpGraph g = std::move(b).GetGraph();
+  OpGraph g = std::move(b).GetGraph(false);  // don't prune now
 
   auto &nodes = g.OpNodes();
   ASSERT_EQ(nodes.size(), 4_uz) << "The nodes were not added properly - abandoning test";


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)


## Description:
New `OpNode` has fields `op_type` and `keep` corresponding to OpSpec's "device" and "preserve" arguments. These are now parsed when adding a node to the graph.

## Additional information:

### Affected modules and functionalities:
New OpGraph and tests.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
`op_graph2_test.cc` updated.
- [X] Existing tests apply (updated)
- [ ] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
