### PR TITLE
SequenceOperator: Do not keep thread pool and output order from the 1st iteration

### DIFF
--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022, 2024, 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -100,6 +100,8 @@ class SequenceOperator : public BaseOp<Backend>, protected SampleBroadcasting<Ba
       DALI_ENFORCE(IsExpandable(),
                    "Operator requested to expand the sequence-like inputs, but no expandable input "
                    "was found");
+      expanded_.SetThreadPool(ws.HasThreadPool() ? &ws.GetThreadPool() : nullptr);
+      expanded_.set_output_order(ws.output_order());
       if (!is_expanded_ws_initialized_) {
         InitializeExpandedWorkspace(ws);
         is_expanded_ws_initialized_ = true;
@@ -507,10 +509,6 @@ class SequenceOperator : public BaseOp<Backend>, protected SampleBroadcasting<Ba
   }
 
   void InitializeExpandedWorkspace(const Workspace &ws) {
-    if (ws.HasThreadPool())
-      expanded_.SetThreadPool(&ws.GetThreadPool());
-    expanded_.set_output_order(ws.output_order());
-
     InitializeExpandedInputs(ws);
     InitializeExpandedArguments(ws);
     InitializeExpandedOutputs(ws);


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Caching the thread pool in the operator instance could lead to SIGSEGV or deadlocks in Dynamic Mode.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
Existing tests cover regressions. The issue becomes apparent in #6254 where hard errors were seen without this fix.

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
