### PR TITLE
Add USE_PREBUILD_PYBIND11 option to use system pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ cmake_dependent_option(BUILD_PYTHON "Build Python bindings" ON
                        "NOT BUILD_DALI_NODEPS" OFF)
 cmake_dependent_option(BUILD_SHM_WRAPPER "Build shared memory bindings, needs BUILD_PYTHON=ON" ON
                       "NOT BUILD_DALI_NODEPS" OFF)
+cmake_dependent_option(USE_PREBUILD_PYBIND11 "Use prebuilt pybind11 from the system instead of the submodule" OFF
+                       "BUILD_PYTHON" OFF)
 cmake_dependent_option(BUILD_LMDB "Build LMDB readers" ON
                        "NOT BUILD_DALI_NODEPS" OFF)
 cmake_dependent_option(BUILD_JPEG_TURBO "Build with libjpeg-turbo support" ON

--- a/cmake/Dependencies.common.cmake
+++ b/cmake/Dependencies.common.cmake
@@ -83,7 +83,11 @@ endif()
 # PyBind
 ##################################################################
 if (BUILD_PYTHON)
-  check_and_add_cmake_submodule(${PROJECT_SOURCE_DIR}/third_party/pybind11)
+  if (USE_PREBUILD_PYBIND11)
+    find_package(pybind11 REQUIRED)
+  else()
+    check_and_add_cmake_submodule(${PROJECT_SOURCE_DIR}/third_party/pybind11)
+  endif()
 endif()
 
 ##################################################################


### PR DESCRIPTION
- Adds cmake_dependent_option to allow using prebuilt pybind11 from the
  system instead of the submodule. This option depends on BUILD_PYTHON
  being enabled.

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- Adds cmake_dependent_option to allow using prebuilt pybind11 from the
  system instead of the submodule. This option depends on BUILD_PYTHON
  being enabled.
- Thanks to this we can remove https://github.com/conda-forge/nvidia-dali-python-feedstock/blob/main/recipe/patches/0001-BLD-Don-t-revend-pybind11.patch
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- main cmake
- Dependencies.common.cmake
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - the whole build
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
