### PR TITLE
Fix gpu empty reductions

### DIFF
--- a/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
@@ -113,7 +113,7 @@ __device__ void ReduceFlatNone(Out *out, const In *in, int64_t n,
 /**
  * @brief This function is used when reducting a degenerate dimension
  *
- * This function store and optionally postprocess the reduction's default value.
+ * This function stores and optionally postprocesses the reduction's default value.
  *
  * @param post          posptprocessing unary functor
  */
@@ -249,9 +249,9 @@ __global__ void ReduceMiddleNoneKernel(const ReduceSampleDesc<Out, In> *samples,
 
 
 /**
- * @brief This kernel is used when reducing an empty middle dimension.
+ * @brief This kernel is used when reducing a degenerate middle dimension.
  *
- * This function will store the reduction's default value and optionally preprocess it.
+ * This function stores and optionally postprocesses the reduction's default value.
  *
  * @param post          posptprocessing unary functor
  */

--- a/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ struct ReduceSampleDesc {
  */
 template <typename Out, typename In, typename PreprocessorBank, typename Postprocessor>
 __device__ void ReduceFlatNone(Out *out, const In *in, int64_t n,
-                                PreprocessorBank pre_bank, Postprocessor post) {
+                               PreprocessorBank pre_bank, Postprocessor post) {
   const int64_t blk_size = blockDim.x * blockDim.y;  // no restriction on block size
   const int64_t grid_stride = static_cast<int64_t>(gridDim.x) * blk_size;
   const int flat_tid = threadIdx.x + threadIdx.y * blockDim.x;
@@ -106,6 +106,26 @@ __device__ void ReduceFlatNone(Out *out, const In *in, int64_t n,
   for (int64_t index = base_idx; index < n; index += grid_stride) {
     auto pre = pre_bank.Get({index});
     out[index] = ConvertSat<Out>(post(pre(in[index])));
+  }
+}
+
+
+/**
+ * @brief This function is used when reducting a degenerate dimension
+ *
+ * This function store and optionally postprocess the reduction's default value.
+ *
+ * @param post          posptprocessing unary functor
+ */
+template <typename Acc, typename Out, typename Reduction, typename Postprocessor>
+__device__ void ReduceFlatDegenerate(Out *out, int64_t n,
+                                     Reduction, Postprocessor post) {
+  const int64_t blk_size = blockDim.x * blockDim.y;  // no restriction on block size
+  const int64_t grid_stride = static_cast<int64_t>(gridDim.x) * blk_size;
+  const int flat_tid = threadIdx.x + threadIdx.y * blockDim.x;
+  int64_t base_idx = static_cast<int64_t>(blockIdx.x) * blk_size + flat_tid;
+  for (int64_t index = base_idx; index < n; index += grid_stride) {
+    out[index] = ConvertSat<Out>(post(Reduction::template neutral<Acc>()));
   }
 }
 
@@ -227,6 +247,27 @@ __global__ void ReduceMiddleNoneKernel(const ReduceSampleDesc<Out, In> *samples,
   }
 }
 
+
+/**
+ * @brief This kernel is used when reducing an empty middle dimension.
+ *
+ * This function will store the reduction's default value and optionally preprocess it.
+ *
+ * @param post          posptprocessing unary functor
+ */
+template <typename Acc, typename Out, typename In,
+          typename Reduction = reductions::sum,
+          typename Postprocessor = identity>
+__global__ void ReduceMiddleDegenerateKernel(const ReduceSampleDesc<Out, In> *samples,
+                                             Reduction r,
+                                             const Postprocessor *post = nullptr) {
+  Postprocessor postprocessor = post ? post[blockIdx.y] : Postprocessor();
+  auto sample = samples[blockIdx.y];
+  Out *out = sample.out;
+
+  int64_t n = sample.n_outer * sample.n_inner;
+  ReduceFlatDegenerate<Acc>(out, n, r, postprocessor);
+}
 
 
 

--- a/dali/kernels/reduce/reduce_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_gpu_impl.cuh
@@ -835,14 +835,7 @@ class ReduceImplGPU {
         }
         reduced[i] = sample_shape[axis];
         outer[i] *= new_outer;
-        if (axis < in_dim - 1) {
-          if (new_outer * reduced[i] > 0)
-            inner[i] /= new_outer * reduced[i];
-          else
-            inner[i] = 0;
-        } else {
-          inner[i] = 1;
-        }
+        inner[i] = volume(sample_shape.begin() + axis + 1, sample_shape.end());
       }
       prev_axis = axis;
 

--- a/dali/kernels/reduce/reduce_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_gpu_impl.cuh
@@ -659,20 +659,6 @@ class ReduceImplGPU {
       rs.reduced_in = 1;
       rs.reduced_out = (i == 0 || !reduce_batch_) ? 1 : 0;
     }
-
-    if (reduce_batch_ && N > 1) {
-      ReductionStage stage;
-      stage.kind = ReductionKind::Fold;
-      stage.shape.resize(N);
-      for (int i = 0; i < N; i ++) {
-        stage.shape[i].outer = 1;
-        stage.shape[i].inner = stages_.back().shape[i].output_elements();
-        stage.shape[i].reduced_in = 1;
-        stage.shape[i].reduced_out = (i == 0) ? 1 : 0;
-      }
-      stage.index = stages_.size();
-      stages_.push_back(std::move(stage));
-    }
     stages_.back().is_last = true;
   }
 

--- a/dali/kernels/reduce/reduce_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_gpu_impl.cuh
@@ -22,6 +22,7 @@
  */
 
 #include <cassert>
+#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/dali/kernels/reduce/reduce_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_gpu_impl.cuh
@@ -1355,7 +1355,7 @@ class ReduceImplGPU {
           This().GetReduction(),
           gpu_post ? gpu_post + sample_offset : nullptr);
 
-      sample_offset += num_none;
+      sample_offset += num_degenerate;
     }
 
     // None

--- a/dali/kernels/reduce/reduce_gpu_impl_test.cu
+++ b/dali/kernels/reduce/reduce_gpu_impl_test.cu
@@ -433,9 +433,9 @@ TEST(SumImplGPU, All_ZeroSize) {
 
 TEST(SumImplGPU, Partial_ZeroShape_Middle) {
   TensorListShape<> in_shape = {{
-    { 3, 4, 5 },
-    { 6, 7, 8 },
-    { 9, 1, 2 }
+    { 3, 0, 5 },
+    { 6, 0, 8 },
+    { 9, 0, 2 }
   }};
   TensorListShape<> ref_out_shape = {{
     TensorShape<>{3, 5},
@@ -456,9 +456,9 @@ TEST(SumImplGPU, Partial_ZeroShape_Middle) {
 
 TEST(SumImplGPU, Partial_ZeroShape_Inner) {
   TensorListShape<> in_shape = {{
-    { 3, 4, 5 },
-    { 6, 7, 8 },
-    { 9, 1, 2 }
+    { 3, 0, 0 },
+    { 6, 0, 0 },
+    { 9, 0, 0 }
   }};
   TensorListShape<> ref_out_shape = {{
     TensorShape<>{3},
@@ -479,9 +479,9 @@ TEST(SumImplGPU, Partial_ZeroShape_Inner) {
 
 TEST(SumImplGPU, Partial_ZeroShape_Outer) {
   TensorListShape<> in_shape = {{
-    { 3, 4, 5 },
-    { 6, 7, 8 },
-    { 9, 1, 2 }
+    { 0, 4, 5 },
+    { 0, 7, 8 },
+    { 0, 1, 2 }
   }};
   TensorListShape<> ref_out_shape = {{
     TensorShape<>{4, 5},
@@ -502,9 +502,9 @@ TEST(SumImplGPU, Partial_ZeroShape_Outer) {
 
 TEST(SumImplGPU, Partial_ZeroShape_OuterInner) {
   TensorListShape<> in_shape = {{
-    { 3, 4, 5 },
-    { 6, 7, 8 },
-    { 9, 1, 2 }
+    { 0, 4, 0 },
+    { 0, 7, 0 },
+    { 0, 1, 0 }
   }};
   TensorListShape<> ref_out_shape = {{
     TensorShape<>{4},

--- a/dali/kernels/reduce/reduce_gpu_impl_test.cu
+++ b/dali/kernels/reduce/reduce_gpu_impl_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -427,6 +427,98 @@ TEST(SumImplGPU, All_ZeroSize) {
   test.Run();
 
   RefReduce(test.ref.cpu(), test.in.cpu(), make_span(axes), false, true, reductions::sum());
+
+  test.Check();
+}
+
+TEST(SumImplGPU, Partial_ZeroShape_Middle) {
+  TensorListShape<> in_shape = {{
+    { 3, 4, 5 },
+    { 6, 7, 8 },
+    { 9, 1, 2 }
+  }};
+  TensorListShape<> ref_out_shape = {{
+    TensorShape<>{3, 5},
+    TensorShape<>{6, 8},
+    TensorShape<>{9, 2}
+  }};
+  int axes[] = { 1 };
+  testing::ReductionKernelTest<SumImplGPU<int64_t, uint8_t>, int64_t, uint8_t> test;
+  test.Setup(in_shape, ref_out_shape, make_span(axes), false, false);
+  test.FillData(0, 255);
+
+  test.Run();
+
+  RefReduce(test.ref.cpu(), test.in.cpu(), make_span(axes), false, false, reductions::sum());
+
+  test.Check();
+}
+
+TEST(SumImplGPU, Partial_ZeroShape_Inner) {
+  TensorListShape<> in_shape = {{
+    { 3, 4, 5 },
+    { 6, 7, 8 },
+    { 9, 1, 2 }
+  }};
+  TensorListShape<> ref_out_shape = {{
+    TensorShape<>{3},
+    TensorShape<>{6},
+    TensorShape<>{9}
+  }};
+  int axes[] = { 1, 2 };
+  testing::ReductionKernelTest<SumImplGPU<int64_t, uint8_t>, int64_t, uint8_t> test;
+  test.Setup(in_shape, ref_out_shape, make_span(axes), false, false);
+  test.FillData(0, 255);
+
+  test.Run();
+
+  RefReduce(test.ref.cpu(), test.in.cpu(), make_span(axes), false, false, reductions::sum());
+
+  test.Check();
+}
+
+TEST(SumImplGPU, Partial_ZeroShape_Outer) {
+  TensorListShape<> in_shape = {{
+    { 3, 4, 5 },
+    { 6, 7, 8 },
+    { 9, 1, 2 }
+  }};
+  TensorListShape<> ref_out_shape = {{
+    TensorShape<>{4, 5},
+    TensorShape<>{7, 8},
+    TensorShape<>{1, 2}
+  }};
+  int axes[] = { 0 };
+  testing::ReductionKernelTest<SumImplGPU<int64_t, uint8_t>, int64_t, uint8_t> test;
+  test.Setup(in_shape, ref_out_shape, make_span(axes), false, false);
+  test.FillData(0, 255);
+
+  test.Run();
+
+  RefReduce(test.ref.cpu(), test.in.cpu(), make_span(axes), false, false, reductions::sum());
+
+  test.Check();
+}
+
+TEST(SumImplGPU, Partial_ZeroShape_OuterInner) {
+  TensorListShape<> in_shape = {{
+    { 3, 4, 5 },
+    { 6, 7, 8 },
+    { 9, 1, 2 }
+  }};
+  TensorListShape<> ref_out_shape = {{
+    TensorShape<>{4},
+    TensorShape<>{7},
+    TensorShape<>{1}
+  }};
+  int axes[] = { 0, 2 };
+  testing::ReductionKernelTest<SumImplGPU<int64_t, uint8_t>, int64_t, uint8_t> test;
+  test.Setup(in_shape, ref_out_shape, make_span(axes), false, false);
+  test.FillData(0, 255);
+
+  test.Run();
+
+  RefReduce(test.ref.cpu(), test.in.cpu(), make_span(axes), false, false, reductions::sum());
 
   test.Check();
 }

--- a/dali/test/python/operator_2/test_reduce.py
+++ b/dali/test/python/operator_2/test_reduce.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -584,6 +584,20 @@ def _test_reduce_large_data(rank, axes, device, in_layout):
         for i in range(batch_size):
             ref = np.sum(batch[i].astype(np.float64), axis=axes)
             assert np.allclose(out[i], ref, 1e-5, 1e-5)
+
+
+def test_reduce_large_data():
+    np.random.seed(12344)
+    for device in ["cpu", "gpu"]:
+        for rank in [1, 2, 3]:
+            for axis_mask in range(1, 2**rank):
+                layout = np.random.choice([None, "DALI"[:rank]])
+                axes = tuple(
+                    filter(
+                        lambda x: x >= 0, (i if axis_mask & (1 << i) else -1 for i in range(rank))
+                    )
+                )
+                yield _test_reduce_large_data, rank, axes, device, layout
 
 
 def empty_batches(rank, axes, batch_size, num_batches):


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
This changes adds proper handling of reductions of degenerate (0-sized) data.
Prior to this change, multiple errors occurred - from segfault to leaving data unwritten.
Additionally, an incorrect assertion (triggered only in debug builds) was removed.

## Additional information:
The fix is twofold:
- to add special middle "degenerate" reduction which writes reductions neutral element to the output
- to fix the way the inner volume is calculated - in case of degeneracy we must recalculate it from scratch - and since it's not expensive, we can just do it all the time

### Affected modules and functionalities:
Reductions.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3086
<!--- DALI-XXXX or NA --->
