### PR TITLE
Reduce the number of mutex locks in ThreadPool.

### DIFF
--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,8 +26,7 @@
 namespace dali {
 
 ThreadPool::ThreadPool(int num_thread, int device_id, bool set_affinity, const char* name)
-    : threads_(num_thread), running_(true), work_complete_(true), started_(false)
-    , active_threads_(0) {
+    : threads_(num_thread), running_(true), started_(false), outstanding_work_(0) {
   DALI_ENFORCE(num_thread > 0, "Thread pool must have non-zero size");
 #if NVML_ENABLED
   // We use NVML only for setting thread affinity
@@ -61,7 +60,7 @@ void ThreadPool::AddWork(Work work, int64_t priority, bool start_immediately) {
   {
     std::lock_guard<std::mutex> lock(mutex_);
     work_queue_.push({priority, std::move(work)});
-    work_complete_ = false;
+    outstanding_work_.fetch_add(1);
     started_before = started_;
     started_ |= start_immediately;
   }
@@ -75,8 +74,10 @@ void ThreadPool::AddWork(Work work, int64_t priority, bool start_immediately) {
 
 // Blocks until all work issued to the thread pool is complete
 void ThreadPool::WaitForWork(bool checkForErrors) {
-  std::unique_lock<std::mutex> lock(mutex_);
-  completed_.wait(lock, [this] { return this->work_complete_; });
+  if (outstanding_work_.load()) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    completed_.wait(lock, [this] { return this->outstanding_work_ == 0; });
+  }
   started_ = false;
   if (checkForErrors) {
     // Check for errors
@@ -150,11 +151,9 @@ void ThreadPool::ThreadMain(int thread_id, int device_id, bool set_affinity,
     // If we're no longer running, exit the run loop
     if (!running_) break;
 
-    // Get work from the queue & mark
-    // this thread as active
+    // Get work from the queue.
     Work work = std::move(work_queue_.top().second);
     work_queue_.pop();
-    ++active_threads_;
 
     // Unlock the lock
     lock.unlock();
@@ -174,13 +173,47 @@ void ThreadPool::ThreadMain(int thread_id, int device_id, bool set_affinity,
       lock.unlock();
     }
 
-    // Mark this thread as idle & check for complete work
-    lock.lock();
-    --active_threads_;
-    if (work_queue_.empty() && active_threads_ == 0) {
-      work_complete_ = true;
+    // The task is now complete - we can atomically decrement the number of outstanding work.
+    // If it reaches zero, we must safely notify the potential threads waiting for the work
+    // to complete.
+    // NOTE: We don't have to acquire the mutex until the number of waiting threads reaches 0.
+    if (--outstanding_work_ == 0) {
+      // We don't need to guard the modification of the atomic value with a mutex -
+      // however, we need to lock it briefly to make sure we don't have this scenario:
+      //
+      // worker                           WaitForWork
+      //
+      //                                  lock.lock()
+      //                                  return outstanding_work_ == 0  (false!)
+      // --outstanding_work == 0 (true)
+      // compleded_.notify_all()          NOT WAITING FOR compleded_ YET!!!!!!!!!!!!!
+      //                                  atomically unlock `lock` and wait for `completed_`
+      //                                                               ^^^^ deadlock
+
+
+      // The brief lock/unlock sequence avoids this scenario:
+      //
+      // worker                           WaitForWork
+      //
+      //                                  lock.lock()
+      //                                  return outstanding_work_ == 0  (false!)
+      // --outstanding_work == 0 (true)
+      // lock.lock()
+      //                                  atomically unlock `lock` and wait for `completed_`
+      //                                                               ^^^^ deadlock
+      // at this point we know that if
+      // anyone was executing WaitForWork
+      // they're not evaluating the
+      // condition but rather waiting on
+      // the condvar
+      //
+      // lock.unlock()
+      // compleded_.notify_all()
+      //                                  continue execution
+
+      lock.lock();
       lock.unlock();
-      completed_.notify_one();
+      completed_.notify_all();
     }
   }
 }

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #ifndef DALI_PIPELINE_UTIL_THREAD_POOL_H_
 #define DALI_PIPELINE_UTIL_THREAD_POOL_H_
 
+#include <atomic>
 #include <cstdlib>
 #include <utility>
 #include <condition_variable>
@@ -87,9 +88,8 @@ class DLL_PUBLIC ThreadPool {
   std::priority_queue<PrioritizedWork, std::vector<PrioritizedWork>, SortByPriority> work_queue_;
 
   bool running_;
-  bool work_complete_;
   bool started_;
-  int active_threads_;
+  std::atomic_int outstanding_work_;
   std::mutex mutex_;
   std::condition_variable condition_;
   std::condition_variable completed_;


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** Optimization

## Description:
This PR optimizes the usage of ThreadPool mutex.
Before we locked the mutex at the end of each task, which led to lock congestion when the threads finished their work in similar time.
With this change, we atomically count the number of outstanding work items and acquire the mutex only once, in the thread executing the final work item.
WaitForWork may skip any locks if the atomic counter has reached 0 before the call, further streamlining execution when latency hiding is used in that thread.

## Additional information:

### Affected modules and functionalities:
CPU operators, decoders.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
ThreadPoolTests
Indirectly - all CPU operator tests with multiple threads.
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [X] Other     **Inline comments inside the tricky code path**
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
