### PR TITLE
Enable tfrecord2idx script to convert a tfrecord from Object Storage into the index file, which is also stored in Object Storage

### DIFF
--- a/tools/tfrecord2idx
+++ b/tools/tfrecord2idx
@@ -1,15 +1,19 @@
 #!/usr/bin/env python
 import sys
 import struct
-import tensorflow as tf
-import tensorflow_io as tfio  # noqa:F401
 
 if len(sys.argv) < 3:
     print("Usage: tfrecord2idx <tfrecord filename> <index filename>")
     exit()
 
-f = tf.io.gfile.GFile(sys.argv[1], 'rb')
-idx = tf.io.gfile.GFile(sys.argv[2], 'w')
+try:
+    import tensorflow as tf
+    import tensorflow_io as tfio  # noqa:F401
+    f = tf.io.gfile.GFile(sys.argv[1], 'rb')
+    idx = tf.io.gfile.GFile(sys.argv[2], 'w')
+except ImportError:
+    f = open(sys.argv[1], 'rb')
+    idx = open(sys.argv[2], 'w')
 
 while True:
     current = f.tell()

--- a/tools/tfrecord2idx
+++ b/tools/tfrecord2idx
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 import sys
 import struct
+import tensorflow as tf
+import tensorflow_io as tfio  # noqa:F401
 
 if len(sys.argv) < 3:
     print("Usage: tfrecord2idx <tfrecord filename> <index filename>")
     exit()
 
-f = open(sys.argv[1], 'rb')
-idx = open(sys.argv[2], 'w')
+f = tf.io.gfile.GFile(sys.argv[1], 'rb')
+idx = tf.io.gfile.GFile(sys.argv[2], 'w')
 
 while True:
     current = f.tell()


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
The current tfrecord2idx script can only work for local files. If we would like to run it against tfrecords in Object Storage and also create index files in Object Storage, we will need to use ``tf.io.gfile.GFile``.



## Additional information:

### Affected modules and functionalities:
tools



### Key points relevant for the review:
change python native ``open()`` to ``tf.io.gfile.GFile`` to access files in Object Storage.

### Tests:
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A



## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
