### PR TITLE
Fix invalid stack read in legacy C API

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -578,7 +578,8 @@ static size_t daliMaxDimTensorsHelper(dali::Workspace* ws, int n) {
     auto shape = out_tensor_list.tensor_shape(i);
     int num_dim = shape.size();
     // squeeze last dimension
-    if (shape[num_dim - 1] == 1) {
+    // TODO(michalz): Remove this logic! The client should be responsible for this!
+    if (num_dim > 0 && shape[num_dim - 1] == 1) {
       --num_dim;
     }
     max_num_dim = std::max(max_num_dim, num_dim);


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
The function reads the last extent of the shape, which is invalid if the shape is 0D.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
`test_dali_tf_plugin_run.get_batch_dali_sparse`
- [X] Existing tests apply
- [ ] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
