### PR TITLE
Make frames decoder to build index without file decoding

### DIFF
--- a/dali/operators/reader/loader/video/frames_decoder.cc
+++ b/dali/operators/reader/loader/video/frames_decoder.cc
@@ -396,6 +396,7 @@ void FramesDecoder::BuildIndex() {
           }
         }
       } else {
+        // for other formats it is enough to check (packet->flags & AV_PKT_FLAG_KEY)
         entry.is_keyframe = true;
       }
     } else {

--- a/dali/operators/reader/loader/video/frames_decoder.cc
+++ b/dali/operators/reader/loader/video/frames_decoder.cc
@@ -383,18 +383,15 @@ void FramesDecoder::BuildIndex() {
       auto codec_id = av_state_->ctx_->streams[packet->stream_index]->codecpar->codec_id;
       if (codec_id == AV_CODEC_ID_H264) {
         if (packet->size >= 5) {  // Ensure there's enough data to inspect
-          // NAL unit type is in the fifth byte for H.264
           uint8_t nal_unit_type = packet->data[4] & 0x1F;
           if (nal_unit_type == 5) {  // IDR frame for H.264
             entry.is_keyframe = true;
           }
         }
       } else if (codec_id == AV_CODEC_ID_HEVC) {
-      // Further check if it's an IDR frame for H.265
         if (packet->size >= 6) {  // Ensure there's enough data to inspect
-          // NAL unit type is in the sixth byte for H.265
           uint8_t nal_unit_type = (packet->data[4] >> 1) & 0x3F;
-          if (nal_unit_type >= 16 && nal_unit_type <= 21) {  // IDR frame types for H.265
+          if (nal_unit_type >= 16 && nal_unit_type <= 21) {
             entry.is_keyframe = true;
           }
         }
@@ -423,7 +420,6 @@ void FramesDecoder::BuildIndex() {
   std::sort(index_->begin(), index_->end(), [](const IndexEntry &a, const IndexEntry &b) {
     return a.pts < b.pts;
   });
-
   Reset();
 }
 


### PR DESCRIPTION
- use only data embedded into packets to build video file index in the frames decoder

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- use only data embedded into packets to build video file index in the frames decoder
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- frames decoder
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- if the logic makes sens
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - FramesDecoder*
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
