### PR TITLE
DLPack overhaul

### DIFF
--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -81,7 +81,7 @@ py::list PrepareDLTensorInputs<CPUBackend>(Workspace &ws) {
     py::list dl_tensor_list;
     auto &input = ws.UnsafeMutableInput<CPUBackend>(idx);
     for (Index i = 0; i < ws.GetInputBatchSize(idx); ++i) {
-      auto dl_capsule = TensorToDLPackView(input[i], input.device_id());
+      auto dl_capsule = TensorToDLPackView(input[i], input.is_pinned(), input.device_id());
       dl_tensor_list.append(dl_capsule);
     }
     input_tuple.append(dl_tensor_list);
@@ -109,7 +109,7 @@ py::list PrepareDLTensorInputsPerSample<CPUBackend>(Workspace &ws) {
     py::list tuple;
     for (Index idx = 0; idx < ws.NumInput(); ++idx) {
       auto &input = ws.UnsafeMutableInput<CPUBackend>(idx);
-      auto dl_capsule = TensorToDLPackView(input[s], input.device_id());
+      auto dl_capsule = TensorToDLPackView(input[s], input.is_pinned(), input.device_id());
       tuple.append(dl_capsule);
     }
     input_tuples.append(tuple);
@@ -193,26 +193,34 @@ struct PyBindInitializer {
 // so this workaround initializes them manually
 static PyBindInitializer pybind_initializer{}; // NOLINT
 
-struct DLTensorNumpyResource: public DLTensorResource<py::array> {
-  explicit DLTensorNumpyResource(const py::array &array)
-  : DLTensorNumpyResource(array, array.request()) {}
-
-  DLTensorNumpyResource(const py::array &array, pybind11::buffer_info buffer) {
-      : DLTensorResource<py::array>(
-          MakeDLTensor(buffer.ptr, TypeFromFormatStr(buffer.format),
-          TensorShape<>(array.shape(), array.shape() + array.ndim())),
-          array(array)) {
-    strides.resize(array.ndim());
+struct PyArrayPayload : TensorViewPayload {
+  explicit PyArrayPayload(const py::array &array) : array(array) {
+    shape = TensorShape<>(array.shape(), array.shape() + array.ndim());
+    strides.resize(shape.size());
     auto itemsize = array.dtype().itemsize();
     for (int i = 0; i < array.ndim(); ++i) {
       strides[i] = array.strides(i) / itemsize;
     }
   }
-
   py::array array;
-
-  ~DLTensorNumpyResource() override = default;
 };
+
+
+using DLTensorNumpyResource = DLTensorResource<PyArrayPayload>;
+
+auto GetDLTensorResource(const py::array &array) {
+  auto rsrc = DLTensorNumpyResource::Create(array);
+  auto &tensor = rsrc->dlm_tensor.dl_tensor;
+  auto buffer = rsrc->payload.array.request();
+  tensor.data = buffer.ptr;
+  tensor.shape = rsrc->payload.shape.data();
+  tensor.ndim = rsrc->payload.shape.size();
+  tensor.strides = rsrc->payload.strides.empty() ? nullptr : rsrc->payload.strides.data();
+  tensor.device = ToDLDevice(false, false, 0);
+  tensor.dtype = ToDLType(TypeFromFormatStr(buffer.format).id());
+  return rsrc;
+}
+
 
 PYBIND11_MODULE(python_function_plugin, m) {
   m.def("current_dali_stream", []() { return reinterpret_cast<uint64_t>(GetCurrentStream()); });
@@ -220,7 +228,7 @@ PYBIND11_MODULE(python_function_plugin, m) {
   m.def("DLTensorToArray", [](py::capsule dl_capsule) {
     auto dlm_tensor_ptr = DLMTensorPtrFromCapsule(dl_capsule);
     const auto &dl_tensor = dlm_tensor_ptr->dl_tensor;
-    auto dali_type = DLToDALIType(dl_tensor.dtype);
+    auto dali_type = ToDALIType(dl_tensor.dtype);
     py::dtype dtype(FormatStrFromType(dali_type));
     auto shape = make_span(dl_tensor.shape, dl_tensor.ndim);
     py::array array;
@@ -238,12 +246,8 @@ PYBIND11_MODULE(python_function_plugin, m) {
   });
 
   m.def("ArrayToDLTensor", [](py::array array) {
-    auto buffer = array.request();
-    auto dlm_tensor_ptr = DLTensorNumpyResource::Create(
-        DLTensor(
-        buffer.ptr, TypeFromFormatStr(buffer.format).id(),
-                                       false, 0, std::make_unique<DLTensorNumpyResource>(array));
-    return DLTensorToCapsule(std::move(dlm_tensor_ptr));
+    auto rsrc = GetDLTensorResource(array);
+    return DLTensorToCapsule(ToDLMTensor(std::move(rsrc)));
   });
 
   // For the _a suffix

--- a/dali/operators/python_function/dltensor_function.h
+++ b/dali/operators/python_function/dltensor_function.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ std::vector<DLMTensorPtr> CastToDLTensorList(py::list &list, Index exp_size, Ind
       result.push_back(DLMTensorPtrFromCapsule(caps));
       DALI_ENFORCE(result[i]->dl_tensor.device.device_type == Backend2DLDevice<Backend>(),
                    "Wrong output backend.");
-      DALI_ENFORCE(DLToDALIType(result[i]->dl_tensor.dtype) == DLToDALIType(dtype),
+      DALI_ENFORCE(ToDALIType(result[i]->dl_tensor.dtype) == ToDALIType(dtype),
                    "Output DLPack tensor list should have consistent data type.");
       DALI_ENFORCE(result[i]->dl_tensor.ndim == ndim,
                    "All samples in the batch should have the same number of dimensions.");
@@ -94,7 +94,7 @@ void PrepareOutputs(Workspace &ws, const py::object &output_o, int batch_size) {
     auto dl_tensors = CastToDLTensorList<Backend>(dl_list, batch_size, idx);
     if (dl_tensors.empty()) continue;
     auto &tlist = ws.Output<Backend>(idx);
-    tlist.Resize(GetDLTensorListShape(dl_tensors), DLToDALIType(dl_tensors[0]->dl_tensor.dtype));
+    tlist.Resize(GetDLTensorListShape(dl_tensors), ToDALIType(dl_tensors[0]->dl_tensor.dtype));
     CopyOutputData(tlist, dl_tensors, ws);
   }
 }

--- a/dali/operators/python_function/jax_function.h
+++ b/dali/operators/python_function/jax_function.h
@@ -47,7 +47,7 @@ DLMTensorPtr SetupTensorResource(std::unique_ptr<DLDaliTensorResource<Backend>> 
   DLManagedTensor &dlm_tensor = tensor_resource->dlm_tensor;
 
   // copy relevant meta-data from the tensor to dl pack struct
-  dlm_tensor.dl_tensor.dtype = GetDLType(tensor.type());
+  dlm_tensor.dl_tensor.dtype = ToDLType(tensor.type());
   dlm_tensor.dl_tensor.data = tensor.raw_mutable_data();
   TensorShape<> &tensor_shape = const_cast<TensorShape<> &>(tensor.shape());
   dlm_tensor.dl_tensor.ndim = tensor_shape.size();
@@ -313,7 +313,7 @@ class JaxFunction : public StatelessOperator<Backend> {
       TensorListShape<> batch_shape =
           uniform_list_shape(batch_size, dl_batch_shape.last(dl_batch_shape.size() - 1));
 
-      auto dtype = DLToDALIType(dl_batch.dtype);
+      auto dtype = ToDALIType(dl_batch.dtype);
       auto type_info = dali::TypeTable::GetTypeInfo(dtype);
       size_t size_of_dtype = type_info.size();
       int64_t bytes = dl_batch_shape.num_elements() * size_of_dtype;

--- a/dali/operators/python_function/jax_function.h
+++ b/dali/operators/python_function/jax_function.h
@@ -31,52 +31,6 @@ namespace dali {
 
 namespace detail {
 
-template <typename Backend>
-struct DLDaliTensorResource {
-  explicit DLDaliTensorResource(Tensor<Backend> &&tensor)
-      : tensor(std::move(tensor)), dlm_tensor{} {}
-  Tensor<Backend> tensor;
-  DLManagedTensor dlm_tensor;
-};
-
-
-template <typename Backend>
-DLMTensorPtr SetupTensorResource(std::unique_ptr<DLDaliTensorResource<Backend>> tensor_resource) {
-  static_assert(std::is_same_v<Backend, GPUBackend> || std::is_same_v<Backend, CPUBackend>);
-  Tensor<Backend> &tensor = tensor_resource->tensor;
-  DLManagedTensor &dlm_tensor = tensor_resource->dlm_tensor;
-
-  // copy relevant meta-data from the tensor to dl pack struct
-  dlm_tensor.dl_tensor.dtype = ToDLType(tensor.type());
-  dlm_tensor.dl_tensor.data = tensor.raw_mutable_data();
-  TensorShape<> &tensor_shape = const_cast<TensorShape<> &>(tensor.shape());
-  dlm_tensor.dl_tensor.ndim = tensor_shape.size();
-  dlm_tensor.dl_tensor.shape = tensor_shape.begin();
-  if (std::is_same_v<Backend, GPUBackend>) {
-    dlm_tensor.dl_tensor.device = {kDLCUDA, tensor.device_id()};
-  } else {
-    dlm_tensor.dl_tensor.device = {kDLCPU, 0};
-  }
-
-  // transfer ownership of both tensor and dl pack structure to dl pack structure
-  // and re-expose it as a unique_ptr to just dlpack structure
-  DLDaliTensorResource<Backend> *raw_ptr = tensor_resource.release();
-  dlm_tensor.manager_ctx = raw_ptr;
-  dlm_tensor.deleter = [](DLManagedTensor *dlm_tensor) {
-    delete static_cast<DLDaliTensorResource<Backend> *>(dlm_tensor->manager_ctx);
-  };
-  return {&raw_ptr->dlm_tensor,
-          [](DLManagedTensor *dlm_tensor) { dlm_tensor->deleter(dlm_tensor); }};
-}
-
-template <typename Backend>
-DLMTensorPtr AsDLTensor(Tensor<Backend> &&tensor) {
-  static_assert(std::is_same_v<Backend, GPUBackend> || std::is_same_v<Backend, CPUBackend>);
-  // 1. allocate DLDaliTensorResource that will hold dlpack struct and the actual tensor together
-  // 2. copy relevant meta-data from the tensor to managed dl pack struct
-  return SetupTensorResource(std::make_unique<DLDaliTensorResource<Backend>>(std::move(tensor)));
-}
-
 /**
  * @brief Exposes vector of tensors as a Python list of DLTensorObjs.
  *
@@ -90,12 +44,12 @@ DLMTensorPtr AsDLTensor(Tensor<Backend> &&tensor) {
  * @return py::list of DlTensorObjs.
  */
 template <typename Backend>
-py::list TensorsAsDLTensorObjs(std::vector<Tensor<Backend>> &&tensors,
+py::list TensorsAsDLTensorObjs(std::vector<Tensor<Backend>> &tensors,
                                std::optional<cudaStream_t> producer_stream) {
   py::list dl_tensor_objs;
   for (size_t i = 0; i < tensors.size(); ++i) {
     dl_tensor_objs.append(
-        py::cast(DLTensorObj{AsDLTensor(std::move(tensors[i])), producer_stream}));
+        py::cast(DLTensorObj{GetSharedDLTensor(tensors[i]), producer_stream}));
   }
   return dl_tensor_objs;
 }
@@ -243,14 +197,14 @@ class JaxFunction : public StatelessOperator<Backend> {
                                               std::vector<Tensor<Backend>> &&batched_inputs) {
     py::gil_scoped_acquire interpreter_guard{};
     if constexpr (std::is_same_v<Backend, CPUBackend>) {
-      auto dl_inputs = detail::TensorsAsDLTensorObjs(std::move(batched_inputs), std::nullopt);
+      auto dl_inputs = detail::TensorsAsDLTensorObjs(batched_inputs, std::nullopt);
       auto dl_outputs = python_function_(*dl_inputs);
       return ConsumePythonOutputs(ws, std::move(dl_outputs));
     } else if constexpr (!std::is_same_v<Backend, CPUBackend>) {  // NOLINT
       static_assert(std::is_same_v<Backend, GPUBackend>,
                     "The operator supports only CPU and GPU backends");
       cudaStream_t stream = ws.stream();
-      auto dl_inputs = detail::TensorsAsDLTensorObjs(std::move(batched_inputs), stream);
+      auto dl_inputs = detail::TensorsAsDLTensorObjs(batched_inputs, stream);
       auto dl_outputs = python_function_(reinterpret_cast<int64_t>(stream), *dl_inputs);
       return ConsumePythonOutputs(ws, std::move(dl_outputs));
     }

--- a/dali/pipeline/data/dltensor.cc
+++ b/dali/pipeline/data/dltensor.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,6 +47,26 @@ void DLMTensorPtrDeleter(DLManagedTensor* dlm_tensor_ptr) {
   if (dlm_tensor_ptr && dlm_tensor_ptr->deleter) {
     dlm_tensor_ptr->deleter(dlm_tensor_ptr);
   }
+}
+
+DLTensor MakeDLTensor(void *data, DALIDataType type,
+                      std::optional<int> device_id,
+                      const TensorShape<> &shape,
+                      const TensorShape<> &strides) {
+  DLTensor dl_tensor{};
+  dl_tensor.data = data;
+  dl_tensor.ndim = shape.size();
+  dl_tensor.shape = shape.data();
+  if (!strides.empty()) {
+    dl_tensor.strides = strides.data();
+  }
+  if (device_id) {
+    dl_tensor.device = {kDLCUDA, *device_id};
+  } else {
+    dl_tensor.device = {kDLCPU, 0};
+  }
+  dl_tensor.dtype = GetDLType(type);
+  return dl_tensor;
 }
 
 DLMTensorPtr MakeDLTensor(void* data, DALIDataType type,

--- a/dali/pipeline/data/dltensor.cc
+++ b/dali/pipeline/data/dltensor.cc
@@ -19,18 +19,18 @@
 
 namespace dali {
 
-DLDataType GetDLType(DALIDataType type) {
+DLDataType ToDLType(DALIDataType type) {
   DLDataType dl_type{};
   TYPE_SWITCH(type, type2id, T, (DALI_NUMERIC_TYPES_FP16, bool), (
     dl_type.bits = sizeof(T) * 8;
       dl_type.lanes = 1;
-      if (dali::is_fp_or_half<T>::value) {
+      if constexpr (dali::is_fp_or_half<T>::value) {
         dl_type.code = kDLFloat;
-      } else if (std::is_same<T, bool>::value) {
+      } else if constexpr (std::is_same_v<T, bool>) {
         dl_type.code = kDLBool;
-      } else if (std::is_unsigned<T>::value) {
+      } else if constexpr (std::is_unsigned_v<T>) {
         dl_type.code = kDLUInt;
-      } else if (std::is_integral<T>::value) {
+      } else if constexpr (std::is_integral_v<T>) {
         dl_type.code = kDLInt;
       } else {
         DALI_FAIL(make_string("This data type (", type, ") cannot be handled by DLTensor."));
@@ -39,65 +39,13 @@ DLDataType GetDLType(DALIDataType type) {
   return dl_type;
 }
 
-void DLManagedTensorDeleter(DLManagedTensor *self) {
-  delete static_cast<DLTensorResource*>(self->manager_ctx);
-}
-
 void DLMTensorPtrDeleter(DLManagedTensor* dlm_tensor_ptr) {
   if (dlm_tensor_ptr && dlm_tensor_ptr->deleter) {
     dlm_tensor_ptr->deleter(dlm_tensor_ptr);
   }
 }
 
-DLTensor MakeDLTensor(void *data, DALIDataType type,
-                      std::optional<int> device_id,
-                      const TensorShape<> &shape,
-                      const TensorShape<> &strides) {
-  DLTensor dl_tensor{};
-  dl_tensor.data = data;
-  dl_tensor.ndim = shape.size();
-  dl_tensor.shape = shape.data();
-  if (!strides.empty()) {
-    dl_tensor.strides = strides.data();
-  }
-  if (device_id) {
-    dl_tensor.device = {kDLCUDA, *device_id};
-  } else {
-    dl_tensor.device = {kDLCPU, 0};
-  }
-  dl_tensor.dtype = GetDLType(type);
-  return dl_tensor;
-}
-
-DLMTensorPtr MakeDLTensor(void* data, DALIDataType type,
-                          bool device, int device_id,
-                          std::unique_ptr<DLTensorResource> resource) {
-  DLManagedTensor *dlm_tensor_ptr = &resource->dlm_tensor;
-  DLTensor &dl_tensor = dlm_tensor_ptr->dl_tensor;
-  dl_tensor.data = data;
-  dl_tensor.ndim = resource->shape.size();
-  dl_tensor.shape = resource->shape.begin();
-  if (!resource->strides.empty()) {
-    dl_tensor.strides = resource->strides.data();
-  }
-  if (device) {
-    dl_tensor.device = {kDLCUDA, device_id};
-  } else {
-    dl_tensor.device = {kDLCPU, 0};
-  }
-  dl_tensor.dtype = GetDLType(type);
-  dlm_tensor_ptr->deleter = &DLManagedTensorDeleter;
-  dlm_tensor_ptr->manager_ctx = resource.release();
-  return {dlm_tensor_ptr, &DLMTensorPtrDeleter};
-}
-
-inline std::string to_string(const DLDataType &dl_type) {
-  return std::string("{code: ")
-    + (dl_type.code ? ((dl_type.code == 2) ? "kDLFloat" : "kDLUInt") : "kDLInt")
-    + ", bits: " + std::to_string(dl_type.bits) + ", lanes: " + std::to_string(dl_type.lanes) + "}";
-}
-
-DALIDataType DLToDALIType(const DLDataType &dl_type) {
+DALIDataType ToDALIType(const DLDataType &dl_type) {
   DALI_ENFORCE(dl_type.lanes == 1,
                "DALI Tensors do not support types with the number of lanes other than 1");
   switch (dl_type.code) {

--- a/dali/pipeline/data/dltensor.h
+++ b/dali/pipeline/data/dltensor.h
@@ -46,7 +46,7 @@ DLL_PUBLIC DALIDataType ToDALIType(const DLDataType &dl_type);
  *
  * The text representation looks like:
  * <type><bits>[x<lanes>]
- * with <lanes>x present only if the number of lanes is > 1
+ * with x<lanes> present only if the number of lanes is > 1
  *
  * Examples:
  * u8     - 8-bit unsigned integer
@@ -68,10 +68,10 @@ inline std::string to_string(const DLDataType &dl_type) {
   if (dl_type.code < std::size(code_str))
     ss << code_str[dl_type.code];
   else
-    ss << "<unknown" << dl_type.code + 0 << ">";
-  ss << dl_type.bits;
+    ss << "<unknown:" << dl_type.code + 0 << ">";
+  ss << dl_type.bits + 0;
   if (dl_type.lanes > 1)
-    ss << 'x' << dl_type.lanes;
+    ss << 'x' << dl_type.lanes + 0;
   return ss.str();
 }
 
@@ -133,7 +133,7 @@ struct SharedTensorPayload : TensorViewPayload {
  *     +-- ...
  * ```
  *
- * You can use any payload structure of your choice, but it must privde the storage for DLTensor's
+ * You can use any payload structure of your choice, but it must provide the storage for DLTensor's
  * `shapes` (and `strides`, if necessary).
  */
 template <typename Payload>

--- a/dali/pipeline/data/dltensor.h
+++ b/dali/pipeline/data/dltensor.h
@@ -236,7 +236,7 @@ inline DLMTensorPtr MakeDLTensor(std::shared_ptr<void> data, DALIDataType type,
 template <typename Backend>
 DLMTensorPtr GetDLTensorView(const SampleView<Backend> &tensor, bool pinned, int device_id) {
   auto rsrc = MakeDLTensorResource(
-                  const_cast<void*>(tensor.raw_data()), tensor.type(),
+                  tensor.raw_mutable_data(), tensor.type(),
                   std::is_same_v<Backend, GPUBackend>, pinned, device_id,
                   tensor.shape());
   return ToDLMTensor(std::move(rsrc));

--- a/dali/pipeline/data/dltensor.h
+++ b/dali/pipeline/data/dltensor.h
@@ -16,6 +16,7 @@
 #define DALI_PIPELINE_DATA_DLTENSOR_H_
 
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 #include "third_party/dlpack/include/dlpack/dlpack.h"
@@ -41,7 +42,7 @@ struct DLTensorResource {
     return { rsrc.release(), uptr_deleter };
   }
 
- private:
+ protected:
   template <typename PayloadArgs>
   explicit DLTensorResource(DLTensor tensor, PayloadArgs &&...args)
   : dlm_tensor{tensor, this, dlm_deleter}
@@ -63,33 +64,45 @@ struct DLTensorResource {
 };
 
 
-DLTensor MakeDLTensor(void *data, DALIDataType type,
-                      bool device, int device_id,
-                      const TensorShape<> &shape,
-                      const TensorShape<> &stride) {
+DLL_PUBLIC DLTensor MakeDLTensor(void *data, DALIDataType type,
+                                 std::optional<int> device_id,
+                                 const TensorShape<> &shape,
+                                 const TensorShape<> &strides = {});
 
+template <typename Backend>
+DLTensor MakeDLTensor(SampleView<Backend> tensor, int device_id) {
+  return MakeDLTensor(tensor.raw_mutable_data(),
+                      tensor.type(),
+                      std::is_same<Backend, GPUBackend>::value ? device_id : std::nullopt,
+                      tensor.shape());
 }
 
 template <typename Backend>
 DLMTensorPtr GetDLTensorView(SampleView<Backend> tensor, int device_id) {
-  return MakeDLTensor(tensor.raw_mutable_data(),
-                      tensor.type(),
-                      std::is_same<Backend, GPUBackend>::value,
-                      device_id,
-                      std::make_unique<DLTensorResource>(tensor.shape()));
+  return DLTensorResource<>::Create(
+      MakeDLTensor(tensor.raw_mutable_data(),
+                   tensor.type(),
+                   std::is_same<Backend, GPUBackend>::value,
+                   tensor.shape(),
+                   device_id));
 }
 
 template <typename Backend>
 std::vector<DLMTensorPtr> GetDLTensorListView(TensorList<Backend> &tensor_list) {
+  std::optional<int> device_id = std::is_same<Backend, GPUBackend>::value
+                               ? tensor_list.device_id()
+                               : std::nullopt;
+
   std::vector<DLMTensorPtr> dl_tensors{};
   dl_tensors.reserve(tensor_list.num_samples());
+
   for (int i = 0; i < tensor_list.num_samples(); ++i) {
     const auto &shape = tensor_list.tensor_shape(i);
-    dl_tensors.push_back(MakeDLTensor(tensor_list.raw_mutable_tensor(i),
-                                      tensor_list.type(),
-                                      std::is_same<Backend, GPUBackend>::value,
-                                      tensor_list.device_id(),
-                                      std::make_unique<DLTensorResource>(shape)));
+    dl_tensors.push_back(DLTensorResource<>::Create(
+        MakeDLTensor(tensor_list.raw_mutable_tensor(i),
+                     tensor_list.type(),
+                     device_id,
+                     shape)));
   }
   return dl_tensors;
 }

--- a/dali/pipeline/data/dltensor.h
+++ b/dali/pipeline/data/dltensor.h
@@ -239,10 +239,10 @@ std::vector<DLMTensorPtr> GetDLTensorListView(TensorList<Backend> &tensor_list) 
 
 
 template <typename Backend>
-DLMTensorPtr GetSharedDLTensor(Tensor<Backend> &tensor, int device_id) {
+DLMTensorPtr GetSharedDLTensor(Tensor<Backend> &tensor) {
   auto rsrc = MakeDLTensorResource(
                   tensor.get_data_ptr(), tensor.type(),
-                  std::is_same_v<Backend, GPUBackend>, tensor.is_pinned(), device_id,
+                  std::is_same_v<Backend, GPUBackend>, tensor.is_pinned(), tensor.device_id(),
                   tensor.shape());
   return ToDLMTensor(std::move(rsrc));
 }

--- a/dali/pipeline/data/dltensor_test.cc
+++ b/dali/pipeline/data/dltensor_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,118 +21,148 @@
 
 namespace dali {
 
-TEST(DLMTensorPtr, CPU) {
+namespace {
+
+void TestSampleViewCPU(bool pinned) {
   Tensor<CPUBackend> tensor;
+  tensor.set_pinned(pinned);
+  tensor.set_device_id(0);
   tensor.Resize({100, 50, 3}, DALI_FLOAT);
   SampleView<CPUBackend> sv{tensor.raw_mutable_data(), tensor.shape(), tensor.type()};
-  DLMTensorPtr dlm_tensor = GetDLTensorView(sv, tensor.device_id());
-  ASSERT_EQ(dlm_tensor->dl_tensor.ndim, 3);
-  ASSERT_EQ(dlm_tensor->dl_tensor.shape[0], 100);
-  ASSERT_EQ(dlm_tensor->dl_tensor.shape[1], 50);
-  ASSERT_EQ(dlm_tensor->dl_tensor.shape[2], 3);
-  ASSERT_EQ(dlm_tensor->dl_tensor.data, sv.raw_data());
-  ASSERT_EQ(dlm_tensor->dl_tensor.dtype.code, kDLFloat);
-  ASSERT_EQ(dlm_tensor->dl_tensor.dtype.bits, sizeof(float) * 8);
-  ASSERT_EQ(dlm_tensor->dl_tensor.device.device_type, kDLCPU);
-  ASSERT_EQ(dlm_tensor->dl_tensor.byte_offset, 0);
+  DLMTensorPtr dlm_tensor = GetDLTensorView(sv, tensor.is_pinned(), tensor.device_id());
+  EXPECT_EQ(dlm_tensor->dl_tensor.ndim, 3);
+  EXPECT_EQ(dlm_tensor->dl_tensor.shape[0], 100);
+  EXPECT_EQ(dlm_tensor->dl_tensor.shape[1], 50);
+  EXPECT_EQ(dlm_tensor->dl_tensor.shape[2], 3);
+  EXPECT_EQ(dlm_tensor->dl_tensor.data, sv.raw_data());
+  EXPECT_EQ(dlm_tensor->dl_tensor.dtype.code, kDLFloat);
+  EXPECT_EQ(dlm_tensor->dl_tensor.dtype.bits, sizeof(float) * 8);
+  EXPECT_EQ(dlm_tensor->dl_tensor.device.device_type, pinned ? kDLCUDAHost : kDLCPU);
+  EXPECT_EQ(dlm_tensor->dl_tensor.byte_offset, 0);
 }
 
-TEST(DLMTensorPtr, GPU) {
+}  // namespace
+
+TEST(DLMTensorPtr, ViewCPU) {
+  TestSampleViewCPU(false);
+}
+
+TEST(DLMTensorPtr, ViewPinnedCPU) {
+  TestSampleViewCPU(true);
+}
+
+TEST(DLMTensorPtr, CPUShared) {
+  Tensor<CPUBackend> tensor;
+  tensor.set_pinned(false);
+  tensor.set_device_id(0);
+  tensor.Resize({100, 50, 3}, DALI_FLOAT);
+  {
+    DLMTensorPtr dlm_tensor = GetSharedDLTensor(tensor, tensor.device_id());
+    EXPECT_EQ(tensor.get_data_ptr().use_count(), 2) << "Reference count not increased";
+    EXPECT_EQ(dlm_tensor->dl_tensor.ndim, 3);
+    EXPECT_EQ(dlm_tensor->dl_tensor.shape[0], 100);
+    EXPECT_EQ(dlm_tensor->dl_tensor.shape[1], 50);
+    EXPECT_EQ(dlm_tensor->dl_tensor.shape[2], 3);
+    EXPECT_EQ(dlm_tensor->dl_tensor.data, tensor.raw_data());
+    EXPECT_EQ(dlm_tensor->dl_tensor.dtype.code, kDLFloat);
+    EXPECT_EQ(dlm_tensor->dl_tensor.dtype.bits, sizeof(float) * 8);
+    EXPECT_EQ(dlm_tensor->dl_tensor.device.device_type, kDLCPU);
+    EXPECT_EQ(dlm_tensor->dl_tensor.byte_offset, 0);
+  }
+  EXPECT_EQ(tensor.get_data_ptr().use_count(), 1) << "Reference leaked.";
+}
+
+TEST(DLMTensorPtr, ViewGPU) {
   Tensor<GPUBackend> tensor;
   tensor.Resize({100, 50, 1}, DALI_INT32);
   SampleView<GPUBackend> sv{tensor.raw_mutable_data(), tensor.shape(), tensor.type()};
-  DLMTensorPtr dlm_tensor = GetDLTensorView(sv, tensor.device_id());
-  ASSERT_EQ(dlm_tensor->dl_tensor.ndim, 3);
-  ASSERT_EQ(dlm_tensor->dl_tensor.shape[0], 100);
-  ASSERT_EQ(dlm_tensor->dl_tensor.shape[1], 50);
-  ASSERT_EQ(dlm_tensor->dl_tensor.shape[2], 1);
-  ASSERT_EQ(dlm_tensor->dl_tensor.data, sv.raw_data());
-  ASSERT_EQ(dlm_tensor->dl_tensor.dtype.code, kDLInt);
-  ASSERT_EQ(dlm_tensor->dl_tensor.dtype.bits, sizeof(int) * 8);
-  ASSERT_EQ(dlm_tensor->dl_tensor.device.device_type, kDLCUDA);
-  ASSERT_EQ(dlm_tensor->dl_tensor.device.device_id, tensor.device_id());
-  ASSERT_EQ(dlm_tensor->dl_tensor.byte_offset, 0);
+  DLMTensorPtr dlm_tensor = GetDLTensorView(sv, false, tensor.device_id());
+  EXPECT_EQ(dlm_tensor->dl_tensor.ndim, 3);
+  EXPECT_EQ(dlm_tensor->dl_tensor.shape[0], 100);
+  EXPECT_EQ(dlm_tensor->dl_tensor.shape[1], 50);
+  EXPECT_EQ(dlm_tensor->dl_tensor.shape[2], 1);
+  EXPECT_EQ(dlm_tensor->dl_tensor.data, sv.raw_data());
+  EXPECT_EQ(dlm_tensor->dl_tensor.dtype.code, kDLInt);
+  EXPECT_EQ(dlm_tensor->dl_tensor.dtype.bits, sizeof(int) * 8);
+  EXPECT_EQ(dlm_tensor->dl_tensor.device.device_type, kDLCUDA);
+  EXPECT_EQ(dlm_tensor->dl_tensor.device.device_id, tensor.device_id());
+  EXPECT_EQ(dlm_tensor->dl_tensor.byte_offset, 0);
 }
 
 TEST(DLMTensorPtr, CPUList) {
   TensorList<CPUBackend> tlist;
+  tlist.set_pinned(false);
   tlist.Resize({{100, 50, 1}, {50, 30, 3}}, DALI_FLOAT64);
   std::vector<DLMTensorPtr> dlm_tensors = GetDLTensorListView(tlist);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.ndim, 3);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.shape[0], 100);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.shape[1], 50);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.shape[2], 1);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.data, tlist.raw_tensor(0));
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.dtype.code, kDLFloat);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.dtype.bits, sizeof(double) * 8);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.device.device_type, kDLCPU);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.byte_offset, 0);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.ndim, 3);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.shape[0], 100);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.shape[1], 50);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.shape[2], 1);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.data, tlist.raw_tensor(0));
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.dtype.code, kDLFloat);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.dtype.bits, sizeof(double) * 8);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.device.device_type, kDLCPU);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.byte_offset, 0);
 
-  ASSERT_EQ(tlist.tensor_shape(1).size(), 3);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.ndim, 3);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.shape[0], 50);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.shape[1], 30);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.shape[2], 3);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.data, tlist.raw_tensor(1));
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.dtype.code, kDLFloat);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.dtype.bits, sizeof(double) * 8);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.device.device_type, kDLCPU);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.byte_offset, 0);
+  EXPECT_EQ(tlist.tensor_shape(1).size(), 3);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.ndim, 3);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.shape[0], 50);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.shape[1], 30);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.shape[2], 3);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.data, tlist.raw_tensor(1));
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.dtype.code, kDLFloat);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.dtype.bits, sizeof(double) * 8);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.device.device_type, kDLCPU);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.byte_offset, 0);
 }
 
 TEST(DLMTensorPtr, GPUList) {
   TensorList<GPUBackend> tlist;
   tlist.Resize({{100, 50, 1}, {50, 30, 3}}, DALI_UINT8);
   std::vector<DLMTensorPtr> dlm_tensors = GetDLTensorListView(tlist);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.ndim, 3);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.shape[0], 100);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.shape[1], 50);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.shape[2], 1);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.data, tlist.raw_tensor(0));
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.dtype.code, kDLUInt);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.dtype.bits, sizeof(uint8_t) * 8);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.device.device_type, kDLCUDA);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.byte_offset, 0);
-  ASSERT_EQ(dlm_tensors[0]->dl_tensor.device.device_id, tlist.device_id());
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.ndim, 3);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.shape[0], 100);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.shape[1], 50);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.shape[2], 1);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.data, tlist.raw_tensor(0));
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.dtype.code, kDLUInt);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.dtype.bits, sizeof(uint8_t) * 8);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.device.device_type, kDLCUDA);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.byte_offset, 0);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.device.device_id, tlist.device_id());
 
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.ndim, 3);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.shape[0], 50);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.shape[1], 30);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.shape[2], 3);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.data, tlist.raw_tensor(1));
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.dtype.code, kDLUInt);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.dtype.bits, sizeof(uint8_t) * 8);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.device.device_type, kDLCUDA);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.byte_offset, 0);
-  ASSERT_EQ(dlm_tensors[1]->dl_tensor.device.device_id, tlist.device_id());
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.ndim, 3);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.shape[0], 50);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.shape[1], 30);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.shape[2], 3);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.data, tlist.raw_tensor(1));
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.dtype.code, kDLUInt);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.dtype.bits, sizeof(uint8_t) * 8);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.device.device_type, kDLCUDA);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.byte_offset, 0);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.device.device_id, tlist.device_id());
 }
 
-struct TestDLTensorResource: public DLTensorResource {
-  TestDLTensorResource(TensorShape<> shape, bool &called)
-  : DLTensorResource(std::move(shape))
-  , called(called) {
-    called = false;
+struct TestDLPayload {
+  explicit TestDLPayload(bool &destroyed)
+  : destroyed(destroyed) {}
+
+  ~TestDLPayload() {
+    destroyed = true;
   }
 
-  bool &called;
-
-  ~TestDLTensorResource() override {
-    called = true;
-  }
+  bool &destroyed;
 };
 
+
 TEST(DLMTensorPtr, Cleanup) {
-  Tensor<CPUBackend> tensor;
-  tensor.Resize({100, 50, 3}, DALI_FLOAT);
   bool deleter_called = false;
   {
-    auto dlm_tensor = MakeDLTensor(tensor.raw_mutable_data(),
-                                   tensor.type(),
-                                   false, -1,
-                                   std::make_unique<TestDLTensorResource>(tensor.shape(),
-                                                                          deleter_called));
+    auto rsrc = DLTensorResource<TestDLPayload>::Create(deleter_called);
+    auto dlm_tensor = ToDLMTensor(std::move(rsrc));
+    EXPECT_EQ(rsrc, nullptr);
   }
-  ASSERT_TRUE(deleter_called);
+  EXPECT_TRUE(deleter_called);
 }
 
 }  // namespace dali

--- a/dali/pipeline/data/dltensor_test.cc
+++ b/dali/pipeline/data/dltensor_test.cc
@@ -21,6 +21,41 @@
 
 namespace dali {
 
+TEST(DLPackTest, DLType) {
+  DLDataType dl;
+  for (DALIDataType dali : {
+      DALI_BOOL,
+      DALI_FLOAT16, DALI_FLOAT, DALI_FLOAT64,
+      DALI_INT8, DALI_UINT8,
+      DALI_INT16, DALI_UINT16,
+      DALI_INT32, DALI_UINT32,
+      DALI_INT64, DALI_UINT64 }) {
+    dl = ToDLType(dali);
+    TypeInfo info = TypeTable::GetTypeInfo(dali);
+    EXPECT_EQ(dl.lanes, 1);
+    EXPECT_EQ(dl.bits, info.size() * 8);
+    if (info.name().find("uint") == 0)
+      EXPECT_EQ(dl.code, kDLUInt);
+    else if (info.name().find("int") == 0)
+      EXPECT_EQ(dl.code, kDLInt);
+    else if (info.name().find("float") == 0)
+      EXPECT_EQ(dl.code, kDLFloat);
+    else if (info.name().find("bool") == 0)
+      EXPECT_EQ(dl.code, kDLBool);
+
+    EXPECT_EQ(ToDALIType(dl), dali) << "Conversion back to DALI type yielded a different type.";
+  }
+}
+
+TEST(DLPackTest, DLTypeToString) {
+  EXPECT_EQ(to_string(DLDataType{ kDLBool, 8, 1 }), "b8");
+  EXPECT_EQ(to_string(DLDataType{ kDLBfloat, 16, 1 }), "bf16");
+  EXPECT_EQ(to_string(DLDataType{ kDLFloat, 32, 4 }), "f32x4");
+  EXPECT_EQ(to_string(DLDataType{ kDLUInt, 16, 2 }), "u16x2");
+  EXPECT_EQ(to_string(DLDataType{ kDLInt, 64, 1 }), "i64");
+  EXPECT_EQ(to_string(DLDataType{ 123, 8, 16 }), "<unknown:123>8x16");
+}
+
 namespace {
 
 void TestSampleViewCPU(bool pinned) {

--- a/dali/pipeline/data/dltensor_test.cc
+++ b/dali/pipeline/data/dltensor_test.cc
@@ -57,7 +57,7 @@ TEST(DLMTensorPtr, CPUShared) {
   tensor.set_device_id(0);
   tensor.Resize({100, 50, 3}, DALI_FLOAT);
   {
-    DLMTensorPtr dlm_tensor = GetSharedDLTensor(tensor, tensor.device_id());
+    DLMTensorPtr dlm_tensor = GetSharedDLTensor(tensor);
     EXPECT_EQ(tensor.get_data_ptr().use_count(), 2) << "Reference count not increased";
     EXPECT_EQ(dlm_tensor->dl_tensor.ndim, 3);
     EXPECT_EQ(dlm_tensor->dl_tensor.shape[0], 100);

--- a/dali/pipeline/data/dltensor_test.cc
+++ b/dali/pipeline/data/dltensor_test.cc
@@ -34,14 +34,15 @@ TEST(DLPackTest, DLType) {
     TypeInfo info = TypeTable::GetTypeInfo(dali);
     EXPECT_EQ(dl.lanes, 1);
     EXPECT_EQ(dl.bits, info.size() * 8);
-    if (info.name().find("uint") == 0)
+    if (info.name().find("uint") == 0) {
       EXPECT_EQ(dl.code, kDLUInt);
-    else if (info.name().find("int") == 0)
+    } else if (info.name().find("int") == 0) {
       EXPECT_EQ(dl.code, kDLInt);
-    else if (info.name().find("float") == 0)
+    } else if (info.name().find("float") == 0) {
       EXPECT_EQ(dl.code, kDLFloat);
-    else if (info.name().find("bool") == 0)
+    } else if (info.name().find("bool") == 0) {
       EXPECT_EQ(dl.code, kDLBool);
+    }
 
     EXPECT_EQ(ToDALIType(dl), dali) << "Conversion back to DALI type yielded a different type.";
   }

--- a/dali/pipeline/data/dltensor_test.cc
+++ b/dali/pipeline/data/dltensor_test.cc
@@ -152,6 +152,39 @@ TEST(DLMTensorPtr, CPUList) {
   EXPECT_EQ(dlm_tensors[1]->dl_tensor.byte_offset, 0);
 }
 
+
+TEST(DLMTensorPtr, CPUSharedList) {
+  TensorList<CPUBackend> tlist;
+  tlist.set_pinned(false);
+  tlist.Resize({{100, 50, 1}, {50, 30, 3}}, DALI_FLOAT64);
+  const auto &ptr = unsafe_owner(tlist);
+  EXPECT_EQ(ptr.use_count(), 3);
+  std::vector<DLMTensorPtr> dlm_tensors = GetSharedDLTensorList(tlist);
+  EXPECT_EQ(ptr.use_count(), 5);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.ndim, 3);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.shape[0], 100);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.shape[1], 50);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.shape[2], 1);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.data, tlist.raw_tensor(0));
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.dtype.code, kDLFloat);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.dtype.bits, sizeof(double) * 8);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.device.device_type, kDLCPU);
+  EXPECT_EQ(dlm_tensors[0]->dl_tensor.byte_offset, 0);
+
+  EXPECT_EQ(tlist.tensor_shape(1).size(), 3);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.ndim, 3);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.shape[0], 50);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.shape[1], 30);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.shape[2], 3);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.data, tlist.raw_tensor(1));
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.dtype.code, kDLFloat);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.dtype.bits, sizeof(double) * 8);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.device.device_type, kDLCPU);
+  EXPECT_EQ(dlm_tensors[1]->dl_tensor.byte_offset, 0);
+  dlm_tensors.clear();
+  EXPECT_EQ(ptr.use_count(), 3);
+}
+
 TEST(DLMTensorPtr, GPUList) {
   TensorList<GPUBackend> tlist;
   tlist.Resize({{100, 50, 1}, {50, 30, 3}}, DALI_UINT8);

--- a/dali/pipeline/util/copy_with_stride_test.cc
+++ b/dali/pipeline/util/copy_with_stride_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,10 +30,7 @@ TEST(CopyWithStrideTest, OneDim) {
   constexpr int vol = 3;
   ASSERT_EQ(vol, volume(shape));
   std::array<T, vol> out;
-  DLTensorResource resource(shape);
-  resource.strides = stride;
-  auto dl_tensor =
-      MakeDLTensor(data, dtype, false, -1, std::make_unique<DLTensorResource>(resource));
+  auto dl_tensor = MakeDLTensor(data, dtype, false, false, -1, shape, stride);
   CopyDlTensorCpu(out.data(), dl_tensor);
   ASSERT_TRUE((out == std::array<T, vol>{1, 3, 5}));
 }
@@ -50,10 +47,7 @@ TEST(CopyWithStrideTest, TwoDims)  {
   constexpr int vol = 8;
   ASSERT_EQ(vol, volume(shape));
   std::array<T, vol> out;
-  DLTensorResource resource(shape);
-  resource.strides = stride;
-  auto dl_tensor =
-      MakeDLTensor(data, dtype, false, -1, std::make_unique<DLTensorResource>(resource));
+  auto dl_tensor = MakeDLTensor(data, dtype, false, false, -1, shape, stride);
   CopyDlTensorCpu(out.data(), dl_tensor);
   ASSERT_TRUE((out == std::array<T, vol>{11, 12, 13, 14,
                                          31, 32, 33, 34}));
@@ -72,10 +66,7 @@ TEST(CopyWithStrideTest, SimpleCopy) {
   constexpr int vol = 8;
   ASSERT_EQ(vol, volume(shape));
   std::array<T, vol> out;
-  DLTensorResource resource(shape);
-  resource.strides = stride;
-  auto dl_tensor =
-      MakeDLTensor(data, dtype, false, -1, std::make_unique<DLTensorResource>(resource));
+  auto dl_tensor = MakeDLTensor(data, dtype, false, false, -1, shape, stride);
   CopyDlTensorCpu(out.data(), dl_tensor);
   ASSERT_TRUE((out == std::array<T, vol>{1, 2,
                                          3, 4,
@@ -85,9 +76,7 @@ TEST(CopyWithStrideTest, SimpleCopy) {
 }
 
 DLMTensorPtr AsDlTensor(void* data, DALIDataType dtype, TensorShape<> shape, TensorShape<> stride) {
-  DLTensorResource resource(shape);
-  resource.strides = stride;
-  return MakeDLTensor(data, dtype, true, 0, std::make_unique<DLTensorResource>(resource));
+  return MakeDLTensor(data, dtype, false, false, -1, shape, stride);
 }
 
 std::vector<DLMTensorPtr> DlTensorSingletonBatch(DLMTensorPtr dl_tensor) {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -200,7 +200,7 @@ void FillTensorFromDlPack(py::capsule capsule, SourceDataType<SrcBackend> *batch
                   dl_tensor.device.device_type == kDLCPU),
                "DLPack device type doesn't match Tensor type");
 
-  const TypeInfo &dali_type = TypeTable::GetTypeInfo(DLToDALIType(dl_tensor.dtype));
+  const TypeInfo &dali_type = TypeTable::GetTypeInfo(ToDALIType(dl_tensor.dtype));
   TensorShape<> shape;
   shape.resize(dl_tensor.ndim);
   for (ssize_t i = 0; i < dl_tensor.ndim; ++i) {
@@ -497,7 +497,7 @@ void ExposeTensor(py::module &m) {
       [](Tensor<CPUBackend> &t) -> py::capsule {
         SampleView<CPUBackend> sv{t.raw_mutable_data(), t.shape(), t.type()};
 
-        return TensorToDLPackView(sv, t.device_id());
+        return TensorToDLPackView(sv, t.is_pinned(), t.device_id());
       },
       R"code(
       Exposes tensor data as DLPack compatible capsule.
@@ -692,7 +692,7 @@ void ExposeTensor(py::module &m) {
       [](Tensor<GPUBackend> &t) -> py::capsule {
         SampleView<GPUBackend> sv{t.raw_mutable_data(), t.shape(), t.type()};
 
-        return TensorToDLPackView(sv, t.device_id());
+        return TensorToDLPackView(sv, t.is_pinned(), t.device_id());
       },
       R"code(
       Exposes tensor data as DLPack compatible capsule.

--- a/dali/util/pybind.h
+++ b/dali/util/pybind.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -217,8 +217,8 @@ static py::capsule DLTensorToCapsule(DLMTensorPtr dl_tensor) {
 }
 
 template <typename Backend>
-py::capsule TensorToDLPackView(SampleView<Backend> tensor, int device_id) {
-  DLMTensorPtr dl_tensor = GetDLTensorView(tensor, device_id);
+py::capsule TensorToDLPackView(SampleView<Backend> tensor, bool pinned, int device_id) {
+  DLMTensorPtr dl_tensor = GetDLTensorView(tensor, pinned, device_id);
   return DLTensorToCapsule(std::move(dl_tensor));
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)



## Description:
This PR reworks the DLPack support in DALI.
New features:
- shared buffer ownership (not just views)
- add pinned memory support
Refactoring:
- remove DLTensorResource inheritance
- unify JAX DLTensorResource and other resources

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Existing tests: ExternalSource, PythonFunction, JAX, dali_test.bin:*DL*
New tests: buffer sharing (reference counting test).
- [X] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
