### PR TITLE
Fix passing the results of `.cpu()` to argument inputs.

### DIFF
--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -324,6 +324,12 @@ int Pipeline::AddOperatorImpl(const OpSpec &const_spec, const std::string &inst_
     std::string input_name = spec.InputName(input_idx);
     auto it = edge_names_.find(input_name);
 
+    // TODO(michalz): This is a bit ugly, but it provides a nice and generic error message.
+    //                In the long run, we should probably allow GPU named inputs and then
+    //                the check should be done based on the schema, without a universal ToCPU.
+    if (dynamic_execution_)
+      ToCPU(it);
+
     DALI_ENFORCE(
         it != edge_names_.end(),
         make_string("Data node \"", input_name, "\" requested as ", FormatArgument(spec, arg_name),
@@ -335,8 +341,6 @@ int Pipeline::AddOperatorImpl(const OpSpec &const_spec, const std::string &inst_
                             ". Named argument inputs to operators must be CPU data nodes. "
                             "However, a GPU data node was provided."));
     }
-
-    ToCPU(it);
   }
 
   // Verify and record the outputs of the op

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -2207,6 +2207,19 @@ def test_gpu2cpu():
         check_batch(cpu, gpu, bs, 0, 0, "HWC")
 
 
+def test_gpu2cpu_arg_input():
+    @pipeline_def(batch_size=1, num_threads=4, device_id=0, exec_dynamic=True)
+    def pdef():
+        data = dali.types.Constant([42], device="gpu")
+        resized = fn.zeros(shape=data.cpu(), dtype=types.INT32)
+        return resized
+
+    pipe = pdef()
+    pipe.build()
+    (o,) = pipe.run()
+    assert o[0].shape() == [42]
+
+
 def test_shapes_gpu():
     bs = 8
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
`.cpu()` doesn't really produce a CPU DataNode and argument inputs don't have a device.
The availability of CPU backend for argument inptu was checked when adding an operator - resulting in an error.
This PR inserts a ToCPU when dynamic executor is used.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
