### PR TITLE
Fix TL3_RN50_short/test_mxnet.sh to load nvimagecodec first to avoid libjpeg symbol clash

### DIFF
--- a/qa/TL3_RN50_short/test_mxnet.sh
+++ b/qa/TL3_RN50_short/test_mxnet.sh
@@ -10,6 +10,9 @@ sed -i -e "s/'--dali-nvjpeg-memory-padding', int, 16/'--dali-nvjpeg-memory-paddi
 # Make sure that nvImageCodec loads before MXNet to avoid getting libjpeg version mismatch
 sed -i -e "s/import nvidia.dali.fn as fn/import nvidia.dali.fn as fn\nfrom nvidia import nvimgcodec/g" /opt/mxnet/python/mxnet/io/dali_utils.py
 
+# TODO(janton): Remove the LD_PRELOAD with next nvImageCodec release
+# Make sure that nvImageCodec's jpeg symbol load before MXNet to avoid getting libjpeg version mismatch
+LD_PRELOAD=$(ls /usr/local/lib/python3.10/dist-packages/nvidia/nvimgcodec/extensions/libjpeg_turbo_ext.so*) \
 python /opt/mxnet/example/image-classification/train_imagenet_runner \
        --data-root=/data/imagenet/train-val-recordio-passthrough/ -b 408 \
        -n $NUM_GPUS -e 5 --seed 42 --dali-threads 8 2>&1 | tee dali.log


### PR DESCRIPTION

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Other** 

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- Workaround for nvimagecodec
- In 0.2.0, the libjpeg version are not hidden, which causes a symbol clash.
- Preloads the nvimagecodec library, so that it doesn't pick the wrong symbols


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
