### PR TITLE
Fix getting operator traces in bulk in C API 2.0

### DIFF
--- a/dali/c_api_2/pipeline_outputs.cc
+++ b/dali/c_api_2/pipeline_outputs.cc
@@ -42,7 +42,7 @@ span<daliOperatorTrace_t> PipelineOutputs::GetTraces() {
   if (!traces_.has_value()) {
     traces_.emplace();
     if (auto iter_data = ws_.GetIterationData()) {
-      auto trace_map = iter_data->operator_traces.GetCopy();
+      auto &trace_map = iter_data->operator_traces.GetRef();
       for (auto &[op, traces] : trace_map) {
         for (auto &[name, value] : traces) {
           traces_->push_back({ op.c_str(), name.c_str(), value.c_str() });

--- a/dali/pipeline/workspace/iteration_data.h
+++ b/dali/pipeline/workspace/iteration_data.h
@@ -70,6 +70,11 @@ class OperatorTraces {
     return map_;
   }
 
+  /** Gets a reference to the operator trace map */
+  auto &GetRef() const & {
+    return map_;
+  }
+
  private:
   mutable std::mutex mtx_;
   std::map<


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Previously the bulk query returned a pointer to a temporary copy.
The fix is to return a reference to the operator trace map so we don't have make the copy.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
CAPI2_PipelineTest.Traces
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
