### PR TITLE
Add a guard for out-of-range memory write in sw_scale

### DIFF
--- a/dali/operators/video/frames_decoder_cpu.cc
+++ b/dali/operators/video/frames_decoder_cpu.cc
@@ -74,11 +74,11 @@ void PlanarToInterleaved(uint8_t *output, const uint8_t *input, int64_t height, 
 void FramesDecoderCpu::CopyToOutput(uint8_t *data) {
   uint8_t *sws_output_data = data;
   AVPixelFormat sws_output_format = AV_PIX_FMT_RGB24;
-  if (image_type_ == DALI_YCbCr || Width() % 8) {
-    // in some cases, whne Width() % 8, sws_scale go past the provided memory for
-    // the list line converted so let us allocate more memory just in case
-    auto alignment = Width() * Channels();
-    tmp_buffer_.resize(FrameSize() + alignment);
+  if (image_type_ == DALI_YCbCr || Width() % 32) {
+    // in some cases, when Width() % 32, sws_scale go past the provided memory for
+    // conversion output, so we need the memory allocated with extra padding
+    auto extra_padding = 32;
+    tmp_buffer_.resize(FrameSize() + extra_padding);
     sws_output_data = tmp_buffer_.data();
     if (image_type_ == DALI_YCbCr) {
       sws_output_format = AV_PIX_FMT_YUV444P;
@@ -117,7 +117,7 @@ void FramesDecoderCpu::CopyToOutput(uint8_t *data) {
   if (image_type_ == DALI_YCbCr) {
     LOG_LINE << "Converting planar YUV to interleaved" << std::endl;
     PlanarToInterleaved(data, sws_output_data, Height(), Width(), Channels());
-  } else if (Width() % 8) {
+  } else if (Width() % 32) {
     std::copy(sws_output_data, sws_output_data + FrameSize(), data);
   }
 

--- a/dali/operators/video/frames_decoder_cpu.cc
+++ b/dali/operators/video/frames_decoder_cpu.cc
@@ -74,10 +74,15 @@ void PlanarToInterleaved(uint8_t *output, const uint8_t *input, int64_t height, 
 void FramesDecoderCpu::CopyToOutput(uint8_t *data) {
   uint8_t *sws_output_data = data;
   AVPixelFormat sws_output_format = AV_PIX_FMT_RGB24;
-  if (image_type_ == DALI_YCbCr) {
-    tmp_buffer_.resize(FrameSize());
+  if (image_type_ == DALI_YCbCr || Width() % 8) {
+    // in some cases, whne Width() % 8, sws_scale go past the provided memory for
+    // the list line converted so let us allocate more memory just in case
+    auto alignment = Width() * Channels();
+    tmp_buffer_.resize(FrameSize() + alignment);
     sws_output_data = tmp_buffer_.data();
-    sws_output_format = AV_PIX_FMT_YUV444P;
+    if (image_type_ == DALI_YCbCr) {
+      sws_output_format = AV_PIX_FMT_YUV444P;
+    }
   }
   if (!sws_ctx_) {
     sws_ctx_ = std::unique_ptr<SwsContext, decltype(&sws_freeContext)>(
@@ -112,6 +117,8 @@ void FramesDecoderCpu::CopyToOutput(uint8_t *data) {
   if (image_type_ == DALI_YCbCr) {
     LOG_LINE << "Converting planar YUV to interleaved" << std::endl;
     PlanarToInterleaved(data, sws_output_data, Height(), Width(), Channels());
+  } else if (Width() % 8) {
+    std::copy(sws_output_data, sws_output_data + FrameSize(), data);
   }
 
   DALI_ENFORCE(ret >= 0,


### PR DESCRIPTION
- for some rare videos, when the width is not divisible by 32,
  the sw_scale writes beyond the designated memory. This change
  makes sure the memory is allocated with enough of a safety margin
- see https://github.com/obsproject/obs-studio/pull/2836

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- for some rare videos, when the width is not divisible by 32,
  the sw_scale writes beyond the designated memory. This change
  makes sure the memory is allocated with enough of a safety margin
- see https://github.com/obsproject/obs-studio/pull/2836
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A
  - I couldn't generate a synthetic video that would reproduce that. And we cannot post the one the issue was detected with.


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
