### PR TITLE
Fix glob_to_regex for Python 3.14

### DIFF
--- a/dali/test/python/nose_utils.py
+++ b/dali/test/python/nose_utils.py
@@ -156,7 +156,7 @@ def glob_to_regex(glob):
     # fnmatch adds special character to match the end of the string, so that when used
     # with re.match it, by default, matches the whole string. Here, it's going to be used
     # with re.search so it would be weird to enforce matching the suffix, but not the prefix.
-    if pattern[-2:] == r"\Z":
+    if pattern[-2:].upper() == r"\Z":
         pattern = pattern[:-2]
     return pattern
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
The `fnmatch` utility in Python 3.14 started returning a lowercase `\z` and we fail to remove it. This PR fixes that.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
