### PR TITLE
FramesDecoder boundary handling, video utils

### DIFF
--- a/dali/operators/video/color_space.cu
+++ b/dali/operators/video/color_space.cu
@@ -15,73 +15,106 @@
 #include "color_space.h"
 
 #include <cuda_runtime.h>
-#include "dali/kernels/imgproc/sampler.h"
+#include "dali/core/static_switch.h"
 #include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
+#include "dali/kernels/imgproc/sampler.h"
 
 namespace dali {
 
-template <bool full_range>
-__global__ static void yuv_to_rgb_kernel(
-    const uint8_t *yuv, int yuv_pitch, uint8_t *rgb, int rgb_pitch, int width, int height) {
-    int halfx = (threadIdx.x + blockIdx.x * blockDim.x);
-    int halfy = (threadIdx.y + blockIdx.y * blockDim.y);
-    int x = 2 * halfx;
-    int y = 2 * halfy;
-    if (x >= width || y >= height) {
-        return;
+template <typename Out, VideoColorSpaceConversionType conversion_type,
+          bool normalized_range = false>
+__global__ static void VideoColorSpaceConversionKernel(Out *out, int out_pitch, const uint8_t *yuv,
+                                                       int yuv_pitch, int height, int width) {
+  int halfx = (threadIdx.x + blockIdx.x * blockDim.x);
+  int halfy = (threadIdx.y + blockIdx.y * blockDim.y);
+  int x = 2 * halfx;
+  int y = 2 * halfy;
+  if (x >= width || y >= height) {
+    return;
+  }
+
+  kernels::Surface2D<const uint8_t> Y_surf, UV_surf;
+  kernels::Surface2D<Out> output;
+  const uint8_t *chroma = yuv + height * yuv_pitch;
+
+  Y_surf = {yuv, width, height, 1, 1, yuv_pitch, 1};
+  UV_surf = {chroma, width / 2, height / 2, 2, 2, yuv_pitch, 1};
+
+  output = {out, width, height, 3, 3, out_pitch, 1};
+
+  auto Y = kernels::make_sampler<DALI_INTERP_NN>(Y_surf);
+  auto UV = kernels::make_sampler<DALI_INTERP_LINEAR>(UV_surf);
+
+#pragma unroll
+  for (int i = 0; i < 2; i++) {
+    float cy = halfy + i * 0.5f + 0.25f;
+#pragma unroll
+    for (int j = 0; j < 2; j++) {
+      float cx = halfx + j * 0.5f + 0.25f;
+      u8vec3 yuv_val;
+      yuv_val[0] = Y.at(ivec2{x + j, y + i}, 0, kernels::BorderClamp());
+
+      UV(&yuv_val[1], vec2(cx, cy), kernels::BorderClamp());
+
+      u8vec3 out_val;
+      switch (conversion_type) {
+        case VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB_FULL_RANGE:
+          out_val = dali::kernels::color::jpeg::ycbcr_to_rgb<uint8_t>(yuv_val);
+          break;
+        case VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB:
+          out_val = dali::kernels::color::itu_r_bt_601::ycbcr_to_rgb<uint8_t>(yuv_val);
+          break;
+        case VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_UPSAMPLE:
+          out_val = yuv_val;
+          break;
+        default:
+          assert(false);
+      }
+      if (normalized_range) {
+        output({x + j, y + i, 0}) = ConvertNorm<Out>(out_val.x);
+        output({x + j, y + i, 1}) = ConvertNorm<Out>(out_val.y);
+        output({x + j, y + i, 2}) = ConvertNorm<Out>(out_val.z);
+      } else {
+        output({x + j, y + i, 0}) = ConvertSat<Out>(out_val.x);
+        output({x + j, y + i, 1}) = ConvertSat<Out>(out_val.y);
+        output({x + j, y + i, 2}) = ConvertSat<Out>(out_val.z);
+      }
     }
-
-    kernels::Surface2D<const uint8_t> Y_surf, UV_surf;
-    kernels::Surface2D<uint8_t> RGB;
-    const uint8_t *chroma = yuv + height * yuv_pitch;
-
-    Y_surf  = { yuv,    width,     height,     1, 1, yuv_pitch, 1 };
-    UV_surf = { chroma, width / 2, height / 2, 2, 2, yuv_pitch, 1 };
-
-    RGB = { rgb, width, height, 3, 3, rgb_pitch, 1 };
-
-    auto Y = kernels::make_sampler<DALI_INTERP_NN>(Y_surf);
-    auto UV = kernels::make_sampler<DALI_INTERP_LINEAR>(UV_surf);
-
-    #pragma unroll
-    for (int i = 0; i < 2; i++) {
-        float cy = halfy + i * 0.5f + 0.25f;
-        #pragma unroll
-        for (int j = 0; j < 2; j++) {
-            float cx = halfx + j * 0.5f + 0.25f;
-            u8vec3 yuv_val;
-            yuv_val[0] = Y.at(ivec2{x + j, y + i}, 0, kernels::BorderClamp());
-
-            UV(&yuv_val[1], vec2(cx, cy), kernels::BorderClamp());
-
-            u8vec3 rgb_val;
-            if (full_range)
-                rgb_val = dali::kernels::color::jpeg::ycbcr_to_rgb<uint8_t>(yuv_val);
-            else
-                rgb_val = dali::kernels::color::itu_r_bt_601::ycbcr_to_rgb<uint8_t>(yuv_val);
-
-            RGB({x + j, y + i, 0}) = rgb_val.x;
-            RGB({x + j, y + i, 1}) = rgb_val.y;
-            RGB({x + j, y + i, 2}) = rgb_val.z;
-        }
-    }
-
+  }
 }
+
+template <typename Out>
+void VideoColorSpaceConversionImpl(Out *out, int out_pitch, const uint8_t *yuv, int yuv_pitch,
+                                   int height, int width,
+                                   VideoColorSpaceConversionType conversion_type,
+                                   bool normalized_range, cudaStream_t stream) {
+  auto grid_layout = dim3((width + 63) / 32 / 2, (height + 3));
+  auto block_layout = dim3(32, 2);
+
+  BOOL_SWITCH(
+      normalized_range, static_normalized_range,
+      (VALUE_SWITCH(static_cast<int>(conversion_type), static_conversion_type, (
+                VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB,
+                VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB_FULL_RANGE,
+                VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_UPSAMPLE), (
+            VideoColorSpaceConversionKernel<Out, static_conversion_type, static_normalized_range>
+                <<<grid_layout, block_layout, 0, stream>>>(out, out_pitch, yuv, yuv_pitch, height, width);
+        ), (DALI_FAIL("wrong value")));));
+}
+
+void VideoColorSpaceConversion(uint8_t *out, int out_pitch, const uint8_t *yuv, int yuv_pitch,
+                               int height, int width, VideoColorSpaceConversionType conversion_type,
+                               bool normalized_range, cudaStream_t stream) {
+  VideoColorSpaceConversionImpl(out, out_pitch, yuv, yuv_pitch, height, width, conversion_type,
+                                normalized_range, stream);
+}
+
+void VideoColorSpaceConversion(float *out, int out_pitch, const uint8_t *yuv, int yuv_pitch,
+                               int height, int width, VideoColorSpaceConversionType conversion_type,
+                               bool normalized_range, cudaStream_t stream) {
+  VideoColorSpaceConversionImpl(out, out_pitch, yuv, yuv_pitch, height, width, conversion_type,
+                                normalized_range, stream);
+}
+
 
 }  // namespace dali
-
-void yuv_to_rgb(uint8_t *yuv, int yuv_pitch, uint8_t *rgb, int rgb_pitch, int width, int height,
-                bool full_range, cudaStream_t stream) {
-    auto grid_layout = dim3((width + 63) / 32 / 2, (height + 3));
-    auto block_layout = dim3(32, 2);
-
-    if (full_range) {
-        dali::yuv_to_rgb_kernel<true>
-            <<<grid_layout, block_layout, 0, stream>>>
-            (yuv, yuv_pitch, rgb, rgb_pitch, width, height);
-    } else {
-        dali::yuv_to_rgb_kernel<false>
-            <<<grid_layout, block_layout, 0, stream>>>
-            (yuv, yuv_pitch, rgb, rgb_pitch, width, height);
-    }
-}

--- a/dali/operators/video/color_space.cu
+++ b/dali/operators/video/color_space.cu
@@ -12,93 +12,92 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "color_space.h"
+#include "dali/operators/video/color_space.h"
 
 #include <cuda_runtime.h>
 #include "dali/core/static_switch.h"
-#include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
 #include "dali/kernels/imgproc/sampler.h"
+#include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
 
 namespace dali {
 
-template <typename Out, VideoColorSpaceConversionType conversion_type,
-          bool normalized_range = false>
-__global__ static void VideoColorSpaceConversionKernel(Out *out, int out_pitch, const uint8_t *yuv,
-                                                       int yuv_pitch, int height, int width) {
-  int halfx = (threadIdx.x + blockIdx.x * blockDim.x);
-  int halfy = (threadIdx.y + blockIdx.y * blockDim.y);
-  int x = 2 * halfx;
-  int y = 2 * halfy;
-  if (x >= width || y >= height) {
-    return;
-  }
-
-  kernels::Surface2D<const uint8_t> Y_surf, UV_surf;
-  kernels::Surface2D<Out> output;
-  const uint8_t *chroma = yuv + height * yuv_pitch;
-
-  Y_surf = {yuv, width, height, 1, 1, yuv_pitch, 1};
-  UV_surf = {chroma, width / 2, height / 2, 2, 2, yuv_pitch, 1};
-
-  output = {out, width, height, 3, 3, out_pitch, 1};
-
-  auto Y = kernels::make_sampler<DALI_INTERP_NN>(Y_surf);
-  auto UV = kernels::make_sampler<DALI_INTERP_LINEAR>(UV_surf);
-
-#pragma unroll
-  for (int i = 0; i < 2; i++) {
-    float cy = halfy + i * 0.5f + 0.25f;
-#pragma unroll
-    for (int j = 0; j < 2; j++) {
-      float cx = halfx + j * 0.5f + 0.25f;
-      u8vec3 yuv_val;
-      yuv_val[0] = Y.at(ivec2{x + j, y + i}, 0, kernels::BorderClamp());
-
-      UV(&yuv_val[1], vec2(cx, cy), kernels::BorderClamp());
-
-      u8vec3 out_val;
-      switch (conversion_type) {
-        case VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB_FULL_RANGE:
-          out_val = dali::kernels::color::jpeg::ycbcr_to_rgb<uint8_t>(yuv_val);
-          break;
-        case VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB:
-          out_val = dali::kernels::color::itu_r_bt_601::ycbcr_to_rgb<uint8_t>(yuv_val);
-          break;
-        case VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_UPSAMPLE:
-          out_val = yuv_val;
-          break;
-        default:
-          assert(false);
-      }
-      if (normalized_range) {
-        output({x + j, y + i, 0}) = ConvertNorm<Out>(out_val.x);
-        output({x + j, y + i, 1}) = ConvertNorm<Out>(out_val.y);
-        output({x + j, y + i, 2}) = ConvertNorm<Out>(out_val.z);
-      } else {
-        output({x + j, y + i, 0}) = ConvertSat<Out>(out_val.x);
-        output({x + j, y + i, 1}) = ConvertSat<Out>(out_val.y);
-        output({x + j, y + i, 2}) = ConvertSat<Out>(out_val.z);
-      }
+template <typename Out, VideoColorSpaceConversionType conversion_type, bool normalized_range = false>
+__global__ static void VideoColorSpaceConversionKernel(
+    Out *out, int out_pitch, const uint8_t *yuv, int yuv_pitch, int height, int width) {
+    int halfx = (threadIdx.x + blockIdx.x * blockDim.x);
+    int halfy = (threadIdx.y + blockIdx.y * blockDim.y);
+    int x = 2 * halfx;
+    int y = 2 * halfy;
+    if (x >= width || y >= height) {
+        return;
     }
-  }
+
+    kernels::Surface2D<const uint8_t> Y_surf, UV_surf;
+    kernels::Surface2D<Out> output;
+    const uint8_t *chroma = yuv + height * yuv_pitch;
+
+    Y_surf  = { yuv,    width,     height,     1, 1, yuv_pitch, 1 };
+    UV_surf = { chroma, width / 2, height / 2, 2, 2, yuv_pitch, 1 };
+
+    output = { out, width, height, 3, 3, out_pitch, 1 };
+
+    auto Y = kernels::make_sampler<DALI_INTERP_NN>(Y_surf);
+    auto UV = kernels::make_sampler<DALI_INTERP_LINEAR>(UV_surf);
+
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        float cy = halfy + i * 0.5f + 0.25f;
+        #pragma unroll
+        for (int j = 0; j < 2; j++) {
+            float cx = halfx + j * 0.5f + 0.25f;
+            u8vec3 yuv_val;
+            yuv_val[0] = Y.at(ivec2{x + j, y + i}, 0, kernels::BorderClamp());
+
+            UV(&yuv_val[1], vec2(cx, cy), kernels::BorderClamp());
+
+            u8vec3 out_val;
+            switch (conversion_type) {
+              case VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB_FULL_RANGE:
+                out_val = dali::kernels::color::jpeg::ycbcr_to_rgb<uint8_t>(yuv_val);
+                break;
+              case VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB:
+                out_val = dali::kernels::color::itu_r_bt_601::ycbcr_to_rgb<uint8_t>(yuv_val);
+                break;
+              case VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_UPSAMPLE:
+                out_val = yuv_val;
+                break;
+              default:
+                assert(false);
+            }
+            if (normalized_range) {
+              output({x + j, y + i, 0}) = ConvertNorm<Out>(out_val.x);
+              output({x + j, y + i, 1}) = ConvertNorm<Out>(out_val.y);
+              output({x + j, y + i, 2}) = ConvertNorm<Out>(out_val.z);
+            } else {
+              output({x + j, y + i, 0}) = ConvertSat<Out>(out_val.x);
+              output({x + j, y + i, 1}) = ConvertSat<Out>(out_val.y);
+              output({x + j, y + i, 2}) = ConvertSat<Out>(out_val.z);
+            }
+        }
+    }
+
 }
 
 template <typename Out>
 void VideoColorSpaceConversionImpl(Out *out, int out_pitch, const uint8_t *yuv, int yuv_pitch,
-                                   int height, int width,
-                                   VideoColorSpaceConversionType conversion_type,
+                                   int height, int width, VideoColorSpaceConversionType conversion_type,
                                    bool normalized_range, cudaStream_t stream) {
-  auto grid_layout = dim3((width + 63) / 32 / 2, (height + 3));
-  auto block_layout = dim3(32, 2);
+    auto grid_layout = dim3((width + 63) / 32 / 2, (height + 3));
+    auto block_layout = dim3(32, 2);
 
-  BOOL_SWITCH(
-      normalized_range, static_normalized_range,
-      (VALUE_SWITCH(static_cast<int>(conversion_type), static_conversion_type, (
-                VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB,
-                VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB_FULL_RANGE,
-                VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_UPSAMPLE), (
-            VideoColorSpaceConversionKernel<Out, static_conversion_type, static_normalized_range>
-                <<<grid_layout, block_layout, 0, stream>>>(out, out_pitch, yuv, yuv_pitch, height, width);
+    BOOL_SWITCH(
+        normalized_range, static_normalized_range,
+        (VALUE_SWITCH(static_cast<int>(conversion_type), static_conversion_type, (
+      VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB,
+      VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB_FULL_RANGE,
+      VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_UPSAMPLE), (
+        VideoColorSpaceConversionKernel<Out, static_conversion_type, static_normalized_range>
+        <<<grid_layout, block_layout, 0, stream>>>(out, out_pitch, yuv, yuv_pitch, height, width);
         ), (DALI_FAIL("wrong value")));));
 }
 
@@ -115,6 +114,5 @@ void VideoColorSpaceConversion(float *out, int out_pitch, const uint8_t *yuv, in
   VideoColorSpaceConversionImpl(out, out_pitch, yuv, yuv_pitch, height, width, conversion_type,
                                 normalized_range, stream);
 }
-
 
 }  // namespace dali

--- a/dali/operators/video/color_space.h
+++ b/dali/operators/video/color_space.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_OPERATORS_VIDEO_COLOR_SPACE_GPU_H_
-#define DALI_OPERATORS_VIDEO_COLOR_SPACE_GPU_H_
+#ifndef DALI_OPERATORS_VIDEO_COLOR_SPACE_H_
+#define DALI_OPERATORS_VIDEO_COLOR_SPACE_H_
 
 #include <stdint.h>
 
@@ -35,4 +35,4 @@ void VideoColorSpaceConversion(float *out, int out_pitch, const uint8_t* yuv, in
 
 }  // namespace dali
 
-#endif  // DALI_OPERATORS_VIDEO_COLOR_SPACE_GPU_H_
+#endif  // DALI_OPERATORS_VIDEO_COLOR_SPACE_H_

--- a/dali/operators/video/color_space.h
+++ b/dali/operators/video/color_space.h
@@ -17,14 +17,22 @@
 
 #include <stdint.h>
 
-void yuv_to_rgb(
-    uint8_t *yuv,
-    int yuv_pitch,
-    uint8_t *rgb,
-    int rgb_pitch,
-    int width,
-    int height,
-    bool full_range,
-    cudaStream_t stream);
+namespace dali {
+
+enum VideoColorSpaceConversionType {
+    VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB,
+    VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_TO_RGB_FULL_RANGE,
+    VIDEO_COLOR_SPACE_CONVERSION_TYPE_YUV_UPSAMPLE,
+};
+
+void VideoColorSpaceConversion(uint8_t *out, int out_pitch, const uint8_t* yuv, int yuv_pitch, int height, int width,
+                               VideoColorSpaceConversionType conversion_type, bool normalized_range,
+                               cudaStream_t stream);
+
+void VideoColorSpaceConversion(float *out, int out_pitch, const uint8_t* yuv, int yuv_pitch, int height, int width,
+                               VideoColorSpaceConversionType conversion_type, bool normalized_range,
+                               cudaStream_t stream);
+
+}  // namespace dali
 
 #endif  // DALI_OPERATORS_VIDEO_COLOR_SPACE_GPU_H_

--- a/dali/operators/video/decoder/video_decoder_base.h
+++ b/dali/operators/video/decoder/video_decoder_base.h
@@ -88,11 +88,9 @@ class DLL_PUBLIC VideoDecoderBase : public Operator<Backend> {
                                                    std::string_view source_info,
                                                    cudaStream_t stream = 0) {
     if constexpr (std::is_same_v<Backend, CPUBackend>) {
-      return std::make_unique<FramesDecoderImpl>(data, size, DALI_RGB, DALI_UINT8, build_index, -1,
-                                                 source_info);
+      return std::make_unique<FramesDecoderImpl>(data, size, source_info);
     } else {
-      return std::make_unique<FramesDecoderImpl>(data, size, DALI_RGB, DALI_UINT8, build_index, -1,
-                                                 source_info, stream);
+      return std::make_unique<FramesDecoderImpl>(data, size, source_info, stream);
     }
   }
 

--- a/dali/operators/video/decoder/video_decoder_base.h
+++ b/dali/operators/video/decoder/video_decoder_base.h
@@ -24,55 +24,19 @@
 #include <utility>
 #include <vector>
 #include "dali/core/boundary.h"
+#include "dali/core/small_vector.h"
 #include "dali/core/span.h"
 #include "dali/kernels/common/copy.h"
 #include "dali/kernels/common/memset.h"
+#include "dali/operators/video/video_utils.h"
 #include "dali/pipeline/operator/arg_helper.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
-#include "dali/core/small_vector.h"
 
 namespace dali {
 
 template <typename Backend, typename FramesDecoderImpl>
 class DLL_PUBLIC VideoDecoderBase : public Operator<Backend> {
- private:
-  struct FrameInfo {
-    static FrameInfo FrameIndex(int frame_idx, int frame_num) {
-      FrameInfo info;
-      info.frame_num = frame_num;
-      info.frame_idx = frame_idx;
-      return info;
-    }
-
-    static FrameInfo Constant(int frame_num) {
-      FrameInfo info;
-      info.frame_num = frame_num;
-      return info;
-    }
-
-    bool operator<(const FrameInfo &other) const {
-      return frame_idx < other.frame_idx;  // sort by frame index
-    }
-
-    bool is_constant() const {
-      return frame_idx == -1;
-    }
-
-    int frame_num = 0;
-    int frame_idx = -1;
-  };
-
-  struct WorkerContext {
-    std::vector<FrameInfo> frame_infos;
-    SmallVector<uint8_t, 16> fill_value;
-    mm::uptr<uint8_t> fill_value_frame_cpu_buffer;
-    mm::uptr<uint8_t> fill_value_frame_gpu_buffer;
-    int64_t fill_value_frame_size = 0;
-    FramesDecoderImpl* frames_decoder = nullptr;
-    cudaStream_t stream = 0;
-  };
-
  public:
   USE_OPERATOR_MEMBERS();
   using InBackend = CPUBackend;
@@ -98,22 +62,7 @@ class DLL_PUBLIC VideoDecoderBase : public Operator<Backend> {
     DALI_ENFORCE(!(sequence_length_.HasValue() && end_frame_.HasValue()),
                  "Cannot specify both `sequence_length` and `end_frame` arguments");
 
-    auto pad_mode_str = spec_.template GetArgument<std::string>("pad_mode");
-    if (pad_mode_str == "none" || pad_mode_str == "") {
-      boundary_type_ = boundary::BoundaryType::ISOLATED;
-    } else if (pad_mode_str == "constant") {
-      boundary_type_ = boundary::BoundaryType::CONSTANT;
-    } else if (pad_mode_str == "edge" || pad_mode_str == "repeat") {
-      boundary_type_ = boundary::BoundaryType::CLAMP;
-    } else if (pad_mode_str == "reflect_1001" || pad_mode_str == "symmetric") {
-      boundary_type_ = boundary::BoundaryType::REFLECT_1001;
-    } else if (pad_mode_str == "reflect_101" || pad_mode_str == "reflect") {
-      boundary_type_ = boundary::BoundaryType::REFLECT_101;
-    } else {
-      DALI_FAIL(make_string("Invalid pad_mode: ", pad_mode_str, "\n",
-                            "Valid options are: none, constant, edge, reflect_1001, reflect_101"));
-    }
-
+    boundary_type_ = GetBoundaryType(spec_);
     build_index_ = spec_.template GetArgument<bool>("build_index");
 
     if (boundary_type_ == boundary::BoundaryType::CONSTANT) {
@@ -129,13 +78,21 @@ class DLL_PUBLIC VideoDecoderBase : public Operator<Backend> {
   DISABLE_COPY_MOVE_ASSIGN(VideoDecoderBase);
 
  protected:
+  struct WorkerContext {
+    FramesDecoderImpl* frames_decoder = nullptr;
+    cudaStream_t stream = 0;
+    Tensor<OutBackend> constant_frame;
+  };
+
   std::unique_ptr<FramesDecoderImpl> CreateDecoder(const char *data, size_t size, bool build_index,
                                                    std::string_view source_info,
                                                    cudaStream_t stream = 0) {
     if constexpr (std::is_same_v<Backend, CPUBackend>) {
-      return std::make_unique<FramesDecoderImpl>(data, size, build_index, -1, source_info);
+      return std::make_unique<FramesDecoderImpl>(data, size, DALI_RGB, DALI_UINT8, build_index, -1,
+                                                 source_info);
     } else {
-      return std::make_unique<FramesDecoderImpl>(data, size, stream, build_index, -1, source_info);
+      return std::make_unique<FramesDecoderImpl>(data, size, DALI_RGB, DALI_UINT8, build_index, -1,
+                                                 source_info, stream);
     }
   }
 
@@ -314,34 +271,6 @@ class DLL_PUBLIC VideoDecoderBase : public Operator<Backend> {
     return true;
   }
 
-  void AddFrame(int frame_num, int frame_idx, int orig_num_frames, WorkerContext &ctx) const {
-    if (frame_idx >= orig_num_frames) {
-      switch (boundary_type_) {
-        case boundary::BoundaryType::CLAMP:
-          ctx.frame_infos.push_back(FrameInfo::FrameIndex(orig_num_frames - 1, frame_num));
-          break;
-        case boundary::BoundaryType::REFLECT_1001:
-          ctx.frame_infos.push_back(FrameInfo::FrameIndex(
-              boundary::idx_reflect_1001<int>(static_cast<int>(frame_idx), orig_num_frames),
-              frame_num));
-          break;
-        case boundary::BoundaryType::REFLECT_101:
-          ctx.frame_infos.push_back(FrameInfo::FrameIndex(
-              boundary::idx_reflect_101<int>(static_cast<int>(frame_idx), orig_num_frames),
-              frame_num));
-          break;
-        case boundary::BoundaryType::CONSTANT:
-          ctx.frame_infos.push_back(FrameInfo::Constant(frame_num));
-          break;
-        default:
-        case boundary::BoundaryType::ISOLATED:
-          break;  // will result in a shorter sequence than requested
-      }
-    } else {
-      ctx.frame_infos.push_back(FrameInfo::FrameIndex(frame_idx, frame_num));
-    }
-  }
-
   void RunImpl(Workspace &ws) override {
     auto &output = ws.Output<OutBackend>(0);
     const auto &input = ws.Input<InBackend>(0);
@@ -357,42 +286,23 @@ class DLL_PUBLIC VideoDecoderBase : public Operator<Backend> {
             auto &ctx = ctx_[tid];
             ctx.frames_decoder = frames_decoders_[s].get();
             ctx.stream = ws.has_stream() ? ws.stream() : 0;
-            ctx.fill_value = fill_value_;
-            ctx.frame_infos.clear();
 
-            if (boundary_type_ == boundary::BoundaryType::CONSTANT) {
-              int nfill_values = fill_value_.size();
-              DALI_ENFORCE(nfill_values == 1 || nfill_values == ctx.frames_decoder->Channels(),
-                           make_string("Constant padding requires either a single fill value or a "
-                                       "fill value per channel. "
-                                       "Got ",
-                                       nfill_values, " fill values for a video with ",
-                                       ctx.frames_decoder->Channels(), " channels."));
-            }
+            const uint8_t *constant_frame = boundary_type_ == boundary::BoundaryType::CONSTANT ?
+                ConstantFrame(ctx.constant_frame, ctx.frames_decoder->FrameShape(),
+                             make_cspan(fill_value_), ctx.stream, true) : nullptr;
 
             if (frames_.HasValue()) {
-              for (int64_t frame_num = 0; frame_num < num_frames; frame_num++) {
-                DALI_ENFORCE(
-                    boundary_type_ != boundary::BoundaryType::ISOLATED ||
-                        frames_[s].data[frame_num] < orig_num_frames,
-                    make_string("Unexpected out-of-bounds frame index ", frames_[s].data[frame_num],
-                                " for pad_mode = 'none' and sample #", s, ", containing only ",
-                                orig_num_frames, " frames. Change `pad_mode` to fill the missing "
-                                "frames."));
-                AddFrame(frame_num, frames_[s].data[frame_num], orig_num_frames, ctx);
-              }
+              frames_decoders_[s]->DecodeFrames(output[s].template mutable_data<uint8_t>(),
+                                                make_cspan(frames_[s].data, frames_[s].shape[0]),
+                                                boundary_type_, constant_frame);
             } else {
-              int stride = GetStride(s);
-              int start_frame = GetStartFrame(s);
-              for (int64_t frame_num = 0, frame_idx = start_frame; frame_num < num_frames;
-                   frame_num++, frame_idx += stride) {
-                AddFrame(frame_num, frame_idx, orig_num_frames, ctx);
-              }
+              auto start_frame = GetStartFrame(s);
+              auto stride = GetStride(s);
+              auto end_frame = start_frame + num_frames * stride;  // it can go beyond the video length
+              frames_decoders_[s]->DecodeFrames(output[s].template mutable_data<uint8_t>(),
+                                                start_frame, end_frame, stride,
+                                                boundary_type_, constant_frame);
             }
-            // Sort the frame indices so that we can decode them in natural order
-            // to avoid unnecessary seeking when possible
-            std::sort(ctx.frame_infos.begin(), ctx.frame_infos.end());
-            DecodeFrames(output[s], ctx);
             frames_decoders_[s].reset();
           },
           output[s].shape().num_elements());
@@ -402,70 +312,6 @@ class DLL_PUBLIC VideoDecoderBase : public Operator<Backend> {
 
   ThreadPool &GetThreadPool(const Workspace &ws) {
     return std::is_same<MixedBackend, Backend>::value ? *thread_pool_ : ws.GetThreadPool();
-  }
-
-  template <typename Storage>
-  void SetConstantPadding(uint8_t *output, int64_t output_size, WorkerContext &ctx) {
-    if (ctx.fill_value.size() == 1) {
-      kernels::memset<Storage>(output, ctx.fill_value[0], output_size, ctx.stream);
-    } else if (std::is_same_v<Storage, StorageCPU>) {
-      for (int64_t i = 0; i < output_size; i++) {
-        output[i] = ctx.fill_value[i % ctx.fill_value.size()];
-      }
-    } else if (std::is_same_v<Storage, StorageGPU>) {
-      bool is_same_fill_value = true;
-      if (ctx.fill_value_frame_size >= static_cast<int64_t>(ctx.fill_value.size())) {
-        for (size_t i = 0; i < ctx.fill_value.size(); i++) {
-          if (ctx.fill_value_frame_cpu_buffer.get()[i] != ctx.fill_value[i]) {
-            is_same_fill_value = false;
-            break;
-          }
-        }
-      }
-      if (ctx.fill_value_frame_size < ctx.frames_decoder->FrameSize() || !is_same_fill_value) {
-        ctx.fill_value_frame_size = ctx.frames_decoder->FrameSize();
-        ctx.fill_value_frame_cpu_buffer =
-            mm::alloc_raw_unique<uint8_t, mm::memory_kind::pinned>(ctx.fill_value_frame_size);
-        ctx.fill_value_frame_gpu_buffer =
-            mm::alloc_raw_unique<uint8_t, mm::memory_kind::device>(ctx.fill_value_frame_size);
-        SetConstantPadding<StorageCPU>(ctx.fill_value_frame_cpu_buffer.get(),
-                                       ctx.fill_value_frame_size, ctx);
-        kernels::copy<StorageGPU, StorageCPU>(ctx.fill_value_frame_gpu_buffer.get(),
-                                              ctx.fill_value_frame_cpu_buffer.get(),
-                                              ctx.fill_value_frame_size, ctx.stream);
-      }
-      for (int64_t offset = 0; offset < output_size; offset += ctx.frames_decoder->FrameSize()) {
-        assert(offset + ctx.frames_decoder->FrameSize() <= output_size);
-        kernels::copy<StorageGPU, StorageGPU>(output + offset,
-                                              ctx.fill_value_frame_gpu_buffer.get(),
-                                              ctx.frames_decoder->FrameSize(), ctx.stream);
-      }
-    }
-  }
-
-  void DecodeFrames(SampleView<OutBackend> output, WorkerContext &ctx) {
-    auto &frames_decoder = *ctx.frames_decoder;
-    int64_t frame_size = frames_decoder.FrameSize();
-    int num_fill_values = ctx.fill_value.size();
-    uint8_t *output_data = output.template mutable_data<uint8_t>();
-
-    FrameInfo last_frame{};
-    for (auto &frame : ctx.frame_infos) {
-      if (frame.is_constant()) {
-        SetConstantPadding<OutStorage>(output_data + frame.frame_num * frame_size, frame_size, ctx);
-      } else if (frame.frame_idx == last_frame.frame_idx) {
-        kernels::copy<OutStorage, OutStorage>(output_data + frame.frame_num * frame_size,
-                                              output_data + last_frame.frame_num * frame_size,
-                                              frame_size, ctx.stream);
-      } else {
-        if (frame.frame_idx != frames_decoder.NextFrameIdx()) {
-          frames_decoder.SeekFrame(frame.frame_idx);
-          assert(frames_decoder.NextFrameIdx() == frame.frame_idx);
-        }
-        frames_decoder.ReadNextFrame(output_data + frame.frame_num * frame_size);
-        last_frame = frame;
-      }
-    }
   }
 
   std::vector<std::unique_ptr<FramesDecoderImpl>> frames_decoders_;

--- a/dali/operators/video/frames_decoder_base.h
+++ b/dali/operators/video/frames_decoder_base.h
@@ -35,11 +35,55 @@ extern "C" {
 #include "dali/operators/video/color_space.h"
 
 namespace dali {
+
 struct IndexEntry {
   int64_t pts;
   int last_keyframe_id;
   bool is_keyframe;
   bool is_flush_frame;
+};
+
+struct FrameIndex {
+  std::string filename;
+  std::vector<IndexEntry> index;
+  AVRational timebase;
+
+  size_t size() const {
+    return index.size();
+  }
+
+  IndexEntry& operator[](size_t idx) {
+    assert(idx < index.size());
+    return index[idx];
+  }
+
+  const IndexEntry& operator[](size_t idx) const {
+    assert(idx < index.size());
+    return index[idx];
+  }
+
+  /**
+   * @brief Returns the index of the frame that has the given timestamp
+   *
+   * @param timestamp Timestamp of the frame to seek to
+   * @param inclusive If true, the seek will be to a frame that has this timestamp or a previous one
+   */
+  int GetFrameIdxByTimestamp(int64_t timestamp, bool inclusive = false) const {
+    int frame_idx = 0;
+    for (size_t i = 1; i < index.size(); i++) {
+      if (index[i].pts >= timestamp) {
+        frame_idx = i;
+        break;
+      }
+    }
+    if (inclusive) {
+      if (frame_idx > 0 && index[frame_idx - 1].pts <= timestamp) {
+        frame_idx--;
+      }
+      assert(index[frame_idx].pts <= timestamp);
+    }
+    return frame_idx;
+  }
 };
 
 /**
@@ -120,35 +164,30 @@ class DLL_PUBLIC FramesDecoderBase {
    *
    * @param filename Path to a video file.
    * @param image_type Image type of the video.
-   * @param dtype Data type of the video.
-   * @param build_index If set to false index will not be build and some features are unavailable.
-   * @param init_codecs If set to false CPU codec part is not initalized, only parser
    */
-  explicit FramesDecoderBase(const std::string &filename,
-                             DALIImageType image_type = DALI_RGB, DALIDataType dtype = DALI_UINT8,
-                             bool build_index = true, bool init_codecs = true);
+  explicit FramesDecoderBase(const std::string &filename);
 
   /**
    * @brief Initialize the decoder from a memory buffer.
    *
    * @param memory_file Pointer to memory with video file data.
    * @param memory_file_size Size of memory_file in bytes.
-   * @param image_type Image type of the video.
-   * @param dtype Data type of the video.
-   * @param build_index If set to false index will not be build and some features are unavailable.
-   * @param init_codecs If set to false CPU codec part is not initalized, only parser
-   * @param num_frames If set, number of frames in the video.
    * @param source_info Source information for the video file.
    */
   explicit FramesDecoderBase(const char *memory_file, size_t memory_file_size,
-                             DALIImageType image_type = DALI_RGB, DALIDataType dtype = DALI_UINT8,
-                             bool build_index = true, bool init_codecs = true, int num_frames = -1,
                              std::string_view source_info = {});
 
   /**
    * @brief Number of frames in the video. It returns 0, if this information is unavailable.
    */
-  int64_t NumFrames() const;
+  int64_t NumFrames();
+
+  /**
+   * @brief Set the number of frames in the video, which can be used to avoid parsing the file.
+   */
+  void SetNumFrames(int64_t num_frames) {
+    num_frames_ = num_frames;
+  }
 
   /**
    * @brief Width of a video frame in pixels
@@ -199,7 +238,7 @@ class DLL_PUBLIC FramesDecoderBase {
    * @param data Output buffer to copy data to. If nullptr, the frame will be effectively skipped.
    * @return Boolean indicating whether the frame was read or not. False means no more frames in the decoder.
    */
-  virtual bool ReadNextFrame(uint8_t *data);
+  virtual bool ReadNextFrame(uint8_t *data) = 0;
 
   /**
    * @brief Seeks to the frame given by id. Next call to ReadNextFrame will return this frame
@@ -211,13 +250,6 @@ class DLL_PUBLIC FramesDecoderBase {
   /**
    * @brief Decodes a collection of frames, not necessarily in ascending order, applying a boundary type
    * (what to do when sampling out of bounds).
-   *
-   * ISOLATED: sampling out of bounds will result in a failure.
-   * CLAMP: sampling out of bounds will result in the last frame being repeated.
-   * CONSTANT: sampling out of bounds will result in a constant frame being repeated (constant_frame must be provided).
-   * REFLECT_1001: sampling out of bounds will result in 1001 reflection.
-   * REFLECT_101: sampling out of bounds will result in 101 reflection.
-   *
    * @param data Output buffer to copy data to. Should be of size FrameSize() * frame_ids.size().
    * @param frame_ids Frame indices to decode.
    * @param boundary_type Boundary type to apply
@@ -229,18 +261,11 @@ class DLL_PUBLIC FramesDecoderBase {
     span<const int> frame_ids,
     boundary::BoundaryType boundary_type = boundary::BoundaryType::ISOLATED,
     const uint8_t *constant_frame = nullptr,
-    span<float> out_timestamps = {});
+    span<double> out_timestamps = {});
 
   /**
    * @brief Decodes a range of evenly spaced frames, applying a boundary type
    * (what to do when sampling out of bounds).
-   *
-   * ISOLATED: sampling out of bounds will result in a failure.
-   * CLAMP: sampling out of bounds will result in the last frame being repeated.
-   * CONSTANT: sampling out of bounds will result in a constant frame being repeated (constant_frame must be provided).
-   * REFLECT_1001: sampling out of bounds will result in 1001 reflection.
-   * REFLECT_101: sampling out of bounds will result in 101 reflection.
-   *
    * @param data Output buffer to copy data to. Should be of size FrameSize() * frame_ids.size().
    * @param start_frame Start frame index.
    * @param end_frame End frame index.
@@ -256,7 +281,7 @@ class DLL_PUBLIC FramesDecoderBase {
     int stride,
     boundary::BoundaryType boundary_type = boundary::BoundaryType::ISOLATED,
     const uint8_t *constant_frame = nullptr,
-    span<float> out_timestamps = {});
+    span<double> out_timestamps = {});
 
   /**
    * @brief Copies a frame from one buffer to another.
@@ -279,7 +304,10 @@ class DLL_PUBLIC FramesDecoderBase {
    * @param timestamp Timestamp of the frame to seek to
    * @param inclusive If true, the seek will be to a frame that has this timestamp or a previous one
    */
-  virtual int GetFrameIdxByTimestamp(int64_t timestamp, bool inclusive = false);
+  int GetFrameIdxByTimestamp(int64_t timestamp, bool inclusive = false) const {
+    DALI_ENFORCE(HasIndex(), "No index available, cannot seek by timestamp");
+    return Index().GetFrameIdxByTimestamp(timestamp, inclusive);
+  }
 
   /**
    * @brief Seeks to the first frame
@@ -296,6 +324,11 @@ class DLL_PUBLIC FramesDecoderBase {
   virtual bool AvSeekFrame(int64_t timestamp, int frame_id);
 
   /**
+   * @brief Flushes the decoder state.
+   */
+  virtual void Flush() = 0;
+
+  /**
    * @brief Returns index of the frame that will be returned by the next call of ReadNextFrame
    *
    * @return int Index of the next frame to be read
@@ -307,7 +340,12 @@ class DLL_PUBLIC FramesDecoderBase {
    *
    * @return Boolean indicating whether or not the index was created.
    */
-  bool HasIndex() const { return !index_.empty(); }
+  bool HasIndex() const { return Index().size() > 0; }
+
+  /**
+   * @brief Builds the index of the video file.
+   */
+  virtual void BuildIndex();
 
   virtual ~FramesDecoderBase() = default;
   FramesDecoderBase(FramesDecoderBase&&) = default;
@@ -321,20 +359,28 @@ class DLL_PUBLIC FramesDecoderBase {
     return is_valid_;
   }
 
-  const IndexEntry& Index(int frame_id) const {
-    assert(HasIndex());
-    return index_[frame_id];
+  const FrameIndex& Index() const {
+    return index_;
+  }
+
+  void SetOutputType(DALIDataType dtype) {
+    dtype_ = dtype;
+  }
+
+  void SetImageType(DALIImageType image_type) {
+    image_type_ = image_type;
   }
 
  protected:
+  /**
+   * @brief Select a stream to decode. If stream_id is -1, the video stream will be selected automatically.
+   */
+  virtual bool SelectVideoStream(int stream_id = -1);
+
   AVUniquePtr<AVFormatContext> ctx_;
   AVUniquePtr<AVCodecContext> codec_ctx_;
   AVUniquePtr<AVFrame> frame_;
   AVUniquePtr<AVPacket> packet_;
-  std::unique_ptr<SwsContext, decltype(&sws_freeContext)> sws_ctx_{
-    nullptr, sws_freeContext};
-
-  const AVCodec *codec_ = nullptr;
   AVCodecParameters *codec_params_ = nullptr;
   int stream_id_ = -1;
   bool is_file_open_ = false;
@@ -342,7 +388,7 @@ class DLL_PUBLIC FramesDecoderBase {
   int OpenFile(const std::string& filename);
   int OpenMemoryFile(MemoryVideoFile& memory_video_file);
 
-  std::vector<IndexEntry> index_;
+  FrameIndex index_;
 
   int next_frame_idx_ = 0;
 
@@ -354,42 +400,7 @@ class DLL_PUBLIC FramesDecoderBase {
   bool is_valid_ = false;
 
  private:
-   /**
-   * @brief Gets the packet from the decoder and reads a frame from it to provided buffer. Returns
-   * boolean indicating, if the frame was succesfully read.
-   * After this method returns false, there might be more frames to read. Call `ReadFlushFrame` until
-   * it returns false, to get all of the frames from the video file.
-   *
-   * @param data Output buffer to copy data to. If nullptr, the frame will be effectively skipped.
-   *
-   * @returns True, if the read was succesful, or false, when all regular frames were consumed.
-   *
-   */
-  bool ReadRegularFrame(uint8_t *data);
-
-  /**
-   * @brief Reads frames from the last packet. This packet can hold
-   * multiple frames. This method will read all of them one by one.
-   *
-   * @param data Output buffer to copy data to. If nullptr, the frame will be effectively skipped.
-   *
-   * @returns True, if the read was succesful, or false, when ther are no more frames in last the packet.
-   */
-  bool ReadFlushFrame(uint8_t *data);
-
-  void CopyToOutput(uint8_t *data);
-
-  void BuildIndex();
-
   void DetectVariableFrameRate();
-
-  void InitAvCodecContext();
-
-  bool OpenAvCodec();
-
-  bool FindVideoStream(bool require_available_avcodec = true);
-
-  bool SelectVideoStream(int stream_id, bool require_available_avcodec);
 
   bool CheckDimensions();
 
@@ -397,13 +408,9 @@ class DLL_PUBLIC FramesDecoderBase {
 
   bool IsFormatSeekable();
 
-  void CountFrames();
-
   std::string GetAllStreamInfo() const;
 
-
   int channels_ = 3;
-  bool flush_state_ = false;
   bool is_vfr_ = false;
 
   std::string filename_ = {};

--- a/dali/operators/video/frames_decoder_cpu.cc
+++ b/dali/operators/video/frames_decoder_cpu.cc
@@ -16,19 +16,21 @@
 #include <algorithm>
 #include <string>
 #include "dali/core/error_handling.h"
+#include <cstring>
 
 namespace dali {
 
-FramesDecoderCpu::FramesDecoderCpu(const std::string &filename, bool build_index)
-    : FramesDecoderBase(filename, build_index, true) {
+FramesDecoderCpu::FramesDecoderCpu(const std::string &filename, DALIImageType image_type,
+                                   DALIDataType dtype, bool build_index)
+    : FramesDecoderBase(filename, image_type, dtype, build_index, true) {
   is_valid_ = is_valid_ && CanDecode(codec_params_->codec_id);
 }
 
 FramesDecoderCpu::FramesDecoderCpu(const char *memory_file, size_t memory_file_size,
-                                   bool build_index, int num_frames,
-                                   std::string_view source_info)
-    : FramesDecoderBase(memory_file, memory_file_size, build_index, true, num_frames,
-                        source_info) {
+                                   DALIImageType image_type, DALIDataType dtype, bool build_index,
+                                   int num_frames, std::string_view source_info)
+    : FramesDecoderBase(memory_file, memory_file_size, image_type, dtype, build_index, true,
+                        num_frames, source_info) {
   is_valid_ = is_valid_ && CanDecode(codec_params_->codec_id);
 }
 
@@ -61,6 +63,10 @@ bool FramesDecoderCpu::CanDecode(AVCodecID codec_id) const {
                   ") is not supported by the libavcodec version provided by DALI, and therefore "
                   "cannot be decoded on the CPU."));
   return false;
+}
+
+void FramesDecoderCpu::CopyFrame(uint8_t *dst, const uint8_t *src) {
+  std::memcpy(dst, src, FrameSize());
 }
 
 }  // namespace dali

--- a/dali/operators/video/frames_decoder_cpu.h
+++ b/dali/operators/video/frames_decoder_cpu.h
@@ -27,22 +27,30 @@ class DLL_PUBLIC FramesDecoderCpu : public FramesDecoderBase {
    * @brief Construct a new FramesDecoder object.
    *
    * @param filename Path to a video file.
+   * @param image_type Image type of the video.
+   * @param dtype Data type of the video.
    * @param build_index If set to false index will not be build and some features are unavailable.
    */
-  explicit FramesDecoderCpu(const std::string &filename, bool build_index = true);
+  explicit FramesDecoderCpu(const std::string &filename,
+                            DALIImageType image_type = DALI_RGB, DALIDataType dtype = DALI_UINT8,
+                            bool build_index = true);
 
   /**
  * @brief Construct a new FramesDecoder object.
  *
  * @param memory_file Pointer to memory with video file data.
  * @param memory_file_size Size of memory_file in bytes.
+ * @param image_type Image type of the video.
+ * @param dtype Data type of the video.
  * @param build_index If set to false index will not be build and some features are unavailable.
  * @param num_frames If set, number of frames in the video.
  *
  * @note This constructor assumes that the `memory_file` and
  * `memory_file_size` arguments cover the entire video file, including the header.
  */
-  FramesDecoderCpu(const char *memory_file, size_t memory_file_size, bool build_index = true,
+  FramesDecoderCpu(const char *memory_file, size_t memory_file_size, 
+                   DALIImageType image_type = DALI_RGB, DALIDataType dtype = DALI_UINT8,
+                   bool build_index = true,
                    int num_frames = -1, std::string_view = {});
 
   FramesDecoderCpu(FramesDecoderCpu&&) = default;
@@ -54,6 +62,8 @@ class DLL_PUBLIC FramesDecoderCpu : public FramesDecoderBase {
    * @return True if the codec is supported, false otherwise.
    */
   bool CanDecode(AVCodecID codec_id) const;
+
+  void CopyFrame(uint8_t *dst, const uint8_t *src) override;
 };
 
 }  // namespace dali

--- a/dali/operators/video/frames_decoder_cpu.h
+++ b/dali/operators/video/frames_decoder_cpu.h
@@ -27,43 +27,40 @@ class DLL_PUBLIC FramesDecoderCpu : public FramesDecoderBase {
    * @brief Construct a new FramesDecoder object.
    *
    * @param filename Path to a video file.
-   * @param image_type Image type of the video.
-   * @param dtype Data type of the video.
-   * @param build_index If set to false index will not be build and some features are unavailable.
    */
-  explicit FramesDecoderCpu(const std::string &filename,
-                            DALIImageType image_type = DALI_RGB, DALIDataType dtype = DALI_UINT8,
-                            bool build_index = true);
+   explicit FramesDecoderCpu(const std::string &filename);
 
   /**
- * @brief Construct a new FramesDecoder object.
- *
- * @param memory_file Pointer to memory with video file data.
- * @param memory_file_size Size of memory_file in bytes.
- * @param image_type Image type of the video.
- * @param dtype Data type of the video.
- * @param build_index If set to false index will not be build and some features are unavailable.
- * @param num_frames If set, number of frames in the video.
- *
- * @note This constructor assumes that the `memory_file` and
- * `memory_file_size` arguments cover the entire video file, including the header.
- */
-  FramesDecoderCpu(const char *memory_file, size_t memory_file_size, 
-                   DALIImageType image_type = DALI_RGB, DALIDataType dtype = DALI_UINT8,
-                   bool build_index = true,
-                   int num_frames = -1, std::string_view = {});
+   * @brief Construct a new FramesDecoder object.
+   *
+   * @param memory_file Pointer to memory with video file data.
+   * @param memory_file_size Size of memory_file in bytes.
+   * @param source_info Source info of the video file.
+   *
+   * @note This constructor assumes that the `memory_file` and
+   * `memory_file_size` arguments cover the entire video file, including the header.
+   */
+  FramesDecoderCpu(const char *memory_file, size_t memory_file_size, std::string_view = {});
 
   FramesDecoderCpu(FramesDecoderCpu&&) = default;
 
-  /**
-   * @brief Check if a codec is supported by the particular implementation.
-   *
-   * @param codec_id Codec ID to check.
-   * @return True if the codec is supported, false otherwise.
-   */
-  bool CanDecode(AVCodecID codec_id) const;
-
+  bool ReadNextFrame(uint8_t *data) override;
   void CopyFrame(uint8_t *dst, const uint8_t *src) override;
+  void Reset() override;
+  void Flush() override;
+
+ protected:
+  bool SelectVideoStream(int stream_id = -1) override;
+
+ private:
+  void CopyToOutput(uint8_t *data);
+  bool ReadRegularFrame(uint8_t *data);
+  bool ReadFlushFrame(uint8_t *data);
+  bool flush_state_ = false;
+
+  const AVCodec *codec_ = nullptr;
+  std::unique_ptr<SwsContext, decltype(&sws_freeContext)> sws_ctx_{
+    nullptr, sws_freeContext};
 };
 
 }  // namespace dali

--- a/dali/operators/video/frames_decoder_gpu.cc
+++ b/dali/operators/video/frames_decoder_gpu.cc
@@ -25,6 +25,7 @@
 #include "dali/pipeline/data/tensor.h"
 #include "dali/operators/video/color_space.h"
 #include "dali/core/static_switch.h"
+#include "dali/operators/video/video_utils.h"
 
 namespace dali {
 
@@ -168,7 +169,6 @@ class NVDECCache {
       caps.eChromaFormat = chroma_format;
       caps.nBitDepthMinus8 = bit_depth_luma_minus8;
       CUDA_CALL(cuvidGetDecoderCaps(&caps));
-
       DALI_ENFORCE(caps.bIsSupported,
                    make_string("Codec configuration not supported on this GPU. ",
                    "Codec: ", codec_to_string(codec_type),
@@ -290,8 +290,6 @@ int handle_picture_display(void *user_data, CUVIDPARSERDISPINFO *picture_display
 
 }  // namespace frame_dec_gpu_impl
 
-using AVPacketScope = std::unique_ptr<AVPacket, decltype(&av_packet_unref)>;
-
 void FramesDecoderGpu::InitBitStreamFilter() {
   const AVBitStreamFilter *bsf = nullptr;
   const char* filtername = nullptr;
@@ -325,7 +323,7 @@ void FramesDecoderGpu::InitBitStreamFilter() {
   default:
     DALI_FAIL(make_string(
       "Could not find suitable bit stream filter for codec: ",
-      codec_->name));
+      avcodec_get_name(codec_params_->codec_id)));
   }
 
   if (filtername != nullptr) {
@@ -422,62 +420,26 @@ void FramesDecoderGpu::InitGpuParser() {
   }
 }
 
-FramesDecoderGpu::FramesDecoderGpu(const std::string &filename, DALIImageType image_type, DALIDataType dtype,
-                                   bool build_index, cudaStream_t stream)
-    : FramesDecoderBase(filename, image_type, dtype, build_index, false),
+FramesDecoderGpu::FramesDecoderGpu(const std::string &filename, cudaStream_t stream)
+    : FramesDecoderBase(filename),
       frame_buffer_(num_decode_surfaces_),
       stream_(stream) {
-  if (is_valid_ && CanDecode(codec_params_->codec_id)) {
+  is_valid_ = is_valid_ && SelectVideoStream();
+  if (is_valid_) {
     InitGpuParser();
-  } else {
-    is_valid_ = false;
   }
 }
 
-FramesDecoderGpu::FramesDecoderGpu(const char *memory_file, size_t memory_file_size,
-                                   DALIImageType image_type, DALIDataType dtype, bool build_index,
-                                   int num_frames, std::string_view source_info,
+FramesDecoderGpu::FramesDecoderGpu(const char *memory_file, size_t memory_file_size, std::string_view source_info,
                                    cudaStream_t stream)
-    : FramesDecoderBase(memory_file, memory_file_size, image_type, dtype, build_index, false,
-                        num_frames, source_info),
+    : FramesDecoderBase(memory_file, memory_file_size, source_info),
       frame_buffer_(num_decode_surfaces_),
       stream_(stream) {
-  if (is_valid_ && CanDecode(codec_params_->codec_id)) {
+  is_valid_ = is_valid_ && SelectVideoStream();
+  if (is_valid_) {
     InitGpuParser();
-  } else {
-    is_valid_ = false;
   }
 }
-
-bool FramesDecoderGpu::CanDecode(AVCodecID codec_id) const {
-  static constexpr std::array<AVCodecID, 7> codecs = {
-    AVCodecID::AV_CODEC_ID_H264,
-    AVCodecID::AV_CODEC_ID_HEVC,
-    AVCodecID::AV_CODEC_ID_VP8,
-    AVCodecID::AV_CODEC_ID_VP9,
-    AVCodecID::AV_CODEC_ID_MJPEG,
-    AVCodecID::AV_CODEC_ID_AV1,
-    AVCodecID::AV_CODEC_ID_MPEG4,
-  };
-  if (std::find(codecs.begin(), codecs.end(), codec_id) == codecs.end()) {
-    DALI_WARN(make_string("Codec ", codec_id, " (", avcodec_get_name(codec_id),
-                          ") is not supported by the GPU variant of this operator."));
-    return false;
-  }
-
-  CUVIDDECODECAPS decoder_caps = {};
-  decoder_caps.eCodecType = GetCodecType(codec_id);
-  decoder_caps.eChromaFormat = cudaVideoChromaFormat_420;
-  decoder_caps.nBitDepthMinus8 = 0;
-  CUDA_CALL(cuvidGetDecoderCaps(&decoder_caps));
-  if (!decoder_caps.bIsSupported) {
-    DALI_WARN(make_string("Codec ", avcodec_get_name(codec_id),
-                          " is not supported by NVDEC on this platform."));
-    return false;
-  }
-  return true;
-}
-
 
 int FramesDecoderGpu::ProcessPictureDecode(CUVIDPICPARAMS *picture_params) {
   // Sending empty packet will call this callback.
@@ -517,18 +479,17 @@ int FramesDecoderGpu::HandlePictureDisplay(CUVIDPARSERDISPINFO *picture_display_
            << next_frame_idx_ << ", timestamp " << std::setw(5) << current_pts << std::endl;
 
   // current_pts is pts of frame that came from the decoder
-  // Index(NextFrameIdx()).pts is pts of the frame that we want to return
+  // Index()[NextFrameIdx()].pts is pts of the frame that we want to return
   // in this call to ReadNextFrame
   // If they are the same, we just return this frame
   // If not, we store it in the buffer for later
 
   void *frame_output = nullptr;
-  if (HasIndex() && current_pts == Index(NextFrameIdx()).pts) {
+  if (HasIndex() && current_pts == Index()[NextFrameIdx()].pts) {
     // Currently decoded frame is actually the one we want to display
     frame_returned_ = true;
     LOG_LINE << "Found frame with correct display timestamp " << current_pts
               << " for index " << next_frame_idx_ << std::endl;
-
     if (current_copy_to_output_ == false) {
       return 1;
     }
@@ -590,7 +551,7 @@ bool FramesDecoderGpu::ReadNextFrameWithIndex(uint8_t *data) {
   // Check if requested frame was buffered earlier
   assert(HasIndex());
   for (auto &frame : frame_buffer_) {
-    if (frame.pts_ != -1 && frame.pts_ == Index(next_frame_idx_).pts) {
+    if (frame.pts_ != -1 && frame.pts_ == Index()[next_frame_idx_].pts) {
       if (copy_to_output) {
         copyD2D(data, frame.frame_.data(), FrameSize(), stream_);
       }
@@ -827,7 +788,7 @@ void FramesDecoderGpu::SendLastPacket(bool flush) {
     do {
       found_frame = false;
       for (auto &frame : frame_buffer_) {
-        if (frame.pts_ != -1 && HasIndex() && frame.pts_ == Index(next_frame_idx_).pts) {
+        if (frame.pts_ != -1 && HasIndex() && frame.pts_ == Index()[next_frame_idx_].pts) {
           LOG_LINE << "Processing remaining buffered frame pts=" << frame.pts_ << " for index "
                    << next_frame_idx_ << std::endl;
           frame.pts_ = -1;
@@ -907,10 +868,15 @@ unsigned int FramesDecoderGpu::NumEmptySpots() const {
 }
 
 void FramesDecoderGpu::Reset() {
+  Flush();
+  FramesDecoderBase::Reset();
+}
+
+void FramesDecoderGpu::Flush() {
+  LOG_LINE << "Flushing decoder state" << std::endl;
   SendLastPacket(true);
   more_frames_to_decode_ = true;
   frame_index_if_no_pts_ = 0;
-  FramesDecoderBase::Reset();
 }
 
 FramesDecoderGpu::~FramesDecoderGpu() {
@@ -929,6 +895,50 @@ bool FramesDecoderGpu::SupportsHevc() {
 
 void FramesDecoderGpu::CopyFrame(uint8_t *dst, const uint8_t *src) {
   CUDA_CALL(cudaMemcpyAsync(dst, src, FrameSize(), cudaMemcpyDeviceToDevice, stream_));
+}
+
+bool FramesDecoderGpu::SelectVideoStream(int stream_id) {
+  if (!FramesDecoderBase::SelectVideoStream(stream_id)) {
+    return false;
+  }
+
+  assert(stream_id_ >= 0 && stream_id_ < static_cast<int>(ctx_->nb_streams));
+  assert(codec_params_);
+  AVCodecID codec_id = codec_params_->codec_id;
+
+  static constexpr std::array<AVCodecID, 7> codecs = {
+    AVCodecID::AV_CODEC_ID_H264,
+    AVCodecID::AV_CODEC_ID_HEVC,
+    AVCodecID::AV_CODEC_ID_VP8,
+    AVCodecID::AV_CODEC_ID_VP9,
+    AVCodecID::AV_CODEC_ID_MJPEG,
+    AVCodecID::AV_CODEC_ID_AV1,
+    AVCodecID::AV_CODEC_ID_MPEG4,
+  };
+  if (std::find(codecs.begin(), codecs.end(), codec_id) == codecs.end()) {
+    DALI_WARN(make_string("Codec ", codec_id, " (", avcodec_get_name(codec_id),
+                          ") is not supported by the GPU variant of this operator."));
+    return false;
+  }
+
+  CUVIDDECODECAPS decoder_caps = {};
+  decoder_caps.eCodecType = GetCodecType(codec_id);
+  decoder_caps.eChromaFormat = cudaVideoChromaFormat_420;
+  decoder_caps.nBitDepthMinus8 = 0;
+  CUDA_CALL(cuvidGetDecoderCaps(&decoder_caps));
+  if (!decoder_caps.bIsSupported) {
+    DALI_WARN(make_string("Codec ", avcodec_get_name(codec_id),
+                          " is not supported by NVDEC on this platform."));
+    return false;
+  }
+
+  codec_ctx_.reset(avcodec_alloc_context3(nullptr));
+  DALI_ENFORCE(codec_ctx_, "Could not alloc av codec context");
+
+  int ret = avcodec_parameters_to_context(codec_ctx_, codec_params_);
+  DALI_ENFORCE(ret >= 0, make_string("Could not fill the codec based on parameters: ",
+                                     av_error_string(ret)));
+  return true;
 }
 
 }  // namespace dali

--- a/dali/operators/video/frames_decoder_gpu.h
+++ b/dali/operators/video/frames_decoder_gpu.h
@@ -130,39 +130,29 @@ class DLL_PUBLIC FramesDecoderGpu : public FramesDecoderBase {
    * @brief Construct a new FramesDecoder object.
    *
    * @param filename Path to a video file.
-   * @param image_type Image type of the video.
-   * @param dtype Data type of the video.
-   * @param build_index If set to false index will not be build and some features are unavailable.
    * @param stream CUDA stream to use for decoding.
    */
-  explicit FramesDecoderGpu(const std::string &filename,
-                            DALIImageType image_type = DALI_RGB, DALIDataType dtype = DALI_UINT8,
-                            bool build_index = true, cudaStream_t stream = 0);
+  explicit FramesDecoderGpu(const std::string &filename, cudaStream_t stream = 0);
 
   /**
- * @brief Construct a new FramesDecoder object.
- *
- * @param memory_file Pointer to memory with video file data.
- * @param memory_file_size Size of memory_file in bytes.
- * @param image_type Image type of the video.
- * @param dtype Data type of the video.
- * @param build_index If set to false index will not be build and some features are unavailable.
- * @param num_frames If set, number of frames in the video.
- * @param stream CUDA stream to use for decoding.
- *
- * @note This constructor assumes that the `memory_file` and
- * `memory_file_size` arguments cover the entire video file, including the header.
- */
-  FramesDecoderGpu(const char *memory_file, size_t memory_file_size,
-                   DALIImageType image_type = DALI_RGB, DALIDataType dtype = DALI_UINT8,
-                   bool build_index = true,
-                   int num_frames = -1, std::string_view = {}, cudaStream_t stream = 0);
+   * @brief Construct a new FramesDecoder object.
+   *
+   * @param memory_file Pointer to memory with video file data.
+   * @param memory_file_size Size of memory_file in bytes.
+   * @param source_info Source info of the video file.
+   * @param stream CUDA stream to use for decoding.
+   * @note This constructor assumes that the `memory_file` and
+   * `memory_file_size` arguments cover the entire video file, including the header.
+   */
+  FramesDecoderGpu(const char *memory_file, size_t memory_file_size, std::string_view source_info = {}, cudaStream_t stream = 0);
 
   bool ReadNextFrame(uint8_t *data) override;
 
   void SeekFrame(int frame_id) override;
 
   void Reset() override;
+
+  void Flush() override;
 
   int ProcessPictureDecode(CUVIDPICPARAMS *picture_params);
 
@@ -178,15 +168,10 @@ class DLL_PUBLIC FramesDecoderGpu : public FramesDecoderBase {
 
   void InitGpuDecoder(CUVIDEOFORMAT *video_format);
 
-  /**
-   * @brief Check if a codec is supported by the particular implementation.
-   *
-   * @param codec_id Codec ID to check.
-   * @return True if the codec is supported, false otherwise.
-   */
-  bool CanDecode(AVCodecID codec_id) const;
-
   void CopyFrame(uint8_t *dst, const uint8_t *src) override;
+
+ protected:
+  bool SelectVideoStream(int stream_id = -1) override;
 
  private:
   std::unique_ptr<NvDecodeState> nvdecode_state_;

--- a/dali/operators/video/frames_decoder_test.cc
+++ b/dali/operators/video/frames_decoder_test.cc
@@ -31,8 +31,8 @@
 namespace dali {
 class FramesDecoderTestBase : public VideoTestBase {
  public:
-  virtual void RunSequentialForwardTest(FramesDecoderBase &decoder, TestVideo &ground_truth,
-                                        double eps = 1.0) {
+  virtual void RunSequentialForwardTest(
+    FramesDecoderBase &decoder, TestVideo &ground_truth, double eps = 1.0) {
     // Iterate through the whole video in order
     for (int i = 0; i < decoder.NumFrames(); ++i) {
       ASSERT_EQ(decoder.NextFrameIdx(), i);
@@ -111,7 +111,7 @@ class FramesDecoderTestBase : public VideoTestBase {
     }
   }
 
-  virtual void AssertFrame(uint8_t *frame, int index, TestVideo &ground_truth,
+  virtual void AssertFrame(uint8_t *frame, int index, TestVideo& ground_truth,
                            double eps = 1.0) = 0;
 
   virtual uint8_t *FrameData() = 0;
@@ -143,8 +143,9 @@ class FramesDecoderTest_CpuOnlyTests : public FramesDecoderTestBase {
   }
 
   void RunConstructorFailureTest(std::string path, std::string expected_error) {
-    RunFailureTest([&]() -> void { FramesDecoderCpu decoder(path, DALI_RGB, DALI_UINT8); },
-                   expected_error);
+    RunFailureTest([&]() -> void {
+      FramesDecoderCpu decoder(path);},
+      expected_error);
   }
 
  private:
@@ -168,7 +169,7 @@ class FramesDecoderGpuTest : public FramesDecoderTestBase {
     FramesDecoderTestBase::RunTest(decoder, ground_truth, has_index, eps);
   }
 
-  void AssertFrame(uint8_t *frame, int index, TestVideo &ground_truth, double eps = 1.0) override {
+  void AssertFrame(uint8_t *frame, int index, TestVideo& ground_truth, double eps = 1.0) override {
     MemCopy(FrameDataCpu(), frame, ground_truth.FrameSize());
     CompareFrameAvgError(index, ground_truth.FrameSize(), ground_truth.Width(),
                          ground_truth.Height(), frame_cpu_buffer_.data(),
@@ -193,40 +194,47 @@ class FramesDecoderGpuTest : public FramesDecoderTestBase {
   DeviceBuffer<uint8_t> frame_gpu_buffer_;
 };
 
-
 TEST_F(FramesDecoderTest_CpuOnlyTests, ConstantFrameRate) {
   FramesDecoderCpu decoder(cfr_videos_paths_[0]);
+  decoder.BuildIndex();
   RunTest(decoder, cfr_videos_[0]);
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, ConstantFrameRateHevc) {
   FramesDecoderCpu decoder(cfr_hevc_videos_paths_[0]);
+  decoder.BuildIndex();
   RunTest(decoder, cfr_videos_[0]);
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, VariableFrameRate) {
   FramesDecoderCpu decoder(vfr_videos_paths_[1]);
+  decoder.BuildIndex();
   RunTest(decoder, vfr_videos_[1]);
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, VariableFrameRateHevc) {
   FramesDecoderCpu decoder(vfr_hevc_videos_paths_[0]);
+  decoder.BuildIndex();
   RunTest(decoder, vfr_hevc_videos_[0]);
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, InvalidSeek) {
   FramesDecoderCpu decoder(cfr_videos_paths_[0]);
-  RunFailureTest([&]() -> void { decoder.SeekFrame(60); },
-                 "Invalid seek frame id. frame_id = 60, num_frames = 50");
+  decoder.BuildIndex();
+  RunFailureTest([&]() -> void {
+    decoder.SeekFrame(60);},
+    "Invalid seek frame id. frame_id = 60, num_frames = 50");
 }
 
 TEST_F(FramesDecoderGpuTest, ConstantFrameRate) {
   FramesDecoderGpu decoder(cfr_videos_paths_[0]);
+  decoder.BuildIndex();
   RunTest(decoder, cfr_videos_[0]);
 }
 
 TEST_F(FramesDecoderGpuTest, VariableFrameRate) {
   FramesDecoderGpu decoder(vfr_videos_paths_[1]);
+  decoder.BuildIndex();
   RunTest(decoder, vfr_videos_[1]);
 }
 
@@ -235,6 +243,7 @@ TEST_F(FramesDecoderGpuTest, ConstantFrameRateHevc) {
     GTEST_SKIP();
   }
   FramesDecoderGpu decoder(cfr_hevc_videos_paths_[0]);
+  decoder.BuildIndex();
   RunTest(decoder, cfr_videos_[0]);
 }
 
@@ -243,36 +252,42 @@ TEST_F(FramesDecoderGpuTest, VariableFrameRateHevc) {
     GTEST_SKIP();
   }
   FramesDecoderGpu decoder(vfr_hevc_videos_paths_[1]);
+  decoder.BuildIndex();
   RunTest(decoder, vfr_hevc_videos_[1]);
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, InMemoryCfrVideo) {
   auto memory_video = MemoryVideo(cfr_videos_paths_[1]);
   FramesDecoderCpu decoder(memory_video.data(), memory_video.size());
+  decoder.BuildIndex();
   RunTest(decoder, cfr_videos_[1]);
 }
 
 TEST_F(FramesDecoderGpuTest, InMemoryCfrVideo) {
   auto memory_video = MemoryVideo(cfr_videos_paths_[0]);
   FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
+  decoder.BuildIndex();
   RunTest(decoder, cfr_videos_[0]);
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, InMemoryVfrVideo) {
   auto memory_video = MemoryVideo(vfr_videos_paths_[1]);
   FramesDecoderCpu decoder(memory_video.data(), memory_video.size());
+  decoder.BuildIndex();
   RunTest(decoder, vfr_videos_[1]);
 }
 
 TEST_F(FramesDecoderGpuTest, InMemoryVfrVideo) {
   auto memory_video = MemoryVideo(vfr_videos_paths_[0]);
   FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
+  decoder.BuildIndex();
   RunTest(decoder, vfr_videos_[0]);
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, InMemoryVfrHevcVideo) {
   auto memory_video = MemoryVideo(vfr_videos_paths_[0]);
   FramesDecoderCpu decoder(memory_video.data(), memory_video.size());
+  decoder.BuildIndex();
   RunTest(decoder, vfr_videos_[0]);
 }
 
@@ -282,30 +297,31 @@ TEST_F(FramesDecoderGpuTest, InMemoryVfrHevcVideo) {
   }
   auto memory_video = MemoryVideo(vfr_hevc_videos_paths_[1]);
   FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
+  decoder.BuildIndex();
   RunTest(decoder, vfr_hevc_videos_[1]);
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, VariableFrameRateNoIndex) {
   auto memory_video = MemoryVideo(vfr_videos_paths_[0]);
-  FramesDecoderCpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderCpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, vfr_videos_[0], false);
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, VariableFrameRateHevcNoIndex) {
   auto memory_video = MemoryVideo(vfr_hevc_videos_paths_[1]);
-  FramesDecoderCpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderCpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, vfr_hevc_videos_[1], false);
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, NoIndexSeek) {
   auto memory_video = MemoryVideo(vfr_videos_paths_[0]);
-  FramesDecoderCpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderCpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, vfr_videos_[0], false);
 }
 
 TEST_F(FramesDecoderGpuTest, VariableFrameRateNoIndex) {
   auto memory_video = MemoryVideo(vfr_videos_paths_[0]);
-  FramesDecoderGpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, vfr_videos_[0], false);
 }
 
@@ -314,57 +330,57 @@ TEST_F(FramesDecoderGpuTest, VariableFrameRateHevcNoIndex) {
     GTEST_SKIP();
   }
   auto memory_video = MemoryVideo(vfr_hevc_videos_paths_[1]);
-  FramesDecoderGpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, vfr_hevc_videos_[1], false);
 }
 
 TEST_F(FramesDecoderGpuTest, CfrFrameRateMpeg4NoIndex) {
   auto memory_video = MemoryVideo(cfr_mpeg4_videos_paths_[0]);
-  FramesDecoderGpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, cfr_videos_[0], false, 3.0);
 }
 
 TEST_F(FramesDecoderGpuTest, VfrFrameRateMpeg4NoIndex) {
   auto memory_video = MemoryVideo(vfr_mpeg4_videos_paths_[0]);
-  FramesDecoderGpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, vfr_videos_[0], false, 3.0);
 }
 
 TEST_F(FramesDecoderGpuTest, CfrFrameRateMpeg4MkvNoIndex) {
   auto memory_video = MemoryVideo(cfr_mpeg4_mkv_videos_paths_[0]);
-  FramesDecoderGpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false,
-                           cfr_videos_[0].NumFrames());
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
+  decoder.SetNumFrames(cfr_videos_[0].NumFrames());
   RunTest(decoder, cfr_videos_[0], false, 3.0);
 }
 
 TEST_F(FramesDecoderGpuTest, CfrFrameRateMpeg4MkvNoIndexNoFrameNum) {
   auto memory_video = MemoryVideo(cfr_mpeg4_mkv_videos_paths_[0]);
-  FramesDecoderGpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, cfr_videos_[0], false, 3.0);
 }
 
 TEST_F(FramesDecoderGpuTest, VfrFrameRateMpeg4MkvNoIndex) {
   auto memory_video = MemoryVideo(vfr_mpeg4_mkv_videos_paths_[1]);
-  FramesDecoderGpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false,
-                           vfr_videos_[1].NumFrames());
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
+  decoder.SetNumFrames(vfr_videos_[1].NumFrames());
   RunTest(decoder, vfr_videos_[1], false, 3.0);
 }
 
 TEST_F(FramesDecoderGpuTest, VfrFrameRateMpeg4MkvNoIndexNoFrameNum) {
   auto memory_video = MemoryVideo(vfr_mpeg4_mkv_videos_paths_[1]);
-  FramesDecoderGpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, vfr_videos_[1], false, 3.0);
 }
 
 TEST_F(FramesDecoderGpuTest, RawH264) {
   auto memory_video = MemoryVideo(cfr_raw_h264_videos_paths_[1]);
-  FramesDecoderGpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, cfr_videos_[1], false, 1.5);
 }
 
 TEST_F(FramesDecoderGpuTest, RawH265) {
   auto memory_video = MemoryVideo(cfr_raw_h264_videos_paths_[0]);
-  FramesDecoderGpu decoder(memory_video.data(), memory_video.size(), DALI_RGB, DALI_UINT8, false);
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, cfr_videos_[0], false, 1.5);
 }
 

--- a/dali/operators/video/input/video_input.h
+++ b/dali/operators/video/input/video_input.h
@@ -213,14 +213,12 @@ class VideoInput : public InputOperator<Backend> {
     }
   }
 
-  std::unique_ptr<FramesDecoderImpl> CreateDecoder(const char *data, size_t size,
+  std::unique_ptr<FramesDecoderImpl> CreateDecoder(const char *data, size_t size, std::string_view source_info,
                                                    cudaStream_t stream = 0) {
     if constexpr (std::is_same_v<Backend, CPUBackend>) {
-      return std::make_unique<FramesDecoderImpl>(data, size, DALI_RGB, DALI_UINT8, false, -1,
-                                                 std::string_view{});
+      return std::make_unique<FramesDecoderImpl>(data, size, source_info);
     } else {
-      return std::make_unique<FramesDecoderImpl>(data, size, DALI_RGB, DALI_UINT8, false, -1,
-                                                 std::string_view{}, stream);
+      return std::make_unique<FramesDecoderImpl>(data, size, source_info, stream);
     }
   }
 
@@ -285,7 +283,8 @@ bool VideoInput<Backend, FramesDecoderImpl>::SetupImpl(std::vector<OutputDesc> &
     auto sample = encoded_video_[0];
     const char *data = reinterpret_cast<const char *>(sample.data<uint8_t>());
     int size = sample.shape().num_elements();
-    frames_decoders_[0] = CreateDecoder(data, size, ws.has_stream() ? ws.stream() : 0);
+    std::string_view source_info{};
+    frames_decoders_[0] = CreateDecoder(data, size, source_info, ws.has_stream() ? ws.stream() : 0);
     DALI_ENFORCE(frames_decoders_[0]->IsValid(),
                  "Failed to create video decoder for provided video data");
 

--- a/dali/operators/video/input/video_input.h
+++ b/dali/operators/video/input/video_input.h
@@ -216,9 +216,11 @@ class VideoInput : public InputOperator<Backend> {
   std::unique_ptr<FramesDecoderImpl> CreateDecoder(const char *data, size_t size,
                                                    cudaStream_t stream = 0) {
     if constexpr (std::is_same_v<Backend, CPUBackend>) {
-      return std::make_unique<FramesDecoderImpl>(data, size, false, -1);
+      return std::make_unique<FramesDecoderImpl>(data, size, DALI_RGB, DALI_UINT8, false, -1,
+                                                 std::string_view{});
     } else {
-      return std::make_unique<FramesDecoderImpl>(data, size, stream, false, -1);
+      return std::make_unique<FramesDecoderImpl>(data, size, DALI_RGB, DALI_UINT8, false, -1,
+                                                 std::string_view{}, stream);
     }
   }
 

--- a/dali/operators/video/reader/video_loader_decoder_gpu.cc
+++ b/dali/operators/video/reader/video_loader_decoder_gpu.cc
@@ -89,9 +89,11 @@ Index VideoLoaderDecoderGpu::SizeImpl() {
 void VideoLoaderDecoderGpu::PrepareMetadataImpl() {
   video_files_.reserve(filenames_.size());
   for (auto &filename : filenames_) {
-    video_files_.emplace_back(filename, DALI_RGB, DALI_UINT8, true, cuda_stream_);
+    video_files_.emplace_back(filename, cuda_stream_);
     if (!video_files_.back().IsValid()) {
       video_files_.pop_back();
+    } else {
+      video_files_.back().BuildIndex();
     }
   }
 

--- a/dali/operators/video/reader/video_loader_decoder_gpu.cc
+++ b/dali/operators/video/reader/video_loader_decoder_gpu.cc
@@ -89,7 +89,7 @@ Index VideoLoaderDecoderGpu::SizeImpl() {
 void VideoLoaderDecoderGpu::PrepareMetadataImpl() {
   video_files_.reserve(filenames_.size());
   for (auto &filename : filenames_) {
-    video_files_.emplace_back(filename, cuda_stream_);
+    video_files_.emplace_back(filename, DALI_RGB, DALI_UINT8, true, cuda_stream_);
     if (!video_files_.back().IsValid()) {
       video_files_.pop_back();
     }

--- a/dali/operators/video/video_test.h
+++ b/dali/operators/video/video_test.h
@@ -27,8 +27,6 @@
 #include "dali/test/cv_mat_utils.h"
 
 namespace dali {
-void CompareFrameAvgError(
-  const uint8_t *ground_truth, const uint8_t *frame, int frame_size, double eps = 1.0);
 
 class TestVideo {
  public:
@@ -58,13 +56,14 @@ class TestVideo {
 
   void CompareFrame(int frame_id, const uint8_t *frame, int eps = 10);
 
-  void CompareFrameAvgError(int frame_id, const uint8_t *frame, double eps = 1.0);
-
   bool IsVfr() { return is_vfr_; }
 
   std::vector<cv::Mat> frames_;
   bool is_vfr_ = false;
 };
+
+void CompareFrameAvgError(int frame_id, size_t frame_size, size_t width, size_t height,
+                          const uint8_t *frame, const uint8_t *ground_truth, double eps);
 
 class VideoTestBase : public ::testing::Test {
  public:

--- a/dali/operators/video/video_utils.cc
+++ b/dali/operators/video/video_utils.cc
@@ -1,0 +1,150 @@
+// Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/video/video_utils.h"
+#include <sys/stat.h>
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace dali {
+
+inline void assemble_video_list(const std::string& path, const std::string& curr_entry, int label,
+                                std::vector<VideoFileMeta>& file_info) {
+  std::string curr_dir_path = path + "/" + curr_entry;
+  DIR* dir = opendir(curr_dir_path.c_str());
+  DALI_ENFORCE(dir != nullptr, "Directory " + curr_dir_path + " could not be opened");
+
+  struct dirent* entry;
+
+  while ((entry = readdir(dir))) {
+    std::string full_path = curr_dir_path + "/" + std::string{entry->d_name};
+#ifdef _DIRENT_HAVE_D_TYPE
+    /*
+     * Regular files and symlinks supported. If FS returns DT_UNKNOWN,
+     * filename is validated.
+     */
+    if (entry->d_type != DT_REG && entry->d_type != DT_LNK && entry->d_type != DT_UNKNOWN) {
+      continue;
+    }
+#endif
+    file_info.push_back(VideoFileMeta{full_path, label, 0, 0});
+  }
+  closedir(dir);
+}
+
+std::vector<VideoFileMeta> GetVideoFiles(const std::string& file_root,
+                                         const std::vector<std::string>& filenames, bool use_labels,
+                                         const std::vector<int>& labels,
+                                         const std::string& file_list) {
+  // open the root
+  std::vector<VideoFileMeta> file_info;
+  std::vector<std::string> entry_name_list;
+
+  if (!file_root.empty()) {
+    DIR* dir = opendir(file_root.c_str());
+
+    DALI_ENFORCE(dir != nullptr, "Directory " + file_root + " could not be opened.");
+
+    struct dirent* entry;
+
+    while ((entry = readdir(dir))) {
+      struct stat s;
+      std::string entry_name(entry->d_name);
+      std::string full_path = file_root + "/" + entry_name;
+      int ret = stat(full_path.c_str(), &s);
+      DALI_ENFORCE(ret == 0, "Could not access " + full_path + " during directory traversal.");
+      if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+        continue;
+      if (S_ISDIR(s.st_mode)) {
+        entry_name_list.push_back(entry_name);
+      }
+    }
+    closedir(dir);
+    // sort directories to preserve class alphabetic order, as readdir could
+    // return unordered dir list. Otherwise file reader for training and validation
+    // could return directories with the same names in completely different order
+    std::sort(entry_name_list.begin(), entry_name_list.end());
+    for (unsigned dir_count = 0; dir_count < entry_name_list.size(); ++dir_count) {
+      assemble_video_list(file_root, entry_name_list[dir_count], dir_count, file_info);
+    }
+
+    // sort file names as well
+    std::sort(file_info.begin(), file_info.end());
+  } else if (!file_list.empty()) {
+    // load (path, label) pairs from list
+    std::ifstream s(file_list);
+    DALI_ENFORCE(s.is_open(), file_list + " could not be opened.");
+
+    string line;
+    string video_file;
+    int label;
+    float start_time;
+    float end_time;
+    int line_num = 0;
+    while (std::getline(s, line)) {
+      line_num++;
+      video_file.clear();
+      label = -1;
+      start_time = end_time = 0;
+      std::istringstream file_line(line);
+      file_line >> video_file >> label;
+      if (video_file.empty())
+        continue;
+      DALI_ENFORCE(label >= 0, "Label value should be >= 0 in file_list at line number: " +
+                                   to_string(line_num) + ", filename: " + video_file);
+      if (file_line >> start_time) {
+        if (file_line >> end_time) {
+          if (start_time == end_time) {
+            DALI_WARN(
+                "Start and end time/frame are the same, skipping the file, in file_list "
+                "at line number: " +
+                to_string(line_num) + ", filename: " + video_file);
+            continue;
+          }
+        }
+      }
+      file_info.push_back(VideoFileMeta{video_file, label, start_time, end_time});
+    }
+
+    DALI_ENFORCE(s.eof(), "Wrong format of file_list.");
+    s.close();
+  } else {
+    file_info.reserve(filenames.size());
+    if (use_labels) {
+      if (!labels.empty()) {
+        for (size_t i = 0; i < filenames.size(); ++i) {
+          file_info.push_back(VideoFileMeta{filenames[i], labels[i], 0, 0});
+        }
+      } else {
+        for (size_t i = 0; i < filenames.size(); ++i) {
+          file_info.push_back(VideoFileMeta{filenames[i], static_cast<int>(i), 0, 0});
+        }
+      }
+    } else {
+      for (size_t i = 0; i < filenames.size(); ++i) {
+        file_info.push_back(VideoFileMeta{filenames[i], 0, 0, 0});
+      }
+    }
+  }
+
+  LOG_LINE << "read " << file_info.size() << " files from " << entry_name_list.size()
+           << " directories\n";
+
+  return file_info;
+}
+
+}  // namespace dali

--- a/dali/operators/video/video_utils.cc
+++ b/dali/operators/video/video_utils.cc
@@ -147,4 +147,10 @@ std::vector<VideoFileMeta> GetVideoFiles(const std::string& file_root,
   return file_info;
 }
 
+std::string av_error_string(int ret) {
+  static char msg[AV_ERROR_MAX_STRING_SIZE];
+  memset(msg, 0, sizeof(msg));
+  return std::string(av_make_error_string(msg, AV_ERROR_MAX_STRING_SIZE, ret));
+}
+
 }  // namespace dali

--- a/dali/operators/video/video_utils.h
+++ b/dali/operators/video/video_utils.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_VIDEO_VIDEO_READER_UTILS_H_
+#define DALI_OPERATORS_VIDEO_VIDEO_READER_UTILS_H_
+
+#include <dirent.h>
+#include <string>
+#include <vector>
+#include "dali/core/error_handling.h"
+#include "dali/core/boundary.h"
+#include "libavutil/rational.h"
+#include "dali/pipeline/operator/op_spec.h"
+
+namespace dali {
+
+struct VideoFileMeta {
+  std::string video_file;
+  int label;
+  float start_time;
+  float end_time;
+  bool operator<(const VideoFileMeta& right) {
+    return video_file < right.video_file;
+  }
+};
+
+inline float TimestampToSeconds(AVRational timebase, int64_t timestamp) {
+  return static_cast<float>(
+    static_cast<double>(timestamp) * timebase.num / timebase.den);
+}
+
+inline int64_t SecondsToTimestamp(AVRational timebase, float seconds) {
+  return static_cast<int64_t>(
+    static_cast<double>(seconds) * timebase.den / timebase.num);
+}
+
+std::vector<VideoFileMeta> GetVideoFiles(const std::string& file_root,
+                                         const std::vector<std::string>& filenames, bool use_labels,
+                                         const std::vector<int>& labels,
+                                         const std::string& file_list);
+
+inline boundary::BoundaryType GetBoundaryType(const OpSpec &spec) {
+  auto pad_mode_str = spec.template GetArgument<std::string>("pad_mode");
+  boundary::BoundaryType boundary_type = boundary::BoundaryType::ISOLATED;
+  if (pad_mode_str == "none" || pad_mode_str == "") {
+    boundary_type = boundary::BoundaryType::ISOLATED;
+  } else if (pad_mode_str == "constant") {
+    boundary_type = boundary::BoundaryType::CONSTANT;
+  } else if (pad_mode_str == "edge" || pad_mode_str == "repeat") {
+    boundary_type = boundary::BoundaryType::CLAMP;
+  } else if (pad_mode_str == "reflect_1001" || pad_mode_str == "symmetric") {
+    boundary_type = boundary::BoundaryType::REFLECT_1001;
+  } else if (pad_mode_str == "reflect_101" || pad_mode_str == "reflect") {
+    boundary_type = boundary::BoundaryType::REFLECT_101;
+  } else {
+    DALI_FAIL(make_string("Invalid pad_mode: ", pad_mode_str, "\n",
+                          "Valid options are: none, constant, edge, reflect_1001, reflect_101"));
+  }
+  return boundary_type;
+}
+
+template <typename Backend>
+const uint8_t* ConstantFrame(Tensor<Backend>& constant_frame, const TensorShape<>& shape,
+                             span<const uint8_t> fill_value, cudaStream_t stream,
+                             bool reuse_existing_data = true) {
+  if (reuse_existing_data && constant_frame.shape().num_elements() >= shape.num_elements()) {
+    return constant_frame.template data<uint8_t>();
+  }
+  if (std::is_same_v<Backend, CPUBackend>) {
+    constant_frame.set_pinned(false);
+  }
+  constant_frame.Resize(shape, DALI_UINT8);
+  DALI_ENFORCE(fill_value.size() == 1 || static_cast<int>(fill_value.size()) == shape[2],
+               make_string("Fill value size must be 1 or equal to the number of channels. Got ",
+                           fill_value.size(), " with num_channels=", shape[2]));
+
+  auto fill_data = [&](uint8_t* data) {
+    if (fill_value.size() == 1) {
+      std::fill(data, data + shape.num_elements(), fill_value[0]);
+    } else {
+      for (int i = 0; i < shape.num_elements(); i++) {
+        data[i] = fill_value[i % fill_value.size()];
+      }
+    }
+  };
+
+  if (std::is_same_v<Backend, GPUBackend>) {
+    Tensor<CPUBackend> tmp;
+    tmp.set_pinned(true);
+    tmp.Resize(shape, DALI_UINT8);
+    fill_data(tmp.template mutable_data<uint8_t>());
+    constant_frame.Copy(tmp, stream);
+  } else {
+    fill_data(constant_frame.template mutable_data<uint8_t>());
+  }
+  return constant_frame.template data<uint8_t>();
+}
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_VIDEO_VIDEO_READER_UTILS_H_

--- a/dali/operators/video/video_utils.h
+++ b/dali/operators/video/video_utils.h
@@ -15,6 +15,13 @@
 #ifndef DALI_OPERATORS_VIDEO_VIDEO_READER_UTILS_H_
 #define DALI_OPERATORS_VIDEO_VIDEO_READER_UTILS_H_
 
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/avutil.h>
+#include <libswscale/swscale.h>
+}
+
 #include <dirent.h>
 #include <string>
 #include <vector>
@@ -24,6 +31,8 @@
 #include "dali/pipeline/operator/op_spec.h"
 
 namespace dali {
+
+using AVPacketScope = std::unique_ptr<AVPacket, decltype(&av_packet_unref)>;
 
 struct VideoFileMeta {
   std::string video_file;
@@ -35,14 +44,12 @@ struct VideoFileMeta {
   }
 };
 
-inline float TimestampToSeconds(AVRational timebase, int64_t timestamp) {
-  return static_cast<float>(
-    static_cast<double>(timestamp) * timebase.num / timebase.den);
+inline double TimestampToSeconds(AVRational timebase, int64_t timestamp) {
+  return static_cast<double>(timestamp) * timebase.num / timebase.den;
 }
 
-inline int64_t SecondsToTimestamp(AVRational timebase, float seconds) {
-  return static_cast<int64_t>(
-    static_cast<double>(seconds) * timebase.den / timebase.num);
+inline int64_t SecondsToTimestamp(AVRational timebase, double seconds) {
+  return static_cast<int64_t>(seconds * timebase.den / timebase.num);
 }
 
 std::vector<VideoFileMeta> GetVideoFiles(const std::string& file_root,
@@ -106,6 +113,8 @@ const uint8_t* ConstantFrame(Tensor<Backend>& constant_frame, const TensorShape<
   }
   return constant_frame.template data<uint8_t>();
 }
+
+std::string av_error_string(int ret);
 
 }  // namespace dali
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

This PR fixes enhances the common video decoder implementation in FramesDecoderBase so that it can be reused by both video reader and decoder operators.
- Handling boundary conditions for out of bounds frame accessing (clamp, reflect, constant).
- Unifies FramesDecoder*pu classes constructor so that the device agnostic code is clearer.
- Extracted video_utils.* from legacy reader, so that they can be reused by the new reader

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

dali/operators/video/frames_decoder_base.cc
dali/operators/video/video_utils.h

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
