### PR TITLE
Mark PropagateError as [[noreturn]]

### DIFF
--- a/dali/pipeline/operator/error_reporting.cc
+++ b/dali/pipeline/operator/error_reporting.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -58,11 +59,10 @@ std::string FormatStack(const std::vector<PythonStackFrame> &stack_summary, bool
   return s.str();
 }
 
-void PropagateError(ErrorInfo error) {
+[[noreturn]] void PropagateError(ErrorInfo error) {
   try {
-    if (error.exception) {
-      std::rethrow_exception(error.exception);
-    }
+    assert(error.exception);
+    std::rethrow_exception(error.exception);
   }
   // DALI <-> Python mapped type errors:
   catch (DaliError &e) {

--- a/dali/pipeline/operator/error_reporting.h
+++ b/dali/pipeline/operator/error_reporting.h
@@ -75,7 +75,7 @@ struct ErrorInfo {
   std::string additional_message;
 };
 
-void PropagateError(ErrorInfo error);
+[[noreturn]] void PropagateError(ErrorInfo error);
 
 
 /**


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:
`PropagateError` function is never used with a NULL exception pointer - it always throws. This PR acknowledges that by requiring non-NULL exception pointer and marking the function as `[[noreturn]]`, silencing warnings that occur when it's used at the end of a non-void function.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
