### PR TITLE
Remove usages of `std::call_once`.

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -222,14 +222,14 @@ inline std::unique_ptr<DALIPipeline> WrapPipeline(std::unique_ptr<dali::Pipeline
 
 
 void daliInitialize() {
-  static std::once_flag init_flag;
-  auto init = [&] {
-      dali::DALIInit(dali::OpSpec("CPUAllocator"),
-                     dali::OpSpec("PinnedCPUAllocator"),
-                     dali::OpSpec("GPUAllocator"));
-      dali_initialized = true;
-  };
-  std::call_once(init_flag, init);
+  static int init = []() {
+    dali::DALIInit(dali::OpSpec("CPUAllocator"),
+                    dali::OpSpec("PinnedCPUAllocator"),
+                    dali::OpSpec("GPUAllocator"));
+    dali_initialized = true;
+    return 0;
+  }();
+  (void)init;
 }
 
 

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -77,8 +77,6 @@ typedef daliPipelineHandle *daliPipelineHandle_t;
 
 namespace {
 
-bool dali_initialized = false;
-
 int PopCurrBatchSize(batch_size_map_t *batch_size_map, int max_batch_size,
                      const std::string &op_name) {
   auto it = batch_size_map->find(op_name);
@@ -224,9 +222,8 @@ inline std::unique_ptr<DALIPipeline> WrapPipeline(std::unique_ptr<dali::Pipeline
 void daliInitialize() {
   static int init = []() {
     dali::DALIInit(dali::OpSpec("CPUAllocator"),
-                    dali::OpSpec("PinnedCPUAllocator"),
-                    dali::OpSpec("GPUAllocator"));
-    dali_initialized = true;
+                   dali::OpSpec("PinnedCPUAllocator"),
+                   dali::OpSpec("GPUAllocator"));
     return 0;
   }();
   (void)init;

--- a/dali/core/call_once_test.cc
+++ b/dali/core/call_once_test.cc
@@ -1,0 +1,74 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <thread>
+#include <vector>
+#include "dali/core/call_once.h"
+
+namespace dali {
+
+TEST(CallOnce, CountCalls) {
+  dali::once_flag once;
+  std::atomic_int calls{0};
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 100; i++) {
+    threads.emplace_back([&]() {
+        dali::call_once(once, [&]() {
+            ++calls;
+        });
+    });
+  }
+  for (auto &t : threads)
+    t.join();
+  EXPECT_EQ(calls.load(), 1);
+}
+
+TEST(CallOnce, RetryOnThrow) {
+  dali::once_flag once;
+  std::atomic_int failures{0}, successes{0};
+
+  {
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 100; i++) {
+      threads.emplace_back([&]() {
+        EXPECT_THROW((dali::call_once(once, [&]() {
+            ++failures;
+            throw std::runtime_error("test");
+          })), std::runtime_error);
+      });
+    }
+    for (auto &t : threads)
+      t.join();
+  }
+  EXPECT_EQ(failures.load(), 100);
+
+  {
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 100; i++) {
+      threads.emplace_back([&]() {
+          dali::call_once(once, [&]() {
+              ++successes;
+          });
+      });
+    }
+    for (auto &t : threads)
+      t.join();
+  }
+
+  EXPECT_EQ(successes.load(), 1);
+}
+
+}  // namespace dali

--- a/dali/kernels/imgproc/resample/resampling_filters.cu
+++ b/dali/kernels/imgproc/resample/resampling_filters.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -170,12 +170,11 @@ std::shared_ptr<ResamplingFilters> GetResamplingFilters() {
 
 std::shared_ptr<ResamplingFilters> GetResamplingFiltersCPU() {
   (void)mm::GetDefaultResource<mm::memory_kind::host>();
-  static std::once_flag once;
-  static std::shared_ptr<ResamplingFilters> cpu_filters;
-  std::call_once(once, []() {
-    cpu_filters = std::make_shared<ResamplingFilters>();
-    InitFilters<mm::memory_kind::host>(*cpu_filters);
-  });
+  static std::shared_ptr<ResamplingFilters> cpu_filters = []() {
+    auto filters = std::make_shared<ResamplingFilters>();
+    InitFilters<mm::memory_kind::host>(*filters);
+    return filters;
+  }();
   return cpu_filters;
 }
 

--- a/dali/operators/image/resize/resampling_attr.cc
+++ b/dali/operators/image/resize/resampling_attr.cc
@@ -85,17 +85,6 @@ void ResamplingFilterAttr::PrepareFilterParams(
   bool has_antialias = spec.ArgumentDefined("antialias");
   antialias_ = spec.GetArgument<bool>("antialias");
 
-  if (!has_antialias) {  // antialias not provided explicitly
-    // ... and linear was selected explicitly
-    auto is_linear_default = [](span<const DALIInterpType> interp_types) -> bool {
-      for (auto &interp_type : interp_types) {
-        if (interp_type == DALI_INTERP_LINEAR)
-          return true;
-      }
-      return false;
-    };
-  }
-
   min_filter_.resize(num_samples, ResamplingFilterType::Triangular);
   mag_filter_.resize(num_samples, ResamplingFilterType::Linear);
 

--- a/dali/operators/image/resize/resampling_attr.cc
+++ b/dali/operators/image/resize/resampling_attr.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #include "dali/operators/image/resize/resampling_attr.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/core/span.h"
+#include "dali/core/call_once.h"
 
 namespace dali {
 
@@ -93,16 +94,6 @@ void ResamplingFilterAttr::PrepareFilterParams(
       }
       return false;
     };
-    if ((has_min && is_linear_default(make_cspan(min_arg_))) ||
-        (has_interp && is_linear_default(make_cspan(interp_type_arg_)))) {
-      static std::once_flag linear_default_warning_flag;
-      std::call_once(linear_default_warning_flag, [&]() {
-        DALI_WARN(
-            "The default behavior for LINEAR interpolation type has been changed to apply an "
-            "antialiasing filter. If you didn't mean to apply an antialiasing filter, please use "
-            "`antialias=False`");
-      });
-    }
   }
 
   min_filter_.resize(num_samples, ResamplingFilterType::Triangular);

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -28,6 +28,7 @@
 #include <atomic>
 #include <unordered_set>
 
+#include "dali/core/call_once.h"
 #include "dali/core/nvtx.h"
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
@@ -469,7 +470,7 @@ class Loader {
     // Fetch image cache factory only the first time that we try to load an image
     // we don't do it in construction because we are not sure that the cache was
     // created since the order of operator creation is not guaranteed.
-    std::call_once(fetch_cache_, [this](){
+    dali::call_once(fetch_cache_, [this](){
       auto &image_cache_factory = ImageCacheFactory::Instance();
       if (image_cache_factory.IsInitialized(device_id_))
         cache_ = image_cache_factory.Get(device_id_);
@@ -553,7 +554,7 @@ class Loader {
   bool loading_flag_;
 
   // Image cache
-  std::once_flag fetch_cache_;
+  dali::once_flag fetch_cache_;
   std::shared_ptr<ImageCache> cache_;
 
   // Counts how many samples the reader have read returned in the current epoch (including padding)

--- a/dali/operators/reader/loader/webdataset_loader.cc
+++ b/dali/operators/reader/loader/webdataset_loader.cc
@@ -25,6 +25,7 @@
 #include "dali/operators/reader/loader/webdataset/tar_utils.h"
 #include "dali/pipeline/data/types.h"
 #include "dali/util/uri.h"
+#include "dali/core/call_once.h"
 
 namespace dali {
 
@@ -447,7 +448,7 @@ void WebdatasetLoader::PrepareMetadataImpl() {
             component.outputs.num++;
             was_output_set[output] = true;
           } else {
-            std::call_once(multiple_files_single_component, [&]() {
+            dali::call_once(multiple_files_single_component, [&]() {
               DALI_WARN(make_string("Multiple components matching output ", output, " at ",
                                     GetSampleSource(new_sample), "."));
             });

--- a/dali/operators/reader/loader/webdataset_loader.h
+++ b/dali/operators/reader/loader/webdataset_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include "dali/core/call_once.h"
 #include "dali/core/bitmask.h"
 #include "dali/operators/reader/loader/loader.h"
 #include "dali/pipeline/data/tensor.h"
@@ -117,7 +118,7 @@ class DLL_PUBLIC WebdatasetLoader : public Loader<CPUBackend, vector<Tensor<CPUB
   std::vector<std::unique_ptr<FileStream>> wds_shards_;
   size_t sample_index_ = 0;
   FileStream::MappingReserver mmap_reserver_;
-  std::once_flag multiple_files_single_component;
+  dali::once_flag multiple_files_single_component;
 
   bool generate_index_ = true;
   std::string GetSampleSource(const detail::wds::SampleDesc& sample);

--- a/dali/operators/sequence/optical_flow/optical_flow.h
+++ b/dali/operators/sequence/optical_flow/optical_flow.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,18 +145,11 @@ class OpticalFlow : public StatelessOperator<Backend> {
    */
   void of_lazy_init(size_t width, size_t height, size_t channels, DALIImageType image_type,
                     int device_id, cudaStream_t stream) {
-    std::call_once(of_initialized_,
-                   [&]() {
-                       optical_flow_.reset(
-                               new optical_flow::OpticalFlowImpl(of_params_,
-                                                                 width,
-                                                                 height,
-                                                                 channels,
-                                                                 image_type,
-                                                                 device_id,
-                                                                 stream));
-                        optical_flow_->Init(of_params_);
-                   });
+    if (!optical_flow_) {
+      optical_flow_ = std::make_unique<optical_flow::OpticalFlowImpl>(
+        of_params_, width, height, channels, image_type, device_id, stream);
+      optical_flow_->Init(of_params_);
+    }
   }
 
   /**
@@ -217,7 +210,6 @@ class OpticalFlow : public StatelessOperator<Backend> {
   const int hint_grid_size_;
   const bool enable_temporal_hints_;
   const bool enable_external_hints_;
-  std::once_flag of_initialized_;
   optical_flow::OpticalFlowParams of_params_;
   std::unique_ptr<optical_flow::OpticalFlowAdapter<ComputeBackend>> optical_flow_;
   DALIImageType image_type_;

--- a/dali/operators/sequence/optical_flow/optical_flow.h
+++ b/dali/operators/sequence/optical_flow/optical_flow.h
@@ -64,8 +64,6 @@ class OpticalFlow : public StatelessOperator<Backend> {
         enable_external_hints_(spec.GetArgument<bool>(detail::kEnableExternalHintsArgName)),
         of_params_({quality_factor_, out_grid_size_, hint_grid_size_, enable_temporal_hints_,
                     enable_external_hints_}),
-        optical_flow_(std::unique_ptr<optical_flow::OpticalFlowAdapter<ComputeBackend>>(
-            new optical_flow::OpticalFlowStub<ComputeBackend>(of_params_))),
         image_type_(spec.GetArgument<DALIImageType>(detail::kImageTypeArgName)),
         device_id_(spec.GetArgument<int>("device_id")) {
     // In case external hints are enabled, we need 2 inputs

--- a/dali/test/dali_test_config.cc
+++ b/dali/test/dali_test_config.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,9 +33,7 @@ const std::string &dali_extra_path() {
   //      There's a "leak" here, but we don't really care about it.
   static std::string *_dali_extra_path = new std::string();
 
-  static std::once_flag noninit_warning;
-
-  std::call_once(noninit_warning, []() {
+  static int noninit_warning = []() {
       auto ptr = std::getenv("DALI_EXTRA_PATH");
       if (!ptr) {
         std::cerr << "WARNING: DALI_EXTRA_PATH not initialized." << std::endl;
@@ -51,7 +49,7 @@ const std::string &dali_extra_path() {
         std::cerr << "WARNING: Could not read the sha of DALI_extra at " << *_dali_extra_path
                   << ". Make sure DALI_EXTRA is checked out to " << DALI_EXTRA_VERSION
                   << " so the test data is in the required version." << std::endl;
-        return;
+        return 0;
       }
       auto count = fread(hash, sizeof(hash[0]), kHashLen, pipe);
       // hash is kHashLen + 1
@@ -61,7 +59,7 @@ const std::string &dali_extra_path() {
         std::cerr << "WARNING: Could not read the sha of DALI_extra at " << *_dali_extra_path
                   << ". Make sure DALI_EXTRA is checked out to " << DALI_EXTRA_VERSION
                   << " so the test data is in the required version." << std::endl;
-        return;
+        return 0;
       }
       if (strncmp(DALI_EXTRA_VERSION, hash, kHashLen) != 0) {
         std::cerr << "WARNING: DALI_extra at " << *_dali_extra_path
@@ -69,7 +67,8 @@ const std::string &dali_extra_path() {
                      "fail to run or produce incorrect results.\nVersion required: "
                   << DALI_EXTRA_VERSION << "\nVersion found: " << hash << std::endl;
       }
-  });
+      return 0;
+  }();
   return *_dali_extra_path;
 }
 

--- a/dali/util/numpy.cc
+++ b/dali/util/numpy.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -161,14 +161,14 @@ void ParseHeaderContents(HeaderData& target, const std::string &header) {
 void CheckNpyVersion(char *token) {
   int api_version = token[6];
   if (api_version != 1) {
-    static std::once_flag unrecognized_version;
-    std::call_once(unrecognized_version, [&]() {
+    static int unrecognized_version = [&]() {
       std::string actual_version =
           (api_version == 2 || api_version == 3) ? "higher" : "unrecognized";
       DALI_WARN(make_string(
           "Expected file in NPY file format version 1. The provided file uses ", actual_version,
           " version. Please note, DALI does not support structured NumPy arrays."));
-    });
+      return 0;
+    }();
   }
 }
 

--- a/dali/util/s3_client_manager.h
+++ b/dali/util/s3_client_manager.h
@@ -33,7 +33,7 @@ struct S3ClientManager {
     static int init = [&]() {
       RunInitOrShutdown([&](int) { Aws::InitAPI(Aws::SDKOptions{}); });
       return 0;
-    })();
+    }();
     // We want RunInitOrShutdown s_thread_pool_ to outlive s_manager_
     static S3ClientManager s_manager_;
     return s_manager_;

--- a/dali/util/s3_client_manager.h
+++ b/dali/util/s3_client_manager.h
@@ -30,10 +30,10 @@ namespace dali {
 struct S3ClientManager {
  public:
   static S3ClientManager& Instance() {
-    static std::once_flag once;
-    std::call_once(once, []() {
+    static int init = [&]() {
       RunInitOrShutdown([&](int) { Aws::InitAPI(Aws::SDKOptions{}); });
-    });
+      return 0;
+    })();
     // We want RunInitOrShutdown s_thread_pool_ to outlive s_manager_
     static S3ClientManager s_manager_;
     return s_manager_;

--- a/include/dali/core/call_once.h
+++ b/include/dali/core/call_once.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_CALL_ONCE_H_
+#define DALI_CORE_CALL_ONCE_H_
+
+#include <mutex>
+#include <atomic>
+
+namespace dali {
+
+class once_flag {
+ public:
+  template <typename Callable>
+  friend void call_once(once_flag &flag, Callable &&callable);
+
+ private:
+  bool was_called = false;
+  std::mutex m;
+};
+
+/** Workaround for glibc bug 78184
+ *
+ * std::call_once hangs on second attempt when the first one throws
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78184
+ */
+template <typename Callable>
+void call_once(once_flag &flag, Callable &&callable) {
+  if (!flag.was_called) {
+    std::lock_guard g(flag.m);
+    if (flag.was_called)
+      return;
+    callable();  // if this throws, there will be another attempt
+    flag.was_called = true;
+  }
+}
+
+}  // namespace dali
+
+#endif  // DALI_CORE_CALL_ONCE_H_


### PR DESCRIPTION
## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
Workaround for a library bug.

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78184

`std::call_once` has a bug in some versions of glibc. A custom implementation has been provided.
Usages with static once_flag have been replaced with "magic statics". Optical flow doesn't need atomicity and the once semantics were not required at all.
Other usages use the custom implementation.

A stale warning about antialiasing (also guarded with call once) was removed.

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
