### PR TITLE
Improve creating image batches in CV-CUDA ops

### DIFF
--- a/dali/operators/nvcvop/nvcvop.cc
+++ b/dali/operators/nvcvop/nvcvop.cc
@@ -153,12 +153,14 @@ void AllocateImagesLike(nvcv::ImageBatchVarShape &output, const TensorList<GPUBa
 
 void PushImagesToBatch(nvcv::ImageBatchVarShape &batch, const TensorList<GPUBackend> &t_list) {
   auto channel_dim = t_list.GetLayout().find('C');
+  auto num_channels = (channel_dim >= 0) ? t_list[0].shape()[channel_dim] : 1;
+  auto format = GetImageFormat(t_list.type(), num_channels);
+  std::vector<nvcv::Image> images;
   for (int s = 0; s < t_list.num_samples(); ++s) {
-    auto num_channels = (channel_dim >= 0) ? t_list[s].shape()[channel_dim] : 1;
-    auto format = GetImageFormat(t_list.type(), num_channels);
     auto image = AsImage(t_list[s], format);
-    batch.pushBack(image);
+    images.push_back(image);
   }
+  batch.pushBack(images.begin(), images.end());
 }
 
 nvcv::Tensor AsTensor(const Tensor<GPUBackend> &tensor, TensorLayout layout,

--- a/dali/operators/nvcvop/nvcvop.cc
+++ b/dali/operators/nvcvop/nvcvop.cc
@@ -127,7 +127,7 @@ nvcv::Image WrapImage(void *data, const TensorShape<> &shape, const nvcv::ImageF
 }
 
 nvcv::Image AsImage(const SampleView<GPUBackend> &sample, const nvcv::ImageFormat &format) {
-  auto shape = sample.shape();
+  auto &shape = sample.shape();
   auto data = sample.raw_mutable_data();
   return WrapImage(data, shape, format);
 }

--- a/dali/operators/nvcvop/nvcvop.h
+++ b/dali/operators/nvcvop/nvcvop.h
@@ -84,7 +84,7 @@ nvcv::ImageFormat GetImageFormat(DALIDataType dtype, int num_channels);
  * @param sample sample view
  * @param format image format. It needs to match the shape and data type of the sample view
  */
-nvcv::Image AsImage(SampleView<GPUBackend> sample, const nvcv::ImageFormat &format);
+nvcv::Image AsImage(const SampleView<GPUBackend> &sample, const nvcv::ImageFormat &format);
 
 /**
  * @brief Wrap a const sample view into an nvcv Image
@@ -92,7 +92,7 @@ nvcv::Image AsImage(SampleView<GPUBackend> sample, const nvcv::ImageFormat &form
  * @param sample sample view
  * @param format image format. It needs to match the shape and data type of the sample view
  */
-nvcv::Image AsImage(ConstSampleView<GPUBackend> sample, const nvcv::ImageFormat &format);
+nvcv::Image AsImage(const ConstSampleView<GPUBackend> &sample, const nvcv::ImageFormat &format);
 
 /**
  * @brief Wrap a DALI tensor as an NVCV Tensor


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

**Refactoring**

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

Refactoring to improve Image Batch creation in CV-CUDA ops. 

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

It moves some parts out of the loop. Most notably - pushing an image to the image batch caused event synchronisation, so now there's only one call to `pushImages`

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
