### PR TITLE
Accept more types in BBoxRotate input_shape argument.

### DIFF
--- a/dali/test/python/operator_2/test_bbox_rotate.py
+++ b/dali/test/python/operator_2/test_bbox_rotate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -316,7 +316,7 @@ def test_allowed_label_shapes(test_labels_shape: list[int]):
             boxes,
             labels,
             angle=45,
-            input_shape=[255, 255],
+            input_shape=np.int32([255, 255]),
             bbox_layout="xyXY",
             bbox_normalized=False,
         )


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
The argument "input_shape" is defined as a vector of `int32` but when it's an argument input, `int64` is required. This is inconsistent (although compatible with the result of `DataNode.shape()`) and doesn't play well with Dynamic Mode.
This PR adds a type switch to accept all integral types.

## Additional information:

### Affected modules and functionalities:
Operator BBoxRotate



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
One of the pre-existing tests was modified to produce int32 tensor. The test was verified to fail without the fix.
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4602
<!--- DALI-XXXX or NA --->
