### PR TITLE
Fix hogging memory by libaviutils

### DIFF
--- a/dali/operators/reader/loader/video/frames_decoder.cc
+++ b/dali/operators/reader/loader/video/frames_decoder.cc
@@ -333,6 +333,7 @@ void FramesDecoder::CountFrames(AvState *av_state) {
     }
     ++num_frames_.value();
   }
+  av_packet_unref(av_state->packet_);
 }
 
 IMPL_HAS_MEMBER(read_seek);
@@ -479,6 +480,7 @@ bool FramesDecoder::ReadRegularFrame(uint8_t *data, bool copy_to_output) {
     ++next_frame_idx_;
     return true;
   }
+  av_packet_unref(av_state_->packet_);
 
   ret = avcodec_send_packet(av_state_->codec_ctx_, nullptr);
   DALI_ENFORCE(

--- a/dali/operators/reader/loader/video/frames_decoder.h
+++ b/dali/operators/reader/loader/video/frames_decoder.h
@@ -59,6 +59,11 @@ struct AvState {
     }
     avcodec_free_context(&codec_ctx_);
     if (ctx_ != nullptr) {
+      // if we use avio_alloc_context we need a custom deallocator for ctx_->pb
+      if (ctx_->flags & AVFMT_FLAG_CUSTOM_IO) {
+        av_freep(&ctx_->pb->buffer);
+        av_freep(&ctx_->pb);
+      }
       avformat_close_input(&ctx_);
       avformat_free_context(ctx_);
     }


### PR DESCRIPTION
- due to lacking packet unreference and missing custom
  deallocator for custom data created by avio_alloc_context
  the experimental frame decoder was hoggin memory. This
  PR fixes that
- related to https://github.com/NVIDIA/DALI/issues/5775
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- due to lacking packet unreference and missing custom
  deallocator for custom data created by avio_alloc_context
  the experimental frame decoder was hoggin memory. This
  PR fixes that
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- frames decoder (experimental video reader and video decoder)
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - experimental video reader/decoder
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
