### PR TITLE
Improve nvcomp header detection for dynamic nvcomp builds

### DIFF
--- a/cmake/Dependencies.common.cmake
+++ b/cmake/Dependencies.common.cmake
@@ -137,27 +137,28 @@ endif()
 ##################################################################
 set(DALI_INSTALL_REQUIRES_NVCOMP "")
 if(BUILD_NVCOMP)
+  find_path(
+    nvcomp_INCLUDE_DIR
+    NAMES nvcomp
+    PATHS ${NVCOMP_ROOT_DIR} "/usr/local/cuda" "/usr/local" ${CMAKE_SYSTEM_PREFIX_PATH}
+    PATH_SUFFIXES include)
+  if (${nvcomp_INCLUDE_DIR} STREQUAL nvcomp_INCLUDE_DIR-NOTFOUND)
+    message(FATAL_ERROR "nvCOMP headers could not be found. Try to specify nvcomp location with `-DNVCOMP_ROOT_DIR`.")
+  endif()
+  include_directories(SYSTEM ${nvcomp_INCLUDE_DIR})
   if (NOT WITH_DYNAMIC_NVCOMP)
     find_library(
       nvcomp_LIBS
       NAMES nvcomp
       PATHS ${NVCOMP_ROOT_DIR} "/usr/local/cuda" "/usr/local" ${CMAKE_SYSTEM_PREFIX_PATH}
       PATH_SUFFIXES lib lib64)
-    find_path(
-      nvcomp_INCLUDE_DIR
-      NAMES nvcomp
-      PATHS ${NVCOMP_ROOT_DIR} "/usr/local/cuda" "/usr/local" ${CMAKE_SYSTEM_PREFIX_PATH}
-      PATH_SUFFIXES include)
     if(${nvcomp_LIBS} STREQUAL nvcomp_LIBS-NOTFOUND)
       message(FATAL_ERROR "nvCOMP libs could not be found. Try to specify nvcomp location with `-DNVCOMP_ROOT_DIR`.")
     endif()
-    if (${nvcomp_INCLUDE_DIR} STREQUAL nvcomp_INCLUDE_DIR-NOTFOUND)
-      message(FATAL_ERROR "nvCOMP headers could not be found. Try to specify nvcomp location with `-DNVCOMP_ROOT_DIR`.")
-    endif()
     message(STATUS "Found nvCOMP: ${nvcomp_LIBS} ${nvcomp_INCLUDE_DIR}.")
-    include_directories(SYSTEM ${nvcomp_INCLUDE_DIR})
     list(APPEND DALI_LIBS ${nvcomp_LIBS})
   else()
+    message(STATUS "Found nvCOMP: ${nvcomp_INCLUDE_DIR}.")
     set(DALI_INSTALL_REQUIRES_NVCOMP "\'nvidia-libnvcomp-cu${CUDA_VERSION_MAJOR} == 5.1.0.21\',")
     message(STATUS "Adding nvComp requirement as: ${DALI_INSTALL_REQUIRES_NVCOMP}")
   endif()

--- a/dali/core/CMakeLists.txt
+++ b/dali/core/CMakeLists.txt
@@ -104,7 +104,7 @@ if (BUILD_NVCOMP)
       OUTPUT ${NVCOMP_GENERATED_STUB}
       COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py --unique_prefix=nvComp --
                   "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/nvcomp.json" ${NVCOMP_GENERATED_STUB}
-                  "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/nvcomp/lz4.h"
+                  "${nvcomp_INCLUDE_DIR}/nvcomp/lz4.h"
                   ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES_DIRECTIVE}
                   # for some reason QNX fails with 'too many errors emitted' is this is not set
                   "-ferror-limit=0"
@@ -112,7 +112,7 @@ if (BUILD_NVCOMP)
                   "--target=${CMAKE_SYSTEM_PROCESSOR}-linux-gnu"
                   ${DEFAULT_COMPILER_INCLUDE}
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py
-              "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/nvcomp/lz4.h"
+              "${nvcomp_INCLUDE_DIR}/nvcomp/lz4.h"
               "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/nvcomp.json"
       COMMENT "Running nvcomp/lz4.hstub generator"
       VERBATIM)


### PR DESCRIPTION
- Moves nvcomp include directory discovery out of the static-only branch
  so it's available for both static and dynamic nvcomp configurations.
  Use the discovered path in the stub generator instead of assuming
  the CUDA toolkit directory.

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- Moves nvcomp include directory discovery out of the static-only branch
  so it's available for both static and dynamic nvcomp configurations.
  Use the discovered path in the stub generator instead of assuming
  the CUDA toolkit directory.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- CMake files
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_inlfate
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
