### PR TITLE
Improve error handling in ThreadPool

### DIFF
--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -96,7 +96,7 @@ void ThreadPool::WaitForWork(bool checkForErrors) {
         // Throw the first error that occurred
         err = std::move(tl_errors_[i].front());
       }
-      tl_errors_.clear();
+      tl_errors_[i] = {};
     }
     if (err)
       std::rethrow_exception(err);

--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -90,15 +90,16 @@ void ThreadPool::WaitForWork(bool checkForErrors) {
   started_ = false;
   if (checkForErrors) {
     // Check for errors
-    std::lock_guard lock(error_mutex_);
+    std::exception_ptr err;
     for (size_t i = 0; i < threads_.size(); ++i) {
-      if (!tl_errors_[i].empty()) {
+      if (!err && !tl_errors_[i].empty()) {
         // Throw the first error that occurred
-        string error = make_string("Error in thread ", i, ": ", tl_errors_[i].front());
-        tl_errors_[i].pop();
-        throw std::runtime_error(error);
+        err = std::move(tl_errors_[i].front());
       }
+      tl_errors_.clear();
     }
+    if (err)
+      std::rethrow_exception(err);
   }
 }
 
@@ -150,12 +151,8 @@ void ThreadPool::ThreadMain(int thread_id, int device_id, bool set_affinity,
       nvml::SetCPUAffinity(core);
     }
 #endif
-  } catch (std::exception &e) {
-    std::lock_guard lock(error_mutex_);
-    tl_errors_[thread_id].push(e.what());
   } catch (...) {
-    std::lock_guard lock(error_mutex_);
-    tl_errors_[thread_id].push("Caught unknown exception");
+    tl_errors_[thread_id].push(std::current_exception());
   }
 
   while (running_) {
@@ -179,12 +176,8 @@ void ThreadPool::ThreadMain(int thread_id, int device_id, bool set_affinity,
     // in the threads and return an error if one occured.
     try {
       work(thread_id);
-    } catch (std::exception &e) {
-      std::lock_guard lock(error_mutex_);
-      tl_errors_[thread_id].push(e.what());
     } catch (...) {
-      std::lock_guard lock(error_mutex_);
-      tl_errors_[thread_id].push("Caught unknown exception");
+      tl_errors_[thread_id].push(std::current_exception());
     }
 
     // The task is now complete - we can atomically decrement the number of outstanding work.

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -24,6 +24,7 @@
 #include <queue>
 #include <thread>
 #include <vector>
+#include <stdexcept>
 #include <string>
 #include "dali/core/common.h"
 #if NVML_ENABLED
@@ -94,11 +95,11 @@ class DLL_PUBLIC ThreadPool {
   bool running_ = true;
   bool started_ = false;
   alignas(64) std::atomic_int outstanding_work_{0};
-  std::mutex error_mutex_, completed_mutex_;
+  std::mutex completed_mutex_;
   std::condition_variable completed_;
 
-  //  Stored error strings for each thread
-  vector<std::queue<string>> tl_errors_;
+  // Stored error strings for each thread
+  vector<std::queue<std::exception_ptr>> tl_errors_;
 #if NVML_ENABLED
   nvml::NvmlInstance nvml_handle_;
 #endif

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -98,7 +98,7 @@ class DLL_PUBLIC ThreadPool {
   std::mutex completed_mutex_;
   std::condition_variable completed_;
 
-  // Stored error strings for each thread
+  // Stored errors for each thread
   vector<std::queue<std::exception_ptr>> tl_errors_;
 #if NVML_ENABLED
   nvml::NvmlInstance nvml_handle_;


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
This change does the following:
- `ThreadPool` now rethrows the actual exception that happened in worker threads instead of always throwing `std::runtime_error`
- if there are more errors, the other errors are discarded instead of being left for subsequent calls to WaitForWork (this was a bug)
- the `error_mutex_` is removed - each thread has a separate list of errors and the main thread never tries to access the `tl_errors_` when the workers are running.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
