### PR TITLE
Fix the redundant usage of pinned memory in the numpy cpu reader

### DIFF
--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -314,6 +314,7 @@ void NumpyReaderCPU::Prefetch() {
       }
       target->data.ShareData(tmp_mem, target->nbytes, false, target->shape, target->type, -1);
     } else {
+      if (!target->data.has_data()) target->data.set_pinned(false);
       target->data.Resize(target->shape, target->type);
       auto data_ptr = static_cast<uint8_t*>(target->data.raw_mutable_data());
       Index ret = target->current_file->Read(data_ptr, target->nbytes);

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -1001,6 +1001,7 @@ def test_box_encoder_cpu():
 def test_numpy_reader_cpu():
     with setup_test_numpy_reader_cpu() as test_data_root:
         check_no_input(fn.readers.numpy, file_root=test_data_root)
+        check_no_input(fn.readers.numpy, file_root=test_data_root, dont_use_mmap=True)
 
 
 @attr("pytorch")


### PR DESCRIPTION
- the numpy cpu reader uses pinned memory when the don't use mmap option
  is on. This PR fixes this and adds a corresponding test

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- the numpy cpu reader uses pinned memory when the don't use mmap option
  is on. This PR fixes this and adds a corresponding test
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- CPU numpy reader op
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - extended test_dali_cpu_only.test_numpy_reader_cpu case
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
