### PR TITLE
Tasking: Test returning a collection of std::any.

### DIFF
--- a/dali/core/exec/tasking_test.cc
+++ b/dali/core/exec/tasking_test.cc
@@ -254,6 +254,35 @@ TEST(TaskingTest, MultiOutputIterable) {
   EXPECT_EQ(ret, 1 + 3 + 42 + 5 + 10);
 }
 
+TEST(TaskingTest, MultiOutputIterableOfAny) {
+  Executor ex(4);
+  ex.Start();
+  auto producer = Task::Create(2, []() {
+    return std::vector<std::any>{1.0, 42};
+  });
+
+  auto consumer1 = Task::Create([](Task *t) {
+    return t->GetInputValue<double>(0) + 3;
+  });
+  consumer1->Subscribe(producer, 0);
+
+  auto consumer2 = Task::Create([](Task *t) {
+    return t->GetInputValue<int>(0) + 5;
+  });
+  consumer2->Subscribe(producer, 1);
+
+  auto apex = Task::Create([](Task *t) {
+    return t->GetInputValue<double>(0) + t->GetInputValue<int>(1) + 10;
+  });
+  apex->Subscribe(consumer1)->Subscribe(consumer2);
+
+  ex.AddSilentTask(producer);
+  ex.AddSilentTask(consumer1);
+  ex.AddSilentTask(consumer2);
+  int ret = ex.AddTask(apex).Value<double>();
+  EXPECT_EQ(ret, 1 + 3 + 42 + 5 + 10);
+}
+
 TEST(TaskingTest, MultiOutputTuple) {
   Executor ex(4);
   ex.Start();


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** Test


## Description:
Test handling of multiple outputs of type std::any.
The desired behavior is that passing an iterable object with element type `std::any` doesn't wrap `any` into another layer of `any`,
but rather forwards the contained object.

When returning:
```C++
return vector<any>{ 1, 2.5f, string("cat") };
```

When getting the results:
```C++
int integer = task->GetInputValue<int>(0);
float fraction = task->GetInputValue<float>(1);
string mammal = task->GetInputValue<string>(2);
```

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
