### PR TITLE
Add Debayer CPU Impl 

### DIFF
--- a/dali/kernels/imgproc/color_manipulation/debayer/debayer.h
+++ b/dali/kernels/imgproc/color_manipulation/debayer/debayer.h
@@ -33,7 +33,11 @@ enum class DALIBayerPattern {
 };
 
 enum class DALIDebayerAlgorithm {
-  DALI_DEBAYER_BILINEAR_NPP = 0
+  DALI_DEBAYER_BILINEAR_NPP = 0,
+  DALI_DEBAYER_BILINEAR_OCV = 1,
+  DALI_DEBAYER_EDGEAWARE_OCV = 2,
+  DALI_DEBAYER_VNG_OCV = 3,
+  DALI_DEBAYER_GRAY_OCV = 4,
 };
 
 inline std::string to_string(DALIBayerPattern bayer_pattern) {
@@ -55,6 +59,14 @@ inline std::string to_string(DALIDebayerAlgorithm alg) {
   switch (alg) {
     case DALIDebayerAlgorithm::DALI_DEBAYER_BILINEAR_NPP:
       return "bilinear_npp";
+    case DALIDebayerAlgorithm::DALI_DEBAYER_BILINEAR_OCV:
+      return "bilinear_ocv";
+    case DALIDebayerAlgorithm::DALI_DEBAYER_EDGEAWARE_OCV:
+      return "edgeaware_ocv";
+    case DALIDebayerAlgorithm::DALI_DEBAYER_VNG_OCV:
+      return "vng_ocv";
+    case DALIDebayerAlgorithm::DALI_DEBAYER_GRAY_OCV:
+      return "gray_ocv";
     default:
       return "<unknown>";
   }
@@ -64,6 +76,18 @@ inline DALIDebayerAlgorithm parse_algorithm_name(std::string alg) {
   std::transform(alg.begin(), alg.end(), alg.begin(), [](auto c) { return std::tolower(c); });
   if (alg == "bilinear_npp") {
     return DALIDebayerAlgorithm::DALI_DEBAYER_BILINEAR_NPP;
+  }
+  if (alg == "bilinear_ocv") {
+    return DALIDebayerAlgorithm::DALI_DEBAYER_BILINEAR_OCV;
+  }
+  if (alg == "edgeaware_ocv") {
+    return DALIDebayerAlgorithm::DALI_DEBAYER_EDGEAWARE_OCV;
+  }
+  if (alg == "vng_ocv") {
+    return DALIDebayerAlgorithm::DALI_DEBAYER_VNG_OCV;
+  }
+  if (alg == "gray_ocv") {
+    return DALIDebayerAlgorithm::DALI_DEBAYER_GRAY_OCV;
   }
   throw std::runtime_error(
       make_string("Unsupported debayer algorithm was specified: `", alg, "`."));

--- a/dali/operators/image/color/debayer.cc
+++ b/dali/operators/image/color/debayer.cc
@@ -101,13 +101,13 @@ Different algorithms are supported on the GPU and CPU.
 
 **GPU Algorithms:**
 
- - ``bilinear_npp`` - - uses bilinear interpolation with chroma correlation for green values.
+ - ``bilinear_npp`` - - bilinear interpolation with chroma correlation for green values.
 
 **CPU Algorithms:**
 
- - ``bilinear_ocv`` - uses bilinear interpolation.
- - ``edgeaware_ocv`` - uses edge-aware interpolation.
- - ``vng_ocv`` - uses Variable Number of Gradients (VNG) interpolation.
+ - ``bilinear_ocv`` - bilinear interpolation.
+ - ``edgeaware_ocv`` - edge-aware interpolation.
+ - ``vng_ocv`` - Variable Number of Gradients (VNG) interpolation (only ``uint8_t`` supported).
  - ``gray_ocv`` - converts the image to grayscale with bilinear interpolation.)code",
             DALI_STRING)
     .InputLayout(0, {"HW", "HWC", "FHW", "FHWC"})

--- a/dali/operators/image/color/debayer_cpu.cc
+++ b/dali/operators/image/color/debayer_cpu.cc
@@ -25,13 +25,13 @@ using namespace dali::kernels::debayer;
 [[nodiscard]] cv::ColorConversionCodes toOpenCVColorConversionCode(DALIBayerPattern pattern) {
   switch (pattern) {
     case DALIBayerPattern::DALI_BAYER_BG:
-      return cv::COLOR_BayerBG2RGB;
+      return cv::COLOR_BayerBG2RGB_EA;
     case DALIBayerPattern::DALI_BAYER_GB:
-      return cv::COLOR_BayerGB2RGB;
+      return cv::COLOR_BayerGB2RGB_EA;
     case DALIBayerPattern::DALI_BAYER_GR:
-      return cv::COLOR_BayerGR2RGB;
+      return cv::COLOR_BayerGR2RGB_EA;
     case DALIBayerPattern::DALI_BAYER_RG:
-      return cv::COLOR_BayerRG2RGB;
+      return cv::COLOR_BayerRG2RGB_EA;
     default:
       DALI_FAIL("Unsupported bayer pattern code " + to_string(pattern));
   }

--- a/dali/operators/image/color/debayer_cpu.cc
+++ b/dali/operators/image/color/debayer_cpu.cc
@@ -1,0 +1,71 @@
+// Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <opencv2/imgproc.hpp>
+
+#include "dali/kernels/imgproc/color_manipulation/debayer/debayer.h"
+#include "dali/operators/image/color/debayer.h"
+#include "dali/util/ocv.h"
+
+namespace dali {
+
+using namespace dali::kernels::debayer;
+
+[[nodiscard]] cv::ColorConversionCodes toOpenCVColorConversionCode(DALIBayerPattern pattern) {
+  switch (pattern) {
+    case DALIBayerPattern::DALI_BAYER_BG:
+      return cv::COLOR_BayerBG2RGB;
+    case DALIBayerPattern::DALI_BAYER_GB:
+      return cv::COLOR_BayerGB2RGB;
+    case DALIBayerPattern::DALI_BAYER_GR:
+      return cv::COLOR_BayerGR2RGB;
+    case DALIBayerPattern::DALI_BAYER_RG:
+      return cv::COLOR_BayerRG2RGB;
+    default:
+      DALI_FAIL("Unsupported bayer pattern code " + to_string(pattern));
+  }
+}
+
+class DebayerCPU : public Debayer<CPUBackend> {
+ public:
+  explicit DebayerCPU(const OpSpec &spec) : Debayer<CPUBackend>(spec) {}
+
+  void RunImpl(Workspace &ws) override {
+    const auto &input = ws.Input<CPUBackend>(0);
+    auto &output = ws.Output<CPUBackend>(0);
+    output.SetLayout("HWC");
+
+    auto &tPool = ws.GetThreadPool();
+    for (int i = 0; i < input.num_samples(); ++i) {
+      tPool.AddWork([&, i](int) {
+        const auto inImage = input[i];
+        auto outImage = output[i];
+
+        const auto &inShape = inImage.shape();
+        const auto height = static_cast<int>(inShape[0]);
+        const auto width = static_cast<int>(inShape[1]);
+        cv::Mat inImg(height, width, OCVMatTypeForDALIData(inImage.type(), 1),
+                      const_cast<void *>(inImage.raw_data()));
+        cv::Mat outImg(height, width, OCVMatTypeForDALIData(outImage.type(), 3),
+                       outImage.raw_mutable_data());
+        cv::cvtColor(inImg, outImg, toOpenCVColorConversionCode(pattern_[i]));
+      });
+    }
+    tPool.RunAll();
+  }
+};
+
+DALI_REGISTER_OPERATOR(experimental__Debayer, DebayerCPU, CPU);
+
+}  // namespace dali

--- a/dali/operators/image/color/debayer_cpu.cc
+++ b/dali/operators/image/color/debayer_cpu.cc
@@ -59,7 +59,7 @@ class DebayerCPU : public Debayer<CPUBackend> {
                       const_cast<void *>(inImage.raw_data()));
         cv::Mat outImg(height, width, OCVMatTypeForDALIData(outImage.type(), 3),
                        outImage.raw_mutable_data());
-        cv::cvtColor(inImg, outImg, toOpenCVColorConversionCode(pattern_[i]));
+        cv::demosaicing(inImg, outImg, toOpenCVColorConversionCode(pattern_[i]));
       });
     }
     tPool.RunAll();

--- a/dali/operators/image/color/debayer_gpu.cc
+++ b/dali/operators/image/color/debayer_gpu.cc
@@ -86,7 +86,8 @@ bool DebayerGPU::SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace
   bool has_inferred = Debayer<GPUBackend>::SetupImpl(output_desc, ws);
   assert(has_inferred);
   if (impl_ == nullptr) {
-    assert(alg_ == debayer::DALIDebayerAlgorithm::DALI_DEBAYER_BILINEAR_NPP);
+    DALI_ENFORCE(alg_ == debayer::DALIDebayerAlgorithm::DALI_DEBAYER_BILINEAR_NPP,
+                 "Only bilinear_npp algorithm is supported on GPU.");
     const auto type = ws.GetInputDataType(0);
     TYPE_SWITCH(type, type2id, InT, DEBAYER_SUPPORTED_TYPES_GPU, (
       impl_ = std::make_unique<debayer::DebayerImplGPU<InT>>(spec_, pattern_);

--- a/dali/test/python/debayer_test_utils.py
+++ b/dali/test/python/debayer_test_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import cv2
 import numpy as np
 from scipy.signal import convolve2d
 
@@ -177,3 +178,18 @@ def debayer_bilinear_npp_pattern_seq(seq, patterns):
     seq_masks = [bayer_masks[pattern] for pattern in patterns]
     reds, greens, blues = [np.stack(channel) for channel in zip(*seq_masks)]
     return debayer_bilinear_npp_masks(seq, (reds, greens, blues))
+
+
+def debayer_opencv(img: np.ndarray, pattern: BayerPattern, algorithm: str):
+    """Debayer image with OpenCV."""
+    if pattern is not BayerPattern.BGGR:
+        raise NotImplementedError("Only BGGR pattern is supported by at the moment.")
+    if algorithm == "bilinear_ocv":
+        return cv2.cvtColor(img, cv2.COLOR_BayerBG2RGB)
+    if algorithm == "edgeaware_ocv":
+        return cv2.cvtColor(img, cv2.COLOR_BayerBG2RGB_EA)
+    if algorithm == "vng_ocv":
+        return cv2.cvtColor(img, cv2.COLOR_BayerBG2RGB_VNG)
+    if algorithm == "gray_ocv":
+        return cv2.cvtColor(img, cv2.COLOR_BayerBG2GRAY)[..., None]  # Make HWC
+    raise ValueError(f"Unknown algorithm: {algorithm}")

--- a/dali/util/ocv.cc
+++ b/dali/util/ocv.cc
@@ -13,58 +13,38 @@
 // limitations under the License.
 
 #include "dali/util/ocv.h"
-#include <cmath>
-#include <utility>
-#include <map>
 #include <algorithm>
+#include <cmath>
+#include <map>
 #include <tuple>
+#include <utility>
 #include "dali/core/error_handling.h"
 #include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
 
 namespace dali {
 
-int OCVInterpForDALIInterp(DALIInterpType type, int *ocv_type) {
-  switch (type) {
-  case DALI_INTERP_NN:
-    *ocv_type =  cv::INTER_NEAREST;
-    break;
-  case DALI_INTERP_LINEAR:
-    *ocv_type =  cv::INTER_LINEAR;
-    break;
-  case DALI_INTERP_CUBIC:
-    *ocv_type =  cv::INTER_CUBIC;
-    break;
-  default:
-    return DALIError;
-  }
-  return DALISuccess;
-}
-
 int GetOpenCvChannelType(size_t c) {
   return type2ocv<uint8_t>::value(c);
 }
 
-static cv::ColorConversionCodes GetOpenCvColorConversionCode(
-  DALIImageType input_type, DALIImageType output_type) {
-    using ColorConversionPair = std::pair<DALIImageType, DALIImageType>;
-    using ColorConversionMap = std::map< ColorConversionPair, cv::ColorConversionCodes >;
-    static const ColorConversionMap color_conversion_map = {
-        { {DALI_RGB, DALI_BGR},  cv::COLOR_RGB2BGR },
-        { {DALI_RGB, DALI_GRAY}, cv::COLOR_RGB2GRAY },
+static cv::ColorConversionCodes GetOpenCvColorConversionCode(DALIImageType input_type,
+                                                             DALIImageType output_type) {
+  using ColorConversionPair = std::pair<DALIImageType, DALIImageType>;
+  using ColorConversionMap = std::map<ColorConversionPair, cv::ColorConversionCodes>;
+  static const ColorConversionMap color_conversion_map = {
+      {{DALI_RGB, DALI_BGR}, cv::COLOR_RGB2BGR},   {{DALI_RGB, DALI_GRAY}, cv::COLOR_RGB2GRAY},
 
-        { {DALI_BGR, DALI_RGB},  cv::COLOR_BGR2RGB },
-        { {DALI_BGR, DALI_GRAY}, cv::COLOR_BGR2GRAY },
+      {{DALI_BGR, DALI_RGB}, cv::COLOR_BGR2RGB},   {{DALI_BGR, DALI_GRAY}, cv::COLOR_BGR2GRAY},
 
-        { {DALI_GRAY, DALI_RGB}, cv::COLOR_GRAY2RGB },
-        { {DALI_GRAY, DALI_BGR}, cv::COLOR_GRAY2BGR },
-    };
+      {{DALI_GRAY, DALI_RGB}, cv::COLOR_GRAY2RGB}, {{DALI_GRAY, DALI_BGR}, cv::COLOR_GRAY2BGR},
+  };
 
-    const ColorConversionPair color_conversion_pair{ input_type, output_type };
-    const auto it = color_conversion_map.find(color_conversion_pair);
-    if (it == color_conversion_map.end()) {
-      return cv::COLOR_COLORCVT_MAX;
-    }
-    return it->second;
+  const ColorConversionPair color_conversion_pair{input_type, output_type};
+  const auto it = color_conversion_map.find(color_conversion_pair);
+  if (it == color_conversion_map.end()) {
+    return cv::COLOR_COLORCVT_MAX;
+  }
+  return it->second;
 }
 
 template <DALIImageType input_type, DALIImageType output_type>
@@ -121,51 +101,50 @@ inline void custom_conversion(const cv::Mat& img, cv::Mat& output_img) {
   const std::size_t input_C = img.elemSize();
   const std::size_t output_C = output_img.elemSize();
   const std::size_t total_size = img.rows * img.cols;
-  for (std::size_t i = 0; i < total_size; i ++) {
-    custom_conversion_pixel<input_type, output_type>(
-      img.data + i*input_C,
-      output_img.data + i*output_C);
+  for (std::size_t i = 0; i < total_size; i++) {
+    custom_conversion_pixel<input_type, output_type>(img.data + i * input_C,
+                                                     output_img.data + i * output_C);
   }
 }
 
 void OpenCvColorConversion(DALIImageType input_type, const cv::Mat& input_img,
                            DALIImageType output_type, cv::Mat& output_img) {
   DALI_ENFORCE(input_img.elemSize() == static_cast<size_t>(NumberOfChannels(input_type)),
-    "Incorrect number of channels");
+               "Incorrect number of channels");
   DALI_ENFORCE(output_img.elemSize() == static_cast<size_t>(NumberOfChannels(output_type)),
-    "Incorrect number of channels");
+               "Incorrect number of channels");
   auto ocv_conversion_code = GetOpenCvColorConversionCode(input_type, output_type);
   bool ocv_supported = (ocv_conversion_code != cv::COLOR_COLORCVT_MAX);
-  if ( ocv_supported ) {
+  if (ocv_supported) {
     cv::cvtColor(input_img, output_img, ocv_conversion_code);
     return;
   }
   using ColorConversionPair = std::pair<DALIImageType, DALIImageType>;
-  ColorConversionPair conversion { input_type, output_type };
+  ColorConversionPair conversion{input_type, output_type};
   // Handle special cases
-  const ColorConversionPair kRGBToYCbCr  { DALI_RGB,   DALI_YCbCr };
-  const ColorConversionPair kBGRToYCbCr  { DALI_BGR,   DALI_YCbCr };
-  const ColorConversionPair kYCbCrToRGB  { DALI_YCbCr, DALI_RGB };
-  const ColorConversionPair kYCbCrToBGR  { DALI_YCbCr, DALI_BGR };
-  const ColorConversionPair kGrayToYCbCr { DALI_GRAY,  DALI_YCbCr };
-  const ColorConversionPair kYCbCrToGray { DALI_YCbCr, DALI_GRAY };
+  const ColorConversionPair kRGBToYCbCr{DALI_RGB, DALI_YCbCr};
+  const ColorConversionPair kBGRToYCbCr{DALI_BGR, DALI_YCbCr};
+  const ColorConversionPair kYCbCrToRGB{DALI_YCbCr, DALI_RGB};
+  const ColorConversionPair kYCbCrToBGR{DALI_YCbCr, DALI_BGR};
+  const ColorConversionPair kGrayToYCbCr{DALI_GRAY, DALI_YCbCr};
+  const ColorConversionPair kYCbCrToGray{DALI_YCbCr, DALI_GRAY};
 
-  if ( conversion == kRGBToYCbCr ) {
+  if (conversion == kRGBToYCbCr) {
     custom_conversion<DALI_RGB, DALI_YCbCr>(input_img, output_img);
     return;
-  } else if ( conversion == kBGRToYCbCr ) {
+  } else if (conversion == kBGRToYCbCr) {
     custom_conversion<DALI_BGR, DALI_YCbCr>(input_img, output_img);
     return;
-  } else if ( conversion == kYCbCrToRGB ) {
+  } else if (conversion == kYCbCrToRGB) {
     custom_conversion<DALI_YCbCr, DALI_RGB>(input_img, output_img);
     return;
-  } else if ( conversion == kYCbCrToBGR ) {
+  } else if (conversion == kYCbCrToBGR) {
     custom_conversion<DALI_YCbCr, DALI_BGR>(input_img, output_img);
     return;
-  } else if ( conversion == kGrayToYCbCr ) {
+  } else if (conversion == kGrayToYCbCr) {
     custom_conversion<DALI_GRAY, DALI_YCbCr>(input_img, output_img);
     return;
-  } else if ( conversion == kYCbCrToGray ) {
+  } else if (conversion == kYCbCrToGray) {
     custom_conversion<DALI_YCbCr, DALI_GRAY>(input_img, output_img);
     return;
   }


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)


## Description:
CPU Backend was missing for debayer operation, this has been added via cv::demosaicing + bayer code. All OpenCV algorithm variants have been added, selectable with the `algorithm` kwarg which is now required (**breaking change**).

All the existing gpu python tests have been applied to the CPU algorithm, but with a loose matching, rather than exact (allowing for 5% max outliers where an outlier differs by more than 5%).

New test has been added to check the plugin produces the same results as just calling cv2.cvtColor() on the input data.

## Additional information:

### Affected modules and functionalities:
In addition to the new `debayer_cpu.cc` file, I've made minor tweaks to move common OpenCV<->DALI interop into `util/ocv.cc` and `util/ocv.h` and refactored `OCVInterpForDALIInterp` since it had an API style different from others. But this function is unused anyway.


### Key points relevant for the review:
~~I'm not sure what the demand is for the algorithm variants that OpenCV includes ("Edge-aware" and "Variable Number of Gradients"). This can be done by adding more options for the `algorithm` argument, NPP only has one.~~

~~Many of the bayer pattern testing functions are currently failing, this was a problem before adding the CPU impl and tests. The objective of these tests needs to be reviewed.~~

```
FAIL: test_debayer_vid_per_frame_pattern:1
'gpu' (test_debayer.DebayerVideoTest.test_debayer_vid_per_frame_pattern:1
'gpu')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspaces/DALI/dali/test/python/operator_1/test_debayer.py", line 264, in test_debayer_vid_per_frame_pattern
    assert np.all(vid_debayered == baseline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError

======================================================================
FAIL: test_debayer_vid_per_frame_pattern:2
'cpu' (test_debayer.DebayerVideoTest.test_debayer_vid_per_frame_pattern:2
'cpu')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspaces/DALI/dali/test/python/operator_1/test_debayer.py", line 264, in test_debayer_vid_per_frame_pattern
    assert np.all(vid_debayered == baseline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

```
Ran 37 tests in 20.625s

FAILED (failures=30)
```

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
