### PR TITLE
Use exec-dynamic in RNN-t pipeline. Fix `asserts` in Exec2.

### DIFF
--- a/dali/pipeline/executor/executor2/exec_node_task.cc
+++ b/dali/pipeline/executor/executor2/exec_node_task.cc
@@ -248,6 +248,9 @@ void OpTask::SetupOp() {
   int nout = node_->outputs.size();
   assert(ws.NumOutput() == nout);
 
+  assert(ws.has_stream() || node_->backend == OpType::CPU);
+  assert(ws.has_event() || node_->backend == OpType::CPU);
+
   skip_ = ShouldSkip();
 
   int device = -1;


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
1. Fix the use of `.shape` in RNN-t pipeline by switching to exec_dynamic (also moves the processing to GPU earlier)
2. Fix the multiple setting of `ready_event` when the same output is returned many times from the pipeline (caused `assert` to be raised).

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
The test was modified.

- [X] Existing tests apply
- [ ] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
