### PR TITLE
Fix null arg input access

### DIFF
--- a/dali/pipeline/executor/executor2/exec_node_task.cc
+++ b/dali/pipeline/executor/executor2/exec_node_task.cc
@@ -507,9 +507,9 @@ void ClearWorkspacePayload(Workspace &ws) {
   }
 
   for (int i = 0; i < ws.NumArgumentInput(); i++) {
-    auto &inp = ws.ArgumentInput(i);
-    if (inp.is_pinned() && event && inp.order() != ws.output_order())
-      inp.order().wait(event);
+    auto &inp = ws.ArgumentInputPtr(i);
+    if (inp && inp->is_pinned() && event && inp->order() != ws.output_order())
+      inp->order().wait(event);
     ws.SetArgumentInput(i, nullptr);
   }
 

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -15,6 +15,7 @@
 #ifndef DALI_PIPELINE_WORKSPACE_WORKSPACE_H_
 #define DALI_PIPELINE_WORKSPACE_WORKSPACE_H_
 
+#include <cassert>
 #include <vector>
 #include <utility>
 #include <memory>
@@ -74,6 +75,7 @@ class ArgumentWorkspace {
   const TensorList<CPUBackend>& ArgumentInput(const std::string &arg_name) const {
     auto it = argument_input_idxs_.find(arg_name);
     DALI_ENFORCE(it != argument_input_idxs_.end(), "Argument \"" + arg_name + "\" not found.");
+    assert(argument_inputs_[it->second].cpu);
     return *argument_inputs_[it->second].cpu;
   }
 
@@ -82,9 +84,15 @@ class ArgumentWorkspace {
     return argument_inputs_[idx].name;
   }
 
-  const TensorList<CPUBackend>& ArgumentInput(int idx) const {
+  const TensorList<CPUBackend> &ArgumentInput(int idx) const {
     DALI_ENFORCE_VALID_INDEX(idx, NumArgumentInput());
+    assert(argument_inputs_[idx].cpu);
     return *argument_inputs_[idx].cpu;
+  }
+
+  const std::shared_ptr<TensorList<CPUBackend>> ArgumentInputPtr(int idx) const {
+    DALI_ENFORCE_VALID_INDEX(idx, NumArgumentInput());
+    return argument_inputs_[idx].cpu;
   }
 
   std::shared_ptr<TensorList<CPUBackend>>&


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
`ClearWorkspacePayload` can iterate over argument inputs in an incomplete workspace, resulting, in some cases, in a NULL pointer dereference. This PR adds an ArgumentInputPtr function which can be used to safely determine whether the input is null and it also adds assertions to normal access functions.

## Additional information:

### Affected modules and functionalities:
New executor (use pointer instead of reference and check whether it's null).
Workspace (asserts, one new function).


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Covered by future PR #5528.
Regressions covered by executor2/*test

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
