### PR TITLE
Fix O_DIRECT expected to read number of bytes numpy reader

### DIFF
--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -296,7 +296,7 @@ void NumpyReaderCPU::Prefetch() {
 
       // split data into chunks and copy separately
       auto file = dynamic_cast<ODirectFileStream*>(target->current_file.get());
-      auto read_tail = alignment_offset(target->data_offset + target->nbytes, o_direct_chunk_size_);
+      auto read_tail = alignment_offset(target_data_offset + target->nbytes, o_direct_chunk_size_);
       for (size_t read_offset = 0; read_offset < aligned_len; read_offset += o_direct_chunk_size_) {
         // read whole chunk or just aligned number of blocks to match aligned_len
         auto read_size = std::min(o_direct_chunk_size_, aligned_len - read_offset);


### PR DESCRIPTION
- Fixes calculation of the amount of data that numpy reader
  should read in O_DIRECT mode
- Adds test for O_DIRECT with 4096-byte aligned numpy file headers
  that this change should fix

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- Fixes calculation of the amount of data that numpy reader
  should read in O_DIRECT mode
- Adds test for O_DIRECT with 4096-byte aligned numpy file headers
  that this change should fix
- Related to https://github.com/NVIDIA/DALI/issues/6147
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- numpy reader
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [s] Python tests
    - test_numpy.test_o_direct_alignment
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
