### PR TITLE
Add default_batch_size to IterationData.

### DIFF
--- a/dali/pipeline/executor/executor_impl.h
+++ b/dali/pipeline/executor/executor_impl.h
@@ -315,7 +315,7 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
 
   StageQueues stage_queue_depths_;
 
-  std::queue<int> batch_sizes_cpu_, batch_sizes_mixed_, batch_sizes_gpu_;
+  std::queue<int> upcoming_batch_sizes_;
 
   OpGraph *graph_ = nullptr;
   EventPool event_pool_;

--- a/dali/pipeline/workspace/iteration_data.h
+++ b/dali/pipeline/workspace/iteration_data.h
@@ -74,7 +74,17 @@ class OperatorTraces {
  * a single iteration.
  */
 struct IterationData {
+  /** The index of the current iteration. */
   int64_t iteration_index = 0;
+
+  /** Default batch size for the current iteration.
+   *
+   * Presently this is the batch size set by external sources or the maximum batch size,
+   * if no external source is present.
+   * Actual batch size may change, e.g. due to conditional execution.
+   */
+  int default_batch_size = 0;
+
   OperatorTraces operator_traces;
   std::shared_ptr<Checkpoint> checkpoint;
 };


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
The executor maintained 3 queues of upcoming batch sizes. This PR ties the default batch size for the iteration to the IterationData object. This will naturally pass across stages, simplifying the executor and allowing the new executor to easily access the default batch size for the iteration.


## Additional information:

### Affected modules and functionalities:
`ExecutorImpl`
`IterationData`


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
All full-pipeline tests cover this code.
The behavior is tested more intensively in test_dali_variable_batch_size.py and other variable batch size tests.
- [X] Existing tests apply
- [ ] New tests added
  - [X] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
