### PR TITLE
Improve DLPack support for external tensor consumption

### DIFF
--- a/dali/pipeline/data/tensor_list.cc
+++ b/dali/pipeline/data/tensor_list.cc
@@ -257,9 +257,11 @@ void TensorList<Backend>::VerifySampleShareCompatibility(DALIDataType type, int 
                            this->GetLayout(), ", new: ", layout, " or come with empty layout ",
                            error_suffix));
 
-  DALI_ENFORCE(this->is_pinned() == pinned,
-               make_string("Sample must have the same pinned status as target batch, current: ",
-                           this->is_pinned(), ", new: ", pinned, error_suffix));
+  if constexpr (std::is_same_v<Backend, CPUBackend>) {
+    DALI_ENFORCE(this->is_pinned() == pinned,
+                 make_string("Sample must have the same pinned status as target batch, current: ",
+                             this->is_pinned(), ", new: ", pinned, error_suffix));
+  }
 
   DALI_ENFORCE(this->device_id() == device_id,
                make_string("Sample must have the same device id as target batch, current: ",

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -983,13 +983,18 @@ TYPED_TEST(TensorListSuite, SetupLikeMultiGPU) {
 template <typename Backend>
 std::vector<std::pair<std::string, std::function<void(TensorList<Backend> &)>>> SetRequiredSetters(
     int sample_dim, DALIDataType type, TensorLayout layout, bool pinned, int device_id) {
-  return {
+  std::vector<std::pair<std::string, std::function<void(TensorList<Backend> &)>>> result = {
       {"sample dim", [sample_dim](TensorList<Backend> &t) { t.set_sample_dim(sample_dim); }},
       {"type", [type](TensorList<Backend> &t) { t.set_type(type); }},
       {"layout", [layout](TensorList<Backend> &t) { t.SetLayout(layout); }},
       {"device id", [device_id](TensorList<Backend> &t) { t.set_device_id(device_id); }},
-      {"pinned", [pinned](TensorList<Backend> &t) { t.set_pinned(pinned); }},
   };
+  // GPU TensorList allows mixed pinned/non-pinned samples in non-contiguous mode
+  // (pinned tensors are valid GPU-accessible staging buffers).
+  if constexpr (std::is_same_v<Backend, CPUBackend>) {
+    result.push_back({"pinned", [pinned](TensorList<Backend> &t) { t.set_pinned(pinned); }});
+  }
+  return result;
 }
 
 TYPED_TEST(TensorListSuite, PartialSetupSetMultiGPU) {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -283,12 +283,12 @@ void FillTensorFromDlPack(
       const std::optional<std::string> &layout) {
   auto dlm_tensor_ptr = DLMTensorPtrFromCapsule(capsule);
   const auto &dl_tensor = dlm_tensor_ptr->dl_tensor;
-  DALI_ENFORCE(
-    (std::is_same<SrcBackend, GPUBackend>::value &&
-      dl_tensor.device.device_type == kDLCUDA) ||
-    (std::is_same<SrcBackend, CPUBackend>::value &&
-      (dl_tensor.device.device_type == kDLCPU || dl_tensor.device.device_type == kDLCUDAHost)),
-    "DLPack device type doesn't match Tensor type");
+  DALI_ENFORCE((std::is_same<SrcBackend, GPUBackend>::value &&
+                  dl_tensor.device.device_type == kDLCUDA) ||
+               (std::is_same<SrcBackend, CPUBackend>::value &&
+                  (dl_tensor.device.device_type == kDLCPU ||
+                   dl_tensor.device.device_type == kDLCUDAHost)),
+               "DLPack device type doesn't match Tensor type");
 
   const TypeInfo &dali_type = TypeTable::GetTypeInfo(ToDALIType(dl_tensor.dtype));
   TensorShape<> shape;

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1489,6 +1489,8 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
         non_contiguous.SetSample(i, t);
       } catch (const py::type_error &) {
         throw;
+      } catch (const py::value_error &) {
+        throw;
       } catch (const std::runtime_error &) {
         auto tensor_type = std::is_same_v<Backend, GPUBackend> ? "TensorGPU." : "TensorCPU.";
         throw py::type_error(

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1295,12 +1295,12 @@ std::shared_ptr<TensorList<CPUBackend>> TensorListFromListOfDLPackObjectsCPU(
   }
 }
 
-std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
+std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjectsGPU(
       py::list &list_of_objects,
       const std::optional<std::string> &layout,
       py::object stream,
       bool contiguous) {
-  DomainTimeRange range("TensorListFromListOfDLPackObjects", kGPUTensorColor);
+  DomainTimeRange range("TensorListFromListOfDLPackObjectsGPU", kGPUTensorColor);
 
   if (list_of_objects.empty()) {
     auto ptr = std::make_shared<TensorList<GPUBackend>>();
@@ -1327,6 +1327,11 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
           "Object at position ", i, " does not support the DLPack protocol."));
     if (py::hasattr(obj, "__dlpack_device__")) {
       py::tuple dev_info = obj.attr("__dlpack_device__")();
+      int dev_type = dev_info[0].cast<int>();
+      if (dev_type != kDLCUDA)
+        throw py::value_error(make_string(
+            "All tensors must reside in GPU memory. "
+            "Tensor at position ", i, " has DLPack device type ", dev_type, "."));
       int dev_id = dev_info[1].cast<int>();
       if (expected_device_id == -1) {
         expected_device_id = dev_id;
@@ -1923,7 +1928,7 @@ void ExposeTesorListGPU(py::module &m) {
           py::object stream = py::none(),
           bool contiguous = false) {
         DomainTimeRange range("TensorListGPU::from_dlpack_list", kGPUTensorColor);
-        return TensorListFromListOfDLPackObjects(list_of_objects, layout, stream, contiguous);
+        return TensorListFromListOfDLPackObjectsGPU(list_of_objects, layout, stream, contiguous);
       },
       "list_of_objects"_a,
       "layout"_a = py::none(),

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1329,6 +1329,15 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
     }
   }
 
+  // If no __dlpack_device__ was found and no explicit stream was provided, fall back to the
+  // current CUDA device so every __dlpack__() call — including tensor 0 — receives a concrete
+  // consumer stream rather than None.
+  if (copy_order == AccessOrder::host()) {
+    int current_dev = -1;
+    CUDA_CALL(cudaGetDevice(&current_dev));
+    copy_order = AccessOrder(UserStream::Get()->GetStream(static_cast<size_t>(current_dev)));
+  }
+
   // Derive the DLPack consumer-stream handle from copy_order so the producer always
   // synchronizes with the exact same stream that DALI will use for the copy.
   py::object stream_handle = py::none();
@@ -1361,11 +1370,6 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
 
       if (i == 0) {
         non_contiguous.SetupLike(tensor);
-        // If __dlpack_device__ was absent for all tensors, fall back to per-tensor UserStream.
-        if (copy_order == AccessOrder::host()) {
-          copy_order = AccessOrder(UserStream::Get()->GetStream(tensor));
-          stream_handle = py::int_(reinterpret_cast<int64_t>(copy_order.stream()));
-        }
         expected_device_id = tensor.device_id();
       } else if (tensor.device_id() != expected_device_id) {
         throw py::value_error(make_string(

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1208,102 +1208,87 @@ std::unique_ptr<Tensor<Backend> > TensorListGetItemImpl(TensorList<Backend> &t, 
   return ptr;
 }
 
-std::shared_ptr<TensorList<CPUBackend>> TensorListFromListOfDLPackObjectsCPU(
-      py::list &list_of_objects,
-      const std::optional<std::string> &layout,
-      bool contiguous) {
-  DomainTimeRange range("TensorListFromListOfDLPackObjectsCPU", kCPUTensorColor);
+template <typename Backend>
+constexpr uint32_t TensorListDLPackRangeColor() {
+  return std::is_same_v<Backend, CPUBackend> ? kCPUTensorColor : kGPUTensorColor;
+}
 
-  if (list_of_objects.empty()) {
-    auto ptr = std::make_shared<TensorList<CPUBackend>>();
-    if (layout.has_value()) {
-      ptr->set_sample_dim(layout->length());
-      ptr->SetLayout(*layout);
-    }
-    return ptr;
-  }
-
-  // Preflight: validate that all elements are CPU tensors before consuming any capsule.
-  // __dlpack__() is single-use, so device mismatches must be caught here — not after
-  // the handshake has started. Throws py::value_error (caught by the Python fast-path
-  // except clause) rather than letting DALI_ENFORCE produce a RuntimeError.
-  for (size_t i = 0; i < list_of_objects.size(); ++i) {
-    py::object obj = list_of_objects[i];
-    if (!py::hasattr(obj, "__dlpack__"))
-      throw py::type_error(make_string(
-          "Object at position ", i, " does not support the DLPack protocol."));
-    if (py::hasattr(obj, "__dlpack_device__")) {
-      py::tuple dev_info = obj.attr("__dlpack_device__")();
-      int dev_type = dev_info[0].cast<int>();
-      if (dev_type != kDLCPU && dev_type != kDLCUDAHost)
-        throw py::value_error(make_string(
-            "All tensors must reside in CPU memory. "
-            "Tensor at position ", i, " has DLPack device type ", dev_type, "."));
-    }
-  }
-
-  std::optional<TensorList<CPUBackend>> non_contiguous_tmp;
-  std::shared_ptr<TensorList<CPUBackend>> non_contiguous_out;
-
-  if (contiguous)
-    non_contiguous_tmp = TensorList<CPUBackend>(list_of_objects.size());
-  else
-    non_contiguous_out = std::make_shared<TensorList<CPUBackend>>(list_of_objects.size());
-
-  TensorList<CPUBackend> &non_contiguous = contiguous
-    ? non_contiguous_tmp.value()
-    : *non_contiguous_out;
-
-  int expected_type = -2;
-
-  {
-    DomainTimeRange build_range("Build initial list", kCPUTensorColor);
-    for (size_t i = 0; i < list_of_objects.size(); ++i) {
-      py::object obj = list_of_objects[i];
-      py::capsule capsule = obj.attr("__dlpack__")();
-      Tensor<CPUBackend> tensor;
-      FillTensorFromDlPack(capsule, &tensor, i == 0 ? layout : std::optional<std::string>{});
-
-      if (i == 0) {
-        non_contiguous.SetupLike(tensor);
-      }
-
-      DALIDataType cur_type = tensor.type();
-      if (expected_type == -2) {
-        expected_type = cur_type;
-      } else if (expected_type != static_cast<int>(cur_type)) {
-        throw py::type_error(make_string(
-            "Tensors cannot have different data types. Tensor at position ", i, " has type '",
-            cur_type, "' expected to have type '", DALIDataType(expected_type), "'."));
-      }
-      non_contiguous.SetSample(i, tensor);
-    }
-  }
-
-  if (!contiguous) {
-    SetLayout(non_contiguous, layout, false);
-    return non_contiguous_out;
-  }
-
-  {
-    DomainTimeRange copy_range("Copy to contiguous", kCPUTensorColor);
-    auto contiguous_out = std::make_shared<TensorList<CPUBackend>>();
-    contiguous_out->SetContiguity(BatchContiguity::Contiguous);
-    contiguous_out->Copy(non_contiguous, AccessOrder::host());
-    SetLayout(*contiguous_out, layout, false);
-    return contiguous_out;
+template <typename Backend>
+const char *TensorListDLPackRangeName() {
+  if constexpr (std::is_same_v<Backend, CPUBackend>) {
+    return "TensorListFromListOfDLPackObjectsCPU";
+  } else {
+    return "TensorListFromListOfDLPackObjectsGPU";
   }
 }
 
-std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjectsGPU(
+template <typename Backend>
+void CheckDLPackDeviceBeforeCapsule(py::object obj, size_t idx,
+                                    int &expected_device_id,
+                                    AccessOrder &copy_order) {
+  if (!py::hasattr(obj, "__dlpack__")) {
+    throw py::type_error(make_string(
+        "Object at position ", idx, " does not support the DLPack protocol."));
+  }
+  if (!py::hasattr(obj, "__dlpack_device__")) {
+    return;
+  }
+
+  py::tuple dev_info = obj.attr("__dlpack_device__")();
+  int dev_type = dev_info[0].cast<int>();
+  if constexpr (std::is_same_v<Backend, CPUBackend>) {
+    (void)expected_device_id;
+    (void)copy_order;
+    if (dev_type != kDLCPU && dev_type != kDLCUDAHost) {
+      throw py::value_error(make_string(
+          "All tensors must reside in CPU memory. "
+          "Tensor at position ", idx, " has DLPack device type ", dev_type, "."));
+    }
+  } else {
+    if (dev_type != kDLCUDA) {
+      throw py::value_error(make_string(
+          "All tensors must reside in GPU memory. "
+          "Tensor at position ", idx, " has DLPack device type ", dev_type, "."));
+    }
+    int dev_id = dev_info[1].cast<int>();
+    if (expected_device_id == -1) {
+      expected_device_id = dev_id;
+      // When no explicit stream was given, look up the UserStream for this device
+      // so every __dlpack__() call below uses the same concrete stream handle.
+      if (copy_order == AccessOrder::host()) {
+        copy_order = AccessOrder(UserStream::Get()->GetStream(
+            static_cast<size_t>(expected_device_id)));
+      }
+    } else if (dev_id != expected_device_id) {
+      throw py::value_error(make_string(
+          "All tensors must reside on the same GPU device. "
+          "Tensor at position ", idx, " is on GPU ", dev_id,
+          " but expected GPU ", expected_device_id, "."));
+    }
+  }
+}
+
+template <typename Backend>
+py::capsule GetDLPackCapsule(py::object obj, py::object stream_handle) {
+  if constexpr (std::is_same_v<Backend, CPUBackend>) {
+    (void)stream_handle;
+    return obj.attr("__dlpack__")();
+  } else {
+    return obj.attr("__dlpack__")("stream"_a = stream_handle);
+  }
+}
+
+template <typename Backend>
+std::shared_ptr<TensorList<Backend>> TensorListFromListOfDLPackObjects(
       py::list &list_of_objects,
       const std::optional<std::string> &layout,
       py::object stream,
       bool contiguous) {
-  DomainTimeRange range("TensorListFromListOfDLPackObjectsGPU", kGPUTensorColor);
+  constexpr uint32_t rangeColor = TensorListDLPackRangeColor<Backend>();
+  DomainTimeRange range(TensorListDLPackRangeName<Backend>(), rangeColor);
 
   if (list_of_objects.empty()) {
-    auto ptr = std::make_shared<TensorList<GPUBackend>>();
+    auto ptr = std::make_shared<TensorList<Backend>>();
     if (layout.has_value()) {
       ptr->set_sample_dim(layout->length());
       ptr->SetLayout(*layout);
@@ -1312,90 +1297,75 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjectsGPU(
   }
 
   AccessOrder copy_order = AccessOrder::host();
-  if (!stream.is_none())
-    copy_order = AccessOrderFromPythonStreamObj(stream);
+  if constexpr (std::is_same_v<Backend, GPUBackend>) {
+    if (!stream.is_none())
+      copy_order = AccessOrderFromPythonStreamObj(stream);
+  }
 
-  // Preflight pass: validate device homogeneity and, when no stream was provided,
-  // resolve the consumer stream via UserStream before any __dlpack__() call.
-  // __dlpack__() is single-use (the capsule is consumed), so device/stream
-  // mismatches must be caught here — not after the handshake has already happened.
+  // Preflight pass: validate device compatibility before consuming any capsule.
+  // __dlpack__() is single-use, so mismatches must be caught before the handshake starts.
   int expected_device_id = -1;
   for (size_t i = 0; i < list_of_objects.size(); ++i) {
     py::object obj = list_of_objects[i];
-    if (!py::hasattr(obj, "__dlpack__"))
-      throw py::type_error(make_string(
-          "Object at position ", i, " does not support the DLPack protocol."));
-    if (py::hasattr(obj, "__dlpack_device__")) {
-      py::tuple dev_info = obj.attr("__dlpack_device__")();
-      int dev_type = dev_info[0].cast<int>();
-      if (dev_type != kDLCUDA)
-        throw py::value_error(make_string(
-            "All tensors must reside in GPU memory. "
-            "Tensor at position ", i, " has DLPack device type ", dev_type, "."));
-      int dev_id = dev_info[1].cast<int>();
-      if (expected_device_id == -1) {
-        expected_device_id = dev_id;
-        // When no explicit stream was given, look up the UserStream for this device
-        // so every __dlpack__() call below uses the same concrete stream handle.
-        if (copy_order == AccessOrder::host())
-          copy_order = AccessOrder(UserStream::Get()->GetStream(
-              static_cast<size_t>(expected_device_id)));
-      } else if (dev_id != expected_device_id) {
-        throw py::value_error(make_string(
-            "All tensors must reside on the same GPU device. "
-            "Tensor at position ", i, " is on GPU ", dev_id,
-            " but expected GPU ", expected_device_id, "."));
-      }
-    }
+    CheckDLPackDeviceBeforeCapsule<Backend>(obj, i, expected_device_id, copy_order);
   }
 
-  // If no __dlpack_device__ was found and no explicit stream was provided, fall back to the
-  // current CUDA device so every __dlpack__() call — including tensor 0 — receives a concrete
-  // consumer stream rather than None.
-  if (copy_order == AccessOrder::host()) {
-    int current_dev = -1;
-    CUDA_CALL(cudaGetDevice(&current_dev));
-    copy_order = AccessOrder(UserStream::Get()->GetStream(static_cast<size_t>(current_dev)));
+  if constexpr (std::is_same_v<Backend, GPUBackend>) {
+    // If no __dlpack_device__ was found and no explicit stream was provided, fall back to the
+    // current CUDA device so every __dlpack__() call receives a concrete consumer stream.
+    if (copy_order == AccessOrder::host()) {
+      int current_dev = -1;
+      CUDA_CALL(cudaGetDevice(&current_dev));
+      copy_order = AccessOrder(UserStream::Get()->GetStream(static_cast<size_t>(current_dev)));
+    }
   }
 
   // Derive the DLPack consumer-stream handle from copy_order so the producer always
   // synchronizes with the exact same stream that DALI will use for the copy.
   py::object stream_handle = py::none();
-  if (copy_order.is_device()) {
-    stream_handle = py::int_(reinterpret_cast<int64_t>(copy_order.stream()));
+  if constexpr (std::is_same_v<Backend, GPUBackend>) {
+    if (copy_order.is_device()) {
+      stream_handle = py::int_(reinterpret_cast<int64_t>(copy_order.stream()));
+    }
   }
 
-  std::optional<TensorList<GPUBackend>> non_contiguous_tmp;
-  std::shared_ptr<TensorList<GPUBackend>> non_contiguous_out;
+  std::optional<TensorList<Backend>> non_contiguous_tmp;
+  std::shared_ptr<TensorList<Backend>> non_contiguous_out;
 
   if (contiguous)
-    non_contiguous_tmp = TensorList<GPUBackend>(list_of_objects.size());
+    non_contiguous_tmp = TensorList<Backend>(list_of_objects.size());
   else
-    non_contiguous_out = std::make_shared<TensorList<GPUBackend>>(list_of_objects.size());
+    non_contiguous_out = std::make_shared<TensorList<Backend>>(list_of_objects.size());
 
-  TensorList<GPUBackend> &non_contiguous = contiguous
+  TensorList<Backend> &non_contiguous = contiguous
     ? non_contiguous_tmp.value()
     : *non_contiguous_out;
 
   int expected_type = -2;
 
   {
-    DomainTimeRange build_range("Build initial list", kGPUTensorColor);
+    DomainTimeRange build_range("Build initial list", rangeColor);
     for (size_t i = 0; i < list_of_objects.size(); ++i) {
       py::object obj = list_of_objects[i];
 
-      py::capsule capsule = obj.attr("__dlpack__")("stream"_a = stream_handle);
-      Tensor<GPUBackend> tensor;
+      py::capsule capsule = GetDLPackCapsule<Backend>(obj, stream_handle);
+      Tensor<Backend> tensor;
       FillTensorFromDlPack(capsule, &tensor, i == 0 ? layout : std::optional<std::string>{});
 
       if (i == 0) {
         non_contiguous.SetupLike(tensor);
-        expected_device_id = tensor.device_id();
-      } else if (tensor.device_id() != expected_device_id) {
-        throw py::value_error(make_string(
-            "All tensors must reside on the same GPU device. "
-            "Tensor at position ", i, " is on GPU ", tensor.device_id(),
-            " but expected GPU ", expected_device_id, "."));
+        if constexpr (std::is_same_v<Backend, GPUBackend>) {
+          expected_device_id = tensor.device_id();
+        }
+      } else {
+        if constexpr (std::is_same_v<Backend, GPUBackend>) {
+          if (tensor.device_id() != expected_device_id) {
+            throw py::value_error(make_string(
+                "All tensors must reside on the same GPU device. "
+                "Tensor at position ", i, " is on GPU ", tensor.device_id(),
+                " but expected GPU ", expected_device_id, "."));
+          }
+        }
       }
 
       DALIDataType cur_type = tensor.type();
@@ -1412,21 +1382,44 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjectsGPU(
 
   if (!contiguous) {
     SetLayout(non_contiguous, layout, false);
-    // Record which stream holds the data so downstream consumers can synchronize correctly.
-    non_contiguous_out->set_order(copy_order);
+    if constexpr (std::is_same_v<Backend, GPUBackend>) {
+      // Record which stream holds the data so downstream consumers can synchronize correctly.
+      non_contiguous_out->set_order(copy_order);
+    }
     return non_contiguous_out;
   }
 
   {
-    DomainTimeRange copy_range("Copy to contiguous", kGPUTensorColor);
-    auto contiguous_out = std::make_shared<TensorList<GPUBackend>>();
+    DomainTimeRange copy_range("Copy to contiguous", rangeColor);
+    auto contiguous_out = std::make_shared<TensorList<Backend>>();
     contiguous_out->SetContiguity(BatchContiguity::Contiguous);
-    contiguous_out->set_pinned(non_contiguous.is_pinned());
+    if constexpr (std::is_same_v<Backend, GPUBackend>) {
+      contiguous_out->set_pinned(non_contiguous.is_pinned());
+    }
     contiguous_out->Copy(non_contiguous, copy_order);
     SetLayout(*contiguous_out, layout, false);
-    contiguous_out->set_order(copy_order);
+    if constexpr (std::is_same_v<Backend, GPUBackend>) {
+      contiguous_out->set_order(copy_order);
+    }
     return contiguous_out;
   }
+}
+
+std::shared_ptr<TensorList<CPUBackend>> TensorListFromListOfDLPackObjectsCPU(
+      py::list &list_of_objects,
+      const std::optional<std::string> &layout,
+      bool contiguous) {
+  return TensorListFromListOfDLPackObjects<CPUBackend>(
+      list_of_objects, layout, py::none(), contiguous);
+}
+
+std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjectsGPU(
+      py::list &list_of_objects,
+      const std::optional<std::string> &layout,
+      py::object stream,
+      bool contiguous) {
+  return TensorListFromListOfDLPackObjects<GPUBackend>(
+      list_of_objects, layout, stream, contiguous);
 }
 
 template <typename Backend>

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1492,9 +1492,9 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
       } catch (const py::type_error &) {
         throw;
       } catch (const std::runtime_error &) {
-        auto tensor_type = std::is_same_v<Backend, GPUBackend> ? "GPU." : "CPU.";
+        auto tensor_type = std::is_same_v<Backend, GPUBackend> ? "TensorGPU." : "TensorCPU.";
         throw py::type_error(
-            make_string("Object at position ", i, " cannot be converted to Tensor ", tensor_type));
+            make_string("Object at position ", i, " cannot be converted to ", tensor_type));
       }
     }
   }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1383,7 +1383,7 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfDLPackObjects(
       } else {
         if constexpr (std::is_same_v<Backend, GPUBackend>) {
           if (tensor.device_id() != expected_device_id) {
-            throw py::value_error(make_string(
+            throw std::runtime_error(make_string(
                 "All tensors must reside on the same GPU device. "
                 "Tensor at position ", i, " is on GPU ", tensor.device_id(),
                 " but expected GPU ", expected_device_id, "."));

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1362,6 +1362,8 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
 
   if (!contiguous) {
     SetLayout(non_contiguous, layout, false);
+    // Record which stream holds the data so downstream consumers can synchronize correctly.
+    non_contiguous_out->set_order(copy_order);
     return non_contiguous_out;
   }
 
@@ -1372,6 +1374,7 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
     contiguous_out->set_pinned(non_contiguous.is_pinned());
     contiguous_out->Copy(non_contiguous, copy_order);
     SetLayout(*contiguous_out, layout, false);
+    contiguous_out->set_order(copy_order);
     return contiguous_out;
   }
 }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1441,7 +1441,6 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
   int expected_type = -2;
   int expected_device_id = -1;
 
-  AccessOrder wait_order = AccessOrder::host();
   AccessOrder copy_order = AccessOrder::host();
 
   {
@@ -1488,7 +1487,6 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
     SetLayout(non_contiguous, layout, false);
     if constexpr (std::is_same_v<Backend, GPUBackend>)
       non_contiguous_out->set_order(copy_order);
-    copy_order.wait(wait_order);
     return non_contiguous_out;
   }
 
@@ -1501,7 +1499,6 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
     SetLayout(*contiguous_out, layout, false);
     if constexpr (std::is_same_v<Backend, GPUBackend>)
       contiguous_out->set_order(copy_order);
-    copy_order.wait(wait_order);
     return contiguous_out;
   }
 }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1223,6 +1223,25 @@ std::shared_ptr<TensorList<CPUBackend>> TensorListFromListOfDLPackObjectsCPU(
     return ptr;
   }
 
+  // Preflight: validate that all elements are CPU tensors before consuming any capsule.
+  // __dlpack__() is single-use, so device mismatches must be caught here — not after
+  // the handshake has started. Throws py::value_error (caught by the Python fast-path
+  // except clause) rather than letting DALI_ENFORCE produce a RuntimeError.
+  for (size_t i = 0; i < list_of_objects.size(); ++i) {
+    py::object obj = list_of_objects[i];
+    if (!py::hasattr(obj, "__dlpack__"))
+      throw py::type_error(make_string(
+          "Object at position ", i, " does not support the DLPack protocol."));
+    if (py::hasattr(obj, "__dlpack_device__")) {
+      py::tuple dev_info = obj.attr("__dlpack_device__")();
+      int dev_type = dev_info[0].cast<int>();
+      if (dev_type != kDLCPU && dev_type != kDLCUDAHost)
+        throw py::value_error(make_string(
+            "All tensors must reside in CPU memory. "
+            "Tensor at position ", i, " has DLPack device type ", dev_type, "."));
+    }
+  }
+
   std::optional<TensorList<CPUBackend>> non_contiguous_tmp;
   std::shared_ptr<TensorList<CPUBackend>> non_contiguous_out;
 
@@ -1241,10 +1260,6 @@ std::shared_ptr<TensorList<CPUBackend>> TensorListFromListOfDLPackObjectsCPU(
     DomainTimeRange build_range("Build initial list", kCPUTensorColor);
     for (size_t i = 0; i < list_of_objects.size(); ++i) {
       py::object obj = list_of_objects[i];
-      if (!py::hasattr(obj, "__dlpack__"))
-        throw py::type_error(make_string(
-            "Object at position ", i, " does not support the DLPack protocol."));
-
       py::capsule capsule = obj.attr("__dlpack__")();
       Tensor<CPUBackend> tensor;
       FillTensorFromDlPack(capsule, &tensor, i == 0 ? layout : std::optional<std::string>{});

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1300,15 +1300,13 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
   if (!stream.is_none())
     copy_order = AccessOrderFromPythonStreamObj(stream);
 
-  // __dlpack__ expects an integer stream handle; extract it from the stream wrapper object
+  // Derive the DLPack consumer-stream handle from copy_order so the producer always
+  // synchronizes with the exact same stream that DALI will use for the copy.
+  // Using copy_order (not the raw Python stream object) avoids mismatches when the
+  // stream wrapper type exposes its handle under a name other than "handle".
   py::object stream_handle = py::none();
-  if (!stream.is_none()) {
-    auto h = getattr(stream, "handle", py::none());
-    if (!h.is_none())
-      stream_handle = h;
-    else if (py::isinstance<py::int_>(stream))
-      stream_handle = stream;
-    // else: unknown stream type - leave stream_handle as None
+  if (copy_order.is_device()) {
+    stream_handle = py::int_(reinterpret_cast<int64_t>(copy_order.stream()));
   }
 
   std::optional<TensorList<GPUBackend>> non_contiguous_tmp;

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1492,7 +1492,7 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
       } catch (const py::type_error &) {
         throw;
       } catch (const std::runtime_error &) {
-        throw py::type_error(make_string("Object at position ", i, " cannot be converted to Tensor",
+        throw py::type_error(make_string("Object at position ", i, " cannot be converted to Tensor ",
                                          std::is_same_v<Backend, GPUBackend> ? "GPU." : "CPU."));
       }
     }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1486,6 +1486,8 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
 
   if (!contiguous) {
     SetLayout(non_contiguous, layout, false);
+    if constexpr (std::is_same_v<Backend, GPUBackend>)
+      non_contiguous_out->set_order(copy_order);
     copy_order.wait(wait_order);
     return non_contiguous_out;
   }
@@ -1497,6 +1499,8 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
     contiguous_out->set_pinned(non_contiguous.is_pinned());
     contiguous_out->Copy(non_contiguous, copy_order);
     SetLayout(*contiguous_out, layout, false);
+    if constexpr (std::is_same_v<Backend, GPUBackend>)
+      contiguous_out->set_order(copy_order);
     copy_order.wait(wait_order);
     return contiguous_out;
   }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1343,14 +1343,37 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfDLPackObjects(
 
   int expected_type = -2;
 
+  // Acquire all DLPack capsules and validate dtype consistency before consuming any of them.
+  // The capsule destructor restores ownership to the producer if a capsule is dropped before
+  // FillTensorFromDlPack consumes it, so a dtype-mismatch error here leaves the slow-path
+  // fallback in _batch.py free to re-call __dlpack__() without hitting a partially-consumed
+  // list of capsules.
+  std::vector<py::capsule> capsules;
+  capsules.reserve(list_of_objects.size());
   {
-    DomainTimeRange build_range("Build initial list", rangeColor);
+    DomainTimeRange peek_range("Peek dtypes", rangeColor);
     for (size_t i = 0; i < list_of_objects.size(); ++i) {
       py::object obj = list_of_objects[i];
-
       py::capsule capsule = GetDLPackCapsule<Backend>(obj, stream_handle);
+      DLManagedTensor *dlm_peek = DLMTensorRawPtrFromCapsule(capsule, /* consume */ false);
+      DALIDataType cur_type = ToDALIType(dlm_peek->dl_tensor.dtype);
+      if (expected_type == -2) {
+        expected_type = cur_type;
+      } else if (expected_type != static_cast<int>(cur_type)) {
+        throw py::type_error(make_string(
+            "Tensors cannot have different data types. Tensor at position ", i, " has type '",
+            cur_type, "' expected to have type '", DALIDataType(expected_type), "'."));
+      }
+      capsules.push_back(std::move(capsule));
+    }
+  }
+
+  {
+    DomainTimeRange build_range("Build initial list", rangeColor);
+    for (size_t i = 0; i < capsules.size(); ++i) {
       Tensor<Backend> tensor;
-      FillTensorFromDlPack(capsule, &tensor, i == 0 ? layout : std::optional<std::string>{});
+      FillTensorFromDlPack(capsules[i], &tensor,
+                           i == 0 ? layout : std::optional<std::string>{});
 
       if (i == 0) {
         non_contiguous.SetupLike(tensor);
@@ -1366,15 +1389,6 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfDLPackObjects(
                 " but expected GPU ", expected_device_id, "."));
           }
         }
-      }
-
-      DALIDataType cur_type = tensor.type();
-      if (expected_type == -2) {
-        expected_type = cur_type;
-      } else if (expected_type != static_cast<int>(cur_type)) {
-        throw py::type_error(make_string(
-            "Tensors cannot have different data types. Tensor at position ", i, " has type '",
-            cur_type, "' expected to have type '", DALIDataType(expected_type), "'."));
       }
       non_contiguous.SetSample(i, tensor);
     }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1492,8 +1492,9 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
       } catch (const py::type_error &) {
         throw;
       } catch (const std::runtime_error &) {
-        throw py::type_error(make_string("Object at position ", i, " cannot be converted to Tensor ",
-                                         std::is_same_v<Backend, GPUBackend> ? "GPU." : "CPU."));
+        auto tensor_type = std::is_same_v<Backend, GPUBackend> ? "GPU." : "CPU.";
+        throw py::type_error(
+            make_string("Object at position ", i, " cannot be converted to Tensor ", tensor_type));
       }
     }
   }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1208,6 +1208,100 @@ std::unique_ptr<Tensor<Backend> > TensorListGetItemImpl(TensorList<Backend> &t, 
   return ptr;
 }
 
+std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
+      py::list &list_of_objects,
+      const std::optional<std::string> &layout,
+      py::object stream,
+      bool contiguous) {
+  DomainTimeRange range("TensorListFromListOfDLPackObjects", kGPUTensorColor);
+
+  if (list_of_objects.empty()) {
+    auto ptr = std::make_shared<TensorList<GPUBackend>>();
+    if (layout.has_value()) {
+      ptr->set_sample_dim(layout->length());
+      ptr->SetLayout(*layout);
+    }
+    return ptr;
+  }
+
+  AccessOrder copy_order = AccessOrder::host();
+  if (!stream.is_none())
+    copy_order = AccessOrderFromPythonStreamObj(stream);
+
+  // __dlpack__ expects an integer stream handle; extract it from the stream wrapper object
+  py::object stream_handle = py::none();
+  if (!stream.is_none()) {
+    auto h = getattr(stream, "handle", py::none());
+    stream_handle = h.is_none() ? stream : h;
+  }
+
+  std::optional<TensorList<GPUBackend>> non_contiguous_tmp;
+  std::shared_ptr<TensorList<GPUBackend>> non_contiguous_out;
+
+  if (contiguous)
+    non_contiguous_tmp = TensorList<GPUBackend>(list_of_objects.size());
+  else
+    non_contiguous_out = std::make_shared<TensorList<GPUBackend>>(list_of_objects.size());
+
+  TensorList<GPUBackend> &non_contiguous = contiguous
+    ? non_contiguous_tmp.value()
+    : *non_contiguous_out;
+
+  int expected_type = -2;
+  int expected_device_id = -1;
+
+  {
+    DomainTimeRange build_range("Build initial list", kGPUTensorColor);
+    for (size_t i = 0; i < list_of_objects.size(); ++i) {
+      py::object obj = list_of_objects[i];
+      if (!py::hasattr(obj, "__dlpack__"))
+        throw py::type_error(make_string(
+            "Object at position ", i, " does not support the DLPack protocol."));
+
+      py::capsule capsule = obj.attr("__dlpack__")("stream"_a = stream_handle);
+      Tensor<GPUBackend> tensor;
+      FillTensorFromDlPack(capsule, &tensor, i == 0 ? layout : std::optional<std::string>{});
+
+      if (i == 0) {
+        non_contiguous.SetupLike(tensor);
+        if (copy_order == AccessOrder::host())
+          copy_order = AccessOrder(UserStream::Get()->GetStream(tensor));
+        expected_device_id = tensor.device_id();
+      } else if (tensor.device_id() != expected_device_id) {
+        throw py::value_error(make_string(
+            "All tensors must reside on the same GPU device. "
+            "Tensor at position ", i, " is on GPU ", tensor.device_id(),
+            " but expected GPU ", expected_device_id, "."));
+      }
+
+      DALIDataType cur_type = tensor.type();
+      if (expected_type == -2) {
+        expected_type = cur_type;
+      } else if (expected_type != static_cast<int>(cur_type)) {
+        throw py::type_error(make_string(
+            "Tensors cannot have different data types. Tensor at position ", i, " has type '",
+            cur_type, "' expected to have type '", DALIDataType(expected_type), "'."));
+      }
+      non_contiguous.SetSample(i, tensor);
+    }
+  }
+
+  if (!contiguous) {
+    SetLayout(non_contiguous, layout, false);
+    return non_contiguous_out;
+  }
+
+  {
+    DomainTimeRange copy_range("Copy to contiguous", kGPUTensorColor);
+    auto contiguous_out = std::make_shared<TensorList<GPUBackend>>();
+    contiguous_out->SetContiguity(BatchContiguity::Contiguous);
+    contiguous_out->set_pinned(non_contiguous.is_pinned());
+    contiguous_out->Copy(non_contiguous, copy_order);
+    SetLayout(*contiguous_out, layout, false);
+    return contiguous_out;
+  }
+}
+
 template <typename Backend>
 std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
       py::list &list_of_tensors,
@@ -1238,6 +1332,7 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
     : *non_contiguous_out;
 
   int expected_type = -2;
+  int expected_device_id = -1;
 
   AccessOrder wait_order = AccessOrder::host();
   AccessOrder copy_order = AccessOrder::host();
@@ -1252,6 +1347,7 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
           non_contiguous.SetupLike(t);
           if constexpr (std::is_same_v<Backend, GPUBackend>) {
             copy_order = AccessOrder(UserStream::Get()->GetStream(t));
+            expected_device_id = t.device_id();
           }
         }
         DALIDataType cur_type = t.type();
@@ -1262,6 +1358,14 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(
           throw py::type_error(make_string(
               "Tensors cannot have different data types. Tensor at position ", i, " has type '",
               cur_type, "' expected to have type '", DALIDataType(expected_type), "'."));
+        }
+        if constexpr (std::is_same_v<Backend, GPUBackend>) {
+          if (t.device_id() != expected_device_id) {
+            throw py::value_error(make_string(
+                "All tensors must reside on the same GPU device. "
+                "Tensor at position ", i, " is on GPU ", t.device_id(),
+                " but expected GPU ", expected_device_id, "."));
+          }
         }
         non_contiguous.SetSample(i, t);
       } catch (const py::type_error &) {
@@ -1668,6 +1772,30 @@ void ExposeTesorListGPU(py::module &m) {
       contiguous : bool = True
             If True, the list of tensors is converted to a contiguous TensorListGPU, necessarily
             creating a copy. Otherwise, the copy may be avoided.
+      )code")
+    .def(py::init([](
+          py::list &list_of_objects,
+          std::optional<std::string> layout = {},
+          py::object stream = py::none(),
+          bool contiguous = false) {
+        DomainTimeRange range("TensorListGPU::init from a list of DLPack objects", kGPUTensorColor);
+        return TensorListFromListOfDLPackObjects(list_of_objects, layout, stream, contiguous);
+      }),
+      "list_of_objects"_a,
+      "layout"_a = py::none(),
+      "stream"_a = py::none(),
+      "contiguous"_a = false,
+      R"code(
+      List of tensors residing in the GPU memory, constructed from a Python list of DLPack objects.
+
+      list_of_objects : list
+            Python list of objects supporting the DLPack protocol (e.g. PyTorch GPU tensors)
+      layout : str
+            Layout of the data
+      stream : stream, optional
+            CUDA stream used for the DLPack export handshake
+      contiguous : bool, default False
+            If True, samples are copied into a single contiguous GPU buffer
       )code")
     .def(py::init([](const py::object &object,
                      const std::optional<std::string> &layout = {},

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1300,10 +1300,37 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
   if (!stream.is_none())
     copy_order = AccessOrderFromPythonStreamObj(stream);
 
+  // Preflight pass: validate device homogeneity and, when no stream was provided,
+  // resolve the consumer stream via UserStream before any __dlpack__() call.
+  // __dlpack__() is single-use (the capsule is consumed), so device/stream
+  // mismatches must be caught here — not after the handshake has already happened.
+  int expected_device_id = -1;
+  for (size_t i = 0; i < list_of_objects.size(); ++i) {
+    py::object obj = list_of_objects[i];
+    if (!py::hasattr(obj, "__dlpack__"))
+      throw py::type_error(make_string(
+          "Object at position ", i, " does not support the DLPack protocol."));
+    if (py::hasattr(obj, "__dlpack_device__")) {
+      py::tuple dev_info = obj.attr("__dlpack_device__")();
+      int dev_id = dev_info[1].cast<int>();
+      if (expected_device_id == -1) {
+        expected_device_id = dev_id;
+        // When no explicit stream was given, look up the UserStream for this device
+        // so every __dlpack__() call below uses the same concrete stream handle.
+        if (copy_order == AccessOrder::host())
+          copy_order = AccessOrder(UserStream::Get()->GetStream(
+              static_cast<size_t>(expected_device_id)));
+      } else if (dev_id != expected_device_id) {
+        throw py::value_error(make_string(
+            "All tensors must reside on the same GPU device. "
+            "Tensor at position ", i, " is on GPU ", dev_id,
+            " but expected GPU ", expected_device_id, "."));
+      }
+    }
+  }
+
   // Derive the DLPack consumer-stream handle from copy_order so the producer always
   // synchronizes with the exact same stream that DALI will use for the copy.
-  // Using copy_order (not the raw Python stream object) avoids mismatches when the
-  // stream wrapper type exposes its handle under a name other than "handle".
   py::object stream_handle = py::none();
   if (copy_order.is_device()) {
     stream_handle = py::int_(reinterpret_cast<int64_t>(copy_order.stream()));
@@ -1322,15 +1349,11 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
     : *non_contiguous_out;
 
   int expected_type = -2;
-  int expected_device_id = -1;
 
   {
     DomainTimeRange build_range("Build initial list", kGPUTensorColor);
     for (size_t i = 0; i < list_of_objects.size(); ++i) {
       py::object obj = list_of_objects[i];
-      if (!py::hasattr(obj, "__dlpack__"))
-        throw py::type_error(make_string(
-            "Object at position ", i, " does not support the DLPack protocol."));
 
       py::capsule capsule = obj.attr("__dlpack__")("stream"_a = stream_handle);
       Tensor<GPUBackend> tensor;
@@ -1338,8 +1361,11 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
 
       if (i == 0) {
         non_contiguous.SetupLike(tensor);
-        if (copy_order == AccessOrder::host())
+        // If __dlpack_device__ was absent for all tensors, fall back to per-tensor UserStream.
+        if (copy_order == AccessOrder::host()) {
           copy_order = AccessOrder(UserStream::Get()->GetStream(tensor));
+          stream_handle = py::int_(reinterpret_cast<int64_t>(copy_order.stream()));
+        }
         expected_device_id = tensor.device_id();
       } else if (tensor.device_id() != expected_device_id) {
         throw py::value_error(make_string(

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1208,6 +1208,78 @@ std::unique_ptr<Tensor<Backend> > TensorListGetItemImpl(TensorList<Backend> &t, 
   return ptr;
 }
 
+std::shared_ptr<TensorList<CPUBackend>> TensorListFromListOfDLPackObjectsCPU(
+      py::list &list_of_objects,
+      const std::optional<std::string> &layout,
+      bool contiguous) {
+  DomainTimeRange range("TensorListFromListOfDLPackObjectsCPU", kCPUTensorColor);
+
+  if (list_of_objects.empty()) {
+    auto ptr = std::make_shared<TensorList<CPUBackend>>();
+    if (layout.has_value()) {
+      ptr->set_sample_dim(layout->length());
+      ptr->SetLayout(*layout);
+    }
+    return ptr;
+  }
+
+  std::optional<TensorList<CPUBackend>> non_contiguous_tmp;
+  std::shared_ptr<TensorList<CPUBackend>> non_contiguous_out;
+
+  if (contiguous)
+    non_contiguous_tmp = TensorList<CPUBackend>(list_of_objects.size());
+  else
+    non_contiguous_out = std::make_shared<TensorList<CPUBackend>>(list_of_objects.size());
+
+  TensorList<CPUBackend> &non_contiguous = contiguous
+    ? non_contiguous_tmp.value()
+    : *non_contiguous_out;
+
+  int expected_type = -2;
+
+  {
+    DomainTimeRange build_range("Build initial list", kCPUTensorColor);
+    for (size_t i = 0; i < list_of_objects.size(); ++i) {
+      py::object obj = list_of_objects[i];
+      if (!py::hasattr(obj, "__dlpack__"))
+        throw py::type_error(make_string(
+            "Object at position ", i, " does not support the DLPack protocol."));
+
+      py::capsule capsule = obj.attr("__dlpack__")();
+      Tensor<CPUBackend> tensor;
+      FillTensorFromDlPack(capsule, &tensor, i == 0 ? layout : std::optional<std::string>{});
+
+      if (i == 0) {
+        non_contiguous.SetupLike(tensor);
+      }
+
+      DALIDataType cur_type = tensor.type();
+      if (expected_type == -2) {
+        expected_type = cur_type;
+      } else if (expected_type != static_cast<int>(cur_type)) {
+        throw py::type_error(make_string(
+            "Tensors cannot have different data types. Tensor at position ", i, " has type '",
+            cur_type, "' expected to have type '", DALIDataType(expected_type), "'."));
+      }
+      non_contiguous.SetSample(i, tensor);
+    }
+  }
+
+  if (!contiguous) {
+    SetLayout(non_contiguous, layout, false);
+    return non_contiguous_out;
+  }
+
+  {
+    DomainTimeRange copy_range("Copy to contiguous", kCPUTensorColor);
+    auto contiguous_out = std::make_shared<TensorList<CPUBackend>>();
+    contiguous_out->SetContiguity(BatchContiguity::Contiguous);
+    contiguous_out->Copy(non_contiguous, AccessOrder::host());
+    SetLayout(*contiguous_out, layout, false);
+    return contiguous_out;
+  }
+}
+
 std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
       py::list &list_of_objects,
       const std::optional<std::string> &layout,
@@ -1232,7 +1304,11 @@ std::shared_ptr<TensorList<GPUBackend>> TensorListFromListOfDLPackObjects(
   py::object stream_handle = py::none();
   if (!stream.is_none()) {
     auto h = getattr(stream, "handle", py::none());
-    stream_handle = h.is_none() ? stream : h;
+    if (!h.is_none())
+      stream_handle = h;
+    else if (py::isinstance<py::int_>(stream))
+      stream_handle = stream;
+    // else: unknown stream type - leave stream_handle as None
   }
 
   std::optional<TensorList<GPUBackend>> non_contiguous_tmp;
@@ -1507,6 +1583,26 @@ void ExposeTensorListCPU(py::module &m) {
             If True, the list of tensors is converted to a contiguous TensorListCPU, necessarily
             creating a copy. Otherwise, the copy may be avoided.
       )code")
+    .def_static("from_dlpack_list", [](
+          py::list &list_of_objects,
+          std::optional<std::string> layout = {},
+          bool contiguous = false) {
+        DomainTimeRange range("TensorListCPU::from_dlpack_list", kCPUTensorColor);
+        return TensorListFromListOfDLPackObjectsCPU(list_of_objects, layout, contiguous);
+      },
+      "list_of_objects"_a,
+      "layout"_a = py::none(),
+      "contiguous"_a = false,
+      R"code(
+      List of tensors residing in the CPU memory, constructed from a Python list of DLPack objects.
+
+      list_of_objects : list
+            Python list of objects supporting the DLPack protocol (e.g. CPU tensors)
+      layout : str
+            Layout of the data
+      contiguous : bool, default False
+            If True, samples are copied into a single contiguous CPU buffer
+      )code")
     .def_static("broadcast", [](const Tensor<CPUBackend> &t, int num_samples) {
         return std::make_shared<TensorList<CPUBackend>>(t, num_samples);
       })
@@ -1773,14 +1869,14 @@ void ExposeTesorListGPU(py::module &m) {
             If True, the list of tensors is converted to a contiguous TensorListGPU, necessarily
             creating a copy. Otherwise, the copy may be avoided.
       )code")
-    .def(py::init([](
+    .def_static("from_dlpack_list", [](
           py::list &list_of_objects,
           std::optional<std::string> layout = {},
           py::object stream = py::none(),
           bool contiguous = false) {
-        DomainTimeRange range("TensorListGPU::init from a list of DLPack objects", kGPUTensorColor);
+        DomainTimeRange range("TensorListGPU::from_dlpack_list", kGPUTensorColor);
         return TensorListFromListOfDLPackObjects(list_of_objects, layout, stream, contiguous);
-      }),
+      },
       "list_of_objects"_a,
       "layout"_a = py::none(),
       "stream"_a = py::none(),

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -369,7 +369,7 @@ class Batch:
                                     stream=cuda_stream,
                                     contiguous=False,
                                 )
-                            except (TypeError, ValueError, BufferError):
+                            except (TypeError, ValueError):
                                 pass  # fall through to slow path
                             else:
                                 if dtype is None or DType.from_type_id(storage.dtype) == dtype:

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -382,7 +382,7 @@ class Batch:
                                     dtype = self._dtype
                                     layout = self._layout
                                     fast_path_used = True
-                    elif int(dl_dev_type) == 1:  # kDLCPU
+                    elif int(dl_dev_type) in (1, 3):  # kDLCPU or kDLCUDAHost (pinned)
                         if device is None or device.device_type == "cpu":
                             try:
                                 storage = _backend.TensorListCPU.from_dlpack_list(

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -369,7 +369,7 @@ class Batch:
                                     stream=cuda_stream,
                                     contiguous=False,
                                 )
-                            except TypeError:
+                            except (TypeError, ValueError, BufferError):
                                 pass  # fall through to slow path
                             else:
                                 if dtype is None or DType.from_type_id(storage.dtype) == dtype:
@@ -390,7 +390,7 @@ class Batch:
                                     layout=layout or None,
                                     contiguous=False,
                                 )
-                            except TypeError:
+                            except (TypeError, ValueError, BufferError):
                                 pass  # fall through to slow path
                             else:
                                 if dtype is None or DType.from_type_id(storage.dtype) == dtype:

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -284,104 +284,129 @@ class Batch:
 
             else:
                 # Materialise first so len() and indexing work for any iterable.
-                _tensors_list = tensors if isinstance(tensors, list) else list(tensors)
-                _fast_path_used = False
+                tensors_list = tensors if isinstance(tensors, list) else list(tensors)
+                fast_path_used = False
 
                 # Native DALI fast path: list of evaluated ndd.Tensor objects.
                 # Build TensorList directly from backend storage objects, preserving all
                 # metadata (layout, enum types, etc.) without going through DLPack.
                 if (
-                    dtype is None
-                    and len(_tensors_list) > 0
-                    and isinstance(_tensors_list[0], Tensor)
-                    and _tensors_list[0]._storage is not None
+                    len(tensors_list) > 0
+                    and isinstance(tensors_list[0], Tensor)
+                    and tensors_list[0]._storage is not None
                 ):
-                    _first_storage = _tensors_list[0]._storage
-                    _storages = []
-                    _native_valid = True
-                    for _t in _tensors_list:
+                    first_storage = tensors_list[0]._storage
+                    first_dev_id = (
+                        first_storage.device_id()
+                        if isinstance(first_storage, _backend.TensorGPU)
+                        else None
+                    )
+                    storages = []
+                    for t in tensors_list:
                         if (
-                            not isinstance(_t, Tensor)
-                            or _t._storage is None
-                            or type(_t._storage) is not type(_first_storage)
+                            not isinstance(t, Tensor)
+                            or t._storage is None
+                            or type(t._storage) is not type(first_storage)
+                            or (first_dev_id is not None and t._storage.device_id() != first_dev_id)
+                            or (dtype is not None and DType.from_type_id(t._storage.dtype) != dtype)
                         ):
-                            _native_valid = False
                             break
-                        _storages.append(_t._storage)
-                    if _native_valid:
-                        if isinstance(_first_storage, _backend.TensorGPU):
-                            _dev_id = _first_storage.device_id()
-                            _dev_matches = device is None or (
-                                device.device_type == "gpu" and device.device_id == _dev_id
+                        storages.append(t._storage)
+                    else:
+                        if isinstance(first_storage, _backend.TensorGPU):
+                            dev_matches = device is None or (
+                                device.device_type == "gpu" and device.device_id == first_dev_id
                             )
-                            _backend_type = _backend.TensorListGPU
-                            _dev = Device("gpu", _dev_id)
+                            BackendType = _backend.TensorListGPU
+                            dev = Device("gpu", first_dev_id)
                         else:
-                            _dev_matches = device is None or device.device_type == "cpu"
-                            _backend_type = _backend.TensorListCPU
-                            _dev = Device("cpu")
-                        if _dev_matches:
+                            dev_matches = device is None or device.device_type == "cpu"
+                            BackendType = _backend.TensorListCPU
+                            dev = Device("cpu")
+                        if dev_matches:
                             try:
-                                _storage = _backend_type(
-                                    _storages, layout=layout or None, contiguous=False
+                                storage = BackendType(
+                                    storages, layout=layout or None, contiguous=False
                                 )
                             except (TypeError, RuntimeError):
                                 pass  # fall through to slow path
                             else:
-                                self._storage = _storage
-                                self._device = _dev
+                                self._storage = storage
+                                self._device = dev
                                 self._dtype = DType.from_type_id(self._storage.dtype)
                                 self._layout = self._storage.layout() or ""
                                 self._wraps_external_data = any(
-                                    t._wraps_external_data for t in _tensors_list
+                                    t._wraps_external_data for t in tensors_list
                                 )
                                 device = self._device
                                 dtype = self._dtype
                                 layout = self._layout
-                                _fast_path_used = True
+                                fast_path_used = True
 
-                # DLPack fast path: list of external GPU tensors (e.g. PyTorch GPU tensors).
-                # Build TensorListGPU directly in C++, skipping per-sample Python Tensor wrappers.
-                if not _fast_path_used and (
-                    dtype is None
-                    and len(_tensors_list) > 0
-                    and not isinstance(_tensors_list[0], Tensor)
-                    and hasattr(_tensors_list[0], "__dlpack_device__")
+                # DLPack fast path: list of external tensors (e.g. PyTorch tensors).
+                # Build TensorListGPU/TensorListCPU directly in C++, skipping per-sample
+                # Python Tensor wrappers.
+                if not fast_path_used and (
+                    len(tensors_list) > 0
+                    and not isinstance(tensors_list[0], Tensor)
+                    and hasattr(tensors_list[0], "__dlpack_device__")
                 ):
-                    _dl_dev_type, _dl_dev_id = _tensors_list[0].__dlpack_device__()
-                    if int(_dl_dev_type) == 2:  # GPU
+                    dl_dev_type, dl_dev_id = tensors_list[0].__dlpack_device__()
+                    if int(dl_dev_type) == 2:  # kDLCUDA - GPU
                         if device is None or (
-                            device.device_type == "gpu" and device.device_id == _dl_dev_id
+                            device.device_type == "gpu" and device.device_id == dl_dev_id
                         ):
                             ctx = _EvalContext.current()
-                            _stream = (
+                            cuda_stream = (
                                 ctx.cuda_stream
-                                if ctx.device_id == _dl_dev_id
-                                else _stream_module.stream(device_id=_dl_dev_id)
+                                if ctx.device_id == dl_dev_id
+                                else _stream_module.stream(device_id=dl_dev_id)
                             )
                             try:
-                                _storage = _backend.TensorListGPU(
-                                    _tensors_list,
+                                storage = _backend.TensorListGPU.from_dlpack_list(
+                                    tensors_list,
                                     layout=layout or None,
-                                    stream=_stream,
+                                    stream=cuda_stream,
                                     contiguous=False,
                                 )
                             except TypeError:
                                 pass  # fall through to slow path
                             else:
-                                self._storage = _storage
-                                self._device = Device("gpu", _dl_dev_id)
-                                self._dtype = DType.from_type_id(self._storage.dtype)
-                                self._layout = self._storage.layout() or ""
-                                self._wraps_external_data = True
-                                device = self._device
-                                dtype = self._dtype
-                                layout = self._layout
-                                _fast_path_used = True
+                                if dtype is None or DType.from_type_id(storage.dtype) == dtype:
+                                    self._storage = storage
+                                    self._device = Device("gpu", dl_dev_id)
+                                    self._dtype = DType.from_type_id(self._storage.dtype)
+                                    self._layout = self._storage.layout() or ""
+                                    self._wraps_external_data = True
+                                    device = self._device
+                                    dtype = self._dtype
+                                    layout = self._layout
+                                    fast_path_used = True
+                    elif int(dl_dev_type) == 1:  # kDLCPU
+                        if device is None or device.device_type == "cpu":
+                            try:
+                                storage = _backend.TensorListCPU.from_dlpack_list(
+                                    tensors_list,
+                                    layout=layout or None,
+                                    contiguous=False,
+                                )
+                            except TypeError:
+                                pass  # fall through to slow path
+                            else:
+                                if dtype is None or DType.from_type_id(storage.dtype) == dtype:
+                                    self._storage = storage
+                                    self._device = Device("cpu")
+                                    self._dtype = DType.from_type_id(self._storage.dtype)
+                                    self._layout = self._storage.layout() or ""
+                                    self._wraps_external_data = True
+                                    device = self._device
+                                    dtype = self._dtype
+                                    layout = self._layout
+                                    fast_path_used = True
 
-                if not _fast_path_used:
+                if not fast_path_used:
                     self._tensors = []
-                    for i, t in enumerate(_tensors_list):
+                    for i, t in enumerate(tensors_list):
                         if t is None:
                             raise TypeError(
                                 f"Tensors must be array-like types or numbers. "

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -302,11 +302,15 @@ class Batch:
                 # DLPack fast path: list of external tensors (e.g. PyTorch tensors).
                 # Build TensorListGPU/TensorListCPU directly in C++, skipping per-sample
                 # Python Tensor wrappers.
+                # Require every element to support DLPack so we never start consuming
+                # capsules in C++ only to discover a non-DLPack element halfway through.
                 if not fast_path_used and (
                     dtype is None
                     and len(tensors_list) > 0
-                    and not isinstance(tensors_list[0], Tensor)
-                    and hasattr(tensors_list[0], "__dlpack_device__")
+                    and all(
+                        not isinstance(t, Tensor) and hasattr(t, "__dlpack_device__")
+                        for t in tensors_list
+                    )
                 ):
                     dl_dev_type, dl_dev_id = tensors_list[0].__dlpack_device__()
                     if int(dl_dev_type) == 2:  # kDLCUDA - GPU

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import importlib.util
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from collections.abc import Iterator
 
 import nvidia.dali.backend as _backend
@@ -22,7 +22,10 @@ import nvidia.dali._tensor_formatting as _tensor_formatting
 from ._nvtx import NVTXRange
 from nvidia.dali._typing import BatchLike, TensorLike
 
-from . import _eval_mode, _invocation
+if TYPE_CHECKING:
+    from . import _invocation
+from . import _eval_mode, _stream as _stream_module
+from ._eval_context import EvalContext as _EvalContext
 from ._arithmetic import _arithm_op
 from ._device import Device, DeviceLike
 from ._device import device as _device
@@ -208,7 +211,7 @@ class Batch:
         dtype: DTypeLike | None = None,
         device: DeviceLike | None = None,
         layout: str | None = None,
-        invocation_result: _invocation.InvocationResult | None = None,
+        invocation_result: "_invocation.InvocationResult | None" = None,
         copy: bool = False,
     ):
         assert isinstance(layout, str) or layout is None
@@ -280,38 +283,136 @@ class Batch:
                 self._dtype = dtype
 
             else:
-                self._tensors = []
-                for i, t in enumerate(tensors):
-                    if t is None:
-                        raise TypeError(
-                            f"Tensors must be array-like types or numbers. Got `None` at index {i}"
-                        )
-                    sample = Tensor(t, dtype=dtype, device=device, layout=layout)
+                # Materialise first so len() and indexing work for any iterable.
+                _tensors_list = tensors if isinstance(tensors, list) else list(tensors)
+                _fast_path_used = False
+
+                # Native DALI fast path: list of evaluated ndd.Tensor objects.
+                # Build TensorList directly from backend storage objects, preserving all
+                # metadata (layout, enum types, etc.) without going through DLPack.
+                if (
+                    dtype is None
+                    and len(_tensors_list) > 0
+                    and isinstance(_tensors_list[0], Tensor)
+                    and _tensors_list[0]._storage is not None
+                ):
+                    _first_storage = _tensors_list[0]._storage
+                    _storages = []
+                    _native_valid = True
+                    for _t in _tensors_list:
+                        if (
+                            not isinstance(_t, Tensor)
+                            or _t._storage is None
+                            or type(_t._storage) is not type(_first_storage)
+                        ):
+                            _native_valid = False
+                            break
+                        _storages.append(_t._storage)
+                    if _native_valid:
+                        if isinstance(_first_storage, _backend.TensorGPU):
+                            _dev_id = _first_storage.device_id()
+                            _dev_matches = device is None or (
+                                device.device_type == "gpu" and device.device_id == _dev_id
+                            )
+                            _backend_type = _backend.TensorListGPU
+                            _dev = Device("gpu", _dev_id)
+                        else:
+                            _dev_matches = device is None or device.device_type == "cpu"
+                            _backend_type = _backend.TensorListCPU
+                            _dev = Device("cpu")
+                        if _dev_matches:
+                            try:
+                                _storage = _backend_type(
+                                    _storages, layout=layout or None, contiguous=False
+                                )
+                            except (TypeError, RuntimeError):
+                                pass  # fall through to slow path
+                            else:
+                                self._storage = _storage
+                                self._device = _dev
+                                self._dtype = DType.from_type_id(self._storage.dtype)
+                                self._layout = self._storage.layout() or ""
+                                self._wraps_external_data = any(
+                                    t._wraps_external_data for t in _tensors_list
+                                )
+                                device = self._device
+                                dtype = self._dtype
+                                layout = self._layout
+                                _fast_path_used = True
+
+                # DLPack fast path: list of external GPU tensors (e.g. PyTorch GPU tensors).
+                # Build TensorListGPU directly in C++, skipping per-sample Python Tensor wrappers.
+                if not _fast_path_used and (
+                    dtype is None
+                    and len(_tensors_list) > 0
+                    and not isinstance(_tensors_list[0], Tensor)
+                    and hasattr(_tensors_list[0], "__dlpack_device__")
+                ):
+                    _dl_dev_type, _dl_dev_id = _tensors_list[0].__dlpack_device__()
+                    if int(_dl_dev_type) == 2:  # GPU
+                        if device is None or (
+                            device.device_type == "gpu" and device.device_id == _dl_dev_id
+                        ):
+                            ctx = _EvalContext.current()
+                            _stream = (
+                                ctx.cuda_stream
+                                if ctx.device_id == _dl_dev_id
+                                else _stream_module.stream(device_id=_dl_dev_id)
+                            )
+                            try:
+                                _storage = _backend.TensorListGPU(
+                                    _tensors_list,
+                                    layout=layout or None,
+                                    stream=_stream,
+                                    contiguous=False,
+                                )
+                            except TypeError:
+                                pass  # fall through to slow path
+                            else:
+                                self._storage = _storage
+                                self._device = Device("gpu", _dl_dev_id)
+                                self._dtype = DType.from_type_id(self._storage.dtype)
+                                self._layout = self._storage.layout() or ""
+                                self._wraps_external_data = True
+                                device = self._device
+                                dtype = self._dtype
+                                layout = self._layout
+                                _fast_path_used = True
+
+                if not _fast_path_used:
+                    self._tensors = []
+                    for i, t in enumerate(_tensors_list):
+                        if t is None:
+                            raise TypeError(
+                                f"Tensors must be array-like types or numbers. "
+                                f"Got `None` at index {i}"
+                            )
+                        sample = Tensor(t, dtype=dtype, device=device, layout=layout)
+                        if dtype is None:
+                            dtype = sample.dtype
+                        if device is None:
+                            device = sample.device
+                        if layout is None:
+                            layout = sample.layout
+                        self._tensors.append(sample)
+                        if sample._wraps_external_data:
+                            self._wraps_external_data = True
+                        else:
+                            if not isinstance(t, Tensor) or t._storage is not sample._storage:
+                                copied = True
                     if dtype is None:
-                        dtype = sample.dtype
+                        # We would have set dtype in the 1st iteration, so the only way it can
+                        # be None is if the `_tensors` are empty.
+                        assert len(self._tensors) == 0
+                        raise ValueError("Element type must be specified if the list is empty")
                     if device is None:
-                        device = sample.device
+                        device = Device.CPU
                     if layout is None:
-                        layout = sample.layout
-                    self._tensors.append(sample)
-                    if sample._wraps_external_data:
-                        self._wraps_external_data = True
-                    else:
-                        if not isinstance(t, Tensor) or t._storage is not sample._storage:
-                            copied = True
-                if dtype is None:
-                    # We would have set dtype in the 1st iteration, so the only way it can
-                    # be None is if the `_tensors` are empty.
-                    assert len(self._tensors) == 0
-                    raise ValueError("Element type must be specified if the list is empty")
-                if device is None:
-                    device = Device.CPU
-                if layout is None:
-                    layout = ""
-                self._device = device
-                self._layout = layout
-                self._dtype = dtype
-                if len(self._tensors) == 0:
+                        layout = ""
+                    self._device = device
+                    self._layout = layout
+                    self._dtype = dtype
+                if self._tensors is not None and len(self._tensors) == 0:
                     with device:
                         t = Tensor([], dtype=dtype, device=device).evaluate()
                         if self._device.device_type == "cpu":

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -299,56 +299,6 @@ class Batch:
                     layout = self._layout
                     fast_path_used = True
 
-                # Native DALI fast path: list of evaluated ndd.Tensor objects.
-                # Build TensorList directly from backend storage objects, preserving all
-                # metadata (layout, enum types, etc.) without going through DLPack.
-                if (
-                    len(tensors_list) > 0
-                    and isinstance(tensors_list[0], Tensor)
-                    and tensors_list[0]._storage is not None
-                ):
-                    first_storage = tensors_list[0]._storage
-                    first_dev_id = (
-                        first_storage.device_id()
-                        if isinstance(first_storage, _backend.TensorGPU)
-                        else None
-                    )
-                    storages = []
-                    for t in tensors_list:
-                        if (
-                            not isinstance(t, Tensor)
-                            or t._storage is None
-                            or type(t._storage) is not type(first_storage)
-                            or (first_dev_id is not None and t._storage.device_id() != first_dev_id)
-                            or (dtype is not None and DType.from_type_id(t._storage.dtype) != dtype)
-                        ):
-                            break
-                        storages.append(t._storage)
-                    else:
-                        if isinstance(first_storage, _backend.TensorGPU):
-                            dev_matches = device is None or (
-                                device.device_type == "gpu" and device.device_id == first_dev_id
-                            )
-                            BackendType = _backend.TensorListGPU
-                            dev = Device("gpu", first_dev_id)
-                        else:
-                            dev_matches = device is None or device.device_type == "cpu"
-                            BackendType = _backend.TensorListCPU
-                            dev = Device("cpu")
-                        if dev_matches:
-                            try:
-                                storage = BackendType(
-                                    storages, layout=layout or None, contiguous=False
-                                )
-                            except (TypeError, RuntimeError):
-                                pass  # fall through to slow path
-                            else:
-                                assign_fast_path_storage(
-                                    storage,
-                                    dev,
-                                    any(t._wraps_external_data for t in tensors_list),
-                                )
-
                 # DLPack fast path: list of external tensors (e.g. PyTorch tensors).
                 # Build TensorListGPU/TensorListCPU directly in C++, skipping per-sample
                 # Python Tensor wrappers.

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -14,7 +14,7 @@
 
 import importlib.util
 from typing import TYPE_CHECKING, Any
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 
 import nvidia.dali.backend as _backend
 import nvidia.dali.types as _dali_types
@@ -284,8 +284,20 @@ class Batch:
 
             else:
                 # Materialise first so len() and indexing work for any iterable.
-                tensors_list = tensors if isinstance(tensors, list) else list(tensors)
+                tensors_list = tensors if isinstance(tensors, Sequence) else list(tensors)
                 fast_path_used = False
+
+                def assign_fast_path_storage(storage, dev, wraps_external_data):
+                    nonlocal device, dtype, layout, fast_path_used
+                    self._storage = storage
+                    self._device = dev
+                    self._dtype = DType.from_type_id(storage.dtype)
+                    self._layout = storage.layout() or ""
+                    self._wraps_external_data = wraps_external_data
+                    device = self._device
+                    dtype = self._dtype
+                    layout = self._layout
+                    fast_path_used = True
 
                 # Native DALI fast path: list of evaluated ndd.Tensor objects.
                 # Build TensorList directly from backend storage objects, preserving all
@@ -331,23 +343,18 @@ class Batch:
                             except (TypeError, RuntimeError):
                                 pass  # fall through to slow path
                             else:
-                                self._storage = storage
-                                self._device = dev
-                                self._dtype = DType.from_type_id(self._storage.dtype)
-                                self._layout = self._storage.layout() or ""
-                                self._wraps_external_data = any(
-                                    t._wraps_external_data for t in tensors_list
+                                assign_fast_path_storage(
+                                    storage,
+                                    dev,
+                                    any(t._wraps_external_data for t in tensors_list),
                                 )
-                                device = self._device
-                                dtype = self._dtype
-                                layout = self._layout
-                                fast_path_used = True
 
                 # DLPack fast path: list of external tensors (e.g. PyTorch tensors).
                 # Build TensorListGPU/TensorListCPU directly in C++, skipping per-sample
                 # Python Tensor wrappers.
                 if not fast_path_used and (
-                    len(tensors_list) > 0
+                    dtype is None
+                    and len(tensors_list) > 0
                     and not isinstance(tensors_list[0], Tensor)
                     and hasattr(tensors_list[0], "__dlpack_device__")
                 ):
@@ -372,16 +379,7 @@ class Batch:
                             except (TypeError, ValueError):
                                 pass  # fall through to slow path
                             else:
-                                if dtype is None or DType.from_type_id(storage.dtype) == dtype:
-                                    self._storage = storage
-                                    self._device = Device("gpu", dl_dev_id)
-                                    self._dtype = DType.from_type_id(self._storage.dtype)
-                                    self._layout = self._storage.layout() or ""
-                                    self._wraps_external_data = True
-                                    device = self._device
-                                    dtype = self._dtype
-                                    layout = self._layout
-                                    fast_path_used = True
+                                assign_fast_path_storage(storage, Device("gpu", dl_dev_id), True)
                     elif int(dl_dev_type) in (1, 3):  # kDLCPU or kDLCUDAHost (pinned)
                         if device is None or device.device_type == "cpu":
                             try:
@@ -393,16 +391,7 @@ class Batch:
                             except (TypeError, ValueError, BufferError):
                                 pass  # fall through to slow path
                             else:
-                                if dtype is None or DType.from_type_id(storage.dtype) == dtype:
-                                    self._storage = storage
-                                    self._device = Device("cpu")
-                                    self._dtype = DType.from_type_id(self._storage.dtype)
-                                    self._layout = self._storage.layout() or ""
-                                    self._wraps_external_data = True
-                                    device = self._device
-                                    dtype = self._dtype
-                                    layout = self._layout
-                                    fast_path_used = True
+                                assign_fast_path_storage(storage, Device.CPU, True)
 
                 if not fast_path_used:
                     self._tensors = []

--- a/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
@@ -201,7 +201,16 @@ class Tensor:
             elif hasattr(data, "__dlpack_device__"):
                 dl_device_type, device_id = data.__dlpack_device__()
                 if int(dl_device_type) == 1 or int(dl_device_type) == 3:  # CPU
-                    self._storage = _backend.TensorCPU(data.__dlpack__(), layout)
+                    try:
+                        self._storage = _backend.TensorCPU(data.__dlpack__(), layout)
+                    except (BufferError, TypeError):
+                        # DLPack may fail for read-only buffers or unsupported dtypes;
+                        # fall back to __array__ if available.
+                        a = _get_array_interface(data)
+                        if a is not None:
+                            self._storage = _backend.TensorCPU(a, layout)
+                        else:
+                            raise
                 elif int(dl_device_type) == 2:  # GPU
                     # If the current context is on the same device, use the same stream.
                     ctx = _EvalContext.current()
@@ -210,8 +219,9 @@ class Tensor:
                     else:
                         stream = _stream.stream(device_id=device_id)
                     args = {"stream": stream.handle}
+                    dlpack_capsule = data.__dlpack__(**args)
                     self._storage = _backend.TensorGPU(
-                        data.__dlpack__(**args),
+                        dlpack_capsule,
                         layout=layout,
                         stream=stream,
                     )
@@ -276,7 +286,7 @@ class Tensor:
                 self._dtype = DType.from_type_id(self._storage.dtype)
                 self._layout = self._storage.layout()
 
-            if self._storage is not None and device != _backend_device(self._storage):
+            if self._storage is not None and device != self._device:
                 self._assign(self.to_device(device).evaluate())
                 copied = True
         elif invocation_result is not None:

--- a/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
@@ -228,25 +228,19 @@ class Tensor:
                     else:
                         stream = _stream.stream(device_id=device_id)
                     args = {"stream": stream.handle}
+                    # Separate capsule acquisition from TensorGPU construction: a TypeError
+                    # from TensorGPU (e.g. unsupported dtype) must not trigger a second
+                    # __dlpack__() call — DLPack capsules are single-use.
+                    # BufferError is intentionally not caught: on GPU it may signal
+                    # a synchronization or ownership constraint.
+                    dlpack_capsule = None
                     try:
                         dlpack_capsule = data.__dlpack__(**args)
-                        self._storage = _backend.TensorGPU(
-                            dlpack_capsule,
-                            layout=layout,
-                            stream=stream,
-                        )
                     except TypeError:
                         # Older DLPack implementations don't accept the stream keyword;
                         # retry without it before considering __cuda_array_interface__.
-                        # BufferError is intentionally not caught: on GPU it may signal
-                        # a synchronization or ownership constraint.
                         try:
                             dlpack_capsule = data.__dlpack__()
-                            self._storage = _backend.TensorGPU(
-                                dlpack_capsule,
-                                layout=layout,
-                                stream=stream,
-                            )
                         except TypeError:
                             # __dlpack__ is entirely non-functional for this object;
                             # only then fall back to __cuda_array_interface__.
@@ -254,6 +248,12 @@ class Tensor:
                                 self._storage = _backend.TensorGPU(data, layout=layout)
                             else:
                                 raise
+                    if dlpack_capsule is not None:
+                        self._storage = _backend.TensorGPU(
+                            dlpack_capsule,
+                            layout=layout,
+                            stream=stream,
+                        )
                 else:
                     raise ValueError(f"Unsupported device type: {dl_device_type}")
                 self._wraps_external_data = True

--- a/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
@@ -236,15 +236,24 @@ class Tensor:
                             stream=stream,
                         )
                     except TypeError:
-                        # TypeError indicates a DLPack protocol mismatch (e.g. keyword-
-                        # only stream arg on older implementations). BufferError is NOT
-                        # caught here: on GPU a BufferError may signal a synchronization
-                        # or ownership constraint, and silently switching to
-                        # __cuda_array_interface__ would bypass the required handshake.
-                        if hasattr(data, "__cuda_array_interface__"):
-                            self._storage = _backend.TensorGPU(data, layout=layout)
-                        else:
-                            raise
+                        # Older DLPack implementations don't accept the stream keyword;
+                        # retry without it before considering __cuda_array_interface__.
+                        # BufferError is intentionally not caught: on GPU it may signal
+                        # a synchronization or ownership constraint.
+                        try:
+                            dlpack_capsule = data.__dlpack__()
+                            self._storage = _backend.TensorGPU(
+                                dlpack_capsule,
+                                layout=layout,
+                                stream=stream,
+                            )
+                        except TypeError:
+                            # __dlpack__ is entirely non-functional for this object;
+                            # only then fall back to __cuda_array_interface__.
+                            if hasattr(data, "__cuda_array_interface__"):
+                                self._storage = _backend.TensorGPU(data, layout=layout)
+                            else:
+                                raise
                 else:
                     raise ValueError(f"Unsupported device type: {dl_device_type}")
                 self._wraps_external_data = True

--- a/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
@@ -203,9 +203,18 @@ class Tensor:
                 if int(dl_device_type) == 1 or int(dl_device_type) == 3:  # CPU
                     try:
                         self._storage = _backend.TensorCPU(data.__dlpack__(), layout)
-                    except (BufferError, TypeError):
-                        # DLPack may fail for read-only buffers or unsupported dtypes;
-                        # fall back to __array__ if available.
+                    except BufferError:
+                        # BufferError means the producer's buffer is immutable (e.g. a
+                        # read-only NumPy array).  Copy the data so DALI does not hold a
+                        # mutable alias of memory that the producer marked as read-only.
+                        a = _get_array_interface(data)
+                        if a is not None:
+                            self._storage = _backend.TensorCPU(np.array(a, copy=True), layout)
+                        else:
+                            raise
+                    except TypeError:
+                        # TypeError typically indicates an unsupported DLPack version or
+                        # dtype; fall back to the array interface without copying.
                         a = _get_array_interface(data)
                         if a is not None:
                             self._storage = _backend.TensorCPU(a, layout)
@@ -226,7 +235,12 @@ class Tensor:
                             layout=layout,
                             stream=stream,
                         )
-                    except (BufferError, TypeError):
+                    except TypeError:
+                        # TypeError indicates a DLPack protocol mismatch (e.g. keyword-
+                        # only stream arg on older implementations). BufferError is NOT
+                        # caught here: on GPU a BufferError may signal a synchronization
+                        # or ownership constraint, and silently switching to
+                        # __cuda_array_interface__ would bypass the required handshake.
                         if hasattr(data, "__cuda_array_interface__"):
                             self._storage = _backend.TensorGPU(data, layout=layout)
                         else:

--- a/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
@@ -219,12 +219,18 @@ class Tensor:
                     else:
                         stream = _stream.stream(device_id=device_id)
                     args = {"stream": stream.handle}
-                    dlpack_capsule = data.__dlpack__(**args)
-                    self._storage = _backend.TensorGPU(
-                        dlpack_capsule,
-                        layout=layout,
-                        stream=stream,
-                    )
+                    try:
+                        dlpack_capsule = data.__dlpack__(**args)
+                        self._storage = _backend.TensorGPU(
+                            dlpack_capsule,
+                            layout=layout,
+                            stream=stream,
+                        )
+                    except (BufferError, TypeError):
+                        if hasattr(data, "__cuda_array_interface__"):
+                            self._storage = _backend.TensorGPU(data, layout=layout)
+                        else:
+                            raise
                 else:
                     raise ValueError(f"Unsupported device type: {dl_device_type}")
                 self._wraps_external_data = True

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -487,12 +487,12 @@ def test_batch_construction_from_list_of_dali_tensors_dtype_mismatch(device_type
 
 @eval_modes()
 @attr("pytorch")
-def test_batch_construction_gpu_dlpack_buffer_error_fallback():
-    """GPU DLPack BufferError is caught; batch falls back to slow path via
-    __cuda_array_interface__."""
+def test_batch_construction_gpu_dlpack_type_error_fallback():
+    """GPU DLPack TypeError (protocol mismatch) is caught; batch falls back to slow path via
+    __cuda_array_interface__. BufferError is intentionally not caught on GPU."""
     import torch
 
-    class _BrokenDlpack:
+    class _TypeErrorDlpack:
         def __init__(self, t):
             self._t = t
 
@@ -501,13 +501,13 @@ def test_batch_construction_gpu_dlpack_buffer_error_fallback():
             return self._t.__cuda_array_interface__
 
         def __dlpack__(self, **kwargs):
-            raise BufferError("DLPack export not supported")
+            raise TypeError("DLPack stream keyword not supported")
 
         def __dlpack_device__(self):
             return (2, self._t.device.index)  # kDLCUDA
 
     data = [
-        _BrokenDlpack(torch.tensor([i, i + 1, i + 2], device="cuda", dtype=torch.int32))
+        _TypeErrorDlpack(torch.tensor([i, i + 1, i + 2], device="cuda", dtype=torch.int32))
         for i in range(3)
     ]
     b = ndd.as_batch(data)

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -488,7 +488,8 @@ def test_batch_construction_from_list_of_dali_tensors_dtype_mismatch(device_type
 @eval_modes()
 @attr("pytorch")
 def test_batch_construction_gpu_dlpack_buffer_error_fallback():
-    """GPU DLPack BufferError is caught; batch falls back to slow path via __cuda_array_interface__."""
+    """GPU DLPack BufferError is caught; batch falls back to slow path via
+    __cuda_array_interface__."""
     import torch
 
     class _BrokenDlpack:
@@ -521,7 +522,8 @@ def test_batch_construction_gpu_dlpack_buffer_error_fallback():
 @eval_modes()
 @attr("pytorch", "multi_gpu")
 def test_batch_construction_mixed_gpu_dlpack_value_error_fallback():
-    """from_dlpack_list raises ValueError for mixed-device tensors; batch falls back to slow path."""
+    """from_dlpack_list raises ValueError for mixed-device tensors; batch falls back to slow
+    path."""
     if _b.GetCUDADeviceCount() < 2:
         raise SkipTest("At least 2 devices needed for the test")
     import torch

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -453,6 +453,112 @@ def test_batch_from_tensor_and_layout(device_type):
 
 @eval_modes()
 @params(("cpu",), ("gpu",))
+def test_batch_construction_from_list_of_dali_tensors_matching_dtype(device_type):
+    """Native fast path: matching dtype does not prevent the fast path from being used."""
+    data = [
+        ndd.tensor(np.array([i, i + 1, i + 2], dtype=np.int32), device=device_type)
+        for i in range(3)
+    ]
+    b = ndd.as_batch(data, dtype=ndd.int32)
+    b.evaluate()
+    assert b.dtype == ndd.int32
+    assert b.device == ndd.Device(device_type)
+    assert b.batch_size == 3
+    for i, t in enumerate(b.tensors):
+        assert np.array_equal(asnumpy(t), np.array([i, i + 1, i + 2], dtype=np.int32))
+
+
+@eval_modes()
+@params(("cpu",), ("gpu",))
+def test_batch_construction_from_list_of_dali_tensors_dtype_mismatch(device_type):
+    """Dtype mismatch in native fast path falls through to slow path with type conversion."""
+    data = [
+        ndd.tensor(np.array([i, i + 1, i + 2], dtype=np.int32), device=device_type)
+        for i in range(3)
+    ]
+    b = ndd.as_batch(data, dtype=ndd.float32)
+    b.evaluate()
+    assert b.dtype == ndd.float32
+    assert b.device == ndd.Device(device_type)
+    assert b.batch_size == 3
+    for i, t in enumerate(b.tensors):
+        assert np.array_equal(asnumpy(t), np.array([i, i + 1, i + 2], dtype=np.float32))
+
+
+@eval_modes()
+@attr("pytorch")
+def test_batch_construction_gpu_dlpack_buffer_error_fallback():
+    """GPU DLPack BufferError is caught; batch falls back to slow path via __cuda_array_interface__."""
+    import torch
+
+    class _BrokenDlpack:
+        def __init__(self, t):
+            self._t = t
+
+        @property
+        def __cuda_array_interface__(self):
+            return self._t.__cuda_array_interface__
+
+        def __dlpack__(self, **kwargs):
+            raise BufferError("DLPack export not supported")
+
+        def __dlpack_device__(self):
+            return (2, self._t.device.index)  # kDLCUDA
+
+    data = [
+        _BrokenDlpack(torch.tensor([i, i + 1, i + 2], device="cuda", dtype=torch.int32))
+        for i in range(3)
+    ]
+    b = ndd.as_batch(data)
+    b.evaluate()
+    assert b.device == ndd.Device("gpu")
+    assert b.dtype == ndd.int32
+    assert b.batch_size == 3
+    for i, t in enumerate(b.tensors):
+        assert np.array_equal(asnumpy(t), np.array([i, i + 1, i + 2], dtype=np.int32))
+
+
+@eval_modes()
+@attr("pytorch", "multi_gpu")
+def test_batch_construction_mixed_gpu_dlpack_value_error_fallback():
+    """from_dlpack_list raises ValueError for mixed-device tensors; batch falls back to slow path."""
+    if _b.GetCUDADeviceCount() < 2:
+        raise SkipTest("At least 2 devices needed for the test")
+    import torch
+
+    data = [
+        torch.tensor([1, 2, 3], device="cuda:0", dtype=torch.int32),
+        torch.tensor([4, 5, 6], device="cuda:1", dtype=torch.int32),
+    ]
+    b = ndd.as_batch(data)
+    b.evaluate()
+    assert b.device.device_type == "gpu"
+    assert b.dtype == ndd.int32
+    assert b.batch_size == 2
+    assert b.shape == [(3,), (3,)]
+
+
+@eval_modes()
+@attr("multi_gpu")
+def test_batch_construction_native_fast_path_mixed_gpu_fallback():
+    """Native fast path rejects tensors from different GPU devices; slow path handles them."""
+    if _b.GetCUDADeviceCount() < 2:
+        raise SkipTest("At least 2 devices needed for the test")
+
+    data = [
+        ndd.tensor(np.array([1, 2, 3], dtype=np.int32)).gpu(0).evaluate(),
+        ndd.tensor(np.array([4, 5, 6], dtype=np.int32)).gpu(1).evaluate(),
+    ]
+    b = ndd.as_batch(data)
+    b.evaluate()
+    assert b.device.device_type == "gpu"
+    assert b.dtype == ndd.int32
+    assert b.batch_size == 2
+    assert b.shape == [(3,), (3,)]
+
+
+@eval_modes()
+@params(("cpu",), ("gpu",))
 def test_layout_change(device_type):
     x = np.zeros((100, 100, 3), dtype=np.uint8)
     a = ndd.batch([x] * 3, layout="HWC", device=device_type)

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -225,8 +225,8 @@ def test_batch_construction_from_list_of_torch_gpu_tensors_dtype_fallback():
 
 @eval_modes()
 @attr("pytorch")
-def test_batch_construction_from_list_of_torch_cpu_tensors_slow_path():
-    """CPU torch tensors do not trigger the GPU fast path; slow path handles them correctly."""
+def test_batch_construction_from_list_of_torch_cpu_tensors():
+    """CPU torch tensors trigger the CPU DLPack fast path via TensorListCPU.from_dlpack_list."""
     import torch
 
     data = [torch.tensor([i, i + 1, i + 2], dtype=torch.int32) for i in range(3)]

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -520,18 +520,20 @@ def test_batch_construction_gpu_dlpack_type_error_fallback():
 
 
 @eval_modes()
-@attr("pytorch", "multi_gpu")
+@attr("multi_gpu")
+@attr("cupy")
 def test_batch_construction_mixed_gpu_dlpack_value_error_fallback():
     """from_dlpack_list raises ValueError for mixed-device tensors; batch falls back to slow
     path."""
     if _b.GetCUDADeviceCount() < 2:
         raise SkipTest("At least 2 devices needed for the test")
-    import torch
+    import cupy as cp
 
-    data = [
-        torch.tensor([1, 2, 3], device="cuda:0", dtype=torch.int32),
-        torch.tensor([4, 5, 6], device="cuda:1", dtype=torch.int32),
-    ]
+    with cp.cuda.Device(0):
+        t0 = cp.array([1, 2, 3], dtype=cp.int32)
+    with cp.cuda.Device(1):
+        t1 = cp.array([4, 5, 6], dtype=cp.int32)
+    data = [t0, t1]
     b = ndd.as_batch(data)
     b.evaluate()
     assert b.device.device_type == "gpu"

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -158,6 +158,91 @@ def test_batch_construction_with_torch_tensor(device_type):
 
 @eval_modes()
 @params(("cpu",), ("gpu",))
+def test_batch_construction_from_list_of_dali_tensors(device_type):
+    """Native fast path: list of evaluated ndd.Tensor builds TensorList directly from storage."""
+    data = [
+        ndd.tensor(np.array([i, i + 1, i + 2], dtype=np.int32), device=device_type, layout="X")
+        for i in range(4)
+    ]
+    b = ndd.as_batch(data)
+    b.evaluate()
+    assert b.device == ndd.Device(device_type)
+    assert b.dtype == ndd.int32
+    assert b.layout == "X"
+    assert b.batch_size == 4
+    assert b.ndim == 1
+    assert b.shape == [(3,)] * 4
+    for i, t in enumerate(b.tensors):
+        expected = np.array([i, i + 1, i + 2], dtype=np.int32)
+        assert np.array_equal(asnumpy(t), expected)
+
+
+@eval_modes()
+@attr("pytorch")
+def test_batch_construction_from_list_of_torch_gpu_tensors():
+    """Fast path: list of PyTorch GPU tensors goes through C++ TensorListGPU bulk constructor."""
+    import torch
+
+    data = [torch.tensor([i, i + 1, i + 2], device="cuda", dtype=torch.int32) for i in range(4)]
+    b = ndd.as_batch(data)
+    b.evaluate()
+    assert b.device == ndd.Device("gpu")
+    assert b.dtype == ndd.int32
+    assert b.batch_size == 4
+    assert b.ndim == 1
+    assert b.shape == [(3,)] * 4
+    for i, t in enumerate(b.tensors):
+        expected = torch.tensor([i, i + 1, i + 2], dtype=torch.int32)
+        assert torch.equal(torch.from_dlpack(t.evaluate()._storage).cpu(), expected)
+
+
+@eval_modes()
+@attr("pytorch")
+def test_batch_construction_from_list_of_torch_gpu_tensors_with_layout():
+    """Fast path: layout parameter is forwarded correctly to the bulk constructor."""
+    import torch
+
+    data = [torch.ones(3, 4, dtype=torch.float32, device="cuda") * i for i in range(3)]
+    b = ndd.as_batch(data, layout="HW")
+    b.evaluate()
+    assert b.layout == "HW"
+    assert b.batch_size == 3
+    assert b.shape == [(3, 4)] * 3
+
+
+@eval_modes()
+@attr("pytorch")
+def test_batch_construction_from_list_of_torch_gpu_tensors_dtype_fallback():
+    """When dtype is specified the fast path is skipped; slow path handles type conversion."""
+    import torch
+
+    data = [torch.tensor([1, 2, 3], device="cuda", dtype=torch.int32)]
+    b = ndd.as_batch(data, dtype=ndd.float32)
+    b.evaluate()
+    assert b.dtype == ndd.float32
+    assert b.batch_size == 1
+
+
+@eval_modes()
+@attr("pytorch")
+def test_batch_construction_from_list_of_torch_cpu_tensors_slow_path():
+    """CPU torch tensors do not trigger the GPU fast path; slow path handles them correctly."""
+    import torch
+
+    data = [torch.tensor([i, i + 1, i + 2], dtype=torch.int32) for i in range(3)]
+    b = ndd.as_batch(data)
+    b.evaluate()
+    assert b.device == ndd.Device("cpu")
+    assert b.dtype == ndd.int32
+    assert b.batch_size == 3
+    assert b.shape == [(3,)] * 3
+    for i, t in enumerate(b.tensors):
+        expected = np.array([i, i + 1, i + 2], dtype=np.int32)
+        assert np.array_equal(asnumpy(t), expected)
+
+
+@eval_modes()
+@params(("cpu",), ("gpu",))
 def test_batch_construction_with_tensor(device_type):
     t = ndd.tensor(np.array([1, 2, 3], dtype=np.uint8), device=device_type, layout="X")
     b = ndd.Batch([t])

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -535,6 +535,7 @@ def test_batch_construction_mixed_gpu_dlpack_value_error_fallback():
     b = ndd.as_batch(data)
     b.evaluate()
     assert b.device.device_type == "gpu"
+    assert b.device.device_id == 0  # slow path uses first tensor's device
     assert b.dtype == ndd.int32
     assert b.batch_size == 2
     assert b.shape == [(3,), (3,)]
@@ -554,6 +555,7 @@ def test_batch_construction_native_fast_path_mixed_gpu_fallback():
     b = ndd.as_batch(data)
     b.evaluate()
     assert b.device.device_type == "gpu"
+    assert b.device.device_id == 0  # slow path uses first tensor's device
     assert b.dtype == ndd.int32
     assert b.batch_size == 2
     assert b.shape == [(3,), (3,)]

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -159,7 +159,8 @@ def test_batch_construction_with_torch_tensor(device_type):
 @eval_modes()
 @params(("cpu",), ("gpu",))
 def test_batch_construction_from_list_of_dali_tensors(device_type):
-    """Native fast path: list of evaluated ndd.Tensor builds TensorList directly from storage."""
+    """Batch from a list of evaluated ndd.Tensor objects preserves device, dtype, layout, shape,
+    and values."""
     data = [
         ndd.tensor(np.array([i, i + 1, i + 2], dtype=np.int32), device=device_type, layout="X")
         for i in range(4)
@@ -175,6 +176,30 @@ def test_batch_construction_from_list_of_dali_tensors(device_type):
     for i, t in enumerate(b.tensors):
         expected = np.array([i, i + 1, i + 2], dtype=np.int32)
         assert np.array_equal(asnumpy(t), expected)
+
+
+@eval_modes(ndd.EvalMode.deferred, ndd.EvalMode.eager)
+@params(("cpu",), ("gpu",))
+def test_as_batch_does_not_eagerly_create_storage(device_type):
+    # as_batch over a list of evaluated ndd.Tensors must not eagerly allocate a TensorList:
+    # the per-sample Tensor objects can still be retrieved via .tensors and the backing
+    # storage is materialised lazily only when required. Each per-sample Tensor must also
+    # share its underlying storage with the corresponding input tensor (no copy).
+    # The sync_* eval modes are excluded because they explicitly evaluate the Batch at the
+    # end of construction.
+    data = [
+        ndd.tensor(np.array([i, i + 1, i + 2], dtype=np.int32), device=device_type, layout="X")
+        for i in range(4)
+    ]
+    for t in data:
+        t.evaluate()
+    b = ndd.as_batch(data)
+    assert b._storage is None
+    extracted = [b.tensors[i] for i in range(4)]
+    assert b._storage is None
+    for i, t in enumerate(extracted):
+        assert t._storage is data[i]._storage
+        assert np.array_equal(asnumpy(t), np.array([i, i + 1, i + 2], dtype=np.int32))
 
 
 @eval_modes()
@@ -454,7 +479,7 @@ def test_batch_from_tensor_and_layout(device_type):
 @eval_modes()
 @params(("cpu",), ("gpu",))
 def test_batch_construction_from_list_of_dali_tensors_matching_dtype(device_type):
-    """Native fast path: matching dtype does not prevent the fast path from being used."""
+    """An explicit dtype that matches the input ndd.Tensor dtype is accepted without conversion."""
     data = [
         ndd.tensor(np.array([i, i + 1, i + 2], dtype=np.int32), device=device_type)
         for i in range(3)
@@ -471,7 +496,7 @@ def test_batch_construction_from_list_of_dali_tensors_matching_dtype(device_type
 @eval_modes()
 @params(("cpu",), ("gpu",))
 def test_batch_construction_from_list_of_dali_tensors_dtype_mismatch(device_type):
-    """Dtype mismatch in native fast path falls through to slow path with type conversion."""
+    """An explicit dtype that differs from the input ndd.Tensor dtype triggers type conversion."""
     data = [
         ndd.tensor(np.array([i, i + 1, i + 2], dtype=np.int32), device=device_type)
         for i in range(3)
@@ -545,8 +570,8 @@ def test_batch_construction_mixed_gpu_dlpack_value_error_fallback():
 
 @eval_modes()
 @attr("multi_gpu")
-def test_batch_construction_native_fast_path_mixed_gpu_fallback():
-    """Native fast path rejects tensors from different GPU devices; slow path handles them."""
+def test_batch_construction_mixed_gpu_ndd_tensors():
+    """Batch from ndd.Tensors residing on different GPU devices uses the first tensor's device."""
     if _b.GetCUDADeviceCount() < 2:
         raise SkipTest("At least 2 devices needed for the test")
 

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -233,6 +233,9 @@ def test_batch_construction_from_list_of_torch_gpu_tensors_with_layout():
     assert b.layout == "HW"
     assert b.batch_size == 3
     assert b.shape == [(3, 4)] * 3
+    for i, t in enumerate(b.tensors):
+        expected = (np.ones((3, 4), dtype=np.float32) * i)
+        assert np.array_equal(asnumpy(t), expected)
 
 
 @eval_modes()
@@ -566,6 +569,8 @@ def test_batch_construction_mixed_gpu_dlpack_value_error_fallback():
     assert b.dtype == ndd.int32
     assert b.batch_size == 2
     assert b.shape == [(3,), (3,)]
+    assert np.array_equal(asnumpy(b.tensors[0]), np.array([1, 2, 3], dtype=np.int32))
+    assert np.array_equal(asnumpy(b.tensors[1]), np.array([4, 5, 6], dtype=np.int32))
 
 
 @eval_modes()
@@ -586,6 +591,8 @@ def test_batch_construction_mixed_gpu_ndd_tensors():
     assert b.dtype == ndd.int32
     assert b.batch_size == 2
     assert b.shape == [(3,), (3,)]
+    assert np.array_equal(asnumpy(b.tensors[0]), np.array([1, 2, 3], dtype=np.int32))
+    assert np.array_equal(asnumpy(b.tensors[1]), np.array([4, 5, 6], dtype=np.int32))
 
 
 @eval_modes()

--- a/dali/test/python/experimental_mode/test_batch.py
+++ b/dali/test/python/experimental_mode/test_batch.py
@@ -234,7 +234,7 @@ def test_batch_construction_from_list_of_torch_gpu_tensors_with_layout():
     assert b.batch_size == 3
     assert b.shape == [(3, 4)] * 3
     for i, t in enumerate(b.tensors):
-        expected = (np.ones((3, 4), dtype=np.float32) * i)
+        expected = np.ones((3, 4), dtype=np.float32) * i
         assert np.array_equal(asnumpy(t), expected)
 
 
@@ -249,6 +249,7 @@ def test_batch_construction_from_list_of_torch_gpu_tensors_dtype_fallback():
     b.evaluate()
     assert b.dtype == ndd.float32
     assert b.batch_size == 1
+    assert np.array_equal(asnumpy(b.tensors[0]), np.array([1, 2, 3], dtype=np.float32))
 
 
 @eval_modes()

--- a/dali/test/python/experimental_mode/test_tensor.py
+++ b/dali/test/python/experimental_mode/test_tensor.py
@@ -442,7 +442,8 @@ def test_from_readonly_numpy(dtype):
 @eval_modes()
 @attr("pytorch")
 def test_tensor_gpu_cai_fallback():
-    """When __dlpack__ raises BufferError, GPU Tensor construction falls back to __cuda_array_interface__."""
+    """When __dlpack__ raises BufferError, GPU Tensor construction falls back to
+    __cuda_array_interface__."""
     import torch
 
     class _BrokenDlpack:

--- a/dali/test/python/experimental_mode/test_tensor.py
+++ b/dali/test/python/experimental_mode/test_tensor.py
@@ -442,11 +442,12 @@ def test_from_readonly_numpy(dtype):
 @eval_modes()
 @attr("pytorch")
 def test_tensor_gpu_cai_fallback():
-    """When __dlpack__ raises BufferError, GPU Tensor construction falls back to
-    __cuda_array_interface__."""
+    """When __dlpack__ raises TypeError (protocol mismatch), GPU Tensor falls back to
+    __cuda_array_interface__. BufferError is not caught on GPU to avoid bypassing
+    producer synchronization contracts."""
     import torch
 
-    class _BrokenDlpack:
+    class _TypeErrorDlpack:
         def __init__(self, t):
             self._t = t
 
@@ -455,13 +456,13 @@ def test_tensor_gpu_cai_fallback():
             return self._t.__cuda_array_interface__
 
         def __dlpack__(self, **kwargs):
-            raise BufferError("DLPack export not supported")
+            raise TypeError("DLPack stream keyword not supported")
 
         def __dlpack_device__(self):
             return (2, self._t.device.index)  # kDLCUDA
 
     data = torch.tensor([[1, 2, 3], [4, 5, 6]], device="cuda", dtype=torch.int32)
-    t = ndd.tensor(_BrokenDlpack(data), device="gpu").evaluate()
+    t = ndd.tensor(_TypeErrorDlpack(data), device="gpu").evaluate()
     assert t.device == ndd.Device("gpu")
     assert t.dtype == ndd.int32
     assert np.array_equal(asnumpy(t), data.cpu().numpy())

--- a/dali/test/python/experimental_mode/test_tensor.py
+++ b/dali/test/python/experimental_mode/test_tensor.py
@@ -440,6 +440,33 @@ def test_from_readonly_numpy(dtype):
 
 
 @eval_modes()
+@attr("pytorch")
+def test_tensor_gpu_cai_fallback():
+    """When __dlpack__ raises BufferError, GPU Tensor construction falls back to __cuda_array_interface__."""
+    import torch
+
+    class _BrokenDlpack:
+        def __init__(self, t):
+            self._t = t
+
+        @property
+        def __cuda_array_interface__(self):
+            return self._t.__cuda_array_interface__
+
+        def __dlpack__(self, **kwargs):
+            raise BufferError("DLPack export not supported")
+
+        def __dlpack_device__(self):
+            return (2, self._t.device.index)  # kDLCUDA
+
+    data = torch.tensor([[1, 2, 3], [4, 5, 6]], device="cuda", dtype=torch.int32)
+    t = ndd.tensor(_BrokenDlpack(data), device="gpu").evaluate()
+    assert t.device == ndd.Device("gpu")
+    assert t.dtype == ndd.int32
+    assert np.array_equal(asnumpy(t), data.cpu().numpy())
+
+
+@eval_modes()
 def test_from_readonly_numpy_scalar():
     data = np.array(42, dtype=np.int32)
     data.flags.writeable = False

--- a/dali/test/python/experimental_mode/test_tensor.py
+++ b/dali/test/python/experimental_mode/test_tensor.py
@@ -423,3 +423,25 @@ def test_batch_to_tensor_no_pad_error():
     data = ragged("cpu")
     with assert_raises(ValueError):
         ndd.as_tensor(data, pad=False).evaluate()
+
+
+@eval_modes()
+@params(
+    (np.int32,),
+    (np.float32,),
+    (np.uint8,),
+)
+def test_from_readonly_numpy(dtype):
+    data = np.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+    data.flags.writeable = False
+    t = ndd.as_tensor(data).evaluate()
+    assert np.array_equal(np.array(t._storage), data)
+    assert t.shape == (2, 3)
+
+
+@eval_modes()
+def test_from_readonly_numpy_scalar():
+    data = np.array(42, dtype=np.int32)
+    data.flags.writeable = False
+    t = ndd.as_tensor(data).evaluate()
+    assert int(np.array(t._storage)) == 42

--- a/dali/util/user_stream.h
+++ b/dali/util/user_stream.h
@@ -89,6 +89,24 @@ class DLL_PUBLIC UserStream {
   }
 
   /**
+   * @brief Obtains cudaStream_t for given device, if there is none new one is created and
+   * stored in the internal map
+   */
+  DLL_PUBLIC cudaStream_t GetStream(size_t dev) {
+    std::lock_guard<std::mutex> lock(m_);
+    auto it = streams_.find(dev);
+    if (it != streams_.end()) {
+      return it->second;
+    } else {
+      DeviceGuard g(dev);
+      constexpr int kDefaultStreamPriority = 0;
+      CUDA_CALL(cudaStreamCreateWithPriority(&streams_[dev], cudaStreamNonBlocking,
+                                             kDefaultStreamPriority));
+      return streams_.at(dev);
+    }
+  }
+
+  /**
    * @brief Synchronizes stream connected with the current device
    */
   DLL_PUBLIC void Wait() {
@@ -122,25 +140,6 @@ class DLL_PUBLIC UserStream {
     int dev = tl.device_id();
     DALI_ENFORCE(dev != -1, "Used a pointer from unknown device");
     return dev;
-  }
-
-
-  /**
-   * @brief Obtains cudaStream_t for for given device, if there is none new one is created and
-   * stored in the internal map
-   */
-  DLL_PUBLIC cudaStream_t GetStream(size_t dev) {
-    std::lock_guard<std::mutex> lock(m_);
-    auto it = streams_.find(dev);
-    if (it != streams_.end()) {
-      return it->second;
-    } else {
-      DeviceGuard g(dev);
-      constexpr int kDefaultStreamPriority = 0;
-      CUDA_CALL(cudaStreamCreateWithPriority(&streams_[dev], cudaStreamNonBlocking,
-                                             kDefaultStreamPriority));
-      return streams_.at(dev);
-    }
   }
 
   /**

--- a/qa/TL0_multigpu/test_body.sh
+++ b/qa/TL0_multigpu/test_body.sh
@@ -38,6 +38,7 @@ test_gtest() {
 
 test_cupy() {
     ${python_new_invoke_test} -A 'multigpu' test_external_source_cupy
+    ${python_new_invoke_test} -A 'cupy,multi_gpu' -s experimental_mode
 }
 
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
-->

## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
-->

## Description:
- Adds bulk DLPack TensorList constructors for lists of external tensors. The C++ path builds
  CPU and GPU TensorLists in one pass after preflighting devices and peeking all capsule dtypes,
  so dtype or device mismatches can fall back without partially consuming single-use capsules.
- Adds `ndd.Batch` fast paths for:
  - lists of already evaluated `ndd.Tensor` objects, preserving storage, layout, dtype, enum
    metadata, laziness behavior where applicable, and CUDA stream order;
  - lists of external GPU tensors exposing DLPack, including stream-keyword handshakes and
    same-device validation;
  - lists of CPU and CUDA-host/pinned CPU DLPack tensors.
- Keeps requested dtype conversion on the existing slow path, so external DLPack capsules are not
  consumed before conversion fallback.
- Improves `ndd.Tensor` DLPack ingestion:
  - CPU read-only arrays that raise `BufferError` fall back to an explicit copy through the array
    interface;
  - GPU objects retry `__dlpack__()` without the `stream` keyword only when the producer rejects
    the keyword, and fall back to `__cuda_array_interface__` only when DLPack is unavailable.
- Fixes mixed pinned/non-pinned non-contiguous GPU TensorLists. GPU sample sharing no longer
  requires uniform `is_pinned()` state, which unblocks mixed-GPU batches where cross-device copies
  use pinned staging memory. CPU TensorLists still enforce pinned-state compatibility.
- Makes `UserStream::GetStream(size_t dev)` public so the new bulk DLPack path can derive a
  concrete per-device consumer stream.

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
-->

## Additional information:

### Affected modules and functionalities:
- `dali/python/backend_impl.cc`: bulk `TensorListCPU/GPU.from_dlpack_list`, DLPack preflight,
  dtype peeking, stream handling, CUDA-host DLPack support, and TensorList-from-tensors order
  propagation.
- `dali/python/nvidia/dali/experimental/dynamic/_batch.py`: fast-path selection and fallback
  policy for `ndd.Batch` / `ndd.as_batch`.
- `dali/python/nvidia/dali/experimental/dynamic/_tensor.py`: read-only CPU fallback and safer
  GPU DLPack / CUDA array interface fallback.
- `dali/pipeline/data/tensor_list.cc`: pinned-state compatibility relaxed for GPU sample sharing
  only.
- `dali/util/user_stream.h`: public per-device stream lookup.
- `qa/TL0_multigpu/test_body.sh`: runs experimental-mode CuPy multi-GPU coverage in TL0.

### Key points relevant for the review:
- The DLPack list path intentionally validates device compatibility and dtype consistency before
  consuming capsules, because `__dlpack__()` capsules are single-use.
- GPU DLPack handshakes pass the consumer stream as a keyword argument and keep the resulting
  TensorList order aligned with that stream.
- `BufferError` is only used as a CPU read-only fallback signal. GPU `BufferError` is not swallowed
  by the Python fast path.
- Mixed-GPU DLPack objects still fall back to the per-sample slow path; mixed-GPU evaluated
  `ndd.Tensor` batches are supported through non-contiguous GPU TensorLists.
- Explicit dtype conversion intentionally bypasses the bulk DLPack fast path.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
-->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - `dali/test/python/experimental_mode/test_batch.py`: DALI tensor list fast path, lazy
      `as_batch`, GPU and CPU DLPack bulk paths, layout propagation, dtype fallback,
      TypeError fallback, mixed-GPU DLPack fallback, and mixed-GPU `ndd.Tensor` batches.
    - `dali/test/python/experimental_mode/test_tensor.py`: read-only NumPy tensors, read-only
      scalar NumPy tensors, and GPU `__cuda_array_interface__` fallback when DLPack raises
      `TypeError`.
  - [x] GTests
    - `dali/pipeline/data/tensor_list_test.cc`: adjusted pinned-state compatibility coverage for
      the relaxed GPU TensorList rule.
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

Latest PR checks are passing: GitHub lint, CodeQL, DCO, GitLab CI, and Jenkins CI.

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
-->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable -->

**JIRA TASK**: DALI-4580
<!--- DALI-XXXX or NA -->
