### PR TITLE
OpSchema major rework

### DIFF
--- a/dali/operators/generic/roi_random_crop.cc
+++ b/dali/operators/generic/roi_random_crop.cc
@@ -40,6 +40,7 @@ either specified with `roi_start`/`roi_end` or `roi_start`/`roi_shape`.
 
 The operator produces an output representing the cropping window start coordinates.
 )code")
+    .AddRandomSeedArg()
     .AddArg("crop_shape",
       R"code(Cropping window dimensions.)code", DALI_INT_VEC, true)
     .AddArg("roi_start",

--- a/dali/operators/image/crop/bbox_crop.cc
+++ b/dali/operators/image/crop/bbox_crop.cc
@@ -194,6 +194,7 @@ associated with each of the bounding boxes.)code")
       return spec.NumRegularInput() - 1 +                    // +1 if labels are provided
              spec.GetArgument<bool>("output_bbox_indices");  // +1 if output_bbox_indices=True
     })
+    .AddRandomSeedArg()
     .AddOptionalArg(
         "thresholds",
         R"code(Minimum IoU or a different metric, if specified by `threshold_type`, of the

--- a/dali/operators/image/crop/random_crop_attr.cc
+++ b/dali/operators/image/crop/random_crop_attr.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ The cropped image's area will be equal to ``A`` * original image's area.)code",
       std::vector<float>{0.08, 1.0})
   .AddOptionalArg("num_attempts",
       R"code(Maximum number of attempts used to choose random area and aspect ratio.)code",
-      10);
+      10)
+  .AddRandomSeedArg();
 
 }  // namespace dali

--- a/dali/operators/image/remap/jitter.cu
+++ b/dali/operators/image/remap/jitter.cu
@@ -29,6 +29,7 @@ and bounded by half of the `nDegree` parameter.)code")
       R"code(Each pixel is moved by a random amount in the ``[-nDegree/2, nDegree/2]`` range)code",
       2)
   .InputLayout(0, "HWC")
+  .AddRandomSeedArg()
   .AddParent("DisplacementFilter");
 
 DALI_REGISTER_OPERATOR(Jitter, Jitter<GPUBackend>, GPU);

--- a/dali/operators/random/batch_permutation.cc
+++ b/dali/operators/random/batch_permutation.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ indexing samples in the batch.)")
       R"(If true, the output can contain repetitions and omissions.)", false)
   .AddOptionalArg("no_fixed_points", R"(If true, the the output permutation cannot contain fixed
 points, that is ``out[i] != i``. This argument is ignored when batch size is 1.)", false)
+  .AddRandomSeedArg()
   .AddParent("ImplicitScopeAttr");
 
 void BatchPermutation::RunImpl(Workspace &ws) {

--- a/dali/operators/random/choice_cpu.cc
+++ b/dali/operators/random/choice_cpu.cc
@@ -48,7 +48,8 @@ that is: :meth:`nvidia.dali.types.DALIDataType`, :meth:`nvidia.dali.types.DALIIm
                                         "Distribution of the probabilities. "
                                         "If not specified, uniform distribution is assumed.",
                                         nullptr, true)
-    .AddOptionalArg<std::vector<int>>("shape", "Shape of the output data.", nullptr, true);
+    .AddOptionalArg<std::vector<int>>("shape", "Shape of the output data.", nullptr, true)
+    .AddRandomSeedArg();
 
 DALI_REGISTER_OPERATOR(random__Choice, Choice<CPUBackend>, CPU);
 

--- a/dali/operators/random/noise/gaussian_noise.cc
+++ b/dali/operators/random/noise/gaussian_noise.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ The shape and data type of the output will match the input.
 )code")
     .NumInput(1)
     .NumOutput(1)
+    .AddRandomSeedArg()
     .AddOptionalArg<float>("mean",
       R"code(Mean of the distribution.)code",
       0.f, true)

--- a/dali/operators/random/noise/salt_and_pepper_noise.cc
+++ b/dali/operators/random/noise/salt_and_pepper_noise.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ The shape and data type of the output will match the input.
 )code")
     .NumInput(1)
     .NumOutput(1)
+    .AddRandomSeedArg()
     .AddOptionalArg<float>("prob",
       R"code(Probability of an output value to take a salt or pepper value.)code",
       0.05f, true)

--- a/dali/operators/random/noise/shot_noise.cc
+++ b/dali/operators/random/noise/shot_noise.cc
@@ -42,6 +42,7 @@ The shape and data type of the output will match the input.
 )code")
     .NumInput(1)
     .NumOutput(1)
+    .AddRandomSeedArg()
     .AddOptionalArg<float>("factor",
       R"code(Factor parameter.)code",
      20.0f, true);

--- a/dali/operators/random/rng_base.cc
+++ b/dali/operators/random/rng_base.cc
@@ -29,6 +29,8 @@ It should be added as parent to all RNG operators.)code")
 
 .. note::
   The generated numbers are converted to the output data type, rounding and clamping if necessary.
-)code", nullptr);
+)code", nullptr)
+  .AddRandomSeedArg();
+
 
 }  // namespace dali

--- a/dali/operators/reader/loader/loader.cc
+++ b/dali/operators/reader/loader/loader.cc
@@ -18,6 +18,7 @@
 namespace dali {
 
 DALI_SCHEMA(LoaderBase)
+  .AddRandomSeedArg()
   .AddOptionalArg("random_shuffle",
       R"code(Determines whether to randomly shuffle data.
 

--- a/dali/operators/reader/tfrecord_reader_op.cc
+++ b/dali/operators/reader/tfrecord_reader_op.cc
@@ -38,6 +38,7 @@ DALI_REGISTER_OPERATOR(readers___TFRecord, TFRecordReader, CPU);
 // Common part of schema for internal readers._tfrecord and public readers.tfrecord schema.
 DALI_SCHEMA(readers___TFRecordBase)
   .DocStr(R"code(Read sample data from a TensorFlow TFRecord file.)code")
+  .AddRandomSeedArg()
   .AddArg("path",
       R"code(List of paths to TFRecord files.)code",
       DALI_STRING_VEC)

--- a/dali/operators/segmentation/random_mask_pixel.cc
+++ b/dali/operators/segmentation/random_mask_pixel.cc
@@ -51,7 +51,8 @@ This argument is mutually exclusive with `value` argument.
 If 0, the pixel position is sampled uniformly from all available pixels.)code",
       0, true)
     .NumInput(1)
-    .NumOutput(1);
+    .NumOutput(1)
+    .AddRandomSeedArg();
 
 class RandomMaskPixelCPU : public rng::OperatorWithRng<CPUBackend> {
  public:

--- a/dali/operators/segmentation/random_object_bbox.cc
+++ b/dali/operators/segmentation/random_object_bbox.cc
@@ -51,6 +51,7 @@ With probability 1-foreground_prob, the entire area of the input is returned.)")
     int output_class = spec.GetArgument<bool>("output_class");
     return 1 + separate_corners + output_class;
   })
+  .AddRandomSeedArg()
   .AddOptionalArg("ignore_class", R"(If True, all objects are picked with equal probability,
 regardless of the class they belong to. Otherwise, a class is picked first and then an object is
 randomly selected from this class.

--- a/dali/operators/ssd/random_crop.cc
+++ b/dali/operators/ssd/random_crop.cc
@@ -34,6 +34,7 @@ cropped and valid bounding boxes and valid labels are returned.)code")
   .NumInput(3)   // [img, bbox, label]
   .NumOutput(3)  // [img, bbox, label]
   .AddOptionalArg("num_attempts", R"code(Number of attempts.)code", 1)
+  .AddRandomSeedArg()
   .Deprecate("RandomBBoxCrop");  // deprecated in DALI 0.30
 
 /*

--- a/dali/pipeline/operator/argument.h
+++ b/dali/pipeline/operator/argument.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2018, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,8 +59,6 @@ class Value {
   }
   virtual ~Value() = default;
 
-  virtual std::unique_ptr<Value> Clone() const = 0;
-
  protected:
   Value() : type_(DALI_NO_TYPE) {}
 
@@ -85,10 +83,6 @@ class ValueInst : public Value {
 
   const T &Get() const {
     return val_;
-  }
-
-  virtual std::unique_ptr<Value> Clone() const override {
-    return std::make_unique<ValueInst<T>>(val_);
   }
 
  private:

--- a/dali/pipeline/operator/builtin/input_operator.h
+++ b/dali/pipeline/operator/builtin/input_operator.h
@@ -570,7 +570,7 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
  * Checks, if the Operator defined by provided Schema is an InputOperator
  */
 inline bool IsInputOperator(const OpSchema &schema) {
-  const auto &parents = schema.GetParents();
+  const auto &parents = schema.GetParentNames();
   return std::any_of(parents.begin(), parents.end(),
                      [](const std::string &p) { return p == "InputOperatorBase"; });
 }

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -217,7 +217,7 @@ OpSchema &OpSchema::AdditionalOutputsFn(SpecFunc f) {
 
 OpSchema &OpSchema::NumInput(int n) {
   if (n < 0)
-    throw invalid_key("The number of inputs must not be negative");
+    throw std::invalid_argument("The number of inputs must not be negative");
   max_num_input_ = n;
   min_num_input_ = n;
   input_info_.resize(n);
@@ -227,9 +227,9 @@ OpSchema &OpSchema::NumInput(int n) {
 
 OpSchema &OpSchema::NumInput(int min, int max) {
   if (min < 0 || max < 0)
-    throw invalid_key("The number of inputs must not be negative");
+    throw std::invalid_argument("The number of inputs must not be negative");
   if (min > max)
-    throw invalid_key("The min. number of inputs must not be greater than max.");
+    throw std::invalid_argument("The min. number of inputs must not be greater than max.");
   min_num_input_ = min;
   max_num_input_ = max;
   input_info_.resize(max);
@@ -257,7 +257,7 @@ DLL_PUBLIC dali::InputDevice OpSchema::GetInputDevice(int index) const {
 
 OpSchema &OpSchema::NumOutput(int n) {
   if (n < 0)
-    throw invalid_key("The number of outputs must not be negative");
+    throw std::invalid_argument("The number of outputs must not be negative");
   num_output_ = n;
   return *this;
 }
@@ -961,7 +961,7 @@ const ArgumentDef *OpSchema::FindTensorArgument(std::string_view name) const {
 
 void OpSchema::CheckInputIndex(int index) const {
   if (index < 0 && index >= max_num_input_)
-    throw invalid_key(make_string(
+    throw std::out_of_range(make_string(
       "Input index ", index, " is out of range [0..", max_num_input_, ").\nWas NumInput called?"));
 }
 

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -76,9 +76,9 @@ OpSchema::OpSchema(DefaultSchemaTag) : name_(""), default_(true) {
   AddInternalArg("default_cuda_stream_priority", "Default cuda stream priority", 0);  // deprecated
   AddInternalArg("checkpointing", "Setting to `true` enables checkpointing", false);
 
-  AddOptionalArg("seed", R"code(Random seed.
+  AddOptionalArg<int>("seed", R"code(Random seed.
 If not provided, it will be populated based on the global seed of the pipeline.)code",
-                 -1);
+                 nullptr);
 
   AddOptionalArg("bytes_per_sample_hint", R"code(Output size hint, in bytes per sample.
 
@@ -473,9 +473,9 @@ OpSchema &OpSchema::AddOptionalTypeArg(std::string_view s, std::string doc) {
 
 
 OpSchema &OpSchema::AddRandomSeedArg() {
-  AddOptionalArg("seed",
-                 "Random seed; if not set, one will be assigned automatically, if needed.",
-                 -1);
+  AddOptionalArg<int>("seed",
+                      "Random seed; if not set, one will be assigned automatically.",
+                      nullptr);
   return *this;
 }
 

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -124,6 +124,10 @@ a pipeline scope. False if it was defined without pipeline being set as current.
                  "Operator name as presented in the API it was instantiated in (without the module "
                  "path), for example: cast_like or CastLike.",
                  OperatorName());
+
+  AddOptionalArg("seed",
+                 "Random seed; if not set, one will be assigned automatically, if needed.",
+                 -1_u64);
 }
 
 

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -475,7 +475,7 @@ OpSchema &OpSchema::AddOptionalTypeArg(std::string_view s, std::string doc) {
 OpSchema &OpSchema::AddRandomSeedArg() {
   AddOptionalArg<int>("seed",
                       "Random seed; if not set, one will be assigned automatically.",
-                      nullptr);
+                      -1);
   return *this;
 }
 

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -70,8 +70,8 @@ OpSchema::OpSchema(const std::string &name) : name_(name) {
   AddInternalArg("default_cuda_stream_priority", "Default cuda stream priority", 0);  // deprecated
   AddInternalArg("checkpointing", "Setting to `true` enables checkpointing", false);
 
-  AddInternalArg("seed", "Deprecated. Only operators which use RNG have a `seed` argument",
-                 -1_i64);
+  AddOptionalArg<int64_t>("seed", "Deprecated. Only operators which use RNG have a `seed` argument",
+                          nullptr);
   DeprecateArg(
     "seed", true,
     "Specifying `seed` for operators which do not use random number generators is deprecated.");
@@ -432,16 +432,13 @@ OpSchema &OpSchema::AddOptionalArg(const std::string &s, const std::string &doc,
 }
 
 OpSchema &OpSchema::AddRandomSeedArg() {
-  internal_arguments_.erase("seed");
   deprecated_arguments_.erase("seed");
-  AddOptionalArg<int64_t>("seed", R"code(Random seed.
-
-  If not provided, it will be populated based on the global seed of the pipeline.)code",
-    nullptr);
-
   return *this;
 }
 
+bool OpSchema::HasRandomSeedArg() const {
+  return arguments_.count("seed") && !deprecated_arguments_.count("seed");
+}
 
 OpSchema &OpSchema::DeprecateArgInFavorOf(const std::string &arg_name, std::string renamed_to,
                                           std::string msg) {

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -70,12 +70,6 @@ OpSchema::OpSchema(const std::string &name) : name_(name) {
   AddInternalArg("default_cuda_stream_priority", "Default cuda stream priority", 0);  // deprecated
   AddInternalArg("checkpointing", "Setting to `true` enables checkpointing", false);
 
-  AddOptionalArg<int64_t>("seed", "Deprecated. Only operators which use RNG have a `seed` argument",
-                          nullptr);
-  DeprecateArg(
-    "seed", true,
-    "Specifying `seed` for operators which do not use random number generators is deprecated.");
-
   AddOptionalArg("bytes_per_sample_hint", R"code(Output size hint, in bytes per sample.
 
 If specified, the operator's outputs residing in GPU or page-locked host memory will be preallocated
@@ -437,7 +431,7 @@ OpSchema &OpSchema::AddRandomSeedArg() {
 }
 
 bool OpSchema::HasRandomSeedArg() const {
-  return arguments_.count("seed") && !deprecated_arguments_.count("seed");
+  return optional_arguments_.count("seed") && !deprecated_arguments_.count("seed");
 }
 
 OpSchema &OpSchema::DeprecateArgInFavorOf(const std::string &arg_name, std::string renamed_to,

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -46,7 +46,7 @@ const OpSchema &SchemaRegistry::GetSchema(std::string_view name) {
   auto &schema_map = registry();
   auto it = schema_map.find(name);
   if (it == schema_map.end())
-    throw std::out_of_range("Schema for operator '" + std::string(name) + "' not registered");
+    throw invalid_key("Schema for operator '" + std::string(name) + "' not registered");
 
   return it->second;
 }
@@ -216,7 +216,7 @@ OpSchema &OpSchema::AdditionalOutputsFn(SpecFunc f) {
 
 OpSchema &OpSchema::NumInput(int n) {
   if (n < 0)
-    throw std::out_of_range("The number of inputs must not be negative");
+    throw invalid_key("The number of inputs must not be negative");
   max_num_input_ = n;
   min_num_input_ = n;
   input_info_.resize(n);
@@ -226,9 +226,9 @@ OpSchema &OpSchema::NumInput(int n) {
 
 OpSchema &OpSchema::NumInput(int min, int max) {
   if (min < 0 || max < 0)
-    throw std::out_of_range("The number of inputs must not be negative");
+    throw invalid_key("The number of inputs must not be negative");
   if (min > max)
-    throw std::out_of_range("The min. number of inputs must not be greater than max.");
+    throw invalid_key("The min. number of inputs must not be greater than max.");
   min_num_input_ = min;
   max_num_input_ = max;
   input_info_.resize(max);
@@ -256,7 +256,7 @@ DLL_PUBLIC dali::InputDevice OpSchema::GetInputDevice(int index) const {
 
 OpSchema &OpSchema::NumOutput(int n) {
   if (n < 0)
-    throw std::out_of_range("The number of outputs must not be negative");
+    throw invalid_key("The number of outputs must not be negative");
   num_output_ = n;
   return *this;
 }
@@ -893,7 +893,7 @@ bool OpSchema::HasInternalArgument(std::string_view name) const {
 const ArgumentDef &OpSchema::GetArgument(std::string_view name) const {
   if (auto *arg = FindArgument(name))
     return *arg;
-  throw std::out_of_range(make_string(
+  throw invalid_key(make_string(
         "Argument \"", name, "\" is not defined for operator \"", this->name(), "\"."));
 }
 
@@ -960,7 +960,7 @@ const ArgumentDef *OpSchema::FindTensorArgument(std::string_view name) const {
 
 void OpSchema::CheckInputIndex(int index) const {
   if (index < 0 && index >= max_num_input_)
-    throw std::out_of_range(make_string(
+    throw invalid_key(make_string(
       "Input index ", index, " is out of range [0..", max_num_input_, ").\nWas NumInput called?"));
 }
 

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -833,7 +833,7 @@ void OpSchema::CheckArgs(const OpSpec &spec) const {
   auto args_in_spec = spec.ListArgumentNames();
   for (const auto &name : args_in_spec) {
     auto *arg = FindArgument(name);
-    if (!arg || arg->internal)
+    if (!arg)
       throw std::invalid_argument(make_string("Got an unexpected argument \"", name, "\""));
   }
   std::vector<std::string_view> missing_args;

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -138,6 +138,7 @@ a pipeline scope. False if it was defined without pipeline being set as current.
   DeprecateArg("seed", true,
                "The argument \"seed\" should not be used with operators that don't use "
                "random numbers.");
+  arguments_["seed"].hidden = true;
 }
 
 

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -269,12 +269,6 @@ OpSchema &OpSchema::DisableAutoInputDox() {
 }
 
 
-OpSchema &OpSchema::DisallowInstanceGrouping() {
-  allow_instance_grouping_ = false;
-  return *this;
-}
-
-
 OpSchema &OpSchema::SequenceOperator() {
   is_sequence_operator_ = true;
   return *this;
@@ -311,10 +305,10 @@ OpSchema &OpSchema::MakeDocPartiallyHidden() {
 }
 
 
-OpSchema &OpSchema::Deprecate(std::string_view in_favor_of, std::string_view explanation) {
+OpSchema &OpSchema::Deprecate(std::string in_favor_of, std::string explanation) {
   is_deprecated_ = true;
-  deprecated_in_favor_of_ = in_favor_of;
-  deprecation_message_ = explanation;
+  deprecated_in_favor_of_ = std::move(in_favor_of);
+  deprecation_message_ = std::move(explanation);
   return *this;
 }
 
@@ -700,11 +694,6 @@ int OpSchema::MinNumInput() const {
 
 int OpSchema::NumOutput() const {
   return num_output_;
-}
-
-
-bool OpSchema::AllowsInstanceGrouping() const {
-  return allow_instance_grouping_;
 }
 
 

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -258,12 +258,6 @@ class DLL_PUBLIC OpSchema {
    */
   OpSchema &DisableAutoInputDox();
 
-  /**
-   * @brief Indicates that multiple instances of this operator cannot share a logical ID to achieve
-   *        uniform processing of multiple input sets
-   */
-  OpSchema &DisallowInstanceGrouping();
-
   /** Notes that this operator expects sequence inputs exclusively */
   OpSchema &SequenceOperator();
 
@@ -290,8 +284,8 @@ class DLL_PUBLIC OpSchema {
    * @param in_favor_of schema name of the replacement
    * @param explanation additional explanation
    */
-  OpSchema &Deprecate(std::string_view in_favor_of = "",
-                      std::string_view explanation = "");
+  OpSchema &Deprecate(std::string in_favor_of = "",
+                      std::string explanation = "");
 
   /** Notes that this operator cannot be serialized */
   OpSchema &Unserializable();
@@ -352,7 +346,7 @@ class DLL_PUBLIC OpSchema {
   /**
    * @brief Adds an optional non-vector argument without default to op
    *        The type can be specified as enum, nullptr_t is used for overload resolution
-   *        If the arg name starts is with an underscore, it will be marked hidden, which
+   *        If the arg name starts with an underscore, it will be marked hidden, which
    *        makes it not listed in the docs.
    */
   OpSchema &AddOptionalArg(std::string_view s, std::string doc,
@@ -362,7 +356,7 @@ class DLL_PUBLIC OpSchema {
 
   /**
    * @brief Adds an optional non-vector argument without default to op.
-   *        If the arg name starts is with an underscore, it will be marked hidden, which
+   *        If the arg name starts with an underscore, it will be marked hidden, which
    *        makes it not listed in the docs.
    */
   template <typename T>
@@ -377,7 +371,7 @@ class DLL_PUBLIC OpSchema {
 
   /**  Adds an optional non-vector argument to op
    *
-   * If the arg name starts is with an underscore, it will be marked hidden, which
+   * If the arg name starts with an underscore, it will be marked hidden, which
    * makes it not listed in the docs.
    */
   template <typename T>
@@ -398,14 +392,14 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
 
   /** Adds an optional argument of type DALIDataType with a default value
    *
-   * If the arg name starts is with an underscore, it will be marked hidden, which
+   * If the arg name starts with an underscore, it will be marked hidden, which
    * makes it not listed in the docs.
    */
   OpSchema &AddOptionalTypeArg(std::string_view name, std::string doc, DALIDataType default_value);
 
   /**  Adds an optional argument of type DALIDataType without a default value
    *
-   * If the arg name starts is with an underscore, it will be marked hidden, which
+   * If the arg name starts with an underscore, it will be marked hidden, which
    * makes it not listed in the docs.
    */
   OpSchema &AddOptionalTypeArg(std::string_view name, std::string doc);
@@ -422,7 +416,7 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
 
   /**  Adds an optional vector argument to op
    *
-   * If the arg name starts is with an underscore, it will be marked hidden, which
+   * If the arg name starts with an underscore, it will be marked hidden, which
    * makes it not listed in the docs.
    */
   template <typename T>
@@ -556,8 +550,6 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
 
   /** Get the number of static outputs, see also CalculateOutputs and CalculateAdditionalOutputs */
   int NumOutput() const;
-
-  bool AllowsInstanceGrouping() const;
 
   /** Whether this operator accepts ONLY sequences as inputs */
   bool IsSequenceOperator() const;
@@ -799,7 +791,6 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
 
   ////////////////////////////////////////////////////////////////////////////
   // Internal flags
-  bool allow_instance_grouping_ = true;
   bool no_prune_ = false;
   bool serializable_ = true;
   const bool default_ = false;

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -723,6 +723,11 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
                               bool local_only = false) const;
 
   /**
+   * @brief Returns true if the operator has a "seed" argument.
+   */
+  DLL_PUBLIC bool HasRandomSeedArg() const;
+
+  /**
    * @brief Get docstring for operator argument of given name (Python Operator Kwargs).
    */
   DLL_PUBLIC std::string GetArgumentDox(const std::string &name) const;

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -143,7 +143,7 @@ struct LazyValue {
     return *data;
   }
   std::unique_ptr<T> data;
-  std::mutex lock;
+  std::recursive_mutex lock;
 };
 }  // namespace detail
 
@@ -758,6 +758,7 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
 
   mutable
   detail::LazyValue<std::map<std::string, const ArgumentDef *, std::less<>>> flattened_arguments_;
+  mutable int circular_inheritance_detector_ = 0;
 
   std::map<std::string, const ArgumentDef *, std::less<>> &GetFlattenedArguments() const;
 

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -37,31 +37,6 @@ namespace dali {
 
 class OpSpec;
 
-struct RequiredArgumentDef {
-  std::string doc;
-  DALIDataType dtype;
-};
-
-struct DefaultedArgumentDef {
-  std::string doc;
-  DALIDataType dtype;
-  Value *default_value;
-  // As opposed to purely internal argument, the hidden argument
-  // can be specified as any other argument on per-operator basis, through Python API, etc.
-  // It is just hidden from the docs.
-  bool hidden;
-};
-
-struct DeprecatedArgDef {
-  std::string renamed_to = {};
-  std::string msg = {};
-  bool removed = false;
-};
-
-struct TensorArgDesc {
-  bool supports_per_frame = false;
-};
-
 enum class InputDevice : uint8_t {
   /** CPU for CPU and Mixed operators; GPU for GPU operators. */
   MatchBackend = 0,
@@ -92,6 +67,26 @@ enum class InputDevice : uint8_t {
    */
   Metadata,
 };
+
+struct ArgumentDeprecation {
+  std::string renamed_to = {};
+  std::string msg = {};
+  bool removed = false;
+};
+
+struct ArgumentDef {
+  std::string doc;
+  DALIDataType dtype;
+  std::unique_ptr<Value> default_value;
+  bool required   : 1 = false;
+  bool tensor     : 1 = false;
+  bool per_frame  : 1 = false;
+  bool internal   : 1 = false;
+  bool hidden     : 1 = false;
+
+  std::unique_ptr<ArgumentDeprecation> deprecated;
+};
+
 
 class DLL_PUBLIC OpSchema {
  public:
@@ -789,6 +784,12 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
    * @brief Initialize the module_path_ and operator_name_ fields based on the schema name.
    */
   void InitNames();
+
+  /**
+   * @brief
+   *
+   */
+  void InitDefaultSchema();
 
   std::string dox_;
   /** @brief The name of the schema */

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -438,6 +438,8 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
     return *this;
   }
 
+  DLL_PUBLIC OpSchema &AddRandomSeedArg();
+
   /**
    * @brief Marks an argument as deprecated in favor of a new argument
    *

--- a/dali/pipeline/operator/op_schema_test.cc
+++ b/dali/pipeline/operator/op_schema_test.cc
@@ -82,7 +82,7 @@ TEST(OpSchemaTest, OptionalArgumentDefaultValue) {
   ASSERT_FALSE(schema.HasArgumentDefaultValue("no_default"));
   ASSERT_THROW(schema.GetDefaultValueForArgument<int>("no_default"), std::invalid_argument);
 
-  ASSERT_THROW(schema.HasArgumentDefaultValue("don't have this one"), std::out_of_range);
+  ASSERT_THROW(schema.HasArgumentDefaultValue("don't have this one"), invalid_key);
 }
 
 DALI_SCHEMA(Dummy4)

--- a/dali/pipeline/operator/op_schema_test.cc
+++ b/dali/pipeline/operator/op_schema_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,9 +80,9 @@ TEST(OpSchemaTest, OptionalArgumentDefaultValue) {
   ASSERT_TRUE(schema.HasArgumentDefaultValue("foo"));
 
   ASSERT_FALSE(schema.HasArgumentDefaultValue("no_default"));
-  ASSERT_THROW(schema.GetDefaultValueForArgument<int>("no_default"), std::runtime_error);
+  ASSERT_THROW(schema.GetDefaultValueForArgument<int>("no_default"), std::invalid_argument);
 
-  ASSERT_THROW(schema.HasArgumentDefaultValue("don't have this one"), std::runtime_error);
+  ASSERT_THROW(schema.HasArgumentDefaultValue("don't have this one"), std::out_of_range);
 }
 
 DALI_SCHEMA(Dummy4)
@@ -109,8 +109,8 @@ TEST(OpSchemaTest, OptionalArgumentDefaultValueInheritance) {
   ASSERT_FALSE(schema.HasArgumentDefaultValue("no_default"));
   ASSERT_FALSE(schema.HasArgumentDefaultValue("no_default2"));
 
-  ASSERT_THROW(schema.GetDefaultValueForArgument<int>("no_default"), std::runtime_error);
-  ASSERT_THROW(schema.GetDefaultValueForArgument<bool>("no_default2"), std::runtime_error);
+  ASSERT_THROW(schema.GetDefaultValueForArgument<int>("no_default"), std::invalid_argument);
+  ASSERT_THROW(schema.GetDefaultValueForArgument<bool>("no_default2"), std::invalid_argument);
 }
 
 DALI_SCHEMA(Dummy5)
@@ -143,8 +143,8 @@ TEST(OpSchemaTest, OptionalArgumentDefaultValueMultipleInheritance) {
   ASSERT_FALSE(schema.HasArgumentDefaultValue("no_default"));
   ASSERT_FALSE(schema.HasArgumentDefaultValue("no_default2"));
 
-  ASSERT_THROW(schema.GetDefaultValueForArgument<int>("no_default"), std::runtime_error);
-  ASSERT_THROW(schema.GetDefaultValueForArgument<bool>("no_default2"), std::runtime_error);
+  ASSERT_THROW(schema.GetDefaultValueForArgument<int>("no_default"), std::invalid_argument);
+  ASSERT_THROW(schema.GetDefaultValueForArgument<bool>("no_default2"), std::invalid_argument);
 }
 
 DALI_SCHEMA(Dummy6)
@@ -183,9 +183,9 @@ TEST(OpSchemaTest, OptionalArgumentDefaultValueMultipleParent) {
   ASSERT_FALSE(schema.HasArgumentDefaultValue("no_default2"));
   ASSERT_FALSE(schema.HasArgumentDefaultValue("no_default3"));
 
-  ASSERT_THROW(schema.GetDefaultValueForArgument<int>("no_default"), std::runtime_error);
-  ASSERT_THROW(schema.GetDefaultValueForArgument<bool>("no_default2"), std::runtime_error);
-  ASSERT_THROW(schema.GetDefaultValueForArgument<float>("no_default3"), std::runtime_error);
+  ASSERT_THROW(schema.GetDefaultValueForArgument<int>("no_default"), std::invalid_argument);
+  ASSERT_THROW(schema.GetDefaultValueForArgument<bool>("no_default2"), std::invalid_argument);
+  ASSERT_THROW(schema.GetDefaultValueForArgument<float>("no_default3"), std::invalid_argument);
 }
 
 DALI_SCHEMA(Dummy8)

--- a/dali/pipeline/operator/op_schema_test.cc
+++ b/dali/pipeline/operator/op_schema_test.cc
@@ -113,6 +113,17 @@ TEST(OpSchemaTest, OptionalArgumentDefaultValueInheritance) {
   ASSERT_THROW(schema.GetDefaultValueForArgument<bool>("no_default2"), std::invalid_argument);
 }
 
+DALI_SCHEMA(Circular1)
+  .AddParent("Circular2");
+
+DALI_SCHEMA(Circular2)
+  .AddParent("Circular1");
+
+TEST(OpSchemaTest, CircularInheritance) {
+  EXPECT_THROW(SchemaRegistry::GetSchema("Circular1").HasArgument("foo"), std::logic_error);
+  EXPECT_THROW(SchemaRegistry::GetSchema("Circular2").HasArgument("foo"), std::logic_error);
+}
+
 DALI_SCHEMA(Dummy5)
   .DocStr("Foo")
   .AddParent("Dummy4")

--- a/dali/pipeline/operator/op_spec.cc
+++ b/dali/pipeline/operator/op_spec.cc
@@ -124,7 +124,7 @@ OpSpec& OpSpec::AddArgumentInput(const string &arg_name, const string &inp_name)
 
 OpSpec& OpSpec::SetInitializedArg(const string& arg_name, std::shared_ptr<Argument> arg) {
   if (schema_ && schema_->IsDeprecatedArg(arg_name)) {
-    const auto& deprecation_meta = schema_->DeprecatedArgMeta(arg_name);
+    const auto& deprecation_meta = schema_->DeprecatedArgInfo(arg_name);
     // Argument was removed, and we can discard it
     if (deprecation_meta.removed) {
       return *this;

--- a/dali/pipeline/operator/op_spec.cc
+++ b/dali/pipeline/operator/op_spec.cc
@@ -110,7 +110,7 @@ OpSpec& OpSpec::AddArgumentInput(const string &arg_name, const string &inp_name)
       "Argument '", arg_name, "' is already specified."));
   const OpSchema& schema = GetSchemaOrDefault();
   DALI_ENFORCE(schema.HasArgument(arg_name),
-               make_string("Argument '", arg_name, "' is not supported by operator `",
+               make_string("Argument '", arg_name, "' is not defined for operator `",
                            GetOpDisplayName(*this, true), "`."));
   DALI_ENFORCE(schema.IsTensorArgument(arg_name),
                make_string("Argument '", arg_name, "' in operator `", GetOpDisplayName(*this, true),

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -15,6 +15,7 @@
 #ifndef DALI_PIPELINE_OPERATOR_OP_SPEC_H_
 #define DALI_PIPELINE_OPERATOR_OP_SPEC_H_
 
+#include <functional>
 #include <map>
 #include <utility>
 #include <string>

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -321,13 +321,13 @@ class DLL_PUBLIC OpSpec {
   /**
    * @brief Lists all arguments specified in this spec.
    */
-  DLL_PUBLIC std::vector<std::string> ListArguments() const {
-    std::vector<std::string> ret;
+  DLL_PUBLIC auto ListArgumentNames() const {
+    std::set<std::string_view, std::less<>> ret;
     for (auto &a : arguments_) {
-      ret.push_back(a->get_name());
+      ret.insert(a->get_name());
     }
     for (auto &a : argument_inputs_) {
-      ret.push_back(a.first);
+      ret.insert(a.first);
     }
     return ret;
   }

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -535,9 +535,9 @@ inline bool OpSpec::TryGetArgumentImpl(
     }
   } else if (schema.HasArgument(name, true) && schema.HasArgumentDefaultValue(name)) {
     // Argument wasn't present locally, get the default from the associated schema if any
-    auto schema_val = schema.FindDefaultValue(name);
+    auto *val = schema.FindDefaultValue(name);
     using VT = const ValueInst<S>;
-    if (VT *vt = dynamic_cast<VT *>(schema_val.second)) {
+    if (VT *vt = dynamic_cast<VT *>(val)) {
       result = static_cast<T>(vt->Get());
       return true;
     }
@@ -577,9 +577,9 @@ inline bool OpSpec::TryGetRepeatedArgumentImpl(C &result, const string &name) co
     }
   } else if (schema.HasArgument(name, true) && schema.HasArgumentDefaultValue(name)) {
     // Argument wasn't present locally, get the default from the associated schema if any
-    auto schema_val = schema.FindDefaultValue(name);
+    auto *val = schema.FindDefaultValue(name);
     using VT = const ValueInst<V>;
-    if (VT *vt = dynamic_cast<VT *>(schema_val.second)) {
+    if (VT *vt = dynamic_cast<VT *>(val)) {
       detail::copy_vector(result, vt->Get());
       return true;
     }

--- a/dali/pipeline/operator/op_spec_test.cc
+++ b/dali/pipeline/operator/op_spec_test.cc
@@ -208,12 +208,12 @@ TEST(OpSpecTest, GetArgumentVec) {
 TEST(OpSpecTest, GetArgumentNonExisting) {
   auto spec0 = OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2);
-  EXPECT_THROW(spec0.GetArgument<int>("<no_such_argument>"), std::out_of_range);
+  EXPECT_THROW(spec0.GetArgument<int>("<no_such_argument>"), invalid_key);
   int result = 0;
   EXPECT_FALSE(spec0.TryGetArgument<int>(result, "<no_such_argument>"));
 
 
-  EXPECT_THROW(spec0.GetRepeatedArgument<int>("<no_such_argument>"), std::out_of_range);
+  EXPECT_THROW(spec0.GetRepeatedArgument<int>("<no_such_argument>"), invalid_key);
   std::vector<int> result_vec;
   EXPECT_FALSE(spec0.TryGetRepeatedArgument(result_vec, "<no_such_argument>"));
   SmallVector<int, 1> result_sv;

--- a/dali/pipeline/operator/op_spec_test.cc
+++ b/dali/pipeline/operator/op_spec_test.cc
@@ -80,36 +80,36 @@ TEST(OpSpecTest, GetArgumentTensorSet) {
     auto spec0 = OpSpec("DummyOpForSpecTest")
         .AddArg("max_batch_size", 2)
         .AddArgumentInput(arg_name, "<not_used>");
-    ASSERT_EQ(spec0.GetArgument<int32_t>(arg_name, &ws0, 0), 42);
-    ASSERT_EQ(spec0.GetArgument<int32_t>(arg_name, &ws0, 1), 43);
+    EXPECT_EQ(spec0.GetArgument<int32_t>(arg_name, &ws0, 0), 42);
+    EXPECT_EQ(spec0.GetArgument<int32_t>(arg_name, &ws0, 1), 43);
     int result = 0;
     ASSERT_TRUE(spec0.TryGetArgument<int32_t>(result, arg_name, &ws0, 0));
-    ASSERT_EQ(result, 42);
+    EXPECT_EQ(result, 42);
     ASSERT_TRUE(spec0.TryGetArgument<int32_t>(result, arg_name, &ws0, 1));
-    ASSERT_EQ(result, 43);
-    ASSERT_THROW(spec0.GetArgument<float>(arg_name, &ws0, 0), std::runtime_error);
+    EXPECT_EQ(result, 43);
+    EXPECT_THROW(spec0.GetArgument<float>(arg_name, &ws0, 0), std::runtime_error);
     float tmp = 0.f;
-    ASSERT_FALSE(spec0.TryGetArgument<float>(tmp, arg_name, &ws0, 0));
+    EXPECT_FALSE(spec0.TryGetArgument<float>(tmp, arg_name, &ws0, 0));
 
     ArgumentWorkspace ws1;
     auto spec1 = OpSpec("DummyOpForSpecTest")
         .AddArg("max_batch_size", 2);
     // If we have a default optional argument, we will just return its value
     if (arg_name != "default_tensor"s) {
-      ASSERT_THROW(spec1.GetArgument<int>(arg_name, &ws1, 0), std::runtime_error);
-      ASSERT_THROW(spec1.GetArgument<int>(arg_name, &ws1, 1), std::runtime_error);
+      EXPECT_THROW(spec1.GetArgument<int>(arg_name, &ws1, 0), std::invalid_argument);
+      EXPECT_THROW(spec1.GetArgument<int>(arg_name, &ws1, 1), std::invalid_argument);
       int result = 0;
-      ASSERT_FALSE(spec1.TryGetArgument<int>(result, arg_name, &ws1, 0));
-      ASSERT_FALSE(spec1.TryGetArgument<int>(result, arg_name, &ws1, 1));
+      EXPECT_FALSE(spec1.TryGetArgument<int>(result, arg_name, &ws1, 0));
+      EXPECT_FALSE(spec1.TryGetArgument<int>(result, arg_name, &ws1, 1));
     } else {
-      ASSERT_EQ(spec1.GetArgument<int>(arg_name, &ws1, 0), 11);
-      ASSERT_EQ(spec1.GetArgument<int>(arg_name, &ws1, 1), 11);
+      EXPECT_EQ(spec1.GetArgument<int>(arg_name, &ws1, 0), 11);
+      EXPECT_EQ(spec1.GetArgument<int>(arg_name, &ws1, 1), 11);
       int result = 0;
-      ASSERT_TRUE(spec1.TryGetArgument<int>(result, arg_name, &ws1, 0));
-      ASSERT_EQ(result, 11);
+      EXPECT_TRUE(spec1.TryGetArgument<int>(result, arg_name, &ws1, 0));
+      EXPECT_EQ(result, 11);
       result = 0;
-      ASSERT_TRUE(spec1.TryGetArgument<int>(result, arg_name, &ws1, 1));
-      ASSERT_EQ(result, 11);
+      EXPECT_TRUE(spec1.TryGetArgument<int>(result, arg_name, &ws1, 1));
+      EXPECT_EQ(result, 11);
     }
   }
 }
@@ -121,14 +121,14 @@ TEST(OpSpecTest, GetArgumentValue) {
     auto spec0 = OpSpec("DummyOpForSpecTest")
         .AddArg("max_batch_size", 2)
         .AddArg(arg_name, 42);
-    ASSERT_EQ(spec0.GetArgument<int>(arg_name, &ws), 42);
+    EXPECT_EQ(spec0.GetArgument<int>(arg_name, &ws), 42);
     int result = 0;
     ASSERT_TRUE(spec0.TryGetArgument(result, arg_name, &ws));
-    ASSERT_EQ(result, 42);
+    EXPECT_EQ(result, 42);
 
-    ASSERT_THROW(spec0.GetArgument<float>(arg_name, &ws), std::runtime_error);
+    EXPECT_THROW(spec0.GetArgument<float>(arg_name, &ws), std::runtime_error);
     float tmp = 0.f;
-    ASSERT_FALSE(spec0.TryGetArgument(tmp, arg_name, &ws));
+    EXPECT_FALSE(spec0.TryGetArgument(tmp, arg_name, &ws));
   }
 
   for (const auto &arg_name : {"required"s, "no_default"s,
@@ -136,28 +136,28 @@ TEST(OpSpecTest, GetArgumentValue) {
     ArgumentWorkspace ws;
     auto spec0 = OpSpec("DummyOpForSpecTest")
         .AddArg("max_batch_size", 2);
-    ASSERT_THROW(spec0.GetArgument<int>(arg_name, &ws), std::runtime_error);
+    EXPECT_THROW(spec0.GetArgument<int>(arg_name, &ws), std::invalid_argument);
     int result = 0;
-    ASSERT_FALSE(spec0.TryGetArgument(result, arg_name, &ws));
+    EXPECT_FALSE(spec0.TryGetArgument(result, arg_name, &ws));
 
-    ASSERT_THROW(spec0.GetArgument<float>(arg_name, &ws), std::runtime_error);
+    EXPECT_THROW(spec0.GetArgument<float>(arg_name, &ws), std::invalid_argument);
     float tmp = 0.f;
-    ASSERT_FALSE(spec0.TryGetArgument(tmp, arg_name, &ws));
+    EXPECT_FALSE(spec0.TryGetArgument(tmp, arg_name, &ws));
   }
 
   for (const auto &arg_name : {"default"s, "default_tensor"s}) {
     ArgumentWorkspace ws;
     auto spec0 = OpSpec("DummyOpForSpecTest")
         .AddArg("max_batch_size", 2);
-    ASSERT_EQ(spec0.GetArgument<int>(arg_name, &ws), 11);
+    EXPECT_EQ(spec0.GetArgument<int>(arg_name, &ws), 11);
 
     int result = 0;
     ASSERT_TRUE(spec0.TryGetArgument(result, arg_name, &ws));
-    ASSERT_EQ(result, 11);
+    EXPECT_EQ(result, 11);
 
-    ASSERT_THROW(spec0.GetArgument<float>(arg_name, &ws), std::runtime_error);
+    EXPECT_THROW(spec0.GetArgument<float>(arg_name, &ws), std::invalid_argument);
     float tmp = 0.f;
-    ASSERT_FALSE(spec0.TryGetArgument(tmp, arg_name, &ws));
+    EXPECT_FALSE(spec0.TryGetArgument(tmp, arg_name, &ws));
   }
 }
 
@@ -170,10 +170,10 @@ TEST(OpSpecTest, GetArgumentVec) {
         .AddArg("max_batch_size", 2)
         .AddArg(arg_name, value);
 
-    ASSERT_EQ(spec0.GetRepeatedArgument<int32_t>(arg_name), value);
+    EXPECT_EQ(spec0.GetRepeatedArgument<int32_t>(arg_name), value);
     std::vector<int32_t> result;
     ASSERT_TRUE(spec0.TryGetRepeatedArgument(result, arg_name));
-    ASSERT_EQ(result, value);
+    EXPECT_EQ(result, value);
   }
 
   for (const auto &arg_name : {"required_vec"s, "no_default_vec"s}) {
@@ -181,17 +181,17 @@ TEST(OpSpecTest, GetArgumentVec) {
     auto spec0 = OpSpec("DummyOpForSpecTest")
         .AddArg("max_batch_size", 2);
 
-    ASSERT_THROW(spec0.GetRepeatedArgument<int32_t>(arg_name), std::runtime_error);
+    EXPECT_THROW(spec0.GetRepeatedArgument<int32_t>(arg_name), std::invalid_argument);
     std::vector<int32_t> result_v;
     ASSERT_FALSE(spec0.TryGetRepeatedArgument(result_v, arg_name));
     SmallVector<int32_t, 1> result_sv;
-    ASSERT_FALSE(spec0.TryGetRepeatedArgument(result_sv, arg_name));
+    EXPECT_FALSE(spec0.TryGetRepeatedArgument(result_sv, arg_name));
 
-    ASSERT_THROW(spec0.GetRepeatedArgument<float>(arg_name), std::runtime_error);
+    EXPECT_THROW(spec0.GetRepeatedArgument<float>(arg_name), std::invalid_argument);
     std::vector<float> tmp_v;
-    ASSERT_FALSE(spec0.TryGetRepeatedArgument(tmp_v, arg_name));
+    EXPECT_FALSE(spec0.TryGetRepeatedArgument(tmp_v, arg_name));
     SmallVector<float, 1> tmp_sv;
-    ASSERT_FALSE(spec0.TryGetRepeatedArgument(tmp_sv, arg_name));
+    EXPECT_FALSE(spec0.TryGetRepeatedArgument(tmp_sv, arg_name));
   }
 
   {
@@ -200,7 +200,7 @@ TEST(OpSpecTest, GetArgumentVec) {
     auto spec0 = OpSpec("DummyOpForSpecTest")
         .AddArg("max_batch_size", 2);
     auto default_val = std::vector<int32_t>{0, 1};
-    ASSERT_EQ(spec0.GetRepeatedArgument<int32_t>(arg_name), default_val);
+    EXPECT_EQ(spec0.GetRepeatedArgument<int32_t>(arg_name), default_val);
   }
 }
 
@@ -208,36 +208,36 @@ TEST(OpSpecTest, GetArgumentVec) {
 TEST(OpSpecTest, GetArgumentNonExisting) {
   auto spec0 = OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2);
-  ASSERT_THROW(spec0.GetArgument<int>("<no_such_argument>"), DALIException);
+  EXPECT_THROW(spec0.GetArgument<int>("<no_such_argument>"), std::out_of_range);
   int result = 0;
-  ASSERT_FALSE(spec0.TryGetArgument<int>(result, "<no_such_argument>"));
+  EXPECT_FALSE(spec0.TryGetArgument<int>(result, "<no_such_argument>"));
 
 
-  ASSERT_THROW(spec0.GetRepeatedArgument<int>("<no_such_argument>"), DALIException);
+  EXPECT_THROW(spec0.GetRepeatedArgument<int>("<no_such_argument>"), std::out_of_range);
   std::vector<int> result_vec;
-  ASSERT_FALSE(spec0.TryGetRepeatedArgument(result_vec, "<no_such_argument>"));
+  EXPECT_FALSE(spec0.TryGetRepeatedArgument(result_vec, "<no_such_argument>"));
   SmallVector<int, 1> result_sv;
-  ASSERT_FALSE(spec0.TryGetRepeatedArgument(result_sv, "<no_such_argument>"));
+  EXPECT_FALSE(spec0.TryGetRepeatedArgument(result_sv, "<no_such_argument>"));
 }
 
 TEST(OpSpecTest, DeprecatedArgs) {
   auto spec0 = OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2)
       .AddArg("deprecated_arg", 1);
-  ASSERT_THROW(spec0.GetArgument<int>("deprecated_arg"), DALIException);
-  ASSERT_EQ(spec0.GetArgument<int>("replacing_arg"), 1);
+  EXPECT_THROW(spec0.GetArgument<int>("deprecated_arg"), std::invalid_argument);
+  EXPECT_EQ(spec0.GetArgument<int>("replacing_arg"), 1);
 
   int result = 0;
-  ASSERT_FALSE(spec0.TryGetArgument<int>(result, "deprecated_arg"));
+  EXPECT_FALSE(spec0.TryGetArgument<int>(result, "deprecated_arg"));
   ASSERT_TRUE(spec0.TryGetArgument<int>(result, "replacing_arg"));
-  ASSERT_EQ(result, 1);
+  EXPECT_EQ(result, 1);
 
-  ASSERT_THROW(OpSpec("DummyOpForSpecTest")
+  EXPECT_THROW(OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2)
       .AddArg("deprecated_arg", 1)
       .AddArg("replacing_arg", 2), DALIException);
 
-  ASSERT_THROW(OpSpec("DummyOpForSpecTest")
+  EXPECT_THROW(OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2)
       .AddArg("replacing_arg", 1)
       .AddArg("deprecated_arg", 2), DALIException);
@@ -247,7 +247,7 @@ TEST(OpSpecTest, DeprecatedArgs) {
       .AddArg("deprecated_ignored_arg", 42);
   // It is marked as to be ingored, but there's no reason we should not be
   // able to query for the argument if it was provided.
-  ASSERT_TRUE(spec0.TryGetArgument<int>(result, "deprecated_ignored_arg"));
+  EXPECT_TRUE(spec0.TryGetArgument<int>(result, "deprecated_ignored_arg"));
 }
 
 TEST(OpSpecTest, DeprecatedArgsParents) {
@@ -256,55 +256,55 @@ TEST(OpSpecTest, DeprecatedArgsParents) {
       .AddArg("grandparent_deprecated_arg", 3)
       .AddArg("parent_zero_deprecated_arg", 4)
       .AddArg("parent_one_deprecated_arg", 5);
-  ASSERT_THROW(spec0.GetArgument<int>("grandparent_deprecated_arg"), DALIException);
-  ASSERT_THROW(spec0.GetArgument<int>("parent_zero_deprecated_arg"), DALIException);
-  ASSERT_THROW(spec0.GetArgument<int>("parent_one_deprecated_arg"), DALIException);
-  ASSERT_EQ(spec0.GetArgument<int>("grandparent_replacing_arg"), 3);
-  ASSERT_EQ(spec0.GetArgument<int>("parent_zero_replacing_arg"), 4);
-  ASSERT_EQ(spec0.GetArgument<int>("parent_one_replacing_arg"), 5);
+  EXPECT_THROW(spec0.GetArgument<int>("grandparent_deprecated_arg"), std::invalid_argument);
+  EXPECT_THROW(spec0.GetArgument<int>("parent_zero_deprecated_arg"), std::invalid_argument);
+  EXPECT_THROW(spec0.GetArgument<int>("parent_one_deprecated_arg"), std::invalid_argument);
+  EXPECT_EQ(spec0.GetArgument<int>("grandparent_replacing_arg"), 3);
+  EXPECT_EQ(spec0.GetArgument<int>("parent_zero_replacing_arg"), 4);
+  EXPECT_EQ(spec0.GetArgument<int>("parent_one_replacing_arg"), 5);
 
 
   int result = 0;
-  ASSERT_FALSE(spec0.TryGetArgument<int>(result, "grandparent_deprecated_arg"));
+  EXPECT_FALSE(spec0.TryGetArgument<int>(result, "grandparent_deprecated_arg"));
   ASSERT_TRUE(spec0.TryGetArgument<int>(result, "grandparent_replacing_arg"));
-  ASSERT_EQ(result, 3);
+  EXPECT_EQ(result, 3);
 
-  ASSERT_FALSE(spec0.TryGetArgument<int>(result, "parent_zero_deprecated_arg"));
+  EXPECT_FALSE(spec0.TryGetArgument<int>(result, "parent_zero_deprecated_arg"));
   ASSERT_TRUE(spec0.TryGetArgument<int>(result, "parent_zero_replacing_arg"));
-  ASSERT_EQ(result, 4);
+  EXPECT_EQ(result, 4);
 
-  ASSERT_FALSE(spec0.TryGetArgument<int>(result, "parent_one_deprecated_arg"));
+  EXPECT_FALSE(spec0.TryGetArgument<int>(result, "parent_one_deprecated_arg"));
   ASSERT_TRUE(spec0.TryGetArgument<int>(result, "parent_one_replacing_arg"));
-  ASSERT_EQ(result, 5);
+  EXPECT_EQ(result, 5);
 
-  ASSERT_THROW(OpSpec("DummyOpForSpecTest")
+  EXPECT_THROW(OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2)
       .AddArg("grandparent_deprecated_arg", 1)
       .AddArg("grandparent_replacing_arg", 2), DALIException);
 
-  ASSERT_THROW(OpSpec("DummyOpForSpecTest")
+  EXPECT_THROW(OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2)
       .AddArg("grandparent_replacing_arg", 1)
       .AddArg("grandparent_deprecated_arg", 2), DALIException);
 
 
-  ASSERT_THROW(OpSpec("DummyOpForSpecTest")
+  EXPECT_THROW(OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2)
       .AddArg("parent_zero_deprecated_arg", 1)
       .AddArg("parent_zero_replacing_arg", 2), DALIException);
 
-  ASSERT_THROW(OpSpec("DummyOpForSpecTest")
+  EXPECT_THROW(OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2)
       .AddArg("parent_zero_replacing_arg", 1)
       .AddArg("parent_zero_deprecated_arg", 2), DALIException);
 
 
-  ASSERT_THROW(OpSpec("DummyOpForSpecTest")
+  EXPECT_THROW(OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2)
       .AddArg("parent_one_deprecated_arg", 1)
       .AddArg("parent_one_replacing_arg", 2), DALIException);
 
-  ASSERT_THROW(OpSpec("DummyOpForSpecTest")
+  EXPECT_THROW(OpSpec("DummyOpForSpecTest")
       .AddArg("max_batch_size", 2)
       .AddArg("parent_one_replacing_arg", 1)
       .AddArg("parent_one_deprecated_arg", 2), DALIException);
@@ -369,7 +369,7 @@ class TestArgumentInput_Consumer : public Operator<CPUBackend> {
     }
     // Non-matching shapes (differnet than 1 scalar value per sample) should not work with
     // OpSpec::GetArgument()
-    ASSERT_THROW(auto z = spec_.GetArgument<float>("arg2", &ws, 0), std::runtime_error);
+    EXPECT_THROW(auto z = spec_.GetArgument<float>("arg2", &ws, 0), std::runtime_error);
 
     // They can be accessed as proper ArgumentInputs
     auto &ref_1 = ws.ArgumentInput("arg1");

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -387,10 +387,6 @@ void Pipeline::AddToOpSpecs(const std::string &inst_name, const OpSpec &spec, in
             GetOpDisplayName(spec, true) + "` using logical_id=" + std::to_string(logical_id) +
             " which is already assigned to " + group_name + ".");
     const OpSchema &schema = SchemaRegistry::GetSchema(spec.SchemaName());
-    DALI_ENFORCE(schema.AllowsInstanceGrouping(),
-                 "Operator `" + GetOpDisplayName(spec, true) +
-                     "` does not support synced random execution required "
-                     "for multiple input sets processing.");
   }
   op_specs_.push_back({inst_name, spec, logical_id});
   logical_ids_[logical_id].push_back(op_specs_.size() - 1);

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -659,8 +659,7 @@ void Pipeline::PrepareOpSpec(OpSpec *spec, int logical_id) {
   if (dev == "gpu" || dev == "mixed")
     spec->AddArg("gpu_prefetch_queue_depth", prefetch_queue_depth_.gpu_size);
 
-  if (spec->GetSchemaOrDefault().HasArgument("seed", false)) {
-
+  if (spec->GetSchemaOrDefault().HasRandomSeedArg()) {
     if (spec->ArgumentDefined("seed")) {
       logical_id_to_seed_[logical_id] = spec->GetArgument<int64_t>("seed");
     } else {

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -701,7 +701,7 @@ void SerializeToProtobuf(dali_proto::OpDef *op, const string &inst_name, const O
   for (auto& a : spec.Arguments()) {
     // filter out args that need to be dealt with on
     // loading a serialized pipeline
-    auto &name = a->get_name();
+    auto name = a->get_name();
     if (name == "max_batch_size" ||
         name == "num_threads" ||
         name == "bytes_per_sample_hint") {

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -523,7 +523,8 @@ TYPED_TEST(PipelineTest, TestSeedSet) {
 
   // Check if seed can be manually set
   EXPECT_EQ(original_graph.GetOp("copy1")->spec.GetArgument<int64_t>("seed"), seed_set);
-  EXPECT_TRUE(original_graph.GetOp("copy2")->spec.HasArgument("seed"));
+  // The "seed" argument is deprecated as removed - so the argument is not added to the OpSpec
+  EXPECT_FALSE(original_graph.GetOp("copy2")->spec.HasArgument("seed"));
   EXPECT_FALSE(original_graph.GetOp("data")->spec.HasArgument("seed"));
 }
 

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -685,30 +685,6 @@ DALI_SCHEMA(DummyOpToAdd)
   .NumOutput(1)
   .AddRandomSeedArg();
 
-
-class DummyOpNoSync : public Operator<CPUBackend> {
- public:
-  explicit DummyOpNoSync(const OpSpec &spec) : Operator<CPUBackend>(spec) {}
-
-  bool HasContiguousOutputs() const override {
-    return false;
-  }
-
-  bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
-    return false;
-  }
-
-  void RunImpl(Workspace &ws) override {}
-};
-
-DALI_REGISTER_OPERATOR(DummyOpNoSync, DummyOpNoSync, CPU);
-
-DALI_SCHEMA(DummyOpNoSync)
-  .DocStr("DummyOpNoSync")
-  .DisallowInstanceGrouping()
-  .NumInput(1)
-  .NumOutput(1);
-
 TEST(PipelineTest, AddOperator) {
   Pipeline pipe(10, 4, 0);
   int input_0 = pipe.AddExternalInput("data_in0");
@@ -734,16 +710,6 @@ TEST(PipelineTest, AddOperator) {
           .AddOutput("data_out2", "cpu"), "third_op");
 
   EXPECT_EQ(third_op, second_op + 1);
-
-  int disallow_sync_op = pipe.AddOperator(OpSpec("DummyOpNoSync")
-          .AddArg("device", "cpu")
-          .AddInput("data_in0", "cpu")
-          .AddOutput("data_out3", "cpu"), "DummyOpNoSync");
-
-  ASSERT_THROW(pipe.AddOperator(OpSpec("DummyOpNoSync")
-          .AddArg("device", "cpu")
-          .AddInput("data_in0", "cpu")
-          .AddOutput("data_out4", "cpu"), "DummyOpNoSync2", disallow_sync_op), std::runtime_error);
 
   vector<std::pair<string, string>> outputs = {
       {"data_out0", "cpu"}, {"data_out1", "cpu"}, {"data_out2", "cpu"}};
@@ -844,7 +810,6 @@ DALI_REGISTER_OPERATOR(DummyInputOperator, DummyInputOperator, CPU);
 
 DALI_SCHEMA(DummyInputOperator)
   .DocStr("DummyInputOperator")
-  .DisallowInstanceGrouping()
   .NumInput(0)
   .NumOutput(2);
 

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1684,7 +1684,7 @@ pools as well as from the host pinned memory pool.
 This function is safe to use while DALI pipelines are running.)");
 }
 
-py::dict DeprecatedArgInfoToDict(const DeprecatedArgDef & meta) {
+py::dict ArgumentDeprecationInfoToDict(const ArgumentDeprecation & meta) {
   py::dict d;
   d["msg"] = meta.msg;
   d["removed"] = meta.removed;
@@ -2413,7 +2413,7 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("DeprecatedArgInfo",
         [](OpSchema *schema, const std::string &arg_name) {
           auto meta = schema->DeprecatedArgInfo(arg_name);
-          return DeprecatedArgInfoToDict(meta);
+          return ArgumentDeprecationInfoToDict(meta);
         })
     .def("GetSupportedLayouts", &OpSchema::GetSupportedLayouts)
     .def("HasArgument",

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1684,7 +1684,7 @@ pools as well as from the host pinned memory pool.
 This function is safe to use while DALI pipelines are running.)");
 }
 
-py::dict DeprecatedArgMetaToDict(const DeprecatedArgDef & meta) {
+py::dict DeprecatedArgInfoToDict(const DeprecatedArgDef & meta) {
   py::dict d;
   d["msg"] = meta.msg;
   d["removed"] = meta.removed;
@@ -2396,8 +2396,7 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("GetArgumentDefaultValueString", &OpSchema::GetArgumentDefaultValueString)
     .def("GetArgumentNames", &OpSchema::GetArgumentNames)
     .def("IsArgumentOptional", &OpSchema::HasOptionalArgument,
-        "arg_name"_a,
-        "local_only"_a = false)
+        "arg_name"_a)
     .def("IsTensorArgument", &OpSchema::IsTensorArgument)
     .def("ArgSupportsPerFrameInput", &OpSchema::ArgSupportsPerFrameInput)
     .def("IsSequenceOperator", &OpSchema::IsSequenceOperator)
@@ -2411,10 +2410,10 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("DeprecatedInFavorOf", &OpSchema::DeprecatedInFavorOf)
     .def("DeprecationMessage", &OpSchema::DeprecationMessage)
     .def("IsDeprecatedArg", &OpSchema::IsDeprecatedArg)
-    .def("DeprecatedArgMeta",
+    .def("DeprecatedArgInfo",
         [](OpSchema *schema, const std::string &arg_name) {
-          auto meta = schema->DeprecatedArgMeta(arg_name);
-          return DeprecatedArgMetaToDict(meta);
+          auto meta = schema->DeprecatedArgInfo(arg_name);
+          return DeprecatedArgInfoToDict(meta);
         })
     .def("GetSupportedLayouts", &OpSchema::GetSupportedLayouts)
     .def("HasArgument",

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2443,6 +2443,8 @@ PYBIND11_MODULE(backend_impl, m) {
     try {
       if (p)
         std::rethrow_exception(p);
+    } catch (const invalid_key &e) {
+      PyErr_SetString(PyExc_KeyError, e.what());
     } catch (const DaliRuntimeError &e) {
       PyErr_SetString(PyExc_RuntimeError, e.what());
     } catch (const DaliIndexError &e) {

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -21,6 +21,7 @@ import weakref
 from itertools import count
 
 import nvidia.dali.python_function_plugin
+import nvidia.dali.types
 from nvidia.dali import backend as _b
 from nvidia.dali import fn as _functional
 from nvidia.dali import internal as _internal
@@ -328,7 +329,19 @@ def _add_spec_args(schema, spec, kwargs):
             # as if the argument was not supplied at all
             continue
 
-        dtype = schema.GetArgumentType(key)
+        try:
+            dtype = schema.GetArgumentType(key)
+        except:
+            if key == "seed" and not schema.HasArgument("seed"):
+                raise ValueError('The argument "seed" is deprecated in operators which '
+                                 "don't use random number generators.")
+            dtype = nvidia.dali.types.INT64
+
+        if isinstance(value, (list, tuple)):
+            if len(value) == 0:
+                spec.AddArgEmptyList(key, _vector_element_type(dtype))
+                continue
+
         if isinstance(value, (list, tuple)):
             if len(value) == 0:
                 spec.AddArgEmptyList(key, _vector_element_type(dtype))

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -21,7 +21,6 @@ import weakref
 from itertools import count
 
 import nvidia.dali.python_function_plugin
-import nvidia.dali.types
 from nvidia.dali import backend as _b
 from nvidia.dali import fn as _functional
 from nvidia.dali import internal as _internal
@@ -329,19 +328,7 @@ def _add_spec_args(schema, spec, kwargs):
             # as if the argument was not supplied at all
             continue
 
-        try:
-            dtype = schema.GetArgumentType(key)
-        except:
-            if key == "seed" and not schema.HasArgument("seed"):
-                raise ValueError('The argument "seed" is deprecated in operators which '
-                                 "don't use random number generators.")
-            dtype = nvidia.dali.types.INT64
-
-        if isinstance(value, (list, tuple)):
-            if len(value) == 0:
-                spec.AddArgEmptyList(key, _vector_element_type(dtype))
-                continue
-
+        dtype = schema.GetArgumentType(key)
         if isinstance(value, (list, tuple)):
             if len(value) == 0:
                 spec.AddArgEmptyList(key, _vector_element_type(dtype))

--- a/dali/python/nvidia/dali/ops/__init__.py
+++ b/dali/python/nvidia/dali/ops/__init__.py
@@ -189,7 +189,7 @@ def _handle_arg_deprecations(schema, kwargs, op_name):
     for arg_name in arg_names:
         if not schema.IsDeprecatedArg(arg_name):
             continue
-        meta = schema.DeprecatedArgMeta(arg_name)
+        meta = schema.DeprecatedArgInfo(arg_name)
         new_name = meta["renamed_to"]
         removed = meta["removed"]
         msg = meta["msg"]

--- a/dali/python/nvidia/dali/ops/_docs.py
+++ b/dali/python/nvidia/dali/ops/_docs.py
@@ -107,7 +107,7 @@ def _get_kwargs(schema):
         doc = ""
         deprecation_warning = None
         if schema.IsDeprecatedArg(arg):
-            meta = schema.DeprecatedArgMeta(arg)
+            meta = schema.DeprecatedArgInfo(arg)
             msg = meta["msg"]
             assert msg is not None
             deprecation_warning = ".. warning::\n\n    " + msg.replace("\n", "\n    ")

--- a/dali/test/python/operator_1/test_crop.py
+++ b/dali/test/python/operator_1/test_crop.py
@@ -678,7 +678,7 @@ def check_crop_wrong_layout(device, batch_size, input_shape=(100, 200, 3), layou
     pipe = get_pipe(batch_size=batch_size, device_id=0, num_threads=3)
     pipe.build()
     with assert_raises(
-        RuntimeError, glob=f'The layout "{layout}" does not match any of the allowed layouts'
+        ValueError, glob=f'The layout "{layout}" does not match any of the allowed layouts'
     ):
         pipe.run()
 

--- a/dali/test/python/operator_1/test_crop_mirror_normalize.py
+++ b/dali/test/python/operator_1/test_crop_mirror_normalize.py
@@ -953,7 +953,7 @@ def check_crop_mirror_normalize_wrong_layout(
     pipe = get_pipe(batch_size=batch_size, device_id=0, num_threads=3)
     pipe.build()
     with assert_raises(
-        RuntimeError, glob=f'The layout "{layout}" does not match any of the allowed layouts'
+        ValueError, glob=f'The layout "{layout}" does not match any of the allowed layouts'
     ):
         pipe.run()
 

--- a/dali/test/python/operator_1/test_debayer.py
+++ b/dali/test/python/operator_1/test_debayer.py
@@ -302,7 +302,7 @@ def test_too_many_channels():
 
 def test_wrong_sample_dim():
     with assert_raises(
-        RuntimeError, glob="The number of dimensions 5 does not match any of the allowed"
+        ValueError, glob="The number of dimensions 5 does not match any of the allowed"
     ):
         _test_shape_pipeline((1, 1, 1, 1, 1), np.uint8)
 

--- a/dali/test/python/operator_2/test_resize.py
+++ b/dali/test/python/operator_2/test_resize.py
@@ -338,7 +338,7 @@ def build_pipes(
         batch_size=batch_size,
         num_threads=8,
         device_id=0,
-        seed=1234,
+        seed=12345,
         exec_async=False,
         exec_pipelined=False,
     )

--- a/dali/test/python/reader/test_coco.py
+++ b/dali/test/python/reader/test_coco.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -193,7 +193,7 @@ def test_operator_coco_reader_same_images():
 
 @raises(
     RuntimeError,
-    glob='Argument "preprocessed_annotations_dir" is not supported by operator *readers*COCO',
+    glob='Argument "preprocessed_annotations_dir" is not defined for operator *readers*COCO',
 )
 def test_invalid_args():
     pipeline = Pipeline(batch_size=2, num_threads=4, device_id=0)

--- a/dali/test/python/reader/test_coco.py
+++ b/dali/test/python/reader/test_coco.py
@@ -192,7 +192,7 @@ def test_operator_coco_reader_same_images():
 
 
 @raises(
-    RuntimeError,
+    KeyError,
     glob='Argument "preprocessed_annotations_dir" is not defined for operator *readers*COCO',
 )
 def test_invalid_args():

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -36,7 +36,7 @@ from test_utils import (
     get_dali_extra_path,
     RandomDataIterator,
 )
-from nose_utils import raises, assert_raises, SkipTest
+from nose_utils import raises, assert_raises, assert_warns, SkipTest
 
 test_data_root = get_dali_extra_path()
 caffe_db_folder = os.path.join(test_data_root, "db", "lmdb")
@@ -491,6 +491,19 @@ def test_none_seed():
             test_out_ref = test_out
         else:
             assert np.sum(np.abs(test_out_ref - test_out)) != 0
+
+
+def test_seed_deprecated():
+    @pipeline_def(batch_size=1, device_id=None, num_threads=1)
+    def my_pipe():
+        with assert_warns(
+            DeprecationWarning,
+            glob='The argument "seed" should not be used with operators '
+            "that don't use random numbers.",
+        ):
+            return fn.reshape(np.float32([1, 2]), shape=[2], seed=123)
+
+    my_pipe()
 
 
 def test_as_array():

--- a/include/dali/core/error_handling.h
+++ b/include/dali/core/error_handling.h
@@ -85,10 +85,12 @@ class DALIException : public std::runtime_error {
 };
 
 struct unsupported_exception : std::runtime_error {
-  explicit unsupported_exception(const std::string &str) : runtime_error(str), msg(str) {}
+  explicit unsupported_exception(const std::string &str) : runtime_error(str) {}
+};
 
-  const char *what() const noexcept override { return msg.c_str(); }
-  std::string msg;
+struct invalid_key : std::out_of_range {
+  explicit invalid_key(const std::string &message) : std::out_of_range(message) {}
+  explicit invalid_key(const char *message) : std::out_of_range(message) {}
 };
 
 inline string BuildErrorString(string statement, string file, int line) {

--- a/include/dali/core/error_handling.h
+++ b/include/dali/core/error_handling.h
@@ -88,6 +88,15 @@ struct unsupported_exception : std::runtime_error {
   explicit unsupported_exception(const std::string &str) : runtime_error(str) {}
 };
 
+/** An exception thrown when an invalid dictionary key is provided
+ *
+ * The exception denotes an invalid key. It can be thrown when:
+ * - the key is not found and the function returns a non-nullable type
+ * - the key doesn't meet some constraints (e.g. a dictionary doesn't accept an empty
+ *   string as a key).
+ *
+ * This exception is used at the Python boundary to raise KeyError rather than IndexError.
+ */
 struct invalid_key : std::out_of_range {
   explicit invalid_key(const std::string &message) : std::out_of_range(message) {}
   explicit invalid_key(const char *message) : std::out_of_range(message) {}


### PR DESCRIPTION
## Category:
**Refactoring** (OpSchema)
**New feature** (restricted seed argument)
**Breaking change** (kind of - only erroneous code is affected)

## Description:
Visible effects:
- `seed` is present only in schemas that need it
- new OpSchema functions: `AddRandomSeedArg` and `HasRandomSeedArg` were added
- `OpSchema` now allows for proper argument shadowing.
- `OpSchema throws proper exceptions (not just DALIException everywhere)
   - *This is visible from Python - different errors are raised now*
- Added `invalid_key` C++ exception, which is translated into Python `KeyError`

Performance:
- query the arguments by string_view
- cache parents
- use a flattened set of arguments - don't traverse parent schemas when querying for default values

Code quality:
- put all arguments in a single map: name->ArgumentDef
- put all input info in a single array InputInfo (instead of separate devices, layouts, dox)
- rewrite almost all argument handling - it's much simpler now

Safety:
- add detection of circular inheritance

## Additional information:

### Affected modules and functionalities:
OpSchema
OpSpec
tests
random ops

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply
- [X] New tests added
  - [X] Python tests (new tests)
  - [X] GTests (tests modified)
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [X] Docstring (seed)
  - [X] Doxygen (schema)
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
