### PR TITLE
Fix Pipeline reference leak in PythonFunction.

### DIFF
--- a/dali/operators/python_function/python_function.cc
+++ b/dali/operators/python_function/python_function.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,11 @@ namespace dali {
 
 DALI_SCHEMA(PythonFunctionBase)
     .AddArg("function",
-            "Function object.",
+            R"code(A callable object that defines the function of the operator.
+
+.. warning::
+    The function must not hold a reference to the pipeline in which it is used. If it does,
+    a circular reference to the pipeline will form and the pipeline will never be freed.)code",
             DALI_PYTHON_OBJECT)
     .AddOptionalArg("num_outputs", R"code(Number of outputs.)code", 1)
     .AddOptionalArg<std::vector<TensorLayout>>("output_layouts",
@@ -41,7 +45,7 @@ a more universal data format, see :meth:`nvidia.dali.fn.dl_tensor_python_functio
 The function should not modify input tensors.
 
 .. warning::
-  This operator is not compatible with TensorFlow integration.
+    This operator is not compatible with TensorFlow integration.
 
 .. warning::
     When the pipeline has conditional execution enabled, additional steps must be taken to

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -14,7 +14,6 @@
 
 
 import nvidia.dali.python_function_plugin
-import weakref
 from nvidia.dali import ops
 from nvidia.dali.ops import _registry
 from nvidia.dali.data_node import DataNode as _DataNode

--- a/dali/python/nvidia/dali/ops/_operators/python_function.py
+++ b/dali/python/nvidia/dali/ops/_operators/python_function.py
@@ -52,11 +52,10 @@ def _get_base_impl(name, impl_name):
 
         def __call__(self, *inputs, **kwargs):
             inputs = ops._preprocess_inputs(inputs, impl_name, self._device, None)
-            if _Pipeline.current():
-                self._pipeline = weakref.ref(_Pipeline.current())
-            else:
-                self._pipeline = None
+            curr_pipe = _Pipeline.current()
+            if curr_pipe is None:
                 _Pipeline._raise_pipeline_required("PythonFunction operator")
+            self.pipeline = curr_pipe._stub()
 
             for inp in inputs:
                 if not isinstance(inp, _DataNode):
@@ -78,10 +77,6 @@ def _get_base_impl(name, impl_name):
             kwargs.update({"function_id": id(self.function), "num_outputs": self.num_outputs})
 
             return super().__call__(*inputs, **kwargs)
-
-        @property
-        def pipeline(self):
-            return None if self._pipeline is None else self._pipeline()
 
     return PythonFunctionBase
 

--- a/dali/python/nvidia/dali/plugin/pytorch/_torch_function.py
+++ b/dali/python/nvidia/dali/plugin/pytorch/_torch_function.py
@@ -56,7 +56,7 @@ class TorchPythonFunction(
             )
 
     def __call__(self, *inputs, **kwargs):
-        pipeline = Pipeline.current()
+        pipeline = Pipeline.current()._stub()
         if pipeline is None:
             Pipeline._raise_pipeline_required("TorchPythonFunction")
         if self.stream is None:

--- a/dali/test/python/operator_2/test_python_function.py
+++ b/dali/test/python/operator_2/test_python_function.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ from PIL import Image, ImageEnhance
 from nvidia.dali.ops import _DataNode
 from nose2.tools import params
 
-from nose_utils import raises
+from nose_utils import raises, assert_raises
 from test_utils import get_dali_extra_path, np_type_to_dali
 
 test_data_root = get_dali_extra_path()
@@ -649,30 +649,6 @@ def test_python_function_conditionals():
     pipe.run()
 
 
-def verify_pipeline(pipeline, input):
-    assert pipeline is Pipeline.current()
-    return input
-
-
-def test_current_pipeline():
-    pipe1 = Pipeline(13, 4, 0)
-    with pipe1:
-        dummy = types.Constant(numpy.ones((1)))
-        output = fn.python_function(dummy, function=lambda inp: verify_pipeline(pipe1, inp))
-        pipe1.set_outputs(output)
-
-    pipe2 = Pipeline(6, 2, 0)
-    with pipe2:
-        dummy = types.Constant(numpy.ones((1)))
-        output = fn.python_function(dummy, function=lambda inp: verify_pipeline(pipe2, inp))
-        pipe2.set_outputs(output)
-
-    pipe1.build()
-    pipe2.build()
-    pipe1.run()
-    pipe2.run()
-
-
 @params(
     numpy.bool_,
     numpy.int_,
@@ -716,3 +692,16 @@ def test_different_types(input_type):
     pipe.build()
 
     _ = pipe.run()
+
+
+def test_delete_pipe_while_function_running():
+    def func(x):
+        time.sleep(0.02)
+        return x
+
+    for i in range(5):
+        with Pipeline(batch_size=1, num_threads=1, device_id=None) as pipe:
+            pipe.set_outputs(fn.python_function(types.Constant(0), function=func))
+            pipe.build()
+            pipe.run()
+        del pipe

--- a/dali/test/python/operator_2/test_python_function.py
+++ b/dali/test/python/operator_2/test_python_function.py
@@ -28,7 +28,7 @@ from PIL import Image, ImageEnhance
 from nvidia.dali.ops import _DataNode
 from nose2.tools import params
 
-from nose_utils import raises, assert_raises
+from nose_utils import raises
 from test_utils import get_dali_extra_path, np_type_to_dali
 
 test_data_root = get_dali_extra_path()


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
This PR removes a back-link from PythonFunction operator to the pipeline, which caused the pipeline to not be properly shut down and leaking resources.
For backward compatibility, a pipeline stub is exposed, carrying the same properties as the original pipeline, but with the native pipeline removed and functions depending on the native pipeline short-circuited to throw an exception.

## Additional information:

### Affected modules and functionalities:
PythonFunction and its flavors
It's officially illegal now to hold a reference to the Pipeline in PythonFunction's `function`. Some tests that depended on that were removed.

### Key points relevant for the review:
N/A

### Tests:
- [X] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
