### PR TITLE
Fix Python 3.9 compatibility in imread type annotations

### DIFF
--- a/dali/python/nvidia/dali/experimental/dynamic/_imread.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_imread.py
@@ -17,12 +17,12 @@ imread - A convenience function for reading and decoding images from file paths.
 """
 
 import numpy as np
-from typing import List
+from typing import List, Union
 from ._tensor import Tensor, tensor
 from ._batch import Batch, batch
 
 
-def _imread_impl(filepaths: str | List[str] | Tensor | Batch, device: str = "cpu", **kwargs):
+def _imread_impl(filepaths: Union[str, List[str], Tensor, Batch], device: str = "cpu", **kwargs):
     """
     Reads and decodes an image (or batch of images) from file path(s).
 


### PR DESCRIPTION
Replace PEP 604 union syntax (str | List[str] | ...) with typing.Union in _imread_impl function signature. The pipe operator for type unions was introduced in Python 3.10, causing TypeError on Python 3.9.

Changes:
- Add Union to typing imports
- Replace `str | List[str] | Tensor | Batch` with `Union[str, List[str], Tensor, Batch]`

Fixes import error: "TypeError: unsupported operand type(s) for |: 'type' and '_GenericAlias'" when importing nvidia.dali.experimental.dynamic

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
This PR fixes a Python 3.9 compatibility issue in the `nvidia.dali.experimental.dynamic` module. The `_imread_impl` function used PEP 604 union type syntax (`str | List[str] | Tensor | Batch`), which was introduced in Python 3.10. This caused a `TypeError: unsupported operand type(s) for |: 'type' and '_GenericAlias'` when importing the module in Python 3.9 environments.

The fix replaces the pipe operator union syntax with the `typing.Union` equivalent, which is compatible with Python 3.9 and earlier versions while maintaining the same functionality.


## Additional information:

### Affected modules and functionalities:
- `dali/python/nvidia/dali/experimental/dynamic/_imread.py`: Updated type annotations in `_imread_impl` function signature to use `typing.Union` instead of PEP 604 pipe operator syntax.

### Key points relevant for the review:
- The change is purely syntactic and does not affect functionality
- Ensures backward compatibility with Python 3.9
- Type checking behavior remains identical

### Tests:
- [x] Existing tests apply
  - `dali/test/python/experimental_mode/test_imread.py`: All existing imread tests
  - `dali/test/python/experimental_mode/test_batch.py`: Tests that import nvidia.dali.experimental.dynamic
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A