### PR TITLE
Adjust test compatibility with numpy 2.x

### DIFF
--- a/dali/test/python/decoder/test_imgcodec.py
+++ b/dali/test/python/decoder/test_imgcodec.py
@@ -518,7 +518,9 @@ def test_image_decoder_lossless_jpeg(img_name, output_type, dtype, precision):
     max_val = np_dtype(1.0) if dtype == types.FLOAT else np.iinfo(np_dtype).max
     need_scaling = max_val != np_dtype(2**precision - 1)
     if need_scaling:
-        multiplier = max_val / (2**precision - 1)
+        # numpy 2.x computes this division as float32 while numpy 1.x as float64
+        # so we need to cast max_val to python float to get the same results
+        multiplier = float(max_val) / float(2**precision - 1)
         ref = ref * multiplier
         if dtype != types.FLOAT:
             kwargs["atol"] = 0.5  # possible rounding error

--- a/dali/test/python/reader/test_numpy.py
+++ b/dali/test/python/reader/test_numpy.py
@@ -146,7 +146,6 @@ all_numpy_types = set(
         np.uintp,
         np.float32,
         np.float64,
-        np.float_,
         np.complex64,
         np.complex128,
         complex,

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -166,7 +166,6 @@ def test_array_interface_types():
         np.uint16,
         np.uint32,
         np.uint64,
-        np.float_,
         np.float32,
         np.float16,
         np.short,

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -219,7 +219,6 @@ def test_mxnet_iterator_empty_array():
         np.uint16,
         np.uint32,
         np.uint64,
-        np.float_,
         np.float32,
         np.float16,
         np.short,

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1196,7 +1196,6 @@ def test_python_formats():
         np.uint16,
         np.uint32,
         np.uint64,
-        np.float_,
         np.float32,
         np.float16,
         np.short,


### PR DESCRIPTION
- np.float_ is an alias for np.float64 and is redundant in the test cases.
  Removing it as the alias has been removed from numpy 2.x
- fixes numerical precision issues in lossless JPEG test by explicitly
  casting max_val to float64 before division. This ensures consistent behavior
  between numpy 1.x (which uses float64) and numpy 2.x (which uses float32)
  when computing the scaling multiplier.

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- np.float_ is an alias for np.float64 and is redundant in the test cases.
  Removing it as the alias has been removed from numpy 2.x
- fixes numerical precision issues in lossless JPEG test by explicitly
  casting max_val to float64 before division. This ensures consistent behavior
  between numpy 1.x (which uses float64) and numpy 2.x (which uses float32)
  when computing the scaling multiplier.


<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- tests
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - dali/test/python/reader/test_numpy.py
  - dali/test/python/test_backend_impl.py
  - dali/test/python/test_fw_iterators.py
  - dali/test/python/test_pipeline.py
  - dali/test/python/decoder/test_imgcodec.py
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
