### PR TITLE
Use MakeContiguous<CPUBackend> when copying CPU->CPU.

### DIFF
--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -357,6 +357,7 @@ int Pipeline::AddOperatorImpl(const OpSpec &const_spec, const std::string &inst_
                    "should not be `CPU_ONLY_DEVICE_ID`.");
     } else if (input_device == "cpu") {
       // device == gpu
+      // TODO(michalz): Add a D2H copy
       DALI_ENFORCE(it->second.has_cpu,
                    make_string("Error while specifying ", FormatInput(spec, i),
                                ". CPU input requested by operator exists only on GPU. CPU "
@@ -546,7 +547,7 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
     if (device == "cpu") {
       DALI_ENFORCE(it->second.has_cpu, "Requested cpu output '" +
           name + "' only exists on gpu.");
-      // Add a make contiguous op to produce this output. [cpu output of mixed]
+      // Add a make contiguous op to produce this output - we need pipeline outputs to be dense.
       auto output_name = AddMakeContiguousNode(it->second, name, "cpu", "cpu", "cpu");
       if (!it->second.has_contiguous) {
         it->second.has_contiguous = true;

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -547,8 +547,7 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
       DALI_ENFORCE(it->second.has_cpu, "Requested cpu output '" +
           name + "' only exists on gpu.");
       // Add a make contiguous op to produce this output. [cpu output of mixed]
-      // TODO(klecki): we can revert back to using CPU stage here by changing mixed to cpu
-      auto output_name = AddMakeContiguousNode(it->second, name, "cpu", "mixed", "cpu");
+      auto output_name = AddMakeContiguousNode(it->second, name, "cpu", "cpu", "cpu");
       if (!it->second.has_contiguous) {
         it->second.has_contiguous = true;
       }
@@ -1020,11 +1019,6 @@ void Pipeline::Shutdown() {
 std::tuple<OpSpec, std::string, std::string> Pipeline::PrepareMakeContiguousNode(
     EdgeMeta &meta, const std::string &input_name, const std::string &input_dev,
     const std::string &device, const std::string &output_dev) {
-  // TODO(klecki): If outputs from CPU stage are enabled, adjust this.
-  DALI_ENFORCE(device != "cpu",
-               "CPU MakeContiguous nodes are not supposed to be inserted this way, only Mixed and "
-               "GPU nodes are currently used as outputs.");
-
   // Prefix for the output name to be generated, so it is distinct after being made contiguous.
   const char *cpu_to_cpu_out = "contiguous_cpu_to_cpu_";
   const char *gpu_to_gpu_out = "contiguous_gpu_to_gpu_";

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -269,16 +269,16 @@ TYPED_TEST(PipelineTest, TestExternalSource) {
   auto &graph = this->GetGraph(&pipe);
 
   // Validate the graph
-  ASSERT_EQ(CountNodes(graph, OpType::CPU), 1);
-  ASSERT_EQ(CountNodes(graph, OpType::MIXED), 1);
-  ASSERT_EQ(CountNodes(graph, OpType::GPU), 0);
+  EXPECT_EQ(CountNodes(graph, OpType::CPU), 2);
+  EXPECT_EQ(CountNodes(graph, OpType::MIXED), 0);
+  EXPECT_EQ(CountNodes(graph, OpType::GPU), 0);
 
   // Validate the gpu source op
   auto it = graph.OpNodes().begin();
   graph::OpNode &node_external_source = *it++;
-  ASSERT_EQ(node_external_source.inputs.size(), 0);
-  ASSERT_EQ(node_external_source.outputs.size(), 1);
-  ASSERT_EQ(node_external_source.instance_name, "data");
+  EXPECT_EQ(node_external_source.inputs.size(), 0);
+  EXPECT_EQ(node_external_source.outputs.size(), 1);
+  EXPECT_EQ(node_external_source.instance_name, "data");
 
 
   graph::OpNode &node_make_contiguous = *it++;


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
Putting a "mixed" op in CPU-only subgraphs seems unnecessary. In CPU-only pipelines it is outright problematic.

## Additional information:
My current best guess for the reason why this code was like it was is that we had TensorVector at the output of CPU stage, which precluded having outputs in CPU stage. This is no longer the case (and hasn't been for a long time).

### Affected modules and functionalities:
Pipelines returning outputs from CPU stage directly.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
...all of them
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
