### PR TITLE
Add proper broadcasting logic to constant_value operator family.

### DIFF
--- a/dali/operators/generic/constant_value.cc
+++ b/dali/operators/generic/constant_value.cc
@@ -87,7 +87,7 @@ void ConstantValue<CPUBackend>::RunImpl(Workspace &ws) {
             auto* out_data = output.mutable_tensor<OutputType>(s);
             auto out_shape = out_shapes.tensor_shape_span(s);
             auto in_shape = fill_value.tensor_shape_span(s);
-            if (in_shape.back() == volume(in_shape)) {
+            if (in_shape.empty() || in_shape.back() == volume(in_shape)) {
               RepeatInner(out_data, volume(out_shape), fill_value_data, volume(in_shape));
             } else {
               TensorShape<> in_strides;

--- a/dali/test/python/operator_1/test_constant_value.py
+++ b/dali/test/python/operator_1/test_constant_value.py
@@ -47,22 +47,51 @@ def test_ones_like():
     np.testing.assert_array_almost_equal(run(fn.ones_like(arr)), np.ones_like(arr))
 
 
-def test_full():
+def test_full_scalar():
     sh = (2, 3, 4)
-    fill_value_sh = (3, 4)
-    fill_value_arr = np.random.uniform(size=fill_value_sh)
-    np.testing.assert_array_almost_equal(
-        run(fn.full(fill_value_arr, shape=sh)), np.full(sh, fill_value_arr)
-    )
+    np.testing.assert_array_almost_equal(run(fn.full(1234, shape=sh)), np.full(sh, 1234))
 
 
-def test_full_broadcast():
+def test_full_broadcast_simple():
     shape = (2, 3)
     data = np.array([1, 2, 3], dtype=np.int32)
+    assert data.shape == (3,)
+    np.testing.assert_array_almost_equal(run(fn.full(data, shape=shape)), np.full(shape, data))
+
+    shape = (2, 4)  # inner extent is a power of 2
+    data = np.array([1, 2, 3, 4], dtype=np.int32)
+    assert data.shape == (4,)
     np.testing.assert_array_almost_equal(run(fn.full(data, shape=shape)), np.full(shape, data))
 
     shape = (3, 2)
     data = np.array([[1], [2], [3]], dtype=np.int32)
+    assert data.shape == (3, 1)
+    np.testing.assert_array_almost_equal(run(fn.full(data, shape=shape)), np.full(shape, data))
+
+
+def test_full_broadcast_complex():
+    shape = (2, 3, 4)
+    # broadcast along middle dim
+    data = np.array([[[1, 2, 3, 4]], [[5, 6, 7, 8]]], dtype=np.int32)
+    assert data.shape == (2, 1, 4)
+    np.testing.assert_array_almost_equal(run(fn.full(data, shape=shape)), np.full(shape, data))
+
+    # broadcast along outer and inner dim, keep middle
+    shape = (2, 3, 4)
+    data = np.array([[[1], [2], [3]]], dtype=np.int32)
+    assert data.shape == (1, 3, 1)
+    np.testing.assert_array_almost_equal(run(fn.full(data, shape=shape)), np.full(shape, data))
+
+    # broadcast along axes 0 and 2
+    shape = (2, 3, 4, 3)
+    data = np.array([[[[1, 2, 3]], [[4, 5, 6]], [[7, 8, 9]]]], dtype=np.int32)
+    assert data.shape == (1, 3, 1, 3)
+    np.testing.assert_array_almost_equal(run(fn.full(data, shape=shape)), np.full(shape, data))
+
+    # broadcast along axes 1 and 3
+    shape = (2, 3, 4, 3)
+    data = np.array([[[[1], [2], [3], [4]]], [[[5], [6], [7], [8]]]], dtype=np.int32)
+    assert data.shape == (2, 1, 4, 1)
     np.testing.assert_array_almost_equal(run(fn.full(data, shape=shape)), np.full(shape, data))
 
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
Previously the data was repeated along the fastest dimension regardless of shape. This was definitely not intended, as it produced unexpected patterns with nontrivial input shapes.
Now the broadcasting follows numpy.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
