### PR TITLE
BLD: Silence warning from setuptools about packages config

### DIFF
--- a/dali/python/setup.py.in
+++ b/dali/python/setup.py.in
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 setup(name='nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@',
       description='NVIDIA DALI @DALI_FLAVOR@ for CUDA @CUDA_VERSION_SHORT@. Git SHA: @GIT_SHA@',
@@ -54,7 +54,9 @@ For more details please check the
       version='@DALI_VERSION@',
       author='NVIDIA Corporation',
       license='Apache License 2.0',
-      packages=find_packages(),
+      packages=find_namespace_packages(
+        include=['nvidia.dali*'],
+      ),
       include_package_data=True,
       zip_safe=False,
       python_requires='>=3.9, <3.14',


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
--->
**Other** (*e.g. Documentation, Tests, Configuration*)


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
Because interface files are generated (.pyi) and placed into folders without accompanying `__init__.py` files, setuptools considers these modules namespace modules. However, because the setuptools configuration uses `find_package` instead of `find_namespace_package` setuptools prints a lot of warnings during the build process.
```
 │ │   !!
 │ │     check.warn(importable)
 │ │   $PREFIX/lib/python3.11/site-packages/setuptools/command/build_py.py:212: _Warning: Package 'nvidia.dali.include.boost.scope.detail.type_traits' is absent from the `packages` configuration.
 │ │   !!
 │ │           ********************************************************************************
 │ │           ############################
 │ │           # Package would be ignored #
 │ │           ############################
 │ │           Python recognizes 'nvidia.dali.include.boost.scope.detail.type_traits' as an importable package[^1],
 │ │           but it is absent from setuptools' `packages` configuration.
 │ │           This leads to an ambiguous overall configuration. If you want to distribute this
 │ │           package, please make sure that 'nvidia.dali.include.boost.scope.detail.type_traits' is explicitly added
 │ │           to the `packages` configuration field.
 │ │           Alternatively, you can also rely on setuptools' discovery methods
 │ │           (for example by using `find_namespace_packages(...)`/`find_namespace:`
 │ │           instead of `find_packages(...)`/`find:`).
 │ │           You can read more about "package discovery" on setuptools documentation page:
 │ │           - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html
 │ │           If you don't want 'nvidia.dali.include.boost.scope.detail.type_traits' to be distributed and are
 │ │           already explicitly excluding 'nvidia.dali.include.boost.scope.detail.type_traits' via
 │ │           `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
 │ │           you can try to use `exclude_package_data`, or `include-package-data=False` in
 │ │           combination with a more fine grained `package-data` configuration.
 │ │           You can read more about "package data files" on setuptools documentation page:
 │ │           - https://setuptools.pypa.io/en/latest/userguide/datafiles.html
 │ │           [^1]: For Python, any directory (with suitable naming) can be imported,
 │ │                 even if it does not contain any `.py` files.
 │ │                 On the other hand, currently there is no concept of package data
 │ │                 directory, all directories are treated like packages.
 │ │           ********************************************************************************

```

This PR, switches from `find_package` to `find_namespace_package` in order to silence these warnings. 

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
