### PR TITLE
Add operator statefulness info to OpSchema

### DIFF
--- a/dali/operators/python_function/dltensor_function.h
+++ b/dali/operators/python_function/dltensor_function.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include "dali/pipeline/operator/checkpointing/stateless_operator.h"
+#include "dali/pipeline/operator/operator.h"
 #include "dali/pipeline/util/copy_with_stride.h"
 
 namespace dali {
@@ -148,10 +148,10 @@ class StreamSynchronizer<CPUBackend> {
 
 
 template <typename Backend>
-class DLTensorPythonFunctionImpl : public StatelessOperator<Backend> {
+class DLTensorPythonFunctionImpl : public Operator<Backend> {
  public:
   inline explicit DLTensorPythonFunctionImpl(const OpSpec &spec)
-      : StatelessOperator<Backend>(spec)
+      : Operator<Backend>(spec)
       , python_function(py::reinterpret_borrow<py::object>(
           reinterpret_cast<PyObject*>(spec.GetArgument<int64_t>("function_id")))) {
     synchronize_stream_ = spec.GetArgument<bool>("synchronize_stream");
@@ -228,7 +228,7 @@ class DLTensorPythonFunctionImpl : public StatelessOperator<Backend> {
   }
 
   USE_OPERATOR_MEMBERS();
-  using StatelessOperator<Backend>::RunImpl;
+  using Operator<Backend>::RunImpl;
 
   py::object python_function;
   py::object output_o_;

--- a/dali/operators/python_function/python_function.cc
+++ b/dali/operators/python_function/python_function.cc
@@ -33,7 +33,7 @@ DALI_SCHEMA(PythonFunctionBase)
 This argument can be a list that contains a distinct layout for each output. If the list has
 fewer than num_outputs elements, only the first outputs have the layout set and the rest of the
 outputs have no layout assigned.)code", nullptr)
-    .MakeStateful()
+    .MakeStateful()  // The python function may have some state
     .MakeInternal();
 
 DALI_SCHEMA(PythonFunction)

--- a/dali/operators/python_function/python_function.cc
+++ b/dali/operators/python_function/python_function.cc
@@ -33,6 +33,7 @@ DALI_SCHEMA(PythonFunctionBase)
 This argument can be a list that contains a distinct layout for each output. If the list has
 fewer than num_outputs elements, only the first outputs have the layout set and the rest of the
 outputs have no layout assigned.)code", nullptr)
+    .MakeStateful()
     .MakeInternal();
 
 DALI_SCHEMA(PythonFunction)

--- a/dali/pipeline/operator/builtin/input_operator.cc
+++ b/dali/pipeline/operator/builtin/input_operator.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ DALI_SCHEMA(InputOperatorBase)
 A base for any operator that forwards in-memory data to DALI pipeline.)doc")
                 .NumInput(0)
                 .NumOutput(0)
+                .MakeStateful()
                 .AddOptionalArg("blocking", R"code(
 **Advanced** If ``True``, this operator will block until the data is available
 (e.g. by calling ``feed_input``).

--- a/dali/pipeline/operator/checkpointing/checkpoint_test.cc
+++ b/dali/pipeline/operator/checkpointing/checkpoint_test.cc
@@ -133,6 +133,7 @@ DALI_SCHEMA(DummySource)
   .DocStr("Dummy")
   .NumInput(0)
   .NumOutput(2)
+  .MakeStateful()
   .AddArg("dummy_state", "internal dummy state", DALI_UINT32);
 
 DALI_REGISTER_OPERATOR(DummyInnerLayer, DummyOperatorWithState<CPUBackend>, CPU);
@@ -143,6 +144,7 @@ DALI_SCHEMA(DummyInnerLayer)
   .DocStr("Dummy")
   .NumInput(1)
   .NumOutput(1)
+  .MakeStateful()
   .AddArg("dummy_state", "internal dummy state", DALI_UINT32);
 
 DALI_REGISTER_OPERATOR(DummyOutput, DummyOperatorWithState<CPUBackend>, CPU);
@@ -153,6 +155,7 @@ DALI_SCHEMA(DummyOutput)
   .DocStr("Dummy")
   .NumInput(2)
   .NumOutput(1)
+  .MakeStateful()
   .AddArg("dummy_state", "internal dummy state", DALI_UINT32);
 
 class CheckpointTest : public DALITest {

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -814,7 +814,16 @@ bool OpSchema::IsSerializable() const {
 
 
 bool OpSchema::IsStateful() const {
-  return is_stateful_;
+  if (!is_stateful_) {
+    for (auto &parent : GetParents()) {
+      if (parent->IsStateful()) {
+        is_stateful_ = true;
+        return true;
+      }
+    }
+    is_stateful_ = false;
+  }
+  return *is_stateful_;
 }
 
 

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -321,6 +321,17 @@ OpSchema &OpSchema::MakeInternal() {
 }
 
 
+OpSchema &OpSchema::MakeStateless() {
+  is_stateful_ = false;
+  return *this;
+}
+
+OpSchema &OpSchema::MakeStateful() {
+  is_stateful_ = true;
+  return *this;
+}
+
+
 OpSchema &OpSchema::MakeDocHidden() {
   is_doc_hidden_ = true;
   return *this;
@@ -499,6 +510,7 @@ OpSchema &OpSchema::AddRandomSeedArg() {
   AddOptionalArg<int>("seed",
                       "Random seed; if not set, one will be assigned automatically.",
                       -1);
+  MakeStateful();
   return *this;
 }
 
@@ -798,6 +810,11 @@ bool OpSchema::IsNoPrune() const {
 
 bool OpSchema::IsSerializable() const {
   return serializable_;
+}
+
+
+bool OpSchema::IsStateful() const {
+  return is_stateful_;
 }
 
 

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -273,6 +273,12 @@ class DLL_PUBLIC OpSchema {
 
   /** Notes that this operator doc should not be visible (but the Op is exposed in Python API) */
   OpSchema &MakeDocHidden();
+
+  /** Notes that this operator doesn't have a state. */
+  OpSchema &MakeStateless();
+
+  /** Notes that this operator is stateful. */
+  OpSchema &MakeStateful();
 
   /**
    * @brief Notes that for this operator only the doc_str should be visible, but not the docs for
@@ -564,6 +570,9 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   /**  Whether this operator is internal to DALI backend (and shouldn't be exposed in Python API) */
   bool IsInternal() const;
 
+  /** Whether this operator is stateful. */
+  bool IsStateful() const;
+
   /** Whether this operator doc should not be visible (but the Op is exposed in Python API) */
   bool IsDocHidden() const;
 
@@ -782,6 +791,7 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   bool is_internal_ = false;
   bool is_doc_hidden_ = false;
   bool is_doc_partially_hidden_ = false;
+  bool is_stateful_ = false;
 
   /// Custom docstring, if not empty should be used in place of input_dox_ descriptions
   std::string call_dox_ = {};

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -275,7 +275,10 @@ class DLL_PUBLIC OpSchema {
   /** Notes that this operator doc should not be visible (but the Op is exposed in Python API) */
   OpSchema &MakeDocHidden();
 
-  /** Notes that this operator doesn't have a state. */
+  /** Notes that this operator doesn't have a state.
+   *
+   * NOTE: This overrides the statefulness inherited from parent schemas.
+   */
   OpSchema &MakeStateless();
 
   /** Notes that this operator is stateful. */
@@ -443,6 +446,11 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
     return *this;
   }
 
+  /** Adds a random seed argument to the operator.
+   *
+   * If not provided, the seed will be selected automatically.
+   * Adding a random seed implies statefulness of the operator.
+   */
   OpSchema &AddRandomSeedArg();
 
   /**  Marks an argument as deprecated in favor of a new argument
@@ -571,7 +579,11 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   /**  Whether this operator is internal to DALI backend (and shouldn't be exposed in Python API) */
   bool IsInternal() const;
 
-  /** Whether this operator is stateful. */
+  /** Whether this operator is stateful.
+   *
+   * Returns the statefulness of the operator. If it wasn't explicitly set, then the operator is
+   * considered stateful if any of its parents is stateful.
+   */
   bool IsStateful() const;
 
   /** Whether this operator doc should not be visible (but the Op is exposed in Python API) */

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <mutex>
 #include <numeric>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -791,7 +792,7 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   bool is_internal_ = false;
   bool is_doc_hidden_ = false;
   bool is_doc_partially_hidden_ = false;
-  bool is_stateful_ = false;
+  mutable std::optional<bool> is_stateful_;
 
   /// Custom docstring, if not empty should be used in place of input_dox_ descriptions
   std::string call_dox_ = {};

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2429,6 +2429,7 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("IsSequenceOperator", &OpSchema::IsSequenceOperator)
     .def("AllowsSequences", &OpSchema::AllowsSequences)
     .def("SupportsVolumetric", &OpSchema::SupportsVolumetric)
+    .def("IsStateful", &OpSchema::IsStateful)
     .def("IsInternal", &OpSchema::IsInternal)
     .def("IsDocHidden", &OpSchema::IsDocHidden)
     .def("IsDocPartiallyHidden", &OpSchema::IsDocPartiallyHidden)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:
This change adds the information about an operator being stateful to OpSchema. This is done with the help of the functions:
`MakeStateful`
`MakeStateless`
`IsStateful`.
By default, the value is unset - and so it's inherited from a base schema. If any of the parents is stateful, then the operator is also marked as stateful. Since the presence of a random seed argument implies the presence of a random number generator (and hence, state), `AddRandomSeedArg` internally calls `MakeStateful`, saving some typing and reducing a chance of error.
In a hypothetical case where a schema inherits from a stateful one but the resulting operator doesn't have a state, it's possible to explicitly disable statefulness by calling `MakeStateless`.
The `IsStateful` query tells whether the schema is stateful and performs the lookup in the parent schemas, if necessary.
`IsStateful` is exposed in Python.

PythonFunction, and input operators are marked as stateful, since the Python function may have side effects and carry a state. Input operators are also inherently stateful, since they go over the data fed to them.

## Additional information:

### Affected modules and functionalities:
OpSchema
Some operators
BackendImpl.
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
