### PR TITLE
Add metadata-only inputs.

### DIFF
--- a/dali/operators/generic/cast.cc
+++ b/dali/operators/generic/cast.cc
@@ -76,7 +76,7 @@ DALI_SCHEMA(Cast)
 DALI_SCHEMA(CastLike)
     .DocStr("Cast the first tensor to the type of the second tensor.")
     .NumInput(2)
-    .InputDevice(1, InputDevice::Any)
+    .InputDevice(1, InputDevice::Metadata)
     .NumOutput(1)
     .AllowSequences()
     .SupportVolumetric();

--- a/dali/operators/generic/constant_value.cc
+++ b/dali/operators/generic/constant_value.cc
@@ -84,7 +84,7 @@ DALI_SCHEMA(FullLike)
     .DocStr(R"code(Returns new data with the same shape and type as the input data, filled with a `fill_value`.)code")
     .NumInput(2)
     .InputDox(0, "data_like", "TensorList", R"code(The input data value to copy the shape and type from.)code")
-    .InputDevice(0, InputDevice::Any)
+    .InputDevice(0, InputDevice::Metadata)
     .InputDox(1, "fill_value", "TensorList", R"code(The fill value.)code")
     .NumOutput(1);
 DALI_REGISTER_OPERATOR(FullLike, FullLike<CPUBackend>, CPU);
@@ -102,7 +102,7 @@ DALI_SCHEMA(ZerosLike)
     .DocStr(R"code(Returns new data with the same shape and type as the input array, filled with zeros.)code")
     .NumInput(1)
     .InputDox(0, "data_like", "TensorList", R"code(The input data value to copy the shape and type from.)code")
-    .InputDevice(0, InputDevice::Any)
+    .InputDevice(0, InputDevice::Metadata)
     .NumOutput(1)
     .AddOptionalTypeArg("dtype", R"code(Overrides the output data type.)code", DALI_INT32);
 DALI_REGISTER_OPERATOR(ZerosLike, ZerosLike<CPUBackend>, CPU);
@@ -120,7 +120,7 @@ DALI_SCHEMA(OnesLike)
     .DocStr(R"code(Returns new data with the same shape and type as the input array, filled with ones.)code")
     .NumInput(1)
     .InputDox(0, "data_like", "TensorList", R"code(The input data value to copy the shape and type from.)code")
-    .InputDevice(0, InputDevice::Any)
+    .InputDevice(0, InputDevice::Metadata)
     .NumOutput(1)
     .AddOptionalTypeArg("dtype", R"code(Overrides the output data type.)code", DALI_INT32);
 DALI_REGISTER_OPERATOR(OnesLike, OnesLike<CPUBackend>, CPU);

--- a/dali/operators/generic/shapes.cc
+++ b/dali/operators/generic/shapes.cc
@@ -19,7 +19,7 @@ namespace dali {
 DALI_SCHEMA(Shapes)
     .DocStr(R"code(Returns the shapes of inputs.)code")
     .NumInput(1)
-    .InputDevice(0, InputDevice::Any)
+    .InputDevice(0, InputDevice::Metadata)
     .NumOutput(1)
     .AllowSequences()
     .SupportVolumetric()

--- a/dali/operators/random/beta_distribution_cpu.cc
+++ b/dali/operators/random/beta_distribution_cpu.cc
@@ -38,6 +38,7 @@ a single value per sample is generated.
     .NumInput(0, 1)
     .InputDox(0, "shape_like", "TensorList",
               "Shape of this input will be used to infer the shape of the output, if provided.")
+    .InputDevice(0, InputDevice::Metadata)
     .NumOutput(1)
     .AddOptionalArg("alpha", R"code(The alpha parameter, a positive ``float32`` scalar.)code", 1.0f,
                     true)

--- a/dali/operators/random/choice_cpu.cc
+++ b/dali/operators/random/choice_cpu.cc
@@ -42,6 +42,7 @@ that is: :meth:`nvidia.dali.types.DALIDataType`, :meth:`nvidia.dali.types.DALIIm
               "Otherwise ``__a`` is treated as 1D array of input samples.")
     .InputDox(1, "shape_like", "TensorList",
               "Shape of this input will be used to infer the shape of the output, if provided.")
+    .InputDevice(1, InputDevice::Metadata)
     .NumOutput(1)
     .AddOptionalArg<std::vector<float>>("p",
                                         "Distribution of the probabilities. "

--- a/dali/operators/random/coin_flip_cpu.cc
+++ b/dali/operators/random/coin_flip_cpu.cc
@@ -30,6 +30,7 @@ a single value per sample is generated.
     .NumInput(0, 1)
     .InputDox(0, "shape_like", "TensorList",
               "Shape of this input will be used to infer the shape of the output, if provided.")
+    .InputDevice(0, InputDevice::Metadata)
     .NumOutput(1)
     .AddOptionalArg<float>("probability",
       R"code(Probability of value 1.)code",
@@ -51,6 +52,7 @@ sample is generated.
     .NumInput(0, 1)
     .InputDox(0, "shape_like", "TensorList",
               "Shape of this input will be used to infer the shape of the output, if provided.")
+    .InputDevice(0, InputDevice::Metadata)
     .NumOutput(1)
     .AddParent("random__CoinFlip")
     .Deprecate("random__CoinFlip");  // Deprecated in 0.30

--- a/dali/operators/random/normal_distribution_cpu.cc
+++ b/dali/operators/random/normal_distribution_cpu.cc
@@ -28,7 +28,7 @@ a single value per sample is generated.
     .NumInput(0, 1)
     .InputDox(0, "shape_like", "TensorList",
               "Shape of this input will be used to infer the shape of the output, if provided.")
-    .InputDevice(0, InputDevice::Any)
+    .InputDevice(0, InputDevice::Metadata)
     .NumOutput(1)
     .AddOptionalArg<float>("mean",
       R"code(Mean of the distribution.)code",
@@ -51,7 +51,7 @@ a single value per sample is generated.
     .NumInput(0, 1)
     .InputDox(0, "shape_like", "TensorList",
               "Shape of this input will be used to infer the shape of the output, if provided.")
-    .InputDevice(0, InputDevice::Any)
+    .InputDevice(0, InputDevice::Metadata)
     .NumOutput(1)
     .AddParent("random__Normal")
     .Deprecate("random__Normal");  // Deprecated in 0.30

--- a/dali/operators/random/uniform_distribution_cpu.cc
+++ b/dali/operators/random/uniform_distribution_cpu.cc
@@ -32,6 +32,7 @@ a single value per sample is generated.
     .NumInput(0, 1)
     .InputDox(0, "shape_like", "TensorList",
               "Shape of this input will be used to infer the shape of the output, if provided.")
+    .InputDevice(0, InputDevice::Metadata)
     .NumOutput(1)
     .AddOptionalArg("range",
       R"code(Range ``[min, max)`` of a continuous uniform distribution.
@@ -67,6 +68,7 @@ a single value per sample is generated.
     .NumInput(0, 1)
     .InputDox(0, "shape_like", "TensorList",
               "Shape of this input will be used to infer the shape of the output, if provided.")
+    .InputDevice(0, InputDevice::Metadata)
     .NumOutput(1)
     .AddOptionalArg("range",
       R"code(Range ``[min, max)`` of a continuous uniform distribution.

--- a/dali/pipeline/executor/executor2/exec_graph.h
+++ b/dali/pipeline/executor/executor2/exec_graph.h
@@ -90,13 +90,16 @@ struct ExecEdge {
   /** The index of the input in OpSpec. It matches the edge's index in consumer->inputs. */
   int consumer_input_idx = 0;
   StorageDevice device = {};
+  /** The input passes only the metadata, skipping stream synchronization. */
+  bool metadata = false;
 
   constexpr bool operator==(const ExecEdge &other) const {
     return producer == other.producer &&
            consumer == other.consumer &&
            producer_output_idx == other.producer_output_idx &&
            consumer_input_idx == other.consumer_input_idx &&
-           device == other.device;
+           device == other.device &&
+           metadata == other.metadata;
   }
 
   constexpr bool operator!=(const ExecEdge &other) const {

--- a/dali/pipeline/executor/executor2/exec_node_task.cc
+++ b/dali/pipeline/executor/executor2/exec_node_task.cc
@@ -477,7 +477,7 @@ tasking::SharedTask ExecNodeTask::CreateTask(ExecNode *node, const WorkspacePara
   }
 }
 
-void ClearWorkspacePayload(Workspace &ws) {
+void ClearWorkspacePayload(Workspace &ws, ExecNode &node) {
   auto event = ws.has_event() ? ws.event() : nullptr;
   for (int i = 0; i < ws.NumInput(); i++) {
     // TODO(michalz): Some smarter deletion management
@@ -492,14 +492,16 @@ void ClearWorkspacePayload(Workspace &ws) {
     if (ws.InputIsType<CPUBackend>(i)) {
       if (auto &pinp = ws.InputPtr<CPUBackend>(i)) {
         auto &inp = *pinp;
-        if (inp.is_pinned() && event && inp.order() != ws.output_order())
+        if (event &&
+            !node.inputs[i]->metadata &&
+            inp.is_pinned() && inp.order() != ws.output_order())
           inp.order().wait(event);
         ws.SetInput<CPUBackend>(i, nullptr);
       }
     } else if (ws.InputIsType<GPUBackend>(i)) {
       if (auto &pinp = ws.InputPtr<GPUBackend>(i)) {
           auto &inp = *pinp;
-        if (event && inp.order() != ws.output_order())
+        if (event && !node.inputs[i]->metadata && inp.order() != ws.output_order())
           inp.order().wait(event);
         ws.SetInput<GPUBackend>(i, nullptr);
       }
@@ -525,7 +527,7 @@ void ClearWorkspacePayload(Workspace &ws) {
 
 void ExecNodeTask::ClearWorkspace() {
   assert(ws_);
-  ClearWorkspacePayload(*ws_);
+  ClearWorkspacePayload(*ws_, *node_);
 }
 
 }  // namespace exec2

--- a/dali/pipeline/executor/executor2/exec_node_task.cc
+++ b/dali/pipeline/executor/executor2/exec_node_task.cc
@@ -31,9 +31,6 @@ namespace exec2 {
 //////////////////////////////////////////////////////////////////////////////////
 // OpTask
 
-inline std::string_view NodeName(const ExecNode &n) {
-  return !n.instance_name.empty() ? n.instance_name : n.op->GetSpec().SchemaName();
-}
 class OpTask : public ExecNodeTask {
  public:
   /** Gets a functor that runs the operator. */

--- a/dali/pipeline/executor/executor2/exec_node_task.cc
+++ b/dali/pipeline/executor/executor2/exec_node_task.cc
@@ -31,6 +31,9 @@ namespace exec2 {
 //////////////////////////////////////////////////////////////////////////////////
 // OpTask
 
+inline std::string_view NodeName(const ExecNode &n) {
+  return !n.instance_name.empty() ? n.instance_name : n.op->GetSpec().SchemaName();
+}
 class OpTask : public ExecNodeTask {
  public:
   /** Gets a functor that runs the operator. */
@@ -278,16 +281,13 @@ void OpTask::SetWorkspaceInputs() {
   auto process_input = [&](int i, auto backend) {
     using Backend = decltype(backend);
     const auto &inp = TaskInput<Backend>(ti);
-    // If the output order of the operator is `host` then we don't wait for GPU
-    // inputs - they can't be accessed directly on host and the operator will
-    // have to issue some sort of synchronization if and when necessary.
-    // This optimization is essential to avoid oversynchronization
-    // when the operator needs to access the metadata only (e.g. getting the shape).
-    if ((order.is_device() || std::is_same_v<Backend, CPUBackend>) /*see comment above */ &&
-        inp.event && inp.order != order)
+    bool is_meta = node_->inputs[i]->metadata;
+    // metadata-only inputs don't need to be synchronized
+    if (!is_meta && inp.event && inp.order != order)
       events.insert(inp.event);
 
-    if (inp.order == order) {  // use the input directly
+    // metadata-only inputs don't need a proper stream
+    if (inp.order == order || is_meta) {  // use the input directly
       ws_->SetInput(i, inp.data);
     } else {  // create another TL and set its order (and layout, while we're at it)
       auto tl = std::make_shared<TensorList<Backend>>();

--- a/dali/pipeline/executor/executor2/stream_assignment.h
+++ b/dali/pipeline/executor/executor2/stream_assignment.h
@@ -35,15 +35,15 @@ template <StreamPolicy policy>
 class StreamAssignment;
 
 inline bool NeedsStream(const ExecNode *node) {
-  if (node->is_pipeline_output) {
-    for (auto &pipe_out : node->inputs) {
-      if (pipe_out->device == StorageDevice::GPU)
+  if (node->backend == OpType::CPU) {
+    for (auto &input : node->inputs) {
+      if (input->device == StorageDevice::GPU && !input->metadata)
         return true;
     }
+    return false;
   } else {
-    return node->backend != OpType::CPU;
+    return true;
   }
-  return false;
 }
 
 inline OpType NodeType(const ExecNode *node) {
@@ -117,6 +117,12 @@ class StreamAssignment<StreamPolicy::PerBackend> {
         if (has_gpu_)
           return;  // we already have both, nothing more can happen
         break;
+      case OpType::CPU:
+        if (NeedsStream(&node)) {  // treat CPU nodes with GPU inputs as GPU
+          has_gpu_ = true;
+          if (has_mixed_)
+            return;
+        }
       default:
         break;
       }
@@ -128,11 +134,14 @@ class StreamAssignment<StreamPolicy::PerBackend> {
    * If the node is a Mixed node, it gets stream index 0.
    * If the node is a GPU node it gets stream index 1 if there are any mixed nodes, otherwise
    * the only stream is the GPU stream and the returned index is 0.
+   * CPU nodes get GPU stream if they need one (i.e. they have a GPU input)
    */
   std::optional<int> operator[](const ExecNode *node) const {
     switch (NodeType(node)) {
     case OpType::CPU:
-      return std::nullopt;
+      if (!NeedsStream(node))
+        return std::nullopt;
+      // fall-through to GPU
     case OpType::GPU:
       return has_mixed_ ? 1 : 0;
     case OpType::MIXED:

--- a/dali/pipeline/executor/executor2/stream_assignment.h
+++ b/dali/pipeline/executor/executor2/stream_assignment.h
@@ -35,7 +35,7 @@ template <StreamPolicy policy>
 class StreamAssignment;
 
 inline bool NeedsStream(const ExecNode *node) {
-  if (node->backend == OpType::CPU) {
+  if (node->is_pipeline_output || node->backend == OpType::CPU) {
     for (auto &input : node->inputs) {
       if (input->device == StorageDevice::GPU && !input->metadata)
         return true;

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -63,11 +63,12 @@ struct TensorArgDesc {
 };
 
 enum class InputDevice : uint8_t {
-  MatchBackend = 0,
-  CPU = 1,
-  GPU = 2,
-  Any = 3,
-  MatchBackendOrCPU = 4
+  MatchBackend = 0,   //< CPU for CPU and Mixed operators; GPU for GPU operators.
+  CPU,
+  GPU,
+  Any,
+  MatchBackendOrCPU,  //< CPU for CPU and Mixed operatorss and anywhere for GPU ops
+  Metadata,           //< Any backend, but the operator doesn't need to access the payload
 };
 
 class DLL_PUBLIC OpSchema {

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -63,12 +63,34 @@ struct TensorArgDesc {
 };
 
 enum class InputDevice : uint8_t {
-  MatchBackend = 0,   //< CPU for CPU and Mixed operators; GPU for GPU operators.
+  /** CPU for CPU and Mixed operators; GPU for GPU operators. */
+  MatchBackend = 0,
+
+  /** Always CPU */
   CPU,
+
+  /** Always GPU */
   GPU,
+
+  /** Any kind of input device, regardless of operator's backend */
   Any,
-  MatchBackendOrCPU,  //< CPU for CPU and Mixed operatorss and anywhere for GPU ops
-  Metadata,           //< Any backend, but the operator doesn't need to access the payload
+
+  /** CPU for CPU and Mixed; anything for GPU */
+  MatchBackendOrCPU,
+
+  /** Any backend, but the operator will not access the actual data.
+   *
+   * This is useful for operators that only look at the metadata of the input - things like shape,
+   * source info, dtype, etc.
+   *
+   * Specifying this flag allows the executor to skip synchronization or even to provide
+   * a tensor without actual payload.
+   * It is forbidden to:
+   * - look at the data inside the operator (`data`, `raw_data`, etc)
+   * - copy the input data (`TensorList::Copy` or calling copy on the samples)
+   * - forward the input or its parts to the output with ShareData, SetSample or similar.
+   */
+  Metadata,
 };
 
 class DLL_PUBLIC OpSchema {

--- a/dali/pipeline/operator/op_spec.cc
+++ b/dali/pipeline/operator/op_spec.cc
@@ -31,6 +31,7 @@ inline bool IsCompatibleDevice(StorageDevice provided, InputDevice required, OpT
   case InputDevice::MatchBackendOrCPU:
     return op_device == OpType::CPU ? provided == StorageDevice::CPU : true;
   case InputDevice::Any:
+  case InputDevice::Metadata:
     return true;
   default:
     return false;
@@ -48,6 +49,7 @@ inline std::string ValidDevices(InputDevice required, OpType op_device) {
     case InputDevice::MatchBackendOrCPU:
       return op_device == OpType::GPU ? "\"gpu\" or \"cpu\"" : "\"cpu\"";
     case InputDevice::Any:
+    case InputDevice::Metadata:
       return "\"gpu\" or \"cpu\"";
     default:
       assert(!"Unrechable");


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)


## Description:
The bug:
The Copy operator from device to host executed in host order, but the synchronization was skipped.
The solution:
Use a stream for CPU operators with GPU inputs.
Add a special class of metadata-only inputs which do need to wait for the data, so the executor can skip synchronization.

The necessary synchronization happens in the consumers of the copy results (the D2H copy result is a pinned buffer and the copy is asynchronous).

## Additional information:

### Affected modules and functionalities:
New executor:
- stream assignment
- workspace setup
- most operators taking `Any` input now take a `Metadata` input

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Stream assignment tests have been updated.
The `pipeline_test.test_gpu2cpu_conditionals` serves as a bug-fix test.

- [X] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
