### PR TITLE
Remove MakeContiguous before CPU inputs of GPU ops. 

### DIFF
--- a/dali/pipeline/executor/op_graph_verifier.h
+++ b/dali/pipeline/executor/op_graph_verifier.h
@@ -59,24 +59,6 @@ struct parent_constraints<OpType::GPU> {
   static constexpr bool supports_argument_inputs = true;
 };
 
-template <typename T, size_t N>
-static constexpr bool is_in_array(const T value, const T (&arr)[N], size_t idx) {
-  // we encountered the end of array -> false
-  // otherwise we found at current position or search in next position recursivelly
-  return idx < N && (value == arr[idx] || is_in_array(value, arr, idx + 1));
-}
-
-template <OpType op_type>
-static constexpr bool allows_op_input(OpType parent) {
-  return is_in_array(parent, parent_constraints<op_type>::allowed_input_ops, 0);
-}
-
-template <OpType op_type>
-static constexpr bool allows_tensor_input(StorageDevice device) {
-  return is_in_array(device, parent_constraints<op_type>::allowed_input_tensors, 0);
-}
-
-
 DLL_PUBLIC std::vector<int> ArgumentInputConstraints();
 DLL_PUBLIC std::vector<std::set<OpType>> ParentOpTypeConstraints();
 

--- a/dali/pipeline/executor/workspace_policy.h
+++ b/dali/pipeline/executor/workspace_policy.h
@@ -53,13 +53,11 @@ inline std::ostream &operator<<(std::ostream &os, StorageDevice device) {
   }
 }
 
-// We instantiate the operation of adding the input only for parent op_type and device
-// that are specifically allowed
+
 // We always use queue_idx = 0 if give queue has only one element -> it is not queued
 template <OpType op_type, OpType producer_type, StorageDevice device>
-enable_if_t<allows_op_input<op_type>(producer_type) && allows_tensor_input<op_type>(device)>
-add_input(Workspace &ws, const tensor_data_store_queue_t &storage,
-          int queue_idx = 0) {
+void add_input(Workspace &ws, const tensor_data_store_queue_t &storage,
+               int queue_idx = 0) {
   auto &queue = get_queue<producer_type, device>(storage);
   DALI_ENFORCE(!queue.IsBuffered() || queue_idx < static_cast<int>(queue.size()),
                "Backing Tensor store queue has not enough elements.");
@@ -67,10 +65,6 @@ add_input(Workspace &ws, const tensor_data_store_queue_t &storage,
   ws.AddInput(tensor);
 }
 
-// If parent op_type or device is not allowed this is a no-op
-template <OpType op_type, OpType producer_type, StorageDevice device>
-enable_if_t<!allows_op_input<op_type>(producer_type) || !allows_tensor_input<op_type>(device)>
-add_input(Workspace &, const tensor_data_store_queue_t &, int = 0) {}
 
 template <OpType op_type, StorageDevice device>
 void add_output(Workspace &ws, const tensor_data_store_queue_t &storage,

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -385,9 +385,6 @@ int Pipeline::AddOperatorImpl(const OpSpec &const_spec, const std::string &inst_
                             ". Named argument inputs to operators must be CPU data nodes. "
                             "However, a GPU data node was provided."));
     }
-
-    if (device == "gpu" && separated_execution_)
-      SetupCPUInput(it, input_idx, &spec);
   }
 
   // Verify and record the outputs of the op
@@ -678,24 +675,6 @@ void Pipeline::ReleaseOutputs() {
   } catch (...) {
     ProcessException(std::current_exception());
   }
-}
-
-void Pipeline::SetupCPUInput(std::map<string, EdgeMeta>::iterator it, int input_idx, OpSpec *spec) {
-  auto [make_contiguous_spec, op_name, contiguous_output_name] =
-      PrepareMakeContiguousNode(it->second, it->first, "cpu", "mixed", "cpu");
-  if (!it->second.has_contiguous) {
-    // Note that we are returning [cpu output of mixed] Operator.
-    AddToOpSpecs(op_name, make_contiguous_spec, GetNextInternalLogicalId());
-    it->second.has_contiguous = true;
-    it->second.has_make_contiguous_cpu = true;
-  }
-
-  // Update the OpSpec to use the contiguous input
-  auto& input_strs = spec->MutableInput(input_idx);
-  DALI_ENFORCE(input_strs.name == it->first, "Input at index " +
-      std::to_string(input_idx) + " does not match input iterator "
-      "name (" + input_strs.name + " v. " + it->first + ").");
-  input_strs.name = contiguous_output_name;
 }
 
 void Pipeline::SetupGPUInput(std::map<string, EdgeMeta>::iterator it) {

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -355,16 +355,19 @@ int Pipeline::AddOperatorImpl(const OpSpec &const_spec, const std::string &inst_
       DALI_ENFORCE(device_id_ != CPU_ONLY_DEVICE_ID || device == "cpu",
                    "Cannot add a Mixed operator with a GPU output, 'device_id' "
                    "should not be `CPU_ONLY_DEVICE_ID`.");
-    } else if (input_device == "cpu") {
-      // device == gpu
-      // TODO(michalz): Add a D2H copy
-      DALI_ENFORCE(it->second.has_cpu,
-                   make_string("Error while specifying ", FormatInput(spec, i),
-                               ". CPU input requested by operator exists only on GPU. CPU "
-                               "operator cannot follow GPU operator."));
-      SetupCPUInput(it, i, &spec);
-    } else {
+    }
+
+    if (input_device == "gpu") {
       SetupGPUInput(it);
+    } else {
+      if (device != "gpu") {
+        // device == gpu
+        // TODO(michalz): Add a D2H copy instead
+        DALI_ENFORCE(it->second.has_cpu,
+                    make_string("Error while specifying ", FormatInput(spec, i),
+                                ". CPU input requested by operator exists only on GPU. CPU "
+                                "operator cannot follow GPU operator."));
+      }
     }
   }
 

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -360,14 +360,12 @@ int Pipeline::AddOperatorImpl(const OpSpec &const_spec, const std::string &inst_
     if (input_device == "gpu") {
       SetupGPUInput(it);
     } else {
-      if (device != "gpu") {
-        // device == gpu
-        // TODO(michalz): Add a D2H copy instead
-        DALI_ENFORCE(it->second.has_cpu,
-                    make_string("Error while specifying ", FormatInput(spec, i),
-                                ". CPU input requested by operator exists only on GPU. CPU "
-                                "operator cannot follow GPU operator."));
-      }
+      // device == gpu
+      // TODO(michalz): Add a D2H copy instead
+      DALI_ENFORCE(it->second.has_cpu,
+                  make_string("Error while specifying ", FormatInput(spec, i),
+                              ". CPU input requested by operator exists only on GPU. CPU "
+                              "operator cannot follow GPU operator."));
     }
   }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -614,8 +614,6 @@ class DLL_PUBLIC Pipeline {
    */
   int AddOperatorImpl(const OpSpec &spec, const std::string& inst_name, int logical_id);
 
-  void SetupCPUInput(std::map<string, EdgeMeta>::iterator it, int input_idx, OpSpec *spec);
-
   void SetupGPUInput(std::map<string, EdgeMeta>::iterator it);
 
   inline EdgeMeta NewEdge(const std::string &device) {

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -58,7 +58,7 @@ class PipelineTest : public DALITest {
 
     // Inputs must be know to the pipeline, i.e. ops
     // must be added in a topological ordering.
-    ASSERT_THROW(
+    EXPECT_THROW(
       pipe.AddOperator(
         OpSpec("Copy")
           .AddArg("device", dev1)
@@ -71,25 +71,10 @@ class PipelineTest : public DALITest {
         .AddArg("device", "gpu")
         .AddOutput("data", "gpu"));
 
-    // TODO(michalz): Remove this constraint and the tests. This should be a build-time error,
-    //                with old executor, not a construction-time error.
-
-    // For dev1 = "cpu": Inputs to CPU ops must be on CPU,
-    //                   we do not auto-copy them from gpu to cpu.
-    // For dev1 = "gpu": CPU inputs to GPU ops must be on CPU,
-    //                   we will not copy them back to the host.
-    ASSERT_THROW(
-      pipe.AddOperator(
-        OpSpec("Copy")
-          .AddArg("device", dev1)
-          .AddInput("data", dev2)
-          .AddOutput("copy_out", dev1)),
-      std::runtime_error);
-
     if (dev1 == "cpu") {
       // Inputs to CPU ops must already exist on CPU,
       // we do not auto-copy them from gpu to cpu.
-      ASSERT_THROW(
+      EXPECT_THROW(
         pipe.AddOperator(
           OpSpec("Copy")
             .AddArg("device", dev1)
@@ -109,7 +94,7 @@ class PipelineTest : public DALITest {
         .AddOutput("data_3", dev1));
 
     // Outputs must have unique names.
-    ASSERT_THROW(
+    EXPECT_THROW(
       pipe.AddOperator(
         OpSpec("Copy")
           .AddArg("device", dev1)
@@ -125,7 +110,7 @@ class PipelineTest : public DALITest {
     }
     // All data must have unique names regardless
     // of the device they exist on.
-    ASSERT_THROW(
+    EXPECT_THROW(
       pipe.AddOperator(
         OpSpec("Copy")
           .AddArg("device", dev1)
@@ -135,7 +120,7 @@ class PipelineTest : public DALITest {
 
 
     // CPU ops can only produce CPU outputs
-    ASSERT_THROW(
+    EXPECT_THROW(
       pipe.AddOperator(
         OpSpec("Copy")
           .AddArg("device", dev1)
@@ -232,7 +217,7 @@ TYPED_TEST_SUITE(PipelineTest, NumThreads);
 TEST_F(PipelineTestOnce, TestInputNotKnown) {
   Pipeline pipe(1, 1, 0);
 
-  ASSERT_THROW(
+  EXPECT_THROW(
       pipe.AddOperator(
           OpSpec("Copy")
           .AddArg("device", "cpu")
@@ -247,10 +232,6 @@ TEST_F(PipelineTestOnce, TestEnforceCPUOpConstraints) {
 
 TEST_F(PipelineTestOnce, TestEnforceGPUOpConstraints) {
   RunTestEnforce("gpu", "cpu");
-}
-
-TEST_F(PipelineTestOnce, TestTriggerToContiguous) {
-  RunTestTrigger("cpu");
 }
 
 TEST_F(PipelineTestOnce, TestTriggerCopyToDevice) {
@@ -565,7 +546,7 @@ class PrefetchedPipelineTest : public DALITest {
 TEST_F(PrefetchedPipelineTest, SetQueueSizesSeparatedFail) {
   Pipeline pipe(this->batch_size_, 4, 0);
   // By default we are non-separated execution
-  ASSERT_THROW(pipe.SetQueueSizes(5, 3), std::runtime_error);
+  EXPECT_THROW(pipe.SetQueueSizes(5, 3), std::runtime_error);
 }
 
 TEST_F(PrefetchedPipelineTest, SetExecutionTypesFailAfterBuild) {
@@ -578,7 +559,7 @@ TEST_F(PrefetchedPipelineTest, SetExecutionTypesFailAfterBuild) {
 
   vector<std::pair<string, string>> outputs = {{"final_images", "gpu"}};
   pipe.Build(outputs);
-  ASSERT_THROW(pipe.SetExecutionTypes(), std::runtime_error);
+  EXPECT_THROW(pipe.SetExecutionTypes(), std::runtime_error);
 }
 
 TEST_F(PrefetchedPipelineTest, SetQueueSizesFailAfterBuild) {
@@ -591,7 +572,7 @@ TEST_F(PrefetchedPipelineTest, SetQueueSizesFailAfterBuild) {
 
   vector<std::pair<string, string>> outputs = {{"final_images", "gpu"}};
   pipe.Build(outputs);
-  ASSERT_THROW(pipe.SetQueueSizes(2, 2), std::runtime_error);
+  EXPECT_THROW(pipe.SetQueueSizes(2, 2), std::runtime_error);
 }
 
 TEST_F(PrefetchedPipelineTest, TestFillQueues) {
@@ -713,7 +694,7 @@ TEST(PipelineTest, AddOperator) {
           .AddOutput("data_out1", "cpu"), "second_op", first_op);
   EXPECT_EQ(first_op, second_op);
 
-  ASSERT_THROW(pipe.AddOperator(OpSpec("Copy"), "another_op", first_op), std::runtime_error);
+  EXPECT_THROW(pipe.AddOperator(OpSpec("Copy"), "another_op", first_op), std::runtime_error);
 
   int third_op = pipe.AddOperator(OpSpec("DummyOpToAdd")
           .AddArg("device", "cpu")
@@ -728,7 +709,7 @@ TEST(PipelineTest, AddOperator) {
           .AddInput("data_in0", "cpu")
           .AddOutput("data_out3", "cpu"), "DummyOpNoSync");
 
-  ASSERT_THROW(pipe.AddOperator(OpSpec("DummyOpNoSync")
+  EXPECT_THROW(pipe.AddOperator(OpSpec("DummyOpNoSync")
           .AddArg("device", "cpu")
           .AddInput("data_in0", "cpu")
           .AddOutput("data_out4", "cpu"), "DummyOpNoSync2", disallow_sync_op), std::runtime_error);

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -524,7 +524,7 @@ def test_as_array():
             )
             return (output, self.labels)
 
-    for i in range(50):
+    for i in range(10):
         pipe = HybridPipe(batch_size=batch_size, num_threads=2, device_id=0)
         pipe.build()
         pipe_out = pipe.run()
@@ -636,7 +636,9 @@ def test_make_contiguous_serialize_and_use():
     new_pipe = Pipeline(batch_size=batch_size, num_threads=2, device_id=0)
     new_pipe.deserialize_and_build(serialized_pipeline)
 
-    compare_pipelines(pipe, new_pipe, batch_size, 50)
+    #compare_pipelines(pipe, new_pipe, batch_size, 50)
+    pipe.build()
+    pipe.run()
 
 
 def test_warpaffine():

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -636,9 +636,7 @@ def test_make_contiguous_serialize_and_use():
     new_pipe = Pipeline(batch_size=batch_size, num_threads=2, device_id=0)
     new_pipe.deserialize_and_build(serialized_pipeline)
 
-    #compare_pipelines(pipe, new_pipe, batch_size, 50)
-    pipe.build()
-    pipe.run()
+    compare_pipelines(pipe, new_pipe, batch_size, 10)
 
 
 def test_warpaffine():


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
* Remove MakeContiguous before CPU inputs of GPU ops. 
* Remove redundant (and dangerous) checks in workspace_policy.

Before the unification of TensorList it was necessary to insert a MakeContiguous operator between CPU and other backends because TensorVector needed to be converted to TensorList. It's no longer the case and the operation is superfluous.
The checks used a no-op function in workspace_policy now kicked in and created an invalid workspace - they are no longer necessary and were removed.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
test_pipeline.py - all of it
- [X] Existing tests apply
- [ ] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4030
<!--- DALI-XXXX or NA --->
