### PR TITLE
Fix constness in (Const)SampleView. Improve erroneuous conversion diagnostics.

### DIFF
--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ namespace dali {
 template <typename Backend, typename ptr_t>
 class SampleViewBase {
  public:
+  template <typename Ptr>
+  static constexpr bool is_mutable = !std::is_const_v<std::remove_pointer_t<Ptr>>;
   /**
    * @name Get the underlying pointer to data
    * @{
@@ -44,7 +46,7 @@ class SampleViewBase {
    * @brief Return an un-typed pointer to the underlying storage.
    */
   template <typename ptr_t_ = ptr_t>
-  std::enable_if_t<std::is_same<ptr_t_, void *>::value, void *> raw_mutable_data() {
+  std::enable_if_t<is_mutable<ptr_t_>, void *> raw_mutable_data() const {
     return data_;
   }
 
@@ -60,7 +62,7 @@ class SampleViewBase {
    * The calling type must match the underlying type of the buffer.
    */
   template <typename T, typename ptr_t_ = ptr_t>
-  inline std::enable_if_t<std::is_same<ptr_t_, void *>::value, T *> mutable_data() {
+  inline std::enable_if_t<is_mutable<ptr_t_>, T *> mutable_data() const {
     DALI_ENFORCE(
         type() == TypeTable::GetTypeId<T>(),
         make_string(
@@ -153,6 +155,9 @@ class SampleView : public SampleViewBase<Backend, void *> {
   using Base = SampleViewBase<Backend, void *>;
   using Base::Base;
 
+  explicit SampleView(const ConstSampleView<Backend> &csv) = delete;
+  SampleView &operator=(const ConstSampleView<Backend> &csv) = delete;
+
  private:
   using Base::data_;
   using Base::shape_;
@@ -166,6 +171,11 @@ class ConstSampleView : public SampleViewBase<Backend, const void *> {
  public:
   using Base = SampleViewBase<Backend, const void *>;
   using Base::Base;
+
+  template <typename T>
+  T *mutable_data() const = delete;
+
+  void *raw_mutable_data() const = delete;
 
   ConstSampleView(const SampleView<Backend> &other)  // NOLINT
       : Base(other.raw_data(), other.shape(), other.type()) {}


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
This PR fixes the buggy behavior where object non-constness was required to obtain a non-const pointer from a SampleView.
There's a ConstSampleView which ensures that the contents are read only this distinction (not reference kind) should be used to distinguish writeable vs read-only sample_view.
Additionally, the forbidden functions and conversions are now explicitly deleted, enhancing compiler diagnostics.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
sample_view_test
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
