### PR TITLE
Fix host-side access to pinned CPU buffers produced with non-host order

### DIFF
--- a/dali/pipeline/executor/executor2/exec_node_task.cc
+++ b/dali/pipeline/executor/executor2/exec_node_task.cc
@@ -336,7 +336,12 @@ void OpTask::SetWorkspaceInputs() {
   int ti = 0;
   assert(ws_->NumInput() + ws_->NumArgumentInput() == static_cast<int>(node_->inputs.size()));
   auto order = ws_->output_order();
+
+  // Events that are waited for in the workspace's associated stream
+  // - they come from non-metadata GPU inputs that were produced on a different stream.
   std::unordered_set<cudaEvent_t> stream_events(ws_->NumInput() + ws_->NumArgumentInput());
+  // Events that are waited for on host
+  // - they come from non-metadata CPU inputs that were produced in non-host-order
   std::unordered_set<cudaEvent_t> host_events(ws_->NumInput() + ws_->NumArgumentInput());
   auto &schema = node_->op->GetSpec().GetSchema();
 
@@ -351,7 +356,7 @@ void OpTask::SetWorkspaceInputs() {
 
     bool is_plain_host = std::is_same_v<Backend, CPUBackend> && !inp.data->is_pinned();
 
-    // metadata-only inputs && non-pinned host inputs don't need a proper stream
+    // metadata-only inputs & non-pinned host inputs don't need a proper stream
     if (inp.order == input_order || is_meta || is_plain_host) {  // use the input directly
       ws_->SetInput(i, inp.data);
     } else {  // create another TL and set its order (and layout, while we're at it)

--- a/dali/pipeline/executor/executor2/exec_node_task.cc
+++ b/dali/pipeline/executor/executor2/exec_node_task.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -336,7 +336,8 @@ void OpTask::SetWorkspaceInputs() {
   int ti = 0;
   assert(ws_->NumInput() + ws_->NumArgumentInput() == static_cast<int>(node_->inputs.size()));
   auto order = ws_->output_order();
-  std::unordered_set<cudaEvent_t> events(ws_->NumInput() + ws_->NumArgumentInput());
+  std::unordered_set<cudaEvent_t> stream_events(ws_->NumInput() + ws_->NumArgumentInput());
+  std::unordered_set<cudaEvent_t> host_events(ws_->NumInput() + ws_->NumArgumentInput());
   auto &schema = node_->op->GetSpec().GetSchema();
 
   auto process_input = [&](int i, auto backend) {
@@ -344,18 +345,19 @@ void OpTask::SetWorkspaceInputs() {
     const auto &inp = TaskInput<Backend>(ti);
     bool is_meta = node_->inputs[i]->metadata;
     // metadata-only inputs don't need to be synchronized
-    if (!is_meta && inp.event() && inp.order != order)
-      events.insert(inp.event());
+    auto input_order = std::is_same_v<Backend, CPUBackend> ? AccessOrder::host() : order;
+    if (!is_meta && inp.event() && inp.order != input_order)
+      (input_order.is_host() ? host_events : stream_events).insert(inp.event());
 
     bool is_plain_host = std::is_same_v<Backend, CPUBackend> && !inp.data->is_pinned();
 
     // metadata-only inputs && non-pinned host inputs don't need a proper stream
-    if (inp.order == order || is_meta || is_plain_host) {  // use the input directly
+    if (inp.order == input_order || is_meta || is_plain_host) {  // use the input directly
       ws_->SetInput(i, inp.data);
     } else {  // create another TL and set its order (and layout, while we're at it)
       auto tl = std::make_shared<TensorList<Backend>>();
       tl->ShareData(*inp.data);
-      tl->set_order(order, false);
+      tl->set_order(input_order, false);
       // this will avoid potentially one more proxy object, when adjusting layouts
       SetDefaultLayoutIfNeeded(*tl, schema, i);
       ws_->SetInput(i, std::move(tl));
@@ -374,7 +376,7 @@ void OpTask::SetWorkspaceInputs() {
   for (int i = 0; i < ws_->NumArgumentInput(); i++, ti++) {
     auto &inp = TaskInput<CPUBackend>(ti);
     if (inp.event())
-      events.insert(inp.event());
+      host_events.insert(inp.event());
     ws_->SetArgumentInput(i, inp.data);
   }
 
@@ -385,7 +387,11 @@ void OpTask::SetWorkspaceInputs() {
     task_->GetInputValue<void>(ti++);
   }
 
-  for (auto e : events)
+  for (auto e : host_events) {
+    AccessOrder::host().wait(e);
+    stream_events.erase(e);  // we've waited on host, so all streams are also synchronized
+  }
+  for (auto e : stream_events)
     ws_->output_order().wait(e);
 
   if (ws_->NumOutput()) {


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
In the Dynamic Executor, it's possible that a CPU buffer is produced by an operator running on a stream. If the CPU content is produced asynchronously (e.g. by D2H copy), then the subsequent consumer of the data must wait (on host) for the data to become available.

This PR adds the necessary synchronization and avoids waits when only metadata is needed.
The readiness events are split into host-awaited and stream-awaited. If an event is waited for on host, it's not waited for on a stream (because host is never behind any stream).

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
