### PR TITLE
Make sure that the proper video stream index is used by the GPU decoder

### DIFF
--- a/dali/operators/input/video_input_cpu.cc
+++ b/dali/operators/input/video_input_cpu.cc
@@ -24,6 +24,8 @@ void VideoInput<CPUBackend, dali::FramesDecoder>::CreateDecoder(const Workspace 
   auto data = reinterpret_cast<const char *>(sample.data<uint8_t>());
   size_t size = sample.shape().num_elements();
   this->frames_decoders_[0] = std::make_unique<dali::FramesDecoder>(data, size, false);
+  DALI_ENFORCE(this->frames_decoders_[0]->IsValid(),
+               "Failed to create video decoder for provided video data");
 }
 
 

--- a/dali/operators/input/video_input_mixed.cc
+++ b/dali/operators/input/video_input_mixed.cc
@@ -25,6 +25,8 @@ void VideoInput<MixedBackend, dali::FramesDecoderGpu>::CreateDecoder(const Works
   size_t size = sample.shape().num_elements();
   this->frames_decoders_[0] = std::make_unique<dali::FramesDecoderGpu>(data, size, ws.stream(),
                                                                        false);
+  DALI_ENFORCE(this->frames_decoders_[0]->IsValid(),
+               "Failed to create video decoder for provided video data");
 }
 
 

--- a/dali/operators/reader/loader/video/frames_decoder.h
+++ b/dali/operators/reader/loader/video/frames_decoder.h
@@ -217,10 +217,10 @@ class DLL_PUBLIC FramesDecoder {
 
   bool is_full_range_ = false;
 
-  std::optional<bool> zero_latency_ = {};
-
-  // False when the file doesn't have any correct content or doesn't have valid video stream
+  // False when the file doesn't have any correct content or doesn't have a valid video stream
   bool is_valid_ = false;
+
+  std::optional<bool> zero_latency_ = {};
 
  private:
    /**

--- a/dali/operators/reader/loader/video/frames_decoder.h
+++ b/dali/operators/reader/loader/video/frames_decoder.h
@@ -219,6 +219,9 @@ class DLL_PUBLIC FramesDecoder {
 
   std::optional<bool> zero_latency_ = {};
 
+  // False when the file doesn't have any correct content or doesn't have valid video stream
+  bool is_valid_ = false;
+
  private:
    /**
    * @brief Gets the packet from the decoder and reads a frame from it to provided buffer. Returns
@@ -275,8 +278,6 @@ class DLL_PUBLIC FramesDecoder {
   int channels_ = 3;
   bool flush_state_ = false;
   bool is_vfr_ = false;
-  // False when the file doesn't have any correct content or doesn't have valid video stream
-  bool is_valid_ = false;
 
   const std::string filename_ = {};
   std::optional<MemoryVideoFile> memory_video_file_ = {};


### PR DESCRIPTION
- fixes the use of 0 index stream inside the GPU decoder by properly
  obtained index
- related to https://github.com/NVIDIA/DALI/issues/5680

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- fixes the use of 0 index stream inside the GPU decoder by properly
  obtained index
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- video GPU decoder
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - inputs/test_video.test_video_input_audio_stream
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
