### PR TITLE
Fix stream handling in tensor join when called from Dynamic mode.

### DIFF
--- a/dali/operators/generic/join.cc
+++ b/dali/operators/generic/join.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -198,8 +198,8 @@ void TensorJoin<Backend, new_axis>::RunImpl(Workspace &ws) {
     TensorListShape<> shape;
     if (new_axis)
       shape = out.shape();
-    out.Copy(ws.Input<Backend>(copy_idx_), ws.has_stream() ? ws.stream()
-                                                                    : AccessOrder::host());
+    constexpr bool use_stream = !std::is_same_v<Backend, CPUBackend>;
+    out.Copy(ws.Input<Backend>(copy_idx_), use_stream ? ws.stream() : AccessOrder::host());
     if (new_axis)
       out.Resize(shape);
     out.SetLayout(output_layout_);

--- a/dali/test/python/experimental_mode/test_tensor.py
+++ b/dali/test/python/experimental_mode/test_tensor.py
@@ -340,3 +340,11 @@ def test_slice_device(device_type):
     assert t[1].device == device
     assert t[0:2].device == device
     assert t[:].device == device
+
+
+def test_join():
+    data = np.array([1, 2, 3, 4], dtype=np.int8)
+    same = ndd.cat(data)
+    assert np.array_equal(data, same)
+    stacked = ndd.stack(data, data)
+    assert np.array_equal(stacked, np.stack([data, data]))


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
TensorJoin operators (stack, cat) have a special case when there's only one non-empty input - in which case it's just copied to the output. It fails in dynamic mode, because it tries to use the workspace stream (it's always present in NDD) to issue a host-to-host copy, which is illegal. This PR fixes this behavior by using the Backend template arg rather than `ws.has_stream()` to make a decision.

The operator worked as expected in Pipeline mode because the executor doesn't supply a stream to CPU operator workspaces.


## Additional information:

### Affected modules and functionalities:
TensorJoin op


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
