### PR TITLE
Suppress Warning when No Boxes in Sample

### DIFF
--- a/dali/operators/image/crop/bbox_crop.cc
+++ b/dali/operators/image/crop/bbox_crop.cc
@@ -793,6 +793,13 @@ class RandomBBoxCropImpl : public OpImplBase<CPUBackend> {
           out_crop = rel_crop;
         }
 
+        if (bounding_boxes.empty()) {
+          // No bounding boxes to consider, just use the first propsed crop
+          crop.crop = out_crop;
+          crop.success = true;
+          continue;
+        }
+
         float min_overlap = 0.0, max_overlap = 0.0;
         std::tie(min_overlap, max_overlap) =
             OverlapMetricRange(rel_crop, make_cspan(bounding_boxes));


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
If there are no boxes in a sample, the `Could not find a valid cropping window to satisfy the specified requirements...` warning message is printed. If I have many negative samples in my dataset (images without boxes), this clogs my logs with thousands of these messages. This PR just uses the first crop proposal if there are no boxes in the sample, skipping the warning and also improves performance by not running the algorithm `total_num_attempts_` times when this is impossible satisfy anyway. 


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

RandomBBoxCropImpl::FindProspectiveCrop early exit condition.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

While I have tested the expected behaviour for `absolute_crop_dims`, returning me a valid crop of the expected shape i.e. a random [200,200] chip of [600,400] image, I am unsure if the randomly generated relative dimension crops will be reasonable. I suppose the `scaling` and `aspect_ratio` arguments set by the user must be reasonable. I have less experience playing with these.

I noted that `contextlib.redirect_stderr` is unable to capture the logging from DALI in the test, I have to use some weird fd redirect hack (courtesy of Copilot+Gemini).

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
