### PR TITLE
Fix enum handling.

### DIFF
--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -250,6 +250,10 @@ class Batch:
         self._device = None
         self._invocation_result = None  # The result of a DALI operator invocation.
         copied = False
+
+        if dtype is not None and not isinstance(dtype, DType):
+            dtype = _dtype(dtype)
+
         if tensors is not None:
             if isinstance(tensors, (_backend.TensorListCPU, _backend.TensorListGPU)):
                 backend_dev = _backend_device(tensors)

--- a/dali/python/setup.py.in
+++ b/dali/python/setup.py.in
@@ -90,6 +90,7 @@ For more details please check the
           'six >= 1.16, <= 1.17',
           'dm-tree <= 0.1.9; python_version>="3.10"',
           'packaging <= 25.0',
+          'numpy',
           'nvtx',
           'makefun',
           @DALI_INSTALL_REQUIRES_NVIMGCODEC@

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -19,6 +19,7 @@ from nose_utils import attr, SkipTest
 from nose2.tools import params
 from nose_utils import assert_raises
 import test_tensor
+import nvidia.dali as dali
 
 
 def asnumpy(batch_or_tensor):
@@ -280,3 +281,45 @@ def test_cross_device_copy():
     g0 = g1.to_device("gpu:0")
     c0 = g0.cpu()
     assert batch_equal(asnumpy(c0), asnumpy(c1))
+
+
+@params(("cpu",), ("gpu",))
+def test_batch_from_enum_auto(device_type):
+    for value, type in [
+        (dali.types.INTERP_CUBIC, ndd.InterpType),
+        (dali.types.YCbCr, ndd.ImageType),
+        (dali.types.INT32, ndd.DataType),
+    ]:
+        t = ndd.Batch([value, value], device=device_type)
+        assert t.dtype == type
+        as_int = ndd.batch(t, dtype=ndd.int32, device="cpu")
+        assert as_int.tensors[0].item() == int(value)
+        assert as_int.tensors[1].item() == int(value)
+
+
+@params(("cpu",), ("gpu",))
+def test_batch_from_enum_with_dtype(device_type):
+    for value, type in [
+        (dali.types.INTERP_CUBIC, ndd.InterpType),
+        (dali.types.YCbCr, ndd.ImageType),
+        (dali.types.INT32, ndd.DataType),
+    ]:
+        t = ndd.Batch([value, value], device=device_type, dtype=type)
+        assert t.dtype == type
+        as_int = ndd.batch(t, dtype=ndd.int32, device="cpu")
+        assert as_int.tensors[0].item() == int(value)
+        assert as_int.tensors[1].item() == int(value)
+
+
+@params(("cpu",), ("gpu",))
+def test_batch_from_enum_value_and_dtype(device_type):
+    for value, type in [
+        (dali.types.INTERP_CUBIC, ndd.InterpType),
+        (dali.types.YCbCr, ndd.ImageType),
+        (dali.types.INT32, ndd.DataType),
+    ]:
+        t = ndd.Batch([int(value), int(value)], device=device_type, dtype=type)
+        assert t.dtype == type
+        as_int = ndd.batch(t, dtype=ndd.int32, device="cpu")
+        assert as_int.tensors[0].item() == int(value)
+        assert as_int.tensors[1].item() == int(value)

--- a/dali/test/python/experimental_mode/test_tensor.py
+++ b/dali/test/python/experimental_mode/test_tensor.py
@@ -17,6 +17,7 @@ import numpy as np
 from nose_utils import SkipTest, attr
 from nose2.tools import params
 import nvidia.dali.backend as _b
+import nvidia.dali as dali
 from nose_utils import assert_raises
 
 
@@ -98,6 +99,45 @@ def test_tensor_converting_constructor(device_type):
     assert np.array_equal(data, asnumpy(orig))
     assert np.array_equal(data_i32, asnumpy(i32))
     assert np.array_equal(data_fp32, asnumpy(fp32))
+
+
+@params(("cpu",), ("gpu",))
+def test_tensor_from_enum_auto(device_type):
+    for value, type in [
+        (dali.types.INTERP_CUBIC, ndd.InterpType),
+        (dali.types.YCbCr, ndd.ImageType),
+        (dali.types.INT32, ndd.DataType),
+    ]:
+        t = ndd.Tensor(value, device=device_type)
+        assert t.dtype == type
+        as_int = ndd.tensor(t, dtype=ndd.int32, device="cpu")
+        assert as_int.item() == int(value)
+
+
+@params(("cpu",), ("gpu",))
+def test_tensor_from_enum_with_dtype(device_type):
+    for value, type in [
+        (dali.types.INTERP_CUBIC, ndd.InterpType),
+        (dali.types.YCbCr, ndd.ImageType),
+        (dali.types.INT32, ndd.DataType),
+    ]:
+        t = ndd.Tensor(value, device=device_type, dtype=type)
+        assert t.dtype == type
+        as_int = ndd.tensor(t, dtype=ndd.int32, device="cpu")
+        assert as_int.item() == int(value)
+
+
+@params(("cpu",), ("gpu",))
+def test_tensor_from_enum_value_and_dtype(device_type):
+    for value, type in [
+        (dali.types.INTERP_CUBIC, ndd.InterpType),
+        (dali.types.YCbCr, ndd.ImageType),
+        (dali.types.INT32, ndd.DataType),
+    ]:
+        t = ndd.Tensor(int(value), device=device_type, dtype=type)
+        assert t.dtype == type
+        as_int = ndd.tensor(t, dtype=ndd.int32, device="cpu")
+        assert as_int.item() == int(value)
 
 
 @params(("cpu",), ("gpu",))


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Other** (dependencies)

## Description:
This PR fixes the handling of DALI enums in NDD tensors and batches.
Prior to this change, when `dtype` was passed to Tensor constructor, DALI enums were not properly converted and an error was raised. This PR fixes that and adds tests for Tensor and Batch.

This PR also adds numpy as an explicit DALI dependency (we require it anyway to perform basic tasks).

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
The tests check that:
a) enums can be converted with automatic type deduction
b) enums can be converted with explicit dtype
c) integers can be converted to enums with explicit dtype
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
