### PR TITLE
Refactor package naming: move from flavor-based names to version-based dev differentiation

### DIFF
--- a/dali/python/CMakeLists.txt
+++ b/dali/python/CMakeLists.txt
@@ -41,8 +41,10 @@ endif (PREBUILD_DALI_LIBS)
 
 if (DALI_BUILD_FLAVOR)
   set(DALI_FLAVOR "${DALI_BUILD_FLAVOR} ")
-  set(DALI_FLAVOR_MINUS "-${DALI_BUILD_FLAVOR}")
-  set(DALI_VERSION "${DALI_VERSION}.${TIMESTAMP}")
+  if(NOT "${DALI_VERSION}" MATCHES "dev")
+    message(FATAL_ERROR "Development build must have 'dev' in DALI_VERSION (current value: ${DALI_VERSION})")
+  endif()
+  set(DALI_VERSION "${DALI_VERSION}${TIMESTAMP}")
 endif()
 
 # Add the COPYRIGHT, LICENSE, and Acknowledgements

--- a/dali/python/setup.py.in
+++ b/dali/python/setup.py.in
@@ -14,7 +14,7 @@
 
 from setuptools import setup, find_namespace_packages
 
-setup(name='nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@',
+setup(name='nvidia-dali-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@',
       description='NVIDIA DALI @DALI_FLAVOR@ for CUDA @CUDA_VERSION_SHORT@. Git SHA: @GIT_SHA@',
           long_description='''NVIDIA DALI
 ===========

--- a/dali_tf_plugin/CMakeLists.txt
+++ b/dali_tf_plugin/CMakeLists.txt
@@ -28,8 +28,10 @@ parse_cuda_version(${CUDA_VERSION} CUDA_VERSION_MAJOR CUDA_VERSION_MINOR CUDA_VE
 get_dali_version(${DALI_ROOT}/VERSION DALI_VERSION)
 if (DALI_BUILD_FLAVOR)
   set(DALI_FLAVOR "${DALI_BUILD_FLAVOR} ")
-  set(DALI_FLAVOR_MINUS "-${DALI_BUILD_FLAVOR}")
-  set(DALI_VERSION "${DALI_VERSION}.${TIMESTAMP}")
+  if(NOT "${DALI_VERSION}" MATCHES "dev")
+    message(FATAL_ERROR "Development build must have 'dev' in DALI_VERSION (current value: ${DALI_VERSION})")
+  endif()
+  set(DALI_VERSION "${DALI_VERSION}${TIMESTAMP}")
 endif()
 
 configure_file("${PROJECT_SOURCE_DIR}/setup.py.in" "${PROJECT_BINARY_DIR}/setup.py")

--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -34,7 +34,7 @@ class CustomDistribution(Distribution):
         # to be built for different platforms
         self.ext_modules = [Extension('nvidia.dali_tf_plugin', [])]
 
-setup(name='nvidia-dali-tf-plugin@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@',
+setup(name='nvidia-dali-tf-plugin-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@',
       description='NVIDIA DALI @DALI_FLAVOR@ TensorFlow plugin for CUDA @CUDA_VERSION_SHORT@. Git SHA: @GIT_SHA@',
       long_description='''TensorFlow plugin for NVIDIA DALI
 =================================
@@ -88,7 +88,7 @@ For more details please check the
           'Programming Language :: Python :: 3.13',
           ],
       install_requires = [
-          'nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@==@DALI_VERSION@',
+          'nvidia-dali-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@==@DALI_VERSION@',
           'packaging',
           ],
 

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -69,8 +69,10 @@ set the following environment variables:
   | The default is ``NO``.
 * | PYVER - Python version used to create the runner image with DALI installed inside mentioned above.
   | The default is ``3.10``.
-* DALI_BUILD_FLAVOR - adds a suffix to DALI package name and put a note about it in the whl package
-  description, i.e. `nightly` will result in the `nvidia-dali-nightly`
+* DALI_BUILD_FLAVOR - adds a ``.dev{TIMESTAMP}`` suffix to the DALI package version and puts a note
+  about the build flavor in the whl package description. The package name remains the same as stable
+  releases (e.g., ``nvidia-dali-cuda120``), with only the version number differentiated
+  (e.g., ``1.53.0.dev20251204``)
 * | CMAKE_BUILD_TYPE - build type, available options: Debug, DevDebug, Release, RelWithDebInfo.
   | The default is ``Release``.
 * | STRIP_BINARY - when used with CMAKE_BUILD_TYPE equal to Debug, DevDebug, or RelWithDebInfo it
@@ -367,7 +369,9 @@ To run with sanitizers enabled issue:
 
   STDC_VERSION used by the system. Usually 6.
 
--  ``DALI_BUILD_FLAVOR`` - Allow to specify custom name suffix (i.e. 'nightly') for nvidia-dali whl package
+-  ``DALI_BUILD_FLAVOR`` - Specifies the build flavor (e.g., 'nightly', 'weekly') which adds a
+   ``.dev{TIMESTAMP}`` suffix to the package version and includes the flavor name in the package
+   description. Unlike legacy builds, the package name is not modified (always ``nvidia-dali-cuda*``)
 -  *(Unofficial)* ``BUILD_JPEG_TURBO`` - build with ``libjpeg-turbo`` (default: ON)
 -  *(Unofficial)* ``BUILD_LIBTIFF`` - build with ``libtiff`` (default: ON)
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -130,13 +130,45 @@ pip - Nightly and Weekly Releases
 
 .. note::
 
-  It is recommended to uninstall regular DALI and TensorFlow plugin before installing nightly or weekly
-  builds as they are installed in the same path
+  **New distribution method (starting from version 1.53):** Nightly and weekly builds now use the same
+  package names as stable releases (e.g., ``nvidia-dali-cuda120``, ``nvidia-dali-cuda130``) but are
+  differentiated by a ``.dev{TIMESTAMP}`` suffix in the version number. To install development builds,
+  you need to specify ``--pre`` flag to allow pre-release versions and use the appropriate index URL
+  for the nightly or weekly channel.
 
 Nightly Builds
 ^^^^^^^^^^^^^^
 
-To access most recent nightly builds please use flowing release channel:
+Nightly builds could be published every weekday (with timestamps from Monday to Friday),
+while weekly builds, which undergo more extensive testing, are released on weekends
+(with timestamps from Saturday and Sunday). To access the latest nightly or weekly builds, use
+the following release channel:
+
+* for CUDA 12.0:
+
+.. code-block:: bash
+
+  pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly --upgrade --pre nvidia-dali-cuda120
+  pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly --upgrade --pre nvidia-dali-tf-plugin-cuda120 --no-build-isolation
+
+* for CUDA 13.0:
+
+.. code-block:: bash
+
+  pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly --upgrade --pre nvidia-dali-cuda130
+  pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly --upgrade --pre nvidia-dali-tf-plugin-cuda130 --no-build-isolation
+
+Nightly and Weekly Builds - Legacy Distribution (pre-1.53)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+  **Legacy distribution method:** Prior to version 1.53, nightly and weekly builds used different package
+  names with flavor suffixes (e.g., ``nvidia-dali-nightly-cuda120``, ``nvidia-dali-weekly-cuda130``).
+  This method is deprecated but may still be available for older versions. If you have these legacy
+  packages installed, it is recommended to uninstall them before installing the new unified packages.
+
+Legacy Nightly Builds:
 
 * for CUDA 12.0:
 
@@ -152,12 +184,7 @@ To access most recent nightly builds please use flowing release channel:
   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly --upgrade nvidia-dali-nightly-cuda130
   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly --upgrade nvidia-dali-tf-plugin-nightly-cuda130 --no-build-isolation
 
-
-Weekly Builds
-^^^^^^^^^^^^^
-
-Also, there is a weekly release channel with more thorough testing. To access most recent weekly
-builds please use the following release channel (available only for CUDA 13):
+Legacy Weekly Builds (available only for CUDA 13):
 
 .. code-block:: bash
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -33,8 +33,10 @@ get_dali_version(${DALI_ROOT}/VERSION DALI_VERSION)
 
 if(DALI_BUILD_FLAVOR)
   set(DALI_FLAVOR "${DALI_BUILD_FLAVOR} ")
-  set(DALI_FLAVOR_MINUS "-${DALI_BUILD_FLAVOR}")
-  set(DALI_VERSION "${DALI_VERSION}")
+  if(NOT "${DALI_VERSION}" MATCHES "dev")
+    message(FATAL_ERROR "Development build must have 'dev' in DALI_VERSION (current value: ${DALI_VERSION})")
+  endif()
+  set(DALI_VERSION "${DALI_VERSION}${TIMESTAMP}")
 endif()
 
 add_subdirectory(video)

--- a/plugins/setup.py.in
+++ b/plugins/setup.py.in
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         os.environ["PYTHON_EXECUTABLE"] = sys.executable
 
     skbuild.setup(
-        name="nvidia-dali-@DALI_PLUGIN_NAME@@DALI_FLAVOR_MINUS@",
+        name="nvidia-dali-@DALI_PLUGIN_NAME@",
         description="@DALI_PLUGIN_DESCRIPTION@. For NVIDIA DALI, @DALI_FLAVOR@. Git SHA: @GIT_SHA@",
         url='https://github.com/NVIDIA/DALI',
         version='@DALI_VERSION@',


### PR DESCRIPTION
- Previously, weekly/nightly builds were differentiated by flavor suffix in the
  package name (e.g., nvidia-dali-weekly-cuda*, nvidia-dali-nightly-cuda*).
  This change moves to a unified naming schema where:
  - Package names are consistent regardless of build type (nvidia-dali-cuda*)
  - Dev builds are differentiated by .dev{TIMESTAMP} suffix in version number
  - Stable and dev packages share the same package name, distinguished only by version
- Removes DALI_FLAVOR_MINUS variable from CMakeLists.txt files
- Updates package names to remove flavor suffix:
  - nvidia-dali-cuda* (was nvidia-dali-{flavor}-cuda*)
  - nvidia-dali-tf-plugin-cuda* (was nvidia-dali-tf-plugin-{flavor}-cuda*)
  - nvidia-dali-{plugin} (was nvidia-dali-{plugin}-{flavor})
- Standardizes dev version format: use .dev{TIMESTAMP} instead of .{TIMESTAMP}
- Updates install_requires in TF plugin to match new naming schema
- Updates installation documentation to explain new distribution method:
  - Documents new unified package naming with .dev{TIMESTAMP} version suffix
  - Explains use of --pre flag for installing dev builds
  - Adds legacy distribution section for pre-1.53 builds
  - Clarifies nightly vs weekly build schedule and availability
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- Previously, weekly/nightly builds were differentiated by flavor suffix in the
  package name (e.g., nvidia-dali-weekly-cuda*, nvidia-dali-nightly-cuda*).
  This change moves to a unified naming schema where:
  - Package names are consistent regardless of build type (nvidia-dali-cuda*)
  - Dev builds are differentiated by .dev{TIMESTAMP} suffix in version number
  - Stable and dev packages share the same package name, distinguished only by version
- Removes DALI_FLAVOR_MINUS variable from CMakeLists.txt files
- Updates package names to remove flavor suffix:
  - nvidia-dali-cuda* (was nvidia-dali-{flavor}-cuda*)
  - nvidia-dali-tf-plugin-cuda* (was nvidia-dali-tf-plugin-{flavor}-cuda*)
  - nvidia-dali-{plugin} (was nvidia-dali-{plugin}-{flavor})
- Standardizes dev version format: use .dev{TIMESTAMP} instead of .{TIMESTAMP}
- Updates install_requires in TF plugin to match new naming schema
- Updates installation documentation to explain new distribution method:
  - Documents new unified package naming with .dev{TIMESTAMP} version suffix
  - Explains use of --pre flag for installing dev builds
  - Adds legacy distribution section for pre-1.53 builds
  - Clarifies nightly vs weekly build schedule and availability
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- cmake files
- setup.py.in files
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - nightly build runs
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [x] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
