### PR TITLE
Fix multiple initialization attempts in optical flow operator.

### DIFF
--- a/dali/operators/sequence/optical_flow/optical_flow.h
+++ b/dali/operators/sequence/optical_flow/optical_flow.h
@@ -144,9 +144,10 @@ class OpticalFlow : public StatelessOperator<Backend> {
   void of_lazy_init(size_t width, size_t height, size_t channels, DALIImageType image_type,
                     int device_id, cudaStream_t stream) {
     if (!optical_flow_) {
-      optical_flow_ = std::make_unique<optical_flow::OpticalFlowImpl>(
+      auto flow = std::make_unique<optical_flow::OpticalFlowImpl>(
         of_params_, width, height, channels, image_type, device_id, stream);
-      optical_flow_->Init(of_params_);
+      flow->Init(of_params_);
+      optical_flow_ = std::move(flow);
     }
   }
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
If the `optical_flow_->Init()` failed, the object was left in an inconsistent state (the `optical_flow_` was set, but not properly initialized). This PR uses a local variable to call `Init` and only sets the member once the initialization is complete.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
`test_optical_flow.test_wrong_out_grid_size`
The test only triggers the problem with the new executor (#5528)

- [X] Existing tests apply
- [ ] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
