### PR TITLE
Move graph visiting utilities to a separate file.

### DIFF
--- a/dali/pipeline/graph/graph_util.h
+++ b/dali/pipeline/graph/graph_util.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_GRAPH_GRAPH_UTIL_H_
+#define DALI_PIPELINE_GRAPH_GRAPH_UTIL_H_
+
+#include <stdexcept>
+#include "dali/core/util.h"
+
+namespace dali {
+namespace graph {
+
+IMPL_HAS_MEMBER(visit_pending);
+
+/** A helper for visiting DAG nodes.
+ *
+ * When the node has a "visit_pending" member, the helper detects cycles.
+ */
+template <typename Node>
+class Visit {
+ public:
+  explicit Visit(Node *n) : node_(n) {
+    if constexpr (has_member_visit_pending_v<Node>) {
+      if (node_->visit_pending)
+        throw std::logic_error("Cycle detected.");
+      node_->visit_pending = true;
+    }
+    new_visit_ = !n->visited;
+    node_->visited = true;
+  }
+  ~Visit() {
+    if constexpr (has_member_visit_pending_v<Node>) {
+      node_->visit_pending = false;
+    }
+  }
+
+  explicit operator bool() const {
+    return new_visit_;
+  }
+
+ private:
+  Node *node_;
+  bool new_visit_;
+};
+
+/** Clears visit markers.
+ *
+ * Sets the `visited` field to `false`.
+ * Typically used at the beginning of a graph-processing algorithm.
+ */
+template <typename NodeList>
+static void ClearVisitMarkers(NodeList &nodes) {
+  for (auto &node : nodes)
+    node.visited = false;
+}
+
+}  // namespace graph
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_GRAPH_GRAPH_UTIL_H_

--- a/dali/pipeline/graph/op_graph2.h
+++ b/dali/pipeline/graph/op_graph2.h
@@ -24,6 +24,7 @@
 #include <utility>
 #include "dali/core/common.h"
 #include "dali/pipeline/operator/op_spec.h"
+#include "dali/pipeline/graph/graph_util.h"
 
 namespace dali {
 namespace graph {
@@ -238,41 +239,6 @@ class DLL_PUBLIC OpGraph {
   class SortHelper;
   friend class SortHelper;
 };
-
-/** A helper for visiting DAG nodes - it features previous visit detection and cycle detection. */
-template <typename Node>
-class Visit {
- public:
-  explicit Visit(Node *n) : node_(n) {
-    if (node_->visit_pending)
-      throw std::logic_error("Cycle detected.");
-    node_->visit_pending = true;
-    new_visit_ = !n->visited;
-    node_->visited = true;
-  }
-  ~Visit() {
-    node_->visit_pending = false;
-  }
-
-  explicit operator bool() const {
-    return new_visit_;
-  }
-
- private:
-  Node *node_;
-  bool new_visit_;
-};
-
-/** Clears visit markers.
- *
- * Sets the `visited` field to `false`.
- * Typically used at the beginning of a graph-processing algorithm.
- */
-template <typename NodeList>
-static void ClearVisitMarkers(NodeList &nodes) {
-  for (auto &node : nodes)
-    node.visited = false;
-}
 
 /** A single-use class for constructing graphs. */
 class DLL_PUBLIC OpGraph::Builder {


### PR DESCRIPTION
## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:
Utilities for DAG visiting have been moved to a standalone file. They can be used with any node structure with a `visit` (and possibly also `visit_pending`) boolean fields.
The `Visit` helper has been modifier to work in the absence of `visit_pending` field, in which case it doesn't provide cycle detection.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
op_graph2_test.cc
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
