### PR TITLE
Add failure tests for stealing subgraphs. Minor fix in pipeline.

### DIFF
--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -722,7 +722,9 @@ class Pipeline(object):
     def _require_unique_names(self):
         ops_by_name = {}
         for op in self._ops:
-            ops = ops_by_name.get(op.name, [])
+            ops = ops_by_name.get(op.name, None)
+            if ops is None:
+                ops = ops_by_name[op.name] = []
             ops.append(op)
         duplicate = {}
         foreign = False


### PR DESCRIPTION
Follow-up on #5506

## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Other** (*e.g. Documentation, Tests, Configuration*)


## Description:
This change adds failure tests to the pipeline, detecting:
- uncheckpointable pipeline (with foreign subgraph)
- invalid pipeline (with duplicate node names)
 
Minor fix:
- error out in Python (instead of C++) when adding a node with a duplicate name

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
