### PR TITLE
Fix audio decoder to support files over 2GB

### DIFF
--- a/dali/operators/decoder/audio/generic_decoder.cc
+++ b/dali/operators/decoder/audio/generic_decoder.cc
@@ -194,7 +194,7 @@ class GenericAudioDecoder : public AudioDecoderBase {
 
 AudioMetadata GenericAudioDecoder::OpenImpl(span<const char> encoded) {
   assert(!encoded.empty());
-  mem_stream_ = {encoded.data(), static_cast<int>(encoded.size())};
+  mem_stream_ = {encoded.data(), static_cast<int64_t>(encoded.size())};
   SF_VIRTUAL_IO sf_virtual_io = {
           &GetFileLen,
           &Seek,


### PR DESCRIPTION
- Casts the encoded buffer size to int64_t instead of int in
   GenericAudioDecoder::OpenImpl to avoid overflow on files exceeding 2GB.
- Adds a corresponding test for that.

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- Casts the encoded buffer size to int64_t instead of int in
   GenericAudioDecoder::OpenImpl to avoid overflow on files exceeding 2GB.
- Adds a corresponding test for that.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- audio decoder
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- test
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_audio.test_audio_decoder_large_file_over_2gb
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
