### PR TITLE
Fix stream ordering in Tensor::Copy and Tensor(List)GPU.as_cpu

### DIFF
--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -113,22 +113,29 @@ class Tensor : public Buffer<Backend> {
   inline void Copy(const Tensor<InBackend> &other, AccessOrder order = {}) {
     constexpr bool is_host_to_host = std::is_same<Backend, CPUBackend>::value &&
                                      std::is_same<InBackend, CPUBackend>::value;
+    auto src_order = other.order();
+    auto dst_order = order_;
     if (!order) {
       if (is_host_to_host)
         order = AccessOrder::host();
-      else
-        order = other.order() ? other.order() : order_;
+      else  // use device order, if available; if not, use whichever (dst, src) is set
+        order = dst_order.is_device()
+                ? dst_order
+                : src_order.is_device()
+                  ? src_order
+                  : dst_order ? dst_order : src_order;
     }
     DALI_ENFORCE(!is_host_to_host || !order.is_device(),
                  "Cannot issue a host-to-host copy on a device stream.");
     this->Resize(other.shape(), other.type());
-    order.wait(order_);
+    order.wait(dst_order);  // wait for the destination to avoid overwriting while in use
+    order.wait(other.order());  // wait for the source to avoid reading while not ready
     this->SetLayout(other.GetLayout());
     this->SetSourceInfo(other.GetSourceInfo());
     this->SetSkipSample(other.ShouldSkipSample());
     type_.template Copy<Backend, InBackend>(this->raw_mutable_data(),
         other.raw_data(), this->size(), order.stream());
-    order_.wait(order);
+    dst_order.wait(order);
   }
 
   /**

--- a/dali/pipeline/data/tensor_list.cc
+++ b/dali/pipeline/data/tensor_list.cc
@@ -45,14 +45,17 @@ namespace copy_impl {
  *
  * The copy ordering can be:
  * - explict, as specified in `order`
- * - the one from `src_order`, if set
- * - the one from `dst_order`
+ * - the one from `dst_order`, if set
+ * - the one from `src_order`
  * @return copy_order - order on which we will do the copy
  */
 AccessOrder SyncBefore(AccessOrder dst_order, AccessOrder src_order, AccessOrder order) {
   if (!order)
-    order = src_order ? src_order : dst_order;
-
+    order = dst_order.is_device()
+            ? dst_order
+            : src_order.is_device()
+              ? src_order
+              : dst_order ? dst_order : src_order;
   // The destination buffer must be ready to be overwritten
   order.wait(dst_order);
   // The source buffer must be ready to cosume


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)



## Description:
This PR fixes the lack of synchronization with the source order when copying a tensor.
It also makes sure that CPU tensors returned by `as_cpu` have a proper host order set.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
`test_standalone_op.py`
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
