### PR TITLE
Fix operator trace caching

### DIFF
--- a/dali/c_api/operator_trace_test.cc
+++ b/dali/c_api/operator_trace_test.cc
@@ -115,13 +115,13 @@ class OperatorTraceTest : public ::testing::TestWithParam<OperatorTraceTestParam
                                    .AddArg("device", "cpu")
                                    .AddInput("compressed_images", "cpu")
                                    .AddOutput("PT_CPU", "cpu")
-                                   .AddArg("trace_name", std::string(operator_trace_names[0])),
+                                   .AddArg("trace_name", operator_trace_names[0]),
                            operator_under_test_names[0]);
     pipeline_->AddOperator(OpSpec("PassthroughWithTraceOp")
                                    .AddArg("device", "gpu")
                                    .AddInput("compressed_images", "gpu")
                                    .AddOutput("PT_GPU", "gpu")
-                                   .AddArg("trace_name", std::string(operator_trace_names[1])),
+                                   .AddArg("trace_name", operator_trace_names[1]),
                            operator_under_test_names[1]);
 
     std::vector<std::pair<std::string, std::string>> outputs = {
@@ -145,11 +145,12 @@ TEST_P(OperatorTraceTest, OperatorTraceTest) {
     for (int i = 0; i < prefetch_depth; i++) {
       daliShareOutput(&h);
 
-      for (size_t i = 0; i < std::size(operator_under_test_names); ++i) {
-        const char *operator_name = operator_under_test_names[i];
-        const char *trace_name = operator_trace_names[i];
+      for (size_t op = 0; op < std::size(operator_under_test_names); op++) {
+        const char *operator_name = operator_under_test_names[op];
+        const char *trace_name = operator_trace_names[op];
         EXPECT_EQ(daliHasOperatorTrace(&h, operator_name, "this_trace_does_not_exist"), 0);
-        ASSERT_NE(daliHasOperatorTrace(&h, operator_name, trace_name), 0) << "name: " << trace_name;
+        ASSERT_NE(daliHasOperatorTrace(&h, operator_name, trace_name), 0)
+          << "operator_name: " << operator_name << "\ntrace_name: " << trace_name;
 
         EXPECT_EQ(std::string(daliGetOperatorTrace(&h, operator_name, trace_name)),
                   make_string("test_value", iteration * prefetch_depth + i));
@@ -194,11 +195,13 @@ class OperatorTraceTestExternalInput : public OperatorTraceTest {
     pipeline_->AddOperator(OpSpec("PassthroughWithTraceOp")
                                    .AddArg("device", "cpu")
                                    .AddInput("OP_TRACE_IN_CPU", "cpu")
+                                   .AddArg("trace_name", operator_trace_names[0])
                                    .AddOutput("PT_CPU", "cpu"),
                            operator_under_test_names[0]);
     pipeline_->AddOperator(OpSpec("PassthroughWithTraceOp")
                                    .AddArg("device", "gpu")
                                    .AddInput("OP_TRACE_IN_GPU", "gpu")
+                                   .AddArg("trace_name", operator_trace_names[1])
                                    .AddOutput("PT_GPU", "gpu"),
                            operator_under_test_names[1]);
 
@@ -262,11 +265,12 @@ TEST_P(OperatorTraceTestExternalInput, OperatorTraceTestExternalInput) {
     for (int i = 0; i < prefetch_depth; i++) {
       daliShareOutput(&h);
 
-      for (size_t i = 0; i < std::size(operator_under_test_names); i++) {
-        const char *operator_name = operator_under_test_names[i];
-        const char *trace_name = operator_trace_names[i];
+      for (size_t op = 0; op < std::size(operator_under_test_names); op++) {
+        const char *operator_name = operator_under_test_names[op];
+        const char *trace_name = operator_trace_names[op];
         EXPECT_EQ(daliHasOperatorTrace(&h, operator_name, "this_trace_does_not_exist"), 0);
-        ASSERT_NE(daliHasOperatorTrace(&h, operator_name, trace_name), 0) << "name: " << trace_name;
+        ASSERT_NE(daliHasOperatorTrace(&h, operator_name, trace_name), 0)
+          << "operator_name: " << operator_name << "\ntrace_name: " << trace_name;
 
         EXPECT_EQ(std::string(daliGetOperatorTrace(&h, operator_name, trace_name)),
                   make_string("test_value", iteration * prefetch_depth + i));

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -174,6 +174,11 @@ class DLL_PUBLIC OpSpec {
     return this->SetArg<std::string>(name, c_str);
   }
 
+  // Forward to string implementation
+  DLL_PUBLIC inline OpSpec& SetArg(const string &name, const char *c_str) {
+    return this->SetArg<std::string>(name, c_str);
+  }
+
   /**
    * @brief Specifies the name and device (cpu or gpu) of an
    * input to the op. Intermediate data all have unique names,

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -590,26 +590,29 @@ class WorkspaceBase : public ArgumentWorkspace {
     GetOperatorTraces().clear();
   }
 
-
+  /** Gets operator traces for the currently assigned operator.
+   *
+   * Returns a map, that maps a trace key to a trace value: `ret_value[trace_key] = trace_value`.
+   * The usage is typically within the scope of an operator.
+   */
   DLL_PUBLIC auto &GetOperatorTraces() const {
-    return GetOperatorTraces(GetOperatorInstanceName());
+    if (!operator_traces_)
+      operator_traces_ = &iter_data_->operator_traces.Get(operator_instance_name_);
+    return *operator_traces_;
   }
 
-  /**
-   * Get the trace map for a given operator.
+  /** Get the trace map for a given operator.
    *
    * Returns a map, that maps a trace key to a trace value: `ret_value[trace_key] = trace_value`.
    *
-   * Typically, this function will be called when the traces shall be read.
+   * Typically, this function is be called when the traces are read.
    *
    * @see operator_trace_map_t
    *
    * @param operator_name Name (ID) of the operator.
    */
   DLL_PUBLIC auto &GetOperatorTraces(const std::string &operator_name) const {
-    if (!operator_traces_)
-      operator_traces_ = &iter_data_->operator_traces.Get(operator_name);
-    return *operator_traces_;
+    return iter_data_->operator_traces.Get(operator_name);
   }
   ///@}
 

--- a/dali/test/operators/passthrough_with_trace.cc
+++ b/dali/test/operators/passthrough_with_trace.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ DALI_SCHEMA(PassthroughWithTraceOp)
             "as pass through. Adds a trace. Used for testing.")
     .NumInput(1)
     .NumOutput(1)
+    .AddOptionalArg("trace_name", "The name of the operator trace", "test_trace")
     .PassThrough({{0, 0}});
 
 }  // namespace dali

--- a/dali/test/operators/passthrough_with_trace.h
+++ b/dali/test/operators/passthrough_with_trace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #ifndef DALI_TEST_OPERATORS_PASSTHROUGH_WITH_TRACE_H_
 #define DALI_TEST_OPERATORS_PASSTHROUGH_WITH_TRACE_H_
 
+#include <string>
 #include <vector>
 
 #include "dali/pipeline/operator/operator.h"
@@ -24,7 +25,8 @@ namespace dali {
 template <typename Backend>
 class PassthroughWithTraceOp : public Operator<Backend> {
  public:
-  inline explicit PassthroughWithTraceOp(const OpSpec &spec) : Operator<Backend>(spec) {}
+  inline explicit PassthroughWithTraceOp(const OpSpec &spec)
+  : Operator<Backend>(spec), trace_name_(spec.GetArgument<std::string>("trace_name")) {}
 
   inline ~PassthroughWithTraceOp() override = default;
 
@@ -38,11 +40,12 @@ class PassthroughWithTraceOp : public Operator<Backend> {
 
   void RunImpl(Workspace &ws) override {
     ws.Output<Backend>(0).ShareData(ws.Input<Backend>(0));
-    ws.SetOperatorTrace("test_trace", make_string("test_value", iteration_id++));
+    ws.SetOperatorTrace(trace_name_, make_string("test_value", iteration_id++));
   }
 
 
  private:
+  std::string trace_name_;
   size_t iteration_id = 0;
 };
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Operator traces have an optimization that caches the trace map for the current executor. This was done with an assumption that the access function is not used for reading trace values for multiple operators - and in C API it was used exactly this way, causing errors.
This PR fixes the problem and adds tests that didn't pass prior to the fix.
Additionally, AddArg overload is added to OpSpec, making it possible to pass `const char *`. This was bugged, causing weird run-time errors when attempting to add an argument this way.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
