### PR TITLE
Fix handling of empty batches in GPU arithmetic operators.

### DIFF
--- a/dali/operators/math/expressions/arithmetic.cu
+++ b/dali/operators/math/expressions/arithmetic.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,10 @@ void ArithmeticGenericOp<GPUBackend>::RunImpl(Workspace &ws) {
   PrepareSamplesPerTask<GPUBackend>(samples_per_task_, exec_order_, ws, constant_storage_, spec_);
   ws.Output<GPUBackend>(0).SetLayout(result_layout_);
   std::tie(tile_cover_, tile_range_) = GetTiledCover(result_shape_, kTileSize, kTaskSize);
+  if (tile_range_.size() == 0) {
+    assert(result_shape_.num_elements() == 0);
+    return;  // nothing to do
+  }
   assert(tile_range_.size() == 1 && "Expected to cover whole GPU execution by 1 task");
   auto tiles = make_cspan(tile_cover_);
   for (size_t i = 0; i < exec_order_.size(); i++) {

--- a/dali/operators/math/expressions/expression_impl_gpu_binary.cuh
+++ b/dali/operators/math/expressions/expression_impl_gpu_binary.cuh
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,6 +90,7 @@ struct InvokerBinOp {
       ExecuteTiledBinOpND<op, Result, Left, Right>
         <<<grid, block, 0, stream>>>(samples, tiles);
     }
+    CUDA_CALL(cudaGetLastError());
   }
 };
 

--- a/dali/operators/math/expressions/expression_impl_gpu_ternary.cuh
+++ b/dali/operators/math/expressions/expression_impl_gpu_ternary.cuh
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,6 +90,7 @@ struct InvokerTernaryOp {
       ExecuteTiledTernaryOpND<op, Result>
           <<<grid, block, 0, stream>>>(samples, tiles);
     }
+    CUDA_CALL(cudaGetLastError());
   }
 };
 

--- a/dali/operators/math/expressions/expression_impl_gpu_unary.cuh
+++ b/dali/operators/math/expressions/expression_impl_gpu_unary.cuh
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ struct InvokerUnOp {
                      dim3 block, cudaStream_t stream, bool is_flat_idx) {
     assert(is_flat_idx);  // should always be for unary ops
     ExecuteTiledUnOp<op, Result, Input><<<grid, block, 0, stream>>>(samples, tiles);
+    CUDA_CALL(cudaGetLastError());
   }
 };
 

--- a/dali/test/python/operator_1/test_arithmetic_ops.py
+++ b/dali/test/python/operator_1/test_arithmetic_ops.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1203,3 +1203,19 @@ def test_nested_datanode_error_arithm(op):
         TypeError, glob=f"input 1 of operator `{op}` must be*" "Got a `list` with nested *DataNode"
     ):
         _ = err_pipe()
+
+
+@params(("cpu",), ("gpu",))
+def test_empty_batch(device):
+    @pipeline_def(
+        device_id=0 if device == "gpu" else None,
+        batch_size=1,
+        num_threads=4,
+    )
+    def empty_input_pipe():
+        x = types.Constant(np.zeros((0, 3), dtype=np.float32), device=device)
+        return x * 42
+
+    p = empty_input_pipe()
+    (o,) = p.run()
+    assert tuple(o[0].shape()) == (0, 3)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
- Add an early exit to GPU arithmetic operators with an empty output.
- Add error checking after kernel launches in arithmetic ops.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
