### PR TITLE
Fix static analysis issues

### DIFF
--- a/dali/c_api_2/data_objects_test.cc
+++ b/dali/c_api_2/data_objects_test.cc
@@ -127,11 +127,10 @@ void TestTensorListResize(daliStorageDevice_t storage_device) {
   for (int i = 0; i < 4; i++) {
     daliTensorDesc_t desc{};
     CHECK_DALI(daliTensorListGetTensorDesc(tl, &desc, i));
-    ASSERT_NE(desc.data, nullptr);
     ASSERT_EQ(desc.ndim, 3);
     if (i == 0)
       base = static_cast<char *>(desc.data);
-    EXPECT_EQ(desc.data, base + offset);
+    ASSERT_EQ(desc.data, base + offset);
     EXPECT_EQ(desc.dtype, dtype);
     ASSERT_NE(desc.shape, nullptr);
     for (int j = 0; j < 3; j++)

--- a/dali/c_api_2/data_objects_test.cc
+++ b/dali/c_api_2/data_objects_test.cc
@@ -127,6 +127,7 @@ void TestTensorListResize(daliStorageDevice_t storage_device) {
   for (int i = 0; i < 4; i++) {
     daliTensorDesc_t desc{};
     CHECK_DALI(daliTensorListGetTensorDesc(tl, &desc, i));
+    ASSERT_NE(desc.data, nullptr);
     ASSERT_EQ(desc.ndim, 3);
     if (i == 0)
       base = static_cast<char *>(desc.data);
@@ -525,6 +526,7 @@ void TestTensorResize(daliStorageDevice_t storage_device) {
   daliDataType_t reported_dtype = DALI_NO_TYPE;
   CHECK_DALI(daliTensorGetDType(t, &reported_dtype));
   EXPECT_EQ(reported_dtype, dtype);
+  ASSERT_NE(desc.data, nullptr);
 
   if (storage_device == DALI_STORAGE_GPU) {
     // Check that the data is accessible for the GPU

--- a/dali/kernels/common/utils.h
+++ b/dali/kernels/common/utils.h
@@ -15,7 +15,6 @@
 #ifndef DALI_KERNELS_COMMON_UTILS_H_
 #define DALI_KERNELS_COMMON_UTILS_H_
 
-#include <limits>
 #include <utility>
 #include "dali/core/util.h"
 #include "dali/core/traits.h"
@@ -38,10 +37,10 @@ inline void CalcStrides(Stride *strides, const Extent *shape, int ndim) {
 template <bool outer_first = true, typename Strides, typename Shape>
 DALI_HOST_DEV std::remove_reference_t<decltype(std::declval<Strides>()[0])> CalcStrides(
     Strides &strides, const Shape &shape) {
-#ifndef __CUDA_ARCH__
-  assert(dali::size(shape) <= std::numeric_limits<int>::max());
-#endif
   int ndim = dali::size(shape);
+#ifndef __CUDA_ARCH__
+  assert(ndim >= 0 && ndim == dali::size(shape));
+#endif
   resize_if_possible(strides, ndim);  // no-op if strides is a plain array or std::array
   int64_t ret = 1;
   if (outer_first) {

--- a/dali/kernels/common/utils.h
+++ b/dali/kernels/common/utils.h
@@ -15,6 +15,7 @@
 #ifndef DALI_KERNELS_COMMON_UTILS_H_
 #define DALI_KERNELS_COMMON_UTILS_H_
 
+#include <limits>
 #include <utility>
 #include "dali/core/util.h"
 #include "dali/core/traits.h"
@@ -37,6 +38,9 @@ inline void CalcStrides(Stride *strides, const Extent *shape, int ndim) {
 template <bool outer_first = true, typename Strides, typename Shape>
 DALI_HOST_DEV std::remove_reference_t<decltype(std::declval<Strides>()[0])> CalcStrides(
     Strides &strides, const Shape &shape) {
+#ifndef __CUDA_ARCH__
+  assert(dali::size(shape) <= std::numeric_limits<int>::max());
+#endif
   int ndim = dali::size(shape);
   resize_if_possible(strides, ndim);  // no-op if strides is a plain array or std::array
   int64_t ret = 1;

--- a/dali/kernels/common/utils.h
+++ b/dali/kernels/common/utils.h
@@ -39,8 +39,7 @@ DALI_HOST_DEV std::remove_reference_t<decltype(std::declval<Strides>()[0])> Calc
     Strides &strides, const Shape &shape) {
   int ndim = dali::size(shape);
 #ifndef __CUDA_ARCH__
-  using ndim_size_t = decltype(dali::size(shape));
-  assert(ndim >= 0 && static_cast<ndim_size_t>(ndim) == dali::size(shape));
+  assert(ndim >= 0 && static_cast<decltype(dali::size(shape))>(ndim) == dali::size(shape));
 #endif
   resize_if_possible(strides, ndim);  // no-op if strides is a plain array or std::array
   int64_t ret = 1;

--- a/dali/kernels/common/utils.h
+++ b/dali/kernels/common/utils.h
@@ -39,7 +39,8 @@ DALI_HOST_DEV std::remove_reference_t<decltype(std::declval<Strides>()[0])> Calc
     Strides &strides, const Shape &shape) {
   int ndim = dali::size(shape);
 #ifndef __CUDA_ARCH__
-  assert(ndim >= 0 && ndim == dali::size(shape));
+  using ndim_size_t = decltype(dali::size(shape));
+  assert(ndim >= 0 && static_cast<ndim_size_t>(ndim) == dali::size(shape));
 #endif
   resize_if_possible(strides, ndim);  // no-op if strides is a plain array or std::array
   int64_t ret = 1;

--- a/dali/kernels/imgproc/convolution/convolution_cpu.h
+++ b/dali/kernels/imgproc/convolution/convolution_cpu.h
@@ -342,9 +342,10 @@ template <int axis, bool has_channels, int max_lanes, typename Out, typename In,
 void ConvolveInplaceOuterLoop(Out* out, const In* in, const W* window,
                               const TensorShape<ndim>& shape, const TensorShape<ndim>& strides,
                               int diameter, In* input_window_buffer, const T& transform) {
+  static_assert(0 <= axis && axis < ndim);
   int64_t outer_elements = volume(&shape[0], &shape[axis]);
   int64_t axis_elements = shape[axis];
-  int64_t inner_elements = volume(&shape[axis + 1], &shape[ndim]);
+  int64_t inner_elements = volume(shape.begin() + axis + 1, shape.end());
   assert(strides[axis] == inner_elements);
 
   int64_t strip_size = max_lanes;

--- a/dali/kernels/imgproc/flip_cpu.h
+++ b/dali/kernels/imgproc/flip_cpu.h
@@ -77,7 +77,8 @@ void FlipZAxis(Type *output, const Type *input, size_t depth, size_t height, siz
 template <typename Type>
 void FlipImpl(Type *output, const Type *input,
               TensorShape<sample_ndim> shape, bool flip_z, bool flip_y, bool flip_x) {
-  auto frame_size = volume(&shape[1], &shape[sample_ndim]);
+  static_assert(sample_ndim == 5);
+  auto frame_size = volume(shape.begin() + 1, shape.end());
   if (flip_x || flip_y) {
     for (Index f = 0; f < shape[0]; ++f) {
       OcvFlip(output, input, shape[1], shape[2], shape[3], shape[4], flip_z, flip_y, flip_x);

--- a/dali/kernels/imgproc/flip_cpu.h
+++ b/dali/kernels/imgproc/flip_cpu.h
@@ -77,6 +77,8 @@ void FlipZAxis(Type *output, const Type *input, size_t depth, size_t height, siz
 template <typename Type>
 void FlipImpl(Type *output, const Type *input,
               TensorShape<sample_ndim> shape, bool flip_z, bool flip_y, bool flip_x) {
+  // the kernel here relies on the sample_dim = 5,
+  // the calling op pads the shape to 5 dimensions
   static_assert(sample_ndim == 5);
   auto frame_size = volume(shape.begin() + 1, shape.end());
   if (flip_x || flip_y) {

--- a/dali/kernels/signal/fft/stft_gpu_impl.cu
+++ b/dali/kernels/signal/fft/stft_gpu_impl.cu
@@ -46,7 +46,7 @@ KernelRequirements StftImplGPU::Setup(
   for (int i = 0; i < N; i++) {
     int64_t l = lengths[i];
     int64_t n = args_.num_windows(l);
-    DALI_ENFORCE(n > 0, make_string("Signal is too short (", l,") for sample", i));
+    DALI_ENFORCE(n > 0, make_string("Signal is too short (", l, ") for sample ", i));
     TensorShape<2> ts_in = { n, transform_in_size() };
     TensorShape<2> ts_out = { n, transform_out_size() };
     transform_out_.shape.set_tensor_shape(i, ts_out);

--- a/dali/kernels/signal/fft/stft_gpu_impl.cu
+++ b/dali/kernels/signal/fft/stft_gpu_impl.cu
@@ -46,6 +46,7 @@ KernelRequirements StftImplGPU::Setup(
   for (int i = 0; i < N; i++) {
     int64_t l = lengths[i];
     int64_t n = args_.num_windows(l);
+    DALI_ENFORCE(n > 0, make_string("Signal is too short (", l,") for sample", i));
     TensorShape<2> ts_in = { n, transform_in_size() };
     TensorShape<2> ts_out = { n, transform_out_size() };
     transform_out_.shape.set_tensor_shape(i, ts_out);

--- a/dali/kernels/signal/window/extract_windows_gpu.cuh
+++ b/dali/kernels/signal/window/extract_windows_gpu.cuh
@@ -509,10 +509,11 @@ struct ExtractHorizontalWindowsImplGPU : ExtractWindowsImplGPU<Dst, Src> {
     constexpr int kDefaultBlockSize = 256;
     logical_block_size = kDefaultBlockSize;
     int64_t max_padded_length = 0;
-    int max_win_per_input = 0;
+    int max_win_per_input = 1;
     for (int i = 0; i < N; i++) {
       int64_t length = lengths[i];
       int nwin = args.num_windows(length);
+      assert(nwin >= 1); // the calling operator should have checked that
 
       int64_t padded_length = static_cast<int64_t>(nwin-1) * args.window_step + args.window_length;
       if (padded_length > max_padded_length)

--- a/dali/kernels/signal/window/extract_windows_gpu.cuh
+++ b/dali/kernels/signal/window/extract_windows_gpu.cuh
@@ -509,7 +509,7 @@ struct ExtractHorizontalWindowsImplGPU : ExtractWindowsImplGPU<Dst, Src> {
     constexpr int kDefaultBlockSize = 256;
     logical_block_size = kDefaultBlockSize;
     int64_t max_padded_length = 0;
-    int max_win_per_input = 1;
+    int max_win_per_input = 0;
     for (int i = 0; i < N; i++) {
       int64_t length = lengths[i];
       int nwin = args.num_windows(length);
@@ -526,6 +526,9 @@ struct ExtractHorizontalWindowsImplGPU : ExtractWindowsImplGPU<Dst, Src> {
         out_shape.set_tensor_shape(i, { nwin, out_win_length });
       }
     }
+    // for each sample, the nwin >= 1 is expected
+    // and the op call should be skipped if there are no samples
+    assert(max_win_per_input >= 1);
 
     if (concatenate) {
       out_shape.set_tensor_shape(0, { total_windows, out_win_length });

--- a/dali/kernels/signal/window/extract_windows_gpu.cuh
+++ b/dali/kernels/signal/window/extract_windows_gpu.cuh
@@ -513,7 +513,7 @@ struct ExtractHorizontalWindowsImplGPU : ExtractWindowsImplGPU<Dst, Src> {
     for (int i = 0; i < N; i++) {
       int64_t length = lengths[i];
       int nwin = args.num_windows(length);
-      assert(nwin >= 1); // the calling operator should have checked that
+      assert(nwin >= 1);  // the calling operator should have checked that
 
       int64_t padded_length = static_cast<int64_t>(nwin-1) * args.window_step + args.window_length;
       if (padded_length > max_padded_length)

--- a/dali/operators/decoder/numpy.cc
+++ b/dali/operators/decoder/numpy.cc
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "dali/core/convert.h"
 #include "dali/operators/decoder/numpy.h"

--- a/dali/operators/decoder/numpy.cc
+++ b/dali/operators/decoder/numpy.cc
@@ -111,7 +111,7 @@ bool NumpyDecoder::SetupImpl(std::vector<OutputDesc> &output_desc, const Workspa
       output_shape.set_tensor_shape(sampleIdx, header.shape);
     }
   }
-  output_desc[0].shape = output_shape;
+  output_desc[0].shape = std::move(output_shape);
 
   return true;
 }
@@ -123,7 +123,7 @@ void RunDecoding(SampleView<CPUBackend> outputSample, ConstSampleView<CPUBackend
     transposeBuffer.Resize(outputSample.shape(), inputView.type());
     auto transposeBufferView = SampleView<CPUBackend>(
         transposeBuffer.raw_mutable_data(), transposeBuffer.shape(), transposeBuffer.type());
-    numpy::FromFortranOrder(transposeBufferView, inputView);
+    numpy::FromFortranOrder(std::move(transposeBufferView), inputView);
     inputView = ConstSampleView<CPUBackend>(transposeBuffer.raw_data(), transposeBuffer.shape(),
                                             transposeBuffer.type());
   }
@@ -157,7 +157,7 @@ void NumpyDecoder::RunImpl(Workspace &ws) {
       ConstSampleView<CPUBackend> inputView(
           static_cast<const uint8_t *>(input.raw_tensor(sampleIdx)) + header.data_offset,
           header.shape, header.type());
-      RunDecoding(output[sampleIdx], inputView, header);
+      RunDecoding(output[sampleIdx], std::move(inputView), header);
     });
   }
   tPool.RunAll();

--- a/dali/operators/image/resize/experimental/resize_op_impl_cvcuda.h
+++ b/dali/operators/image/resize/experimental/resize_op_impl_cvcuda.h
@@ -269,9 +269,9 @@ class ResizeOpImplCvCuda : public ResizeBase<GPUBackend>::Impl {
   }
 
   TensorListShape<frame_ndim> in_shape_, out_shape_;
-  int total_frames_;  // number of non-empty frames
+  int total_frames_ = 0;  // number of non-empty frames
   std::vector<ResamplingParamsND<spatial_ndim>> params_;
-  int first_spatial_dim_;
+  int first_spatial_dim_ = 0;
 
   cvcuda::HQResize resize_op_{};
   nvcvop::NVCVOpWorkspace op_workspace_;

--- a/dali/operators/imgcodec/image_decoder.h
+++ b/dali/operators/imgcodec/image_decoder.h
@@ -554,7 +554,6 @@ class ImageDecoder : public StatelessOperator<Backend> {
     st.image_info = st.parsed_sample.nvimgcodec_img_info;
     st.req_layout = "HWC";
     st.req_img_type = format_;
-    auto info = st.parsed_sample.dali_img_info;
     int64_t &nchannels = st.out_shape[2];
     auto decode_shape = st.out_shape;
 

--- a/dali/operators/signal/fft/spectrogram.cc
+++ b/dali/operators/signal/fft/spectrogram.cc
@@ -210,6 +210,10 @@ bool SpectrogramImplCpu<time_major>::SetupImpl(std::vector<OutputDesc> &out_desc
 
   for (int sample_id = 0; sample_id < in_shape.num_samples(); sample_id++) {
     int64_t signal_length = in_shape[sample_id].num_elements();
+    if (signal_length == 0) {
+      DALI_FAIL(make_string("Spectogram does not support empty (0-volume) samples. The sample ",
+                            sample_id, " shape is ", in_shape[sample_id]));
+    }
     DALI_ENFORCE(window_args_.num_windows(signal_length) > 0,
       make_string("Signal is too short (", signal_length, ") for sample ", sample_id));
   }

--- a/dali/operators/signal/fft/spectrogram_gpu.cc
+++ b/dali/operators/signal/fft/spectrogram_gpu.cc
@@ -82,13 +82,16 @@ struct SpectrogramOpImplGPU : public OpImplBase<GPUBackend> {
     TensorListShape<> out_shape;
     in_shape_1D.resize(in_shape.num_samples());
 
+    for (int i = 0; i < in_shape.num_samples(); i++) {
+      if (volume(in_shape.tensor_shape_span(i)) == 0) {
+        DALI_FAIL(make_string("Spectogram does not support empty (0-volume) samples. The sample ",
+                              i, " shape is ", in_shape[i]));
+      }
+    }
+
     int axis = -1;
     if (in_shape.sample_dim() > 1) {
       for (int i = 0; i < in_shape.num_samples(); i++) {
-        if (volume(in_shape.tensor_shape_span(i)) == 0) {
-          in_shape_1D.tensor_shape_span(i)[0] = 0;
-          continue;
-        }
         if (axis < 0) {
           int max_extent = 0;
           // looking for non-degenerate dimension

--- a/dali/operators/video/frames_decoder_gpu.cc
+++ b/dali/operators/video/frames_decoder_gpu.cc
@@ -357,7 +357,6 @@ cudaVideoCodec FramesDecoderGpu::GetCodecType(AVCodecID codec_id) const {
     case AV_CODEC_ID_AV1: return cudaVideoCodec_AV1;
     default: {
       DALI_FAIL(make_string("Unsupported codec type ", avcodec_get_name(codec_id)));
-      return {};
     }
   }
 }
@@ -650,7 +649,7 @@ bool FramesDecoderGpu::ReadNextFrameWithoutIndex(uint8_t *data) {
   current_copy_to_output_ = data != nullptr;
   current_frame_output_ = data;
 
-  int frame_to_return_index = -1;
+  int64_t frame_to_return_index = -1;
 
   // Handle the case, when packet has more frames that we have empty spots
   // in the buffer.

--- a/dali/pipeline/executor/executor2/exec_node_task.cc
+++ b/dali/pipeline/executor/executor2/exec_node_task.cc
@@ -576,8 +576,8 @@ tasking::SharedTask ExecNodeTask::CreateTask(ExecNode *node, const WorkspacePara
   } else {
     int nout = node->outputs.size();
     // the size of outputs is limited by the compile-time operator schema
-    // that uses int for to represent the number of outputs
-    assert(nout >= 0 && nout == node->outputs.size());
+    // that uses int to represent the number of outputs
+    assert(nout >= 0 && static_cast<size_t>(nout) == node->outputs.size());
     return tasking::Task::Create(
       nout,
       OpTask(node, params).GetRunnable());

--- a/dali/pipeline/executor/executor2/exec_node_task.cc
+++ b/dali/pipeline/executor/executor2/exec_node_task.cc
@@ -574,6 +574,9 @@ tasking::SharedTask ExecNodeTask::CreateTask(ExecNode *node, const WorkspacePara
     return tasking::Task::Create(
       OutputTask(node, params).GetRunnable());
   } else {
+    // the size of outputs is limited by the compile-time operator schema
+    // that uses int for to represent the number of outputs
+    assert(node->outputs.size() <= std::numeric_limits<int>::max());
     int nout = node->outputs.size();
     return tasking::Task::Create(
       nout,

--- a/dali/pipeline/executor/executor2/exec_node_task.cc
+++ b/dali/pipeline/executor/executor2/exec_node_task.cc
@@ -574,10 +574,10 @@ tasking::SharedTask ExecNodeTask::CreateTask(ExecNode *node, const WorkspacePara
     return tasking::Task::Create(
       OutputTask(node, params).GetRunnable());
   } else {
+    int nout = node->outputs.size();
     // the size of outputs is limited by the compile-time operator schema
     // that uses int for to represent the number of outputs
-    assert(node->outputs.size() <= std::numeric_limits<int>::max());
-    int nout = node->outputs.size();
+    assert(nout >= 0 && nout == node->outputs.size());
     return tasking::Task::Create(
       nout,
       OpTask(node, params).GetRunnable());

--- a/dali/pipeline/graph/graph2dot.cc
+++ b/dali/pipeline/graph/graph2dot.cc
@@ -98,6 +98,7 @@ void GenerateDOTFromGraph(std::ostream &os, const OpGraph &graph,
         PrintTo(os, *data) << "[label=" << i++ << "];\n";
         for (auto &consumer : data->consumers) {
           PrintTo(os, *data) << " -> ";
+          assert(consumer.op);
           PrintTo(os, *consumer.op) << "[label=" << consumer.idx << "];\n";
         }
       }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2282,7 +2282,7 @@ void ExposeWorkspace(py::module &m) {
   py::class_<PyWorkspace>(m, "_Workspace")
     .def(py::init([](std::shared_ptr<ThreadPool> thread_pool, py::object stream) {
       auto ws = std::make_unique<PyWorkspace>();
-      ws->SetThreadPool(thread_pool);
+      ws->SetThreadPool(std::move(thread_pool));
       if (!stream.is_none()) {
         cudaStream_t s = static_cast<cudaStream_t>(ctypes_void_ptr(stream));
         ws->set_output_order(s);
@@ -2318,7 +2318,7 @@ void ExposeWorkspace(py::module &m) {
       }
     }, "device"_a)
     .def("SetThreadPool", [](PyWorkspace &self, std::shared_ptr<ThreadPool> thread_pool) {
-      self.SetThreadPool(thread_pool);
+      self.SetThreadPool(std::move(thread_pool));
     }, "thread_pool"_a)
     .def("GetOutputs", [](PyWorkspace &self) {
       py::tuple ret(self.NumOutput());

--- a/dali/test/python/operator_2/test_spectrogram.py
+++ b/dali/test/python/operator_2/test_spectrogram.py
@@ -421,22 +421,57 @@ def test_operator_decoder_and_spectrogram():
 
 
 @params(
-    ("cpu",),
-    ("gpu",),
+    *[
+        (device, inp, center)
+        for device in ["cpu", "gpu"]
+        for inp in ["arange", "zero_vol", "empty_batch"]
+        for center in [False, True]
+    ],
 )
-def test_no_windows(device):
+def test_no_windows(device, inp, center):
     def sample(sample_info):
-        return np.arange(sample_info.idx_in_batch + 1, dtype=np.float32)
+        if inp == "arange":
+            return np.arange(sample_info.idx_in_batch + 1, dtype=np.float32)
+        elif inp in ("zero_vol", "empty_batch"):
+            return np.arange(sample_info.idx_in_batch, dtype=np.float32)
+        else:
+            raise AssertionError(f"Invalid input: {inp}")
 
-    @dali.pipeline_def(batch_size=1, num_threads=4, device_id=0)
+    enable_conditionals = inp == "empty_batch"
+
+    @dali.pipeline_def(
+        batch_size=1, num_threads=4, device_id=0, enable_conditionals=enable_conditionals
+    )
     def pipeline(device):
         sig = dali.fn.external_source(source=sample, batch=False)
         if device == "gpu":
             sig = sig.gpu()
-        spec = dali.fn.spectrogram(sig, window_length=512, center_windows=False, window_step=3)
+        if enable_conditionals:
+            dummy = dali.fn.external_source(
+                source=lambda x: np.array(42, dtype=np.int32), batch=False
+            )
+            if dummy < 0:
+                spec = dali.fn.spectrogram(
+                    sig, window_length=512, center_windows=center, window_step=3
+                )
+            else:
+                spec = sig
+        else:
+            spec = dali.fn.spectrogram(sig, window_length=512, center_windows=center, window_step=3)
         return spec
 
     pipe = pipeline(device=device)
     pipe.build()
-    with assert_raises(Exception, glob="Signal is too short"):
+    # empty batch should be supported by any op
+    # and non-empty sample with centered window always ends up
+    # with a positive number of windows
+    if inp == "empty_batch" or (inp == "arange" and center):
         pipe.run()
+    else:
+        error_msg = (
+            "Signal is too short"
+            if inp == "arange"
+            else "Spectogram does not support empty (0-volume) samples"
+        )
+        with assert_raises(RuntimeError, glob=error_msg):
+            pipe.run()

--- a/dali/util/odirect_file.cc
+++ b/dali/util/odirect_file.cc
@@ -101,12 +101,18 @@ ptrdiff_t ODirectFileStream::TellRead() const {
 }
 
 size_t ODirectFileStream::ReadAt(void * buffer, size_t n_bytes, off_t offset) {
-  size_t n_read = pread(fd_, buffer, n_bytes, offset);
+  auto n_read = pread(fd_, buffer, n_bytes, offset);
+  static_assert(std::is_same_v<decltype(n_read), ssize_t>);
+  DALI_ENFORCE(n_read >= 0, make_string(
+               "ReadAt operation failed: ", std::strerror(errno)));
   return n_read;
 }
 
 size_t ODirectFileStream::Read(void *buffer, size_t n_bytes) {
-  size_t n_read = read(fd_, buffer, n_bytes);
+  auto n_read = read(fd_, buffer, n_bytes);
+  static_assert(std::is_same_v<decltype(n_read), ssize_t>);
+  DALI_ENFORCE(n_read >= 0, make_string(
+               "Read operation failed: ", std::strerror(errno)));
   return n_read;
 }
 

--- a/dali/util/odirect_file.cc
+++ b/dali/util/odirect_file.cc
@@ -102,7 +102,6 @@ ptrdiff_t ODirectFileStream::TellRead() const {
 
 size_t ODirectFileStream::ReadAt(void * buffer, size_t n_bytes, off_t offset) {
   auto n_read = pread(fd_, buffer, n_bytes, offset);
-  static_assert(std::is_same_v<decltype(n_read), ssize_t>);
   DALI_ENFORCE(n_read >= 0, make_string(
                "ReadAt operation failed: ", std::strerror(errno)));
   return n_read;
@@ -110,7 +109,6 @@ size_t ODirectFileStream::ReadAt(void * buffer, size_t n_bytes, off_t offset) {
 
 size_t ODirectFileStream::Read(void *buffer, size_t n_bytes) {
   auto n_read = read(fd_, buffer, n_bytes);
-  static_assert(std::is_same_v<decltype(n_read), ssize_t>);
   DALI_ENFORCE(n_read >= 0, make_string(
                "Read operation failed: ", std::strerror(errno)));
   return n_read;

--- a/include/dali/core/mm/detail/free_list.h
+++ b/include/dali/core/mm/detail/free_list.h
@@ -364,6 +364,7 @@ class coalescing_free_list : public best_fit_free_list {
     }
     // found both - glue them and remove one of the blocks
     block *next = *pwhere;
+    assert(!prev || prev->next == next);
     assert((!next || next->start >= static_cast<char*>(ptr) + bytes) &&
           "Free list corruption: current block overlaps with next one.");
     assert((!prev || prev->end <= static_cast<char*>(ptr)) &&

--- a/include/dali/core/permute.h
+++ b/include/dali/core/permute.h
@@ -27,10 +27,10 @@ DALI_NO_EXEC_CHECK
 template <typename OutContainer, typename InContainer, typename Permutation>
 DALI_HOST_DEV
 void permute(OutContainer &&out, const InContainer &in, const Permutation &source_indices) {
-#ifndef __CUDA_ARCH__
-  assert(dali::size(source_indices) <= std::numeric_limits<int>::max());
-#endif
   int n = dali::size(source_indices);
+#ifndef __CUDA_ARCH__
+  assert(n >= 0 && n == dali::size(source_indices));
+#endif
   resize_if_possible(out, n);
 #ifndef __CUDA_ARCH__
   assert(static_cast<int>(dali::size(out)) == n);

--- a/include/dali/core/permute.h
+++ b/include/dali/core/permute.h
@@ -27,6 +27,9 @@ DALI_NO_EXEC_CHECK
 template <typename OutContainer, typename InContainer, typename Permutation>
 DALI_HOST_DEV
 void permute(OutContainer &&out, const InContainer &in, const Permutation &source_indices) {
+#ifndef __CUDA_ARCH__
+  assert(dali::size(source_indices) <= std::numeric_limits<int>::max());
+#endif
   int n = dali::size(source_indices);
   resize_if_possible(out, n);
 #ifndef __CUDA_ARCH__

--- a/include/dali/core/permute.h
+++ b/include/dali/core/permute.h
@@ -29,7 +29,8 @@ DALI_HOST_DEV
 void permute(OutContainer &&out, const InContainer &in, const Permutation &source_indices) {
   int n = dali::size(source_indices);
 #ifndef __CUDA_ARCH__
-  assert(n >= 0 && n == dali::size(source_indices));
+  using n_size_t = decltype(dali::size(source_indices));
+  assert(n >= 0 && static_cast<n_size_t>(n) == dali::size(source_indices));
 #endif
   resize_if_possible(out, n);
 #ifndef __CUDA_ARCH__

--- a/include/dali/core/permute.h
+++ b/include/dali/core/permute.h
@@ -29,8 +29,8 @@ DALI_HOST_DEV
 void permute(OutContainer &&out, const InContainer &in, const Permutation &source_indices) {
   int n = dali::size(source_indices);
 #ifndef __CUDA_ARCH__
-  using n_size_t = decltype(dali::size(source_indices));
-  assert(n >= 0 && static_cast<n_size_t>(n) == dali::size(source_indices));
+  assert(n >= 0 &&
+         static_cast<decltype(dali::size(source_indices))>(n) == dali::size(source_indices));
 #endif
   resize_if_possible(out, n);
 #ifndef __CUDA_ARCH__


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Bug fixes:
* ODirectFileStream Read and ReadAt used to call the unistd read and pread assuming they return type to be unsigned, while they are signed and can return -1 to report error.
* The GPU spectrogram can end up with 0 or negative number of windows if `center_windows=False` is passed. This leads to invalid gpu configuration or plain segfault. Added the check in the setup that enforces num windows to be positive for all samples. The same check was there already for CPU. Added a test for this case. Added assertion in the extract window utilities that echoes this check, as the code seem to rely on the assumption that num_windows >= 1.
* The GPU spectogram does not support empty samples, added validation that prevents from processing zero-vol samples. Added a test covering this case.

Other:
* Changed the `frame_to_return_index` type from int to int64_t. We use 64-bit index type in the loops that assign to frame_to_return_index. @awolant, @JanuszL I am not sure if that's really possible to process so many frames there that int is not enough, but I guess, for host code going with int64_t should have no real perf difference.
* Removed unused `info = st.parsed_sample.dali_img_info;` from nvimgcodec image_decoder.h

Nits:
* Added a couple of std::moves where applicable
* Changed `volume` usages that pass one past last element to mark end of the range from `&shape[ndim]` to `shape.end()` to avoid (even the veneer of) UB coming from accessing the element out of bounds.
* Added assertions to utilities that operate on shape with respect to ndim fitting into int. In TensorShape we use int to represent the ndim anyway, but some of the wrappers along the way (like span) can upcast to size_t.
* Added a couple of gtest assertions in the tests
* Added assert in the free_list to help the tool figure out prev->next is not null.

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4287
<!--- DALI-XXXX or NA --->
