### PR TITLE
Use absolute addressing for parameters

### DIFF
--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -147,7 +147,7 @@ class Pipeline(object):
         More details can be found in
         `this documentation section <advanced_topics_checkpointing.html>`_.
     py_num_workers : int, optional, default = 1
-        The number of Python workers that will process :meth:`~nvidia.dali.fn.external_source`
+        The number of Python workers that will process parallel :meth:`~nvidia.dali.fn.external_source`
         callbacks.
         The pool starts only if there is at least one ExternalSource with
         :paramref:`~nvidia.dali.fn.external_source.parallel` set to True.

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -147,10 +147,12 @@ class Pipeline(object):
         More details can be found in
         `this documentation section <advanced_topics_checkpointing.html>`_.
     py_num_workers : int, optional, default = 1
-        The number of Python workers that will process ``ExternalSource`` callbacks.
-        The pool starts only if there is at least one ExternalSource with ``parallel`` set to True.
+        The number of Python workers that will process :meth:`~nvidia.dali.fn.external_source`
+        callbacks.
+        The pool starts only if there is at least one ExternalSource with
+        :paramref:`~nvidia.dali.fn.external_source.parallel` set to True.
         Setting it to 0 disables the pool and all ExternalSource operators fall back to non-parallel
-        mode even if ``parallel`` is set to True.
+        mode even if :paramref:`~nvidia.dali.fn.external_source.parallel` is set to True.
     py_start_method : str, default = "fork"
         Determines how Python workers are started. Supported methods:
 

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -147,8 +147,8 @@ class Pipeline(object):
         More details can be found in
         `this documentation section <advanced_topics_checkpointing.html>`_.
     py_num_workers : int, optional, default = 1
-        The number of Python workers that will process parallel :meth:`~nvidia.dali.fn.external_source`
-        callbacks.
+        The number of Python workers that will process parallel
+        :meth:`~nvidia.dali.fn.external_source` callbacks.
         The pool starts only if there is at least one ExternalSource with
         :paramref:`~nvidia.dali.fn.external_source.parallel` set to True.
         Setting it to 0 disables the pool and all ExternalSource operators fall back to non-parallel


### PR DESCRIPTION

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Bug fix**,  **Other**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Injecting full qualified path to parameters solve problems with lookup of enclosing entity and generating valid links for submodules that are runtime generated.

The missing-reference resolver of sphinx paramlinks assume that `source` of all nodes has format:
"/path/to/file.py:docstring of module.clsname.methname" and requires the `:`, while members of generated DALI submodules have only the:
"docstring of nvidia.dali.fn.decoders.image"
part, so the regex doesn't match. If the reference is fully specified, the plugin doesn't need to look it up and doesn't use the unsuitable regex.

Some nvidia.dali.ops module specific code is added, so we try to always obtain the `__call__` signature (it contains all inputs and kwargs) and we try to link to either class or `__call__` documentation depending if we are documenting input or kwarg - as that API has this specific distinction.

Other parts of API don't have specific conventions.

One example in pipeline doc showcases the ability to reference parameters of other functions.

## Additional information:

### Affected modules and functionalities:
Sphinx doc generation



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [x] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
