### PR TITLE
Thread pool with semaphore and spinlock

### DIFF
--- a/dali/core/semaphore_test.cc
+++ b/dali/core/semaphore_test.cc
@@ -1,0 +1,174 @@
+// Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <thread>
+#include <vector>
+#include <chrono>
+#include "dali/core/semaphore.h"
+
+namespace dali {
+namespace test {
+
+class SemaphoreTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(SemaphoreTest, BasicAcquireRelease) {
+  counting_semaphore sem(1);
+
+  // Should be able to acquire immediately
+  EXPECT_TRUE(sem.try_acquire());
+
+  // Should not be able to acquire again
+  EXPECT_FALSE(sem.try_acquire());
+
+  // Release and acquire again
+  sem.release();
+  EXPECT_TRUE(sem.try_acquire());
+}
+
+TEST_F(SemaphoreTest, InitialCount) {
+  counting_semaphore sem(3);
+
+  // Should be able to acquire 3 times
+  EXPECT_TRUE(sem.try_acquire());
+  EXPECT_TRUE(sem.try_acquire());
+  EXPECT_TRUE(sem.try_acquire());
+
+  // Should not be able to acquire 4th time
+  EXPECT_FALSE(sem.try_acquire());
+}
+
+TEST_F(SemaphoreTest, ReleaseMultiple) {
+  counting_semaphore sem(0);
+
+  // Should not be able to acquire initially
+  EXPECT_FALSE(sem.try_acquire());
+
+  // Release multiple times
+  sem.release();
+  sem.release();
+  sem.release();
+
+  // Should be able to acquire 3 times
+  EXPECT_TRUE(sem.try_acquire());
+  EXPECT_TRUE(sem.try_acquire());
+  EXPECT_TRUE(sem.try_acquire());
+
+  // Should not be able to acquire 4th time
+  EXPECT_FALSE(sem.try_acquire());
+}
+
+TEST_F(SemaphoreTest, AcquireTimeout) {
+  counting_semaphore sem(0);
+
+  auto start = std::chrono::steady_clock::now();
+  bool acquired = sem.try_acquire_for(std::chrono::milliseconds(10));
+  auto end = std::chrono::steady_clock::now();
+
+  EXPECT_FALSE(acquired);
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  EXPECT_GE(duration.count(), 10);
+}
+
+TEST_F(SemaphoreTest, AcquireUntilTimeout) {
+  counting_semaphore sem(0);
+
+  auto timeout = std::chrono::steady_clock::now() + std::chrono::milliseconds(10);
+  bool acquired = sem.try_acquire_until(timeout);
+
+  EXPECT_FALSE(acquired);
+}
+
+TEST_F(SemaphoreTest, MultiThreadedAcquire) {
+  counting_semaphore sem(0);
+  std::atomic<int> acquired_count{0};
+  std::atomic<bool> should_stop{false};
+
+  // Start consumer threads
+  std::vector<std::thread> consumers;
+  for (int i = 0; i < 3; ++i) {
+    consumers.emplace_back([&sem, &acquired_count, &should_stop]() {
+      while (!should_stop) {
+        if (sem.try_acquire_for(std::chrono::milliseconds(10))) {
+          acquired_count.fetch_add(1);
+        }
+      }
+    });
+  }
+
+  // Producer thread
+  std::thread producer([&sem]() {
+    for (int i = 0; i < 10; ++i) {
+      sem.release();
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  });
+
+  producer.join();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  should_stop = true;
+
+  for (auto& consumer : consumers) {
+    consumer.join();
+  }
+
+  EXPECT_EQ(acquired_count.load(), 10);
+}
+
+
+TEST_F(SemaphoreTest, AcquireUntil) {
+  counting_semaphore sem(0);
+
+  // Consumer thread
+  std::thread consumer([&sem]() {
+    auto timeout = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+    bool acquired = sem.try_acquire_until(timeout);
+    EXPECT_TRUE(acquired);
+  });
+
+  // Producer thread
+  std::thread producer([&sem]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    sem.release();
+  });
+
+  consumer.join();
+  producer.join();
+}
+
+TEST_F(SemaphoreTest, AcquireFor) {
+  counting_semaphore sem(0);
+
+  // Consumer thread
+  std::thread consumer([&sem]() {
+    bool acquired = sem.try_acquire_for(std::chrono::milliseconds(100));
+    EXPECT_TRUE(acquired);
+  });
+
+  // Producer thread
+  std::thread producer([&sem]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    sem.release();
+  });
+
+  consumer.join();
+  producer.join();
+}
+
+}  // namespace test
+}  // namespace dali

--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -27,22 +27,6 @@
 
 namespace dali {
 
-using perf_timer_t = std::chrono::high_resolution_clock;
-
-template <typename T>
-T atomic_max(std::atomic<T> &target, T value) {
-  T old = target;
-  while (old < value && !target.compare_exchange_weak(old, value)) {}
-  return old;
-}
-
-template <typename T>
-T atomic_min(std::atomic<T> &target, T value) {
-  T old = target;
-  while (old > value && !target.compare_exchange_weak(old, value)) {}
-  return old;
-}
-
 ThreadPool::ThreadPool(int num_thread, int device_id, bool set_affinity, const char* name)
     : threads_(num_thread), running_(true), started_(false), outstanding_work_(0) {
   DALI_ENFORCE(num_thread > 0, "Thread pool must have non-zero size");
@@ -95,7 +79,7 @@ void ThreadPool::AddWork(Work work, int64_t priority, bool start_immediately) {
   }
 }
 
-// Blocks until all work issued to the thread pool is   lete
+// Blocks until all work issued to the thread pool is complete
 void ThreadPool::WaitForWork(bool checkForErrors) {
   if (outstanding_work_.load()) {
     std::unique_lock<std::mutex> lock(completed_mutex_);

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -29,6 +29,7 @@
 #if NVML_ENABLED
 #include "dali/util/nvml.h"
 #endif
+#include "dali/core/semaphore.h"
 
 
 namespace dali {
@@ -90,10 +91,9 @@ class DLL_PUBLIC ThreadPool {
   bool running_;
   bool started_;
   std::atomic_int outstanding_work_;
-  std::mutex mutex_;
-  std::condition_variable condition_;
+  std::mutex queue_mutex_, error_mutex_, completed_mutex_;
   std::condition_variable completed_;
-  std::mutex completed_mutex_;
+  dali::counting_semaphore queue_semaphore_{0};
 
   //  Stored error strings for each thread
   vector<std::queue<string>> tl_errors_;

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -89,13 +89,13 @@ class DLL_PUBLIC ThreadPool {
   };
   std::priority_queue<PrioritizedWork, std::vector<PrioritizedWork>, SortByPriority> work_queue_;
 
-  bool running_;
-  bool started_;
-  std::atomic_int outstanding_work_;
-  std::mutex queue_mutex_, error_mutex_, completed_mutex_;
-  spinlock queue_lock_;
-  std::condition_variable completed_;
+  alignas(64) spinlock queue_lock_;
   dali::counting_semaphore queue_semaphore_{0};
+  bool running_ = true;
+  bool started_ = false;
+  alignas(64) std::atomic_int outstanding_work_{0};
+  std::mutex error_mutex_, completed_mutex_;
+  std::condition_variable completed_;
 
   //  Stored error strings for each thread
   vector<std::queue<string>> tl_errors_;

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -30,6 +30,7 @@
 #include "dali/util/nvml.h"
 #endif
 #include "dali/core/semaphore.h"
+#include "dali/core/spinlock.h"
 
 
 namespace dali {
@@ -92,6 +93,7 @@ class DLL_PUBLIC ThreadPool {
   bool started_;
   std::atomic_int outstanding_work_;
   std::mutex queue_mutex_, error_mutex_, completed_mutex_;
+  spinlock queue_lock_;
   std::condition_variable completed_;
   dali::counting_semaphore queue_semaphore_{0};
 

--- a/include/dali/core/semaphore.h
+++ b/include/dali/core/semaphore.h
@@ -1,0 +1,142 @@
+// Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_SEMAPHORE_H_
+#define DALI_CORE_SEMAPHORE_H_
+
+#if __cpp_lib_semaphore >= 201907L
+#include <semaphore>
+
+namespace dali {
+using counting_semaphore = std::counting_semaphore;
+}  // namespace dali
+
+#else
+
+#include <errno.h>
+#include <limits.h>
+#include <semaphore.h>
+#include <time.h>
+#include <cassert>
+#include <chrono>
+#include <cstddef>
+#include <system_error>
+
+namespace dali {
+
+class counting_semaphore {
+ public:
+  explicit counting_semaphore(ptrdiff_t initial_count) {
+    assert(initial_count >= 0 && initial_count <= max());
+    sem_init(&sem, 0, initial_count);
+  }
+  ~counting_semaphore() {
+    sem_destroy(&sem);
+  }
+
+  counting_semaphore(const counting_semaphore &) = delete;
+  counting_semaphore(counting_semaphore &&) = delete;
+  counting_semaphore &operator=(const counting_semaphore &) = delete;
+  counting_semaphore &operator=(counting_semaphore &&) = delete;
+
+  static constexpr ptrdiff_t max() noexcept {
+#ifdef SEM_VALUE_MAX
+    return SEM_VALUE_MAX;
+#else
+    return _POSIX_SEM_VALUE_MAX;
+#endif
+  }
+
+  void acquire() {
+    for (;;) {
+        if (sem_wait(&sem)) {
+          if (errno == EINTR)
+              continue;
+          if (errno == ETIMEDOUT)
+              continue;
+          throw std::system_error(errno, std::generic_category());
+        } else {
+          break;
+        }
+    }
+  }
+
+  void release(ptrdiff_t update = 1) {
+    assert(update >= 0 && update <= max());
+    for (; update > 0; update--) {
+      if (sem_post(&sem))
+          throw std::system_error(errno, std::generic_category());
+    }
+  }
+
+  bool try_acquire() noexcept {
+    for (;;) {
+      if (sem_trywait(&sem)) {
+        if (errno == EINTR)
+          continue;
+        if (errno == EAGAIN)
+          return false;
+        std::terminate();
+      } else {
+        return true;
+      }
+    }
+  }
+
+  template <typename Clock, typename Duration>
+  bool try_acquire_until(const std::chrono::time_point<Clock, Duration> &abs_time) {
+    auto wait_until_time = convert_time(abs_time);
+    auto s = std::chrono::time_point_cast<std::chrono::seconds>(wait_until_time);
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(wait_until_time - s);
+
+    timespec ts = {
+      static_cast<std::time_t>(s.time_since_epoch().count()),
+      static_cast<long>(ns.count())  // NOLINT(runtime/int)
+    };
+
+    for (;;) {
+      if (sem_timedwait(&sem, &ts)) {
+        if (errno == EINTR)
+            continue;
+        if (errno == ETIMEDOUT || errno == EINVAL)
+            return false;
+        throw std::system_error(errno, std::generic_category());
+      } else {
+        return true;
+      }
+    }
+  }
+
+  template <typename Rep, typename Period>
+  bool try_acquire_for(const std::chrono::duration<Rep, Period> &duration) {
+    return try_acquire_until(std::chrono::system_clock::now() + duration);
+  }
+
+ private:
+  template <typename Clock, typename Duration>
+  static auto convert_time(const std::chrono::time_point<Clock, Duration> &time) {
+    if constexpr (std::is_same_v<Clock, std::chrono::system_clock>) {
+      return std::chrono::time_point_cast<std::chrono::system_clock::duration>(time);
+    } else {
+      return std::chrono::system_clock::now() + (time - Clock::now());
+    }
+  }
+  sem_t sem;
+};
+
+}  // namespace dali
+
+#endif
+
+#endif  // DALI_CORE_SEMAPHORE_H_


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)


## Description:
This PR changes the work tracking mechanism in the ThreadPool from a condition variable to a semaphore.
The semaphore is a simple POSIX semaphore wrapped in a C++-20-compatible class.
The use of semaphore avoids the locking of a mutex just to wait on a condition variables.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
New tests: semaphore
Existing tests: thread pool tests
- [X] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
