### PR TITLE
Adds `enable_frame_num` to the experimental video reader

### DIFF
--- a/dali/operators/reader/loader/video/video_loader_decoder_base.h
+++ b/dali/operators/reader/loader/video/video_loader_decoder_base.h
@@ -47,7 +47,7 @@ class VideoLoaderDecoderBase {
     stride_(spec.GetArgument<int>("stride")),
     step_(spec.GetArgument<int>("step")) {
     has_labels_ = spec.TryGetRepeatedArgument(labels_, "labels");
-    has_frame_no_ = spec.GetArgument<bool>("enable_frame_num");
+    has_frame_idx_ = spec.GetArgument<bool>("enable_frame_num");
     DALI_ENFORCE(
         !has_labels_ || labels_.size() == filenames_.size(),
         make_string(
@@ -63,7 +63,7 @@ class VideoLoaderDecoderBase {
   std::vector<std::string> filenames_;
   std::vector<int> labels_;
   bool has_labels_ = false;
-  bool has_frame_no_ = false;
+  bool has_frame_idx_ = false;
 
   Index current_index_ = 0;
 

--- a/dali/operators/reader/loader/video/video_loader_decoder_base.h
+++ b/dali/operators/reader/loader/video/video_loader_decoder_base.h
@@ -35,8 +35,8 @@ template <typename Backend>
 class VideoSample {
  public:
   Tensor<Backend> data_;
-  int label_;
-  int first_frame_;
+  int label_ = -1;
+  int first_frame_ = -1;
 };
 
 class VideoLoaderDecoderBase {

--- a/dali/operators/reader/loader/video/video_loader_decoder_base.h
+++ b/dali/operators/reader/loader/video/video_loader_decoder_base.h
@@ -36,6 +36,7 @@ class VideoSample {
  public:
   Tensor<Backend> data_;
   int label_;
+  int first_frame_;
 };
 
 class VideoLoaderDecoderBase {
@@ -46,6 +47,7 @@ class VideoLoaderDecoderBase {
     stride_(spec.GetArgument<int>("stride")),
     step_(spec.GetArgument<int>("step")) {
     has_labels_ = spec.TryGetRepeatedArgument(labels_, "labels");
+    has_frame_no_ = spec.GetArgument<bool>("enable_frame_num");
     DALI_ENFORCE(
         !has_labels_ || labels_.size() == filenames_.size(),
         make_string(
@@ -61,6 +63,7 @@ class VideoLoaderDecoderBase {
   std::vector<std::string> filenames_;
   std::vector<int> labels_;
   bool has_labels_ = false;
+  bool has_frame_no_ = false;
 
   Index current_index_ = 0;
 

--- a/dali/operators/reader/loader/video/video_loader_decoder_cpu.cc
+++ b/dali/operators/reader/loader/video/video_loader_decoder_cpu.cc
@@ -45,6 +45,9 @@ void VideoLoaderDecoderCpu::ReadSample(VideoSample<CPUBackend> &sample) {
   if (has_labels_) {
     sample.label_ = labels_[sample_span.video_idx_];
   }
+  if (has_frame_no_) {
+    sample.first_frame_ = sample_span.start_;
+  }
 }
 
 Index VideoLoaderDecoderCpu::SizeImpl() {

--- a/dali/operators/reader/loader/video/video_loader_decoder_cpu.cc
+++ b/dali/operators/reader/loader/video/video_loader_decoder_cpu.cc
@@ -45,7 +45,7 @@ void VideoLoaderDecoderCpu::ReadSample(VideoSample<CPUBackend> &sample) {
   if (has_labels_) {
     sample.label_ = labels_[sample_span.video_idx_];
   }
-  if (has_frame_no_) {
+  if (has_frame_idx_) {
     sample.first_frame_ = sample_span.start_;
   }
 }

--- a/dali/operators/reader/video_reader_decoder_cpu_op.cc
+++ b/dali/operators/reader/video_reader_decoder_cpu_op.cc
@@ -50,11 +50,9 @@ void VideoReaderDecoderCpu::RunImpl(SampleWorkspace &ws) {
 
 namespace detail {
 inline int VideoReaderDecoderOutputFn(const OpSpec &spec) {
-  int num_outputs = 1;
-  if (spec.HasArgument("labels")) num_outputs++;
-  bool enable_frame_num = spec.GetArgument<bool>("enable_frame_num");
-  if (enable_frame_num) num_outputs++;
-  return num_outputs;
+  bool has_labels = spec.HasArgument("labels")
+  bool has_frame_num_output  = spec.GetArgument<bool>("enable_frame_num");
+  return 1 + has_labels + has_frame_num_output;
 }
 }  // namespace detail
 
@@ -82,8 +80,8 @@ even in the variable frame rate scenario.)code")
       R"code(Frames to load per sequence.)code",
       DALI_INT32)
   .AddOptionalArg("enable_frame_num",
-      R"code(If set, returns the first frame number in the decoded sequence
-as a separate output.)code",
+      R"code(If set, returns the index of the first frame in the decoded sequence
+as an additional output.)code",
       false)
   .AddOptionalArg("step",
       R"code(Frame interval between each sequence.

--- a/dali/operators/reader/video_reader_decoder_cpu_op.cc
+++ b/dali/operators/reader/video_reader_decoder_cpu_op.cc
@@ -21,7 +21,7 @@ namespace dali {
 VideoReaderDecoderCpu::VideoReaderDecoderCpu(const OpSpec &spec)
     : DataReader<CPUBackend, VideoSampleCpu, VideoSampleCpu, true>(spec),
       has_labels_(spec.HasArgument("labels")),
-      has_frame_no_(spec.GetArgument<bool>("enable_frame_num")) {
+      has_frame_idx_(spec.GetArgument<bool>("enable_frame_num")) {
       loader_ = InitLoader<VideoLoaderDecoderCpu>(spec);
       this->SetInitialSnapshot();
 }
@@ -40,10 +40,10 @@ void VideoReaderDecoderCpu::RunImpl(SampleWorkspace &ws) {
     label_output.mutable_data<int>()[0] = sample.label_;
     out_index++;
   }
-  if (has_frame_no_) {
-    auto &frame_no_output = ws.Output<CPUBackend>(out_index);
-    frame_no_output.Resize({}, DALIDataType::DALI_INT32);
-    frame_no_output.mutable_data<int>()[0] = sample.first_frame_;
+  if (has_frame_idx_) {
+    auto &frame_idx_output = ws.Output<CPUBackend>(out_index);
+    frame_idx_output.Resize({}, DALIDataType::DALI_INT32);
+    frame_idx_output.mutable_data<int>()[0] = sample.first_frame_;
     out_index++;
   }
 }

--- a/dali/operators/reader/video_reader_decoder_cpu_op.cc
+++ b/dali/operators/reader/video_reader_decoder_cpu_op.cc
@@ -50,7 +50,7 @@ void VideoReaderDecoderCpu::RunImpl(SampleWorkspace &ws) {
 
 namespace detail {
 inline int VideoReaderDecoderOutputFn(const OpSpec &spec) {
-  bool has_labels = spec.HasArgument("labels")
+  bool has_labels = spec.HasArgument("labels");
   bool has_frame_num_output  = spec.GetArgument<bool>("enable_frame_num");
   return 1 + has_labels + has_frame_num_output;
 }

--- a/dali/operators/reader/video_reader_decoder_cpu_op.h
+++ b/dali/operators/reader/video_reader_decoder_cpu_op.h
@@ -29,6 +29,7 @@ class VideoReaderDecoderCpu
 
  private:
   bool has_labels_ = false;
+  bool has_frame_no_ = false;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/video_reader_decoder_cpu_op.h
+++ b/dali/operators/reader/video_reader_decoder_cpu_op.h
@@ -29,7 +29,7 @@ class VideoReaderDecoderCpu
 
  private:
   bool has_labels_ = false;
-  bool has_frame_no_ = false;
+  bool has_frame_idx_ = false;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/video_reader_decoder_gpu_op.cc
+++ b/dali/operators/reader/video_reader_decoder_gpu_op.cc
@@ -106,17 +106,17 @@ void VideoReaderDecoderGpu::RunImpl(Workspace &ws) {
     out_index++;
   }
   if (has_frame_idx_) {
-    auto &frame_no_output = ws.Output<GPUBackend>(out_index);
-    SmallVector<int, 32> frame_no_output_cpu;
+    auto &frame_idx_output = ws.Output<GPUBackend>(out_index);
+    SmallVector<int, 32> frame_idx_output_cpu;
 
     for (int sample_id = 0; sample_id < batch_size; ++sample_id) {
       auto &sample = GetSample(sample_id);
-      frame_no_output_cpu[sample_id] = sample.span_ ? sample.span_->start_ : -1;
+      frame_idx_output_cpu[sample_id] = sample.span_ ? sample.span_->start_ : -1;
     }
 
     MemCopy(
-      frame_no_output.AsTensor().raw_mutable_data(),
-      frame_no_output_cpu.data(),
+      frame_idx_output.AsTensor().raw_mutable_data(),
+      frame_idx_output_cpu.data(),
       batch_size * sizeof(DALI_INT32),
       ws.stream());
     out_index++;

--- a/dali/operators/reader/video_reader_decoder_gpu_op.cc
+++ b/dali/operators/reader/video_reader_decoder_gpu_op.cc
@@ -21,7 +21,7 @@ namespace dali {
 VideoReaderDecoderGpu::VideoReaderDecoderGpu(const OpSpec &spec)
     : DataReader<GPUBackend, VideoSampleGpu, VideoSampleGpu, true>(spec),
       has_labels_(spec.HasArgument("labels")),
-      has_frame_no_(spec.GetArgument<bool>("enable_frame_num")) {
+      has_frame_idx_(spec.GetArgument<bool>("enable_frame_num")) {
       loader_ = InitLoader<VideoLoaderDecoderGpu>(spec);
       this->SetInitialSnapshot();
 }
@@ -59,7 +59,7 @@ bool VideoReaderDecoderGpu::SetupImpl(
     };
     out_index++;
   }
-  if (has_frame_no_) {
+  if (has_frame_idx_) {
     output_desc[out_index] = {
       uniform_list_shape<1>(batch_size, {1}),
       DALI_INT32
@@ -105,7 +105,7 @@ void VideoReaderDecoderGpu::RunImpl(Workspace &ws) {
       ws.stream());
     out_index++;
   }
-  if (has_frame_no_) {
+  if (has_frame_idx_) {
     auto &frame_no_output = ws.Output<GPUBackend>(out_index);
     SmallVector<int, 32> frame_no_output_cpu;
 

--- a/dali/operators/reader/video_reader_decoder_gpu_op.h
+++ b/dali/operators/reader/video_reader_decoder_gpu_op.h
@@ -35,6 +35,7 @@ class VideoReaderDecoderGpu : public DataReader<GPUBackend, VideoSampleGpu, Vide
 
  private:
   bool has_labels_ = false;
+  bool has_frame_no_ = false;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/video_reader_decoder_gpu_op.h
+++ b/dali/operators/reader/video_reader_decoder_gpu_op.h
@@ -35,7 +35,7 @@ class VideoReaderDecoderGpu : public DataReader<GPUBackend, VideoSampleGpu, Vide
 
  private:
   bool has_labels_ = false;
-  bool has_frame_no_ = false;
+  bool has_frame_idx_  = false;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/video_reader_decoder_op_test.cc
+++ b/dali/operators/reader/video_reader_decoder_op_test.cc
@@ -40,6 +40,9 @@ class VideoReaderDecoderBaseTest : public VideoTestBase {
   virtual void AssertFrame(
     int frame_id, const uint8_t *frame, TestVideo &ground_truth) = 0;
 
+  template<typename Backend>
+  int GetFrameNo(dali::TensorList<Backend> &device_frame_no);
+
  private:
   template<typename Backend>
   void RunTestImpl(
@@ -129,15 +132,15 @@ class VideoReaderDecoderBaseTest : public VideoTestBase {
       .AddArg("device", backend)
       .AddArg("sequence_length", sequence_length)
       .AddArg("random_shuffle", true)
+      .AddArg("enable_frame_num", true)
       .AddArg("initial_fill", cfr_videos_[0].NumFrames())
       .AddArg(
         "filenames",
         std::vector<std::string>{cfr_videos_paths_[0]})
-      .AddOutput("frames", backend));
+      .AddOutput("frames", backend)
+      .AddOutput("frame_no", backend));
 
-    pipe.Build({{"frames", backend}});
-
-    std::vector<int> expected_order = {29, 46, 33, 6, 37};
+    pipe.Build({{"frames", backend}, {"frame_no", backend}});
 
     int num_sequences = 5;
 
@@ -148,9 +151,10 @@ class VideoReaderDecoderBaseTest : public VideoTestBase {
 
       auto &frame_video_output = ws.Output<Backend>(0);
       const auto sample = frame_video_output.template tensor<uint8_t>(0);
+      int frame_no = GetFrameNo(ws.Output<Backend>(1));
 
-      // We want to access correct order, so we comapre only the first frame of the sequence
-      AssertFrame(expected_order[sequence_id], sample, ground_truth_video);
+      // We want to access correct order, so we compare only the first frame of the sequence
+      AssertFrame(frame_no, sample, ground_truth_video);
     }
   }
 };
@@ -169,6 +173,15 @@ void VideoReaderDecoderBaseTest::RunShuffleTest<dali::CPUBackend>() {
 }
 
 template<>
+int VideoReaderDecoderBaseTest::GetFrameNo(
+  dali::TensorList<dali::CPUBackend> &device_frame_no) {
+    const auto frame_no = device_frame_no.template tensor<int>(0);
+    int frame_no_buffer = -1;
+    std::copy_n(frame_no, 1, &frame_no_buffer);
+    return frame_no_buffer;
+}
+
+template<>
 void VideoReaderDecoderBaseTest::RunTest<dali::GPUBackend>(
   std::vector<std::string> &videos_paths,
   std::vector<TestVideo> &ground_truth_videos) {
@@ -179,6 +192,15 @@ void VideoReaderDecoderBaseTest::RunTest<dali::GPUBackend>(
 template<>
 void VideoReaderDecoderBaseTest::RunShuffleTest<dali::GPUBackend>() {
     RunShuffleTestImpl<dali::GPUBackend>("gpu", 0);
+}
+
+template<>
+int VideoReaderDecoderBaseTest::GetFrameNo(
+  dali::TensorList<dali::GPUBackend> &device_frame_no) {
+    const auto frame_no = device_frame_no.template tensor<int>(0);
+    int frame_no_buffer = -1;
+    MemCopy(&frame_no_buffer, frame_no, sizeof(int));
+    return frame_no_buffer;
 }
 
 class VideoReaderDecoderCpuTest : public VideoReaderDecoderBaseTest {

--- a/dali/operators/reader/video_reader_decoder_op_test.cc
+++ b/dali/operators/reader/video_reader_decoder_op_test.cc
@@ -41,7 +41,7 @@ class VideoReaderDecoderBaseTest : public VideoTestBase {
     int frame_id, const uint8_t *frame, TestVideo &ground_truth) = 0;
 
   template<typename Backend>
-  int GetFrameNo(dali::TensorList<Backend> &device_frame_no);
+  int GetFrameIdx(dali::TensorList<Backend> &device_frame_idx);
 
  private:
   template<typename Backend>
@@ -151,7 +151,7 @@ class VideoReaderDecoderBaseTest : public VideoTestBase {
 
       auto &frame_video_output = ws.Output<Backend>(0);
       const auto sample = frame_video_output.template tensor<uint8_t>(0);
-      int frame_no = GetFrameNo(ws.Output<Backend>(1));
+      int frame_no = GetFrameIdx(ws.Output<Backend>(1));
 
       // We want to access correct order, so we compare only the first frame of the sequence
       AssertFrame(frame_no, sample, ground_truth_video);
@@ -173,9 +173,9 @@ void VideoReaderDecoderBaseTest::RunShuffleTest<dali::CPUBackend>() {
 }
 
 template<>
-int VideoReaderDecoderBaseTest::GetFrameNo(
-  dali::TensorList<dali::CPUBackend> &device_frame_no) {
-    const auto frame_no = device_frame_no.template tensor<int>(0);
+int VideoReaderDecoderBaseTest::GetFrameIdx(
+  dali::TensorList<dali::CPUBackend> &device_frame_idx) {
+    const auto frame_no = device_frame_idx.template tensor<int>(0);
     int frame_no_buffer = -1;
     std::copy_n(frame_no, 1, &frame_no_buffer);
     return frame_no_buffer;
@@ -195,9 +195,9 @@ void VideoReaderDecoderBaseTest::RunShuffleTest<dali::GPUBackend>() {
 }
 
 template<>
-int VideoReaderDecoderBaseTest::GetFrameNo(
-  dali::TensorList<dali::GPUBackend> &device_frame_no) {
-    const auto frame_no = device_frame_no.template tensor<int>(0);
+int VideoReaderDecoderBaseTest::GetFrameIdx(
+  dali::TensorList<dali::GPUBackend> &device_frame_idx) {
+    const auto frame_no = device_frame_idx.template tensor<int>(0);
     int frame_no_buffer = -1;
     MemCopy(&frame_no_buffer, frame_no, sizeof(int));
     return frame_no_buffer;

--- a/dali/operators/reader/video_reader_decoder_op_test.cc
+++ b/dali/operators/reader/video_reader_decoder_op_test.cc
@@ -138,9 +138,9 @@ class VideoReaderDecoderBaseTest : public VideoTestBase {
         "filenames",
         std::vector<std::string>{cfr_videos_paths_[0]})
       .AddOutput("frames", backend)
-      .AddOutput("frame_no", backend));
+      .AddOutput("frame_idx", backend));
 
-    pipe.Build({{"frames", backend}, {"frame_no", backend}});
+    pipe.Build({{"frames", backend}, {"frame_idx", backend}});
 
     int num_sequences = 5;
 
@@ -151,10 +151,10 @@ class VideoReaderDecoderBaseTest : public VideoTestBase {
 
       auto &frame_video_output = ws.Output<Backend>(0);
       const auto sample = frame_video_output.template tensor<uint8_t>(0);
-      int frame_no = GetFrameIdx(ws.Output<Backend>(1));
+      int frame_idx = GetFrameIdx(ws.Output<Backend>(1));
 
       // We want to access correct order, so we compare only the first frame of the sequence
-      AssertFrame(frame_no, sample, ground_truth_video);
+      AssertFrame(frame_idx, sample, ground_truth_video);
     }
   }
 };
@@ -175,10 +175,10 @@ void VideoReaderDecoderBaseTest::RunShuffleTest<dali::CPUBackend>() {
 template<>
 int VideoReaderDecoderBaseTest::GetFrameIdx(
   dali::TensorList<dali::CPUBackend> &device_frame_idx) {
-    const auto frame_no = device_frame_idx.template tensor<int>(0);
-    int frame_no_buffer = -1;
-    std::copy_n(frame_no, 1, &frame_no_buffer);
-    return frame_no_buffer;
+    const auto frame_idx = device_frame_idx.template tensor<int>(0);
+    int frame_idx_buffer = -1;
+    std::copy_n(frame_idx, 1, &frame_idx_buffer);
+    return frame_idx_buffer;
 }
 
 template<>
@@ -197,10 +197,10 @@ void VideoReaderDecoderBaseTest::RunShuffleTest<dali::GPUBackend>() {
 template<>
 int VideoReaderDecoderBaseTest::GetFrameIdx(
   dali::TensorList<dali::GPUBackend> &device_frame_idx) {
-    const auto frame_no = device_frame_idx.template tensor<int>(0);
-    int frame_no_buffer = -1;
-    MemCopy(&frame_no_buffer, frame_no, sizeof(int));
-    return frame_no_buffer;
+    const auto frame_idx = device_frame_idx.template tensor<int>(0);
+    int frame_idx_buffer = -1;
+    MemCopy(&frame_idx_buffer, frame_idx, sizeof(int));
+    return frame_idx_buffer;
 }
 
 class VideoReaderDecoderCpuTest : public VideoReaderDecoderBaseTest {


### PR DESCRIPTION
- adds an ability to output frame numbers in the experimental video
  reader
- this allows making VideoReaderDecoderCpuTest.RandomShuffle_* test
  independent from the hardcoding of the expected frame order (in case
  random generator implementation changes)

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- adds an ability to output frame numbers in the experimental video
  reader
- this allows making VideoReaderDecoderCpuTest.RandomShuffle_* test
  independent from the hardcoding of the expected frame order (in case
  random generator implementation changes)
- needed for https://github.com/NVIDIA/DALI/pull/5608 as the random generator output changes with the manylinux change
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- experimental video reader
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - VideoReaderDecoderCpuTest.RandomShuffle_*
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [x] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [x] Affects existing requirements
- [ ] N/A

**REQ IDs**: RDVID.13
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
