### PR TITLE
Make semaphore implementation selectable. Default is POSIX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ option(WITH_DYNAMIC_NVIMGCODEC "Links nvimgcodec library dynamically during runt
 option(BUILD_WITH_ASAN "Build with ASAN" OFF)
 option(BUILD_WITH_LSAN "Build with LSAN" OFF)
 option(BUILD_WITH_UBSAN "Build with UBSAN" OFF)
-
+option(BUILD_STD_SEMAPHORE "Whether to use std::counting_semaphore instead of POSIX one." OFF)
 
 # Tests use OpenCV...
 cmake_dependent_option(BUILD_TEST "Build googletest test suite" ON
@@ -403,6 +403,10 @@ endif()
 
 if ("${ARCH}" STREQUAL "aarch64-linux")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a")
+endif()
+
+if (BUILD_STD_SEMAPHORE)
+  add_definitions("-DDALI_USE_STD_SEMAPHORE")
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/include/dali/core/semaphore.h
+++ b/include/dali/core/semaphore.h
@@ -15,9 +15,8 @@
 #ifndef DALI_CORE_SEMAPHORE_H_
 #define DALI_CORE_SEMAPHORE_H_
 
-#if __cpp_lib_semaphore >= 201907L
+#if __cpp_lib_semaphore >= 201907L && DALI_USE_STD_SEMAPHORE
 #include <semaphore>
-
 namespace dali {
 using counting_semaphore = std::counting_semaphore<>;
 }  // namespace dali


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)


## Description:
This PR makes semaphore implementation switchable and default to POSIX (as opposed to whatever C++ std::counting_semaphore uses).
This hopefully fixes a performance regression.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
HW decoder bench
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
CMake option description
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [X] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
