### PR TITLE
Fixes problems with fetching LFS objects during nvImageCodec conda build

### DIFF
--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -61,7 +61,16 @@ conda mambabuild ${CONDA_BUILD_OPTIONS} third_party/dali_opencv/recipe
 conda mambabuild ${CONDA_BUILD_OPTIONS} third_party/dali_ffmpeg/recipe
 
 # Build nvimagecodec
+# conda does bare mirror first and then clones the code to the build dir
+# it also fetches the LFS object, but it does that only for the built reference, if there are
+# other objects they are left out. Then it does the full cone and checkout and that is why it
+# complains about missing objects. Also, it doesn't allow running any post-clone hooks.
+# see https://github.com/conda/conda-build/issues/1462
+export GIT_LFS_SKIP_SMUDGE=1
+export GIT_CLONE_PROTECTION_ACTIVE=false
 conda mambabuild ${CONDA_BUILD_OPTIONS} third_party/dali_nvimagecodec/recipe
+export GIT_LFS_SKIP_SMUDGE=0
+export GIT_CLONE_PROTECTION_ACTIVE=true
 
 # Building DALI core package
 conda mambabuild ${CONDA_BUILD_OPTIONS} dali_native_libs/recipe


### PR DESCRIPTION
- conda does bare mirror first and then clones the code to the build dir
  it also fetches the LFS object, but it does that only for the built reference, if there are
  other objects they are left out. Then it does the full cone and checkout and that is why it
  complains about missing objects. Also, it doesn't allow running any post-clone hooks.
  see https://github.com/conda/conda-build/issues/1462

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- conda does bare mirror first and then clones the code to the build dir
  it also fetches the LFS object, but it does that only for the built reference, if there are
  other objects they are left out. Then it does the full cone and checkout and that is why it
  complains about missing objects. Also, it doesn't allow running any post-clone hooks.
  see https://github.com/conda/conda-build/issues/1462
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- conda build of nvImageCodec
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - conda build
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
