### PR TITLE
Fix handling of sink operators in Exec2

### DIFF
--- a/dali/pipeline/executor/executor2/exec2_ops_for_test.cu
+++ b/dali/pipeline/executor/executor2/exec2_ops_for_test.cu
@@ -37,6 +37,13 @@ DALI_SCHEMA(Exec2Counter)
 
 DALI_REGISTER_OPERATOR(Exec2Counter, exec2::test::CounterOp, CPU);
 
+DALI_SCHEMA(Exec2Sink)
+  .NumInput(0, 99)
+  .NumOutput(0)
+  .NoPrune();
+
+DALI_REGISTER_OPERATOR(Exec2Sink, exec2::test::SinkOp, CPU);
+
 namespace exec2 {
 namespace test {
 

--- a/dali/pipeline/executor/executor2/exec2_test.cc
+++ b/dali/pipeline/executor/executor2/exec2_test.cc
@@ -125,6 +125,27 @@ TEST_P(Exec2Test, Graph2_CPU2GPU) {
   }
 }
 
+TEST_P(Exec2Test, Graph3_SinkOnly) {
+  Executor2 exec(config_);
+  graph::OpGraph graph = GetTestGraph3();
+  exec.Build(graph);
+  for (int i = 0; i < 10; i++) {
+    exec.Run();
+  }
+  Workspace ws;
+  int64_t acc = 0;
+  int bs = config_.max_batch_size;
+  for (int i = 0; i < 10; i++) {
+    ws.Clear();
+    exec.Outputs(&ws);
+    auto *sink = dynamic_cast<SinkOp*>(exec.GetOperator("op1"));
+    ASSERT_NE(sink, nullptr);
+    int64_t batch_sum = bs * (bs - 1) / 2;
+    acc += batch_sum;
+    EXPECT_EQ(sink->acc, acc);
+  }
+}
+
 
 Executor2::Config MakeCfg(QueueDepthPolicy q, OperatorConcurrency c, StreamPolicy s) {
   Executor2::Config cfg;

--- a/dali/pipeline/executor/executor2/exec2_test.h
+++ b/dali/pipeline/executor/executor2/exec2_test.h
@@ -154,6 +154,21 @@ inline void CheckTestGraph2Results(const Workspace &ws, int batch_size) {
   }
 }
 
+inline auto GetTestGraph3() {
+  auto spec0 = OpSpec(kTestOpName)
+    .AddArg("name", "op0")
+    .AddOutput("op0_0", "cpu")
+    .AddArg("addend", 0);
+  auto spec1 = OpSpec(kSinkOpName)
+    .AddArg("name", "op1")
+    .AddInput("op0_0", "cpu");
+
+  graph::OpGraph::Builder b;
+  b.Add("op0",  std::move(AddCommonArgs(spec0,  32, "cpu", 1)));
+  b.Add("op1",  std::move(AddCommonArgs(spec1,  32, "cpu", 1)));
+  return std::move(b).GetGraph(true);
+}
+
 }  // namespace test
 }  // namespace exec2
 }  // namespace dali

--- a/dali/pipeline/graph/op_graph2.cc
+++ b/dali/pipeline/graph/op_graph2.cc
@@ -30,7 +30,7 @@ OpNode &OpGraph::AddOp(std::string instance_name, OpSpec spec) {
   std::string device;
   if (spec.TryGetArgument(device, "device"))
     type = ParseOpType(device);
-  bool preserve = spec.GetArgument<bool>("preserve");
+  bool preserve = spec.GetArgument<bool>("preserve") || spec.GetSchemaOrDefault().IsNoPrune();
   auto &op_node = tmp.emplace_back(std::move(instance_name), type, std::move(spec));
   if (!name2op_.emplace(op_node.instance_name, &op_node).second) {
     throw std::invalid_argument(


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)



## Description:
Detection history: python op. sink operator test failed in debug build for Executor2
Reason:
- tasking didn't properly handle multi-output tasks with zero outputs.
Fix:
- zero-output tasks have now special treatment
- a scalar void value is used when there are zero outputs

## Additional information:

### Affected modules and functionalities:
Tasking
Exec2



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
