### PR TITLE
Fix UB in JpegCompressionDistortion: use data() for past-the-end pointer

### DIFF
--- a/dali/operators/image/distortion/jpeg_compression_distortion_op_cpu.cc
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op_cpu.cc
@@ -97,7 +97,8 @@ void JpegCompressionDistortionCPU::RunImpl(Workspace &ws) {
 
     int64_t nframes =
         volume(shape.begin(), shape.begin() + f_dim + 1);  // note that if f_dim is -1, this
-                                                           // evaluates to an empty range, volume of 1
+                                                           // evaluates to an empty range,
+                                                           // volume of 1
     int64_t frame_size = volume(shape.begin() + f_dim + 1, shape.begin() + ndim);
     int64_t width = shape[w_dim];
     int64_t height = shape[h_dim];


### PR DESCRIPTION
- Replace `&shape[ndim]` and `&shape[0]` with `shape.data() + ndim` and
  `shape.data()` in JpegCompressionDistortionCPU::RunImpl.
- `&shape[ndim]` calls operator[] with an out-of-bounds index before taking
   the address, which is undefined behavior and triggers assertion failures in
   debug builds. Using `shape.data() + ndim` computes the past-the-end pointer
   via pointer arithmetic, which is explicitly permitted by the C++ standard
   ([expr.add]) and is the correct way to form a one-past-the-end pointer
   without dereferencing it.
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- Replace `&shape[ndim]` and `&shape[0]` with `shape.data() + ndim` and
  `shape.data()` in JpegCompressionDistortionCPU::RunImpl.
- `&shape[ndim]` calls operator[] with an out-of-bounds index before taking
   the address, which is undefined behavior and triggers assertion failures in
   debug builds. Using `shape.data() + ndim` computes the past-the-end pointer
   via pointer arithmetic, which is explicitly permitted by the C++ standard
   ([expr.add]) and is the correct way to form a one-past-the-end pointer
   without dereferencing it.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- JPEG CPU distortion
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
