### PR TITLE
Limit the max. tensor list size in TensorTest

### DIFF
--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,19 +37,24 @@ inline TensorShape<> empty_tensor_shape() {
 template <typename Backend>
 class TensorTest : public DALITest {
  public:
-  TensorListShape<> GetRandShapeList() {
-    int num_tensor = this->RandInt(1, 128);
-    int dims = this->RandInt(2, 3);
-    TensorListShape<> shape(num_tensor, dims);
-    for (int i = 0; i < num_tensor; ++i) {
-      TensorShape<> tensor_shape;
-      tensor_shape.resize(dims);
-      for (int j = 0; j < dims; ++j) {
-        tensor_shape[j] = this->RandInt(1, 512);
+  TensorListShape<> GetRandShapeList(int64_t min_elements = 1_u64 << 16,
+                                     int64_t max_elements = 1_u64 << 28) {
+    for (;;) {
+      int num_tensor = this->RandInt(1, 128);
+      int dims = this->RandInt(2, 3);
+      TensorListShape<> shape(num_tensor, dims);
+      for (int i = 0; i < num_tensor; ++i) {
+        TensorShape<> tensor_shape;
+        tensor_shape.resize(dims);
+        for (int j = 0; j < dims; ++j) {
+          tensor_shape[j] = this->RandInt(1, 512);
+        }
+        shape.set_tensor_shape(i, tensor_shape);
       }
-      shape.set_tensor_shape(i, tensor_shape);
+      int64_t n = shape.num_elements();
+      if (n >= min_elements && n <= max_elements)
+        return shape;
     }
-    return shape;
   }
 
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)


## Description:
This PR caps the maximum size of the tensor list used in TensorTest.
Before this change it could reach sizes as large as 64 GiB, causing random problems on some test systems.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4207
<!--- DALI-XXXX or NA --->
