### PR TITLE
Forbid passing axes to expand_dims as an input.

### DIFF
--- a/dali/operators/generic/expand_dims.cc
+++ b/dali/operators/generic/expand_dims.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,8 +39,7 @@ layout will be empty.")code")
   .PassThrough({{0, 0}})
   .AllowSequences()
   .SupportVolumetric()
-  .AddArg("axes", R"code(Indices at which the new dimensions are inserted.)code",
-    DALI_INT_VEC, true)
+  .AddArg("axes", R"code(Indices at which the new dimensions are inserted.)code", DALI_INT_VEC)
   .AddOptionalArg("new_axis_names", R"code(Names of the new dimensions in the data layout.
 
 The length of `new_axis_names` must match the length of `axes`.

--- a/dali/test/python/operator_1/test_expand_dims.py
+++ b/dali/test/python/operator_1/test_expand_dims.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 
 from nvidia.dali import pipeline_def
+import nvidia.dali as dali
 import nvidia.dali.fn as fn
 import numpy as np
 from nose_utils import assert_raises
@@ -121,16 +122,23 @@ def test_expand_dims_throw_error():
             [(10, 20, 30)],
             r"Specifying ``new_axis_names`` requires an input with a proper layout.",
         ),
+        (
+            dali.types.Constant([2], device="cpu"),  # argument input
+            "C",
+            None,
+            [(10, 20, 30)],
+            r"should not be a 'DataNode'",
+        ),
     ]
     for axes, new_axis_names, layout, shapes, err_msg in args:
-        pipe = expand_dims_pipe(
-            batch_size=len(shapes),
-            num_threads=1,
-            device_id=0,
-            shapes=shapes,
-            axes=axes,
-            new_axis_names=new_axis_names,
-            layout=layout,
-        )
-        with assert_raises(RuntimeError, regex=err_msg):
+        with assert_raises((RuntimeError, TypeError), regex=err_msg):
+            pipe = expand_dims_pipe(
+                batch_size=len(shapes),
+                num_threads=1,
+                device_id=0,
+                shapes=shapes,
+                axes=axes,
+                new_axis_names=new_axis_names,
+                layout=layout,
+            )
             pipe.run()


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
This PR removes the erroneous "allow tensor" flag on `axes` parameter to ExpandDims.
This prevented ExpandDims from working in dynamic mode - and passing an input resulted in an unavoidable error.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ X New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
