### PR TITLE
Expose executor policy flags

### DIFF
--- a/dali/pipeline/executor/executor_type.h
+++ b/dali/pipeline/executor/executor_type.h
@@ -40,6 +40,10 @@ constexpr ExecutorFlags operator&(ExecutorFlags a, ExecutorFlags b) {
   return static_cast<ExecutorFlags>(static_cast<int>(a) & static_cast<int>(b));
 }
 
+constexpr ExecutorFlags operator~(ExecutorFlags flags) {
+  return static_cast<ExecutorFlags>(~static_cast<int>(flags));
+}
+
 constexpr bool Test(ExecutorFlags all_flags, ExecutorFlags flags_to_test) {
   return (all_flags & flags_to_test) == flags_to_test;
 }

--- a/dali/python/__init__.py.in
+++ b/dali/python/__init__.py.in
@@ -28,5 +28,5 @@ from . import tfrecord
 from . import types
 from . import plugin_manager
 from . import sysconfig
-from .pipeline import Pipeline, pipeline_def
+from .pipeline import Pipeline, pipeline_def, StreamPolicy, OperatorConcurrency
 from .data_node import newaxis

--- a/dali/python/nvidia/dali/backend.py
+++ b/dali/python/nvidia/dali/backend.py
@@ -40,10 +40,14 @@ import sys
 _ExecutorType.__bool__ = lambda self: self.value != 0
 _ExecutorType.__and__ = lambda x, y: _ExecutorType(x.value & y.value)
 _ExecutorType.__or__ = lambda x, y: _ExecutorType(x.value | y.value)
+_ExecutorType.__xor__ = lambda x, y: _ExecutorType(x.value ^ y.value)
+_ExecutorType.__invert__ = lambda x: _ExecutorType(~x.value)
 
 _ExecutorFlags.__bool__ = lambda self: self.value != 0
 _ExecutorFlags.__and__ = lambda x, y: _ExecutorFlags(x.value & y.value)
 _ExecutorFlags.__or__ = lambda x, y: _ExecutorFlags(x.value | y.value)
+_ExecutorFlags.__xor__ = lambda x, y: _ExecutorFlags(x.value ^ y.value)
+_ExecutorFlags.__invert__ = lambda x: _ExecutorFlags(~x.value)
 
 
 def deprecation_warning(what):

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -81,6 +81,7 @@ class OperatorConcurrency(Enum):
         No concurrency.
     FULL:
         All independent operators will run in parallel.
+        NOTE: Due to internal limitations, CPU operators cannot run in paralle with each other.
     BACKEND:
         Independent operators with different backends will run in parallel.
     """

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -60,17 +60,19 @@ def _show_warning(message):
 class StreamPolicy(Enum):
     """Stream policy for the pipeline.
 
-    PER_OPERATOR:
-        Each operator will have its own stream.
     SINGLE:
         All operators will share a single stream.
     PER_BACKEND:
         Each backend will have its own stream.
+    PER_OPERATOR:
+        The operators that can run in parallel will have distinct streams.
+        The number of streams is kept at minimum required for independent scheduling - for example
+        strictly sequential pipelines will have only one stream.
     """
 
-    PER_OPERATOR = b._ExecutorFlags.StreamPolicyPerOperator
     SINGLE = b._ExecutorFlags.StreamPolicySingle
     PER_BACKEND = b._ExecutorFlags.StreamPolicyPerBackend
+    PER_OPERATOR = b._ExecutorFlags.StreamPolicyPerOperator
     UNSPECIFIED = b._ExecutorFlags.NoFlags
 
 
@@ -79,16 +81,16 @@ class OperatorConcurrency(Enum):
 
     NONE:
         No concurrency.
+    BACKEND:
+        Independent operators with different backends (cpu, gpu, mixed) will run in parallel.
     FULL:
         All independent operators will run in parallel.
         NOTE: Due to internal limitations, CPU operators cannot run in paralle with each other.
-    BACKEND:
-        Independent operators with different backends will run in parallel.
     """
 
     NONE = b._ExecutorFlags.ConcurrencyNone
-    FULL = b._ExecutorFlags.ConcurrencyFull
     BACKEND = b._ExecutorFlags.ConcurrencyBackend
+    FULL = b._ExecutorFlags.ConcurrencyFull
     UNSPECIFIED = b._ExecutorFlags.NoFlags
 
 

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -215,6 +215,8 @@ def DALIIteratorWrapper(
     batch_size=-1,
     prefetch_queue_depth=2,
     exec_dynamic=None,
+    stream_policy=None,
+    concurrency=None,
     **kwargs,
 ):
     """
@@ -290,6 +292,8 @@ def DALIIteratorWrapper(
         gpu_prefetch_queue_depth=gpu_prefetch_queue_depth,
         cpu_prefetch_queue_depth=cpu_prefetch_queue_depth,
         exec_dynamic=exec_dynamic,
+        stream_policy=stream_policy,
+        concurrency=concurrency,
         **kwargs,
     )
     new_out = []
@@ -1018,6 +1022,12 @@ DALIDataset.__doc__ = """Creates a ``DALIDataset`` compatible with
         resistant to uneven execution time of each batch, but it also
         consumes more memory for internal buffers.
         Value will be used with `exec_separated` set to ``True``.
+    stream_policy : nvidia.dali.StreamPolicy, optional, default = None
+        Stream policy (only for dynamic executor).
+        If not specified, the default value is ``StreamPolicy.PER_BACKEND``.
+    concurrency : nvidia.dali.OperatorConcurrency, optional, default = None
+        Operator concurrency policy (only for dynamic executor).
+        If not specified, the default value is ``OperatorConcurrency.BACKEND``.
 
     Returns
     -------


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:
This change exposes the executor's stream policy and operator concurrency policy flags in Python.
The tests check that the flags are set and survive pipeline serialization.
The PipelineParams update was fixed to update the flags separately (otherwise they got cleared).

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [X] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
