### PR TITLE
Remove python tests with forced new executor.

### DIFF
--- a/qa/TL0_python-self-test-core-exec2/test.sh
+++ b/qa/TL0_python-self-test-core-exec2/test.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -e
-export DALI_USE_EXEC2=1
-pushd ../TL0_python-self-test-core
-bash -e ./test_nofw.sh
-bash -e ./test_pytorch.sh
-popd


### PR DESCRIPTION

## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)

## Description:
This PR removes the test configuration which runs Python tests with forced new executor.
New executor has been the default one for quite some time, this test doesn't improve coverage significantly.

## Additional information:

### Affected modules and functionalities:
Tests.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
