### PR TITLE
Fix layout handling in `batch` and `as_batch`.

### DIFF
--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -340,3 +340,33 @@ def test_batch_from_enum_value_and_dtype(device_type):
         as_int = ndd.batch(t, dtype=ndd.int32, device="cpu")
         assert as_int.tensors[0].item() == int(value)
         assert as_int.tensors[1].item() == int(value)
+
+
+@eval_modes()
+@params(("cpu",), ("gpu",))
+def test_batch_from_tensor_and_layout(device_type):
+    x = np.zeros((4, 100, 100, 3), dtype=np.uint8)
+    b = ndd.batch(x, layout="HWC", device=device_type)
+    assert b.layout == "HWC"
+
+
+@eval_modes()
+@params(("cpu",), ("gpu",))
+def test_layout_change(device_type):
+    x = np.zeros((100, 100, 3), dtype=np.uint8)
+    a = ndd.batch([x] * 3, layout="HWC", device=device_type)
+    b = ndd.batch([x] * 3, device=device_type)
+    c = ndd.as_batch(a, layout="XYZ")
+    d = ndd.as_batch(b, layout="ABC")
+    e = ndd.batch(a, layout="XYZ")
+    f = ndd.batch(b, layout="ABC")
+    assert a.layout == "HWC"
+    assert b.layout is None
+    assert c.layout == "XYZ"
+    assert d.layout == "ABC"
+    assert c.device.device_type == device_type
+    assert d.device.device_type == device_type
+    assert e.layout == "XYZ"
+    assert f.layout == "ABC"
+    assert e.device.device_type == device_type
+    assert f.device.device_type == device_type


### PR DESCRIPTION
Fix batch construction from a tensor and layout. Add ability to change batch layout in batch and as_batch.

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
This PR fixes the handling of layouts when creating a batch form a tensor and a layout as well as fixes the (missing) ability to change the layout when passing `Batch` to `batch` and `as_batch` with a new layout.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
