### PR TITLE
Fix slicing with negative stride.

### DIFF
--- a/dali/operators/generic/slice/subscript.h
+++ b/dali/operators/generic/slice/subscript.h
@@ -254,9 +254,6 @@ class TensorSubscript : public StatelessOperator<Backend> {
 
         start_.tensor_shape_span(i)[d] = lo;
 
-        if (step < 0 && !s.hi.IsDefined()) {
-          hi = -1_i64;
-        }
         int64_t out_extent = step > 0 ? div_ceil(hi - lo, step) : div_ceil(lo - hi, -step);
 
         if (out_extent < 0)

--- a/dali/test/python/operator_2/test_subscript.py
+++ b/dali/test/python/operator_2/test_subscript.py
@@ -316,7 +316,7 @@ def test_empty_slice():
 )
 def test_negative_stride(length, ranges):
     def slice_func(x):
-        return x.__getitem__(ranges)
+        return x[ranges]
 
     data = [np.arange(length, dtype=np.int32)]
     src = fn.external_source(lambda: data)


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
This PR fixes the "stop" boundary clamping when slicing with a negative stride.
Prior to this change the "stop" value was clamped to 0 and (should be to -1 due to the exclusive nature of the stop boundary), thus making it impossible to slice the array backwards to the beginning. The only case when it actually worked was a special case when the stop boundary is None (which is, admittedly, the most frequent usage).

## Additional information:

### Affected modules and functionalities:
Subscript operator


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4565
<!--- DALI-XXXX or NA --->
