### PR TITLE
Handle NVML_ERROR_NOT_SUPPORTED gracefully on partial-NVML platforms

### DIFF
--- a/dali/util/nvml.cc
+++ b/dali/util/nvml.cc
@@ -15,6 +15,7 @@
 #include "dali/util/nvml.h"
 #include <pthread.h>
 #include <sys/sysinfo.h>
+#include <atomic>
 #include <vector>
 
 namespace dali {
@@ -23,26 +24,44 @@ namespace impl {
 
 
 float GetDriverVersion() {
-  if (!nvmlIsInitialized()) {
+  static std::atomic<bool> supported{true};
+  if (!supported || !nvmlIsInitialized()) {
     return 0;
   }
 
-  float driver_version = 0;
   char version[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
-
-  CUDA_CALL(nvmlSystemGetDriverVersion(version, sizeof version));
-  driver_version = std::stof(version);
-  return driver_version;
+  try {
+    CUDA_CALL(nvmlSystemGetDriverVersion(version, sizeof version));
+  } catch (const NvmlError &e) {
+    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
+      if (supported.exchange(false)) {
+        DALI_WARN("nvmlSystemGetDriverVersion is not supported on this platform.");
+      }
+      return 0;
+    }
+    throw;
+  }
+  return std::stof(version);
 }
 
 int GetCudaDriverVersion() {
-  if (!nvmlIsInitialized()) {
+  static std::atomic<bool> supported{true};
+  if (!supported || !nvmlIsInitialized()) {
     return 0;
   }
 
   int driver_version = 0;
-
-  CUDA_CALL(nvmlSystemGetCudaDriverVersion(&driver_version));
+  try {
+    CUDA_CALL(nvmlSystemGetCudaDriverVersion(&driver_version));
+  } catch (const NvmlError &e) {
+    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
+      if (supported.exchange(false)) {
+        DALI_WARN("nvmlSystemGetCudaDriverVersion is not supported on this platform.");
+      }
+      return 0;
+    }
+    throw;
+  }
   return driver_version;
 }
 
@@ -81,49 +100,61 @@ nvmlDevice_t nvmlGetDeviceHandleForCUDA(int cuda_idx) {
 }
 
 void GetNVMLAffinityMask(cpu_set_t *mask, size_t num_cpus) {
-  if (!nvmlIsInitialized()) {
+  static std::atomic<bool> supported{true};
+  if (!supported || !nvmlIsInitialized()) {
     return;
   }
-  int device_idx;
-  CUDA_CALL(cudaGetDevice(&device_idx));
+  try {
+    int device_idx;
+    CUDA_CALL(cudaGetDevice(&device_idx));
 
-  // Get the ideal placement from NVML
-  size_t cpu_set_size = (num_cpus + 63) / 64;
-  std::vector<unsigned long> nvml_mask_container(cpu_set_size);  // NOLINT(runtime/int)
-  auto * nvml_mask = nvml_mask_container.data();
-  nvmlDevice_t device = nvmlGetDeviceHandleForCUDA(device_idx);
-  #if (CUDART_VERSION >= 11000)
-    if (nvmlHasCuda11NvmlFunctions()) {
-      CUDA_CALL(nvmlDeviceGetCpuAffinityWithinScope(device, cpu_set_size, nvml_mask,
-                                                        NVML_AFFINITY_SCOPE_SOCKET));
-    } else {
+    // Get the ideal placement from NVML
+    size_t cpu_set_size = (num_cpus + 63) / 64;
+    std::vector<unsigned long> nvml_mask_container(cpu_set_size);  // NOLINT(runtime/int)
+    auto * nvml_mask = nvml_mask_container.data();
+    nvmlDevice_t device = nvmlGetDeviceHandleForCUDA(device_idx);
+    #if (CUDART_VERSION >= 11000)
+      if (nvmlHasCuda11NvmlFunctions()) {
+        CUDA_CALL(nvmlDeviceGetCpuAffinityWithinScope(device, cpu_set_size, nvml_mask,
+                                                          NVML_AFFINITY_SCOPE_SOCKET));
+      } else {
+        CUDA_CALL(nvmlDeviceGetCpuAffinity(device, cpu_set_size, nvml_mask));
+      }
+    #else
       CUDA_CALL(nvmlDeviceGetCpuAffinity(device, cpu_set_size, nvml_mask));
-    }
-  #else
-    CUDA_CALL(nvmlDeviceGetCpuAffinity(device, cpu_set_size, nvml_mask));
-  #endif
+    #endif
 
-  // Convert it to cpu_set_t
-  cpu_set_t nvml_set;
-  CPU_ZERO(&nvml_set);
-  const size_t n_bits = sizeof(unsigned long) * 8;  // NOLINT(runtime/int)
-  for (size_t i = 0; i < num_cpus; ++i) {
-    const size_t position = i % n_bits;
-    const size_t index = i / n_bits;
-    const unsigned long current_mask = 1ul << position;  // NOLINT(runtime/int)
-    const bool cpu_is_set = (nvml_mask[index] & current_mask) != 0;
-    if (cpu_is_set) {
-        CPU_SET(i, &nvml_set);
+    // Convert it to cpu_set_t
+    cpu_set_t nvml_set;
+    CPU_ZERO(&nvml_set);
+    const size_t n_bits = sizeof(unsigned long) * 8;  // NOLINT(runtime/int)
+    for (size_t i = 0; i < num_cpus; ++i) {
+      const size_t position = i % n_bits;
+      const size_t index = i / n_bits;
+      const unsigned long current_mask = 1ul << position;  // NOLINT(runtime/int)
+      const bool cpu_is_set = (nvml_mask[index] & current_mask) != 0;
+      if (cpu_is_set) {
+          CPU_SET(i, &nvml_set);
+      }
     }
+
+    // Get the current affinity mask
+    cpu_set_t current_set;
+    CPU_ZERO(&current_set);
+    pthread_getaffinity_np(pthread_self(), sizeof(current_set), &current_set);
+
+    // AND masks
+    CPU_AND(mask, &nvml_set, &current_set);
+  } catch (const NvmlError &e) {
+    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
+      if (supported.exchange(false)) {
+        DALI_WARN("nvmlDeviceGetCpuAffinity is not supported on this platform,"
+                  " skipping CPU affinity setting.");
+      }
+      return;
+    }
+    throw;
   }
-
-  // Get the current affinity mask
-  cpu_set_t current_set;
-  CPU_ZERO(&current_set);
-  pthread_getaffinity_np(pthread_self(), sizeof(current_set), &current_set);
-
-  // AND masks
-  CPU_AND(mask, &nvml_set, &current_set);
 }
 
 void SetCPUAffinity(int core) {

--- a/dali/util/nvml.cc
+++ b/dali/util/nvml.cc
@@ -148,8 +148,8 @@ void GetNVMLAffinityMask(cpu_set_t *mask, size_t num_cpus) {
   } catch (const NvmlError &e) {
     if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
       if (supported.exchange(false)) {
-        DALI_WARN("nvmlDeviceGetCpuAffinity is not supported on this platform,"
-                  " skipping CPU affinity setting.");
+        DALI_WARN("nvmlDeviceGetCpuAffinityWithinScope/nvmlDeviceGetCpuAffinity is not supported"
+                  " on this platform, skipping CPU affinity setting.");
       }
       return;
     }

--- a/dali/util/nvml.cc
+++ b/dali/util/nvml.cc
@@ -25,44 +25,24 @@ namespace impl {
 
 float GetDriverVersion() {
   static std::atomic<bool> supported{true};
-  if (!supported || !nvmlIsInitialized()) {
-    return 0;
-  }
-
-  char version[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
-  try {
-    CUDA_CALL(nvmlSystemGetDriverVersion(version, sizeof version));
-  } catch (const NvmlError &e) {
-    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
-      if (supported.exchange(false)) {
-        DALI_WARN("nvmlSystemGetDriverVersion is not supported on this platform.");
-      }
-      return 0;
-    }
-    throw;
-  }
-  return std::stof(version);
+  return detail::NvmlCall(supported,
+      "nvmlSystemGetDriverVersion is not supported on this platform.",
+      0.0f, [&]() -> float {
+        char version[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
+        CUDA_CALL(nvmlSystemGetDriverVersion(version, sizeof version));
+        return std::stof(version);
+      });
 }
 
 int GetCudaDriverVersion() {
   static std::atomic<bool> supported{true};
-  if (!supported || !nvmlIsInitialized()) {
-    return 0;
-  }
-
-  int driver_version = 0;
-  try {
-    CUDA_CALL(nvmlSystemGetCudaDriverVersion(&driver_version));
-  } catch (const NvmlError &e) {
-    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
-      if (supported.exchange(false)) {
-        DALI_WARN("nvmlSystemGetCudaDriverVersion is not supported on this platform.");
-      }
-      return 0;
-    }
-    throw;
-  }
-  return driver_version;
+  return detail::NvmlCall(supported,
+      "nvmlSystemGetCudaDriverVersion is not supported on this platform.",
+      0, [&]() -> int {
+        int driver_version = 0;
+        CUDA_CALL(nvmlSystemGetCudaDriverVersion(&driver_version));
+        return driver_version;
+      });
 }
 
 }  // namespace impl
@@ -101,60 +81,51 @@ nvmlDevice_t nvmlGetDeviceHandleForCUDA(int cuda_idx) {
 
 void GetNVMLAffinityMask(cpu_set_t *mask, size_t num_cpus) {
   static std::atomic<bool> supported{true};
-  if (!supported || !nvmlIsInitialized()) {
-    return;
-  }
-  try {
-    int device_idx;
-    CUDA_CALL(cudaGetDevice(&device_idx));
+  detail::NvmlCall(supported,
+      "nvmlDeviceGetCpuAffinityWithinScope/nvmlDeviceGetCpuAffinity is not supported"
+      " on this platform, skipping CPU affinity setting.",
+      [&]() {
+        int device_idx;
+        CUDA_CALL(cudaGetDevice(&device_idx));
 
-    // Get the ideal placement from NVML
-    size_t cpu_set_size = (num_cpus + 63) / 64;
-    std::vector<unsigned long> nvml_mask_container(cpu_set_size);  // NOLINT(runtime/int)
-    auto * nvml_mask = nvml_mask_container.data();
-    nvmlDevice_t device = nvmlGetDeviceHandleForCUDA(device_idx);
-    #if (CUDART_VERSION >= 11000)
-      if (nvmlHasCuda11NvmlFunctions()) {
-        CUDA_CALL(nvmlDeviceGetCpuAffinityWithinScope(device, cpu_set_size, nvml_mask,
-                                                          NVML_AFFINITY_SCOPE_SOCKET));
-      } else {
-        CUDA_CALL(nvmlDeviceGetCpuAffinity(device, cpu_set_size, nvml_mask));
-      }
-    #else
-      CUDA_CALL(nvmlDeviceGetCpuAffinity(device, cpu_set_size, nvml_mask));
-    #endif
+        // Get the ideal placement from NVML
+        size_t cpu_set_size = (num_cpus + 63) / 64;
+        std::vector<unsigned long> nvml_mask_container(cpu_set_size);  // NOLINT(runtime/int)
+        auto *nvml_mask = nvml_mask_container.data();
+        nvmlDevice_t device = nvmlGetDeviceHandleForCUDA(device_idx);
+        #if (CUDART_VERSION >= 11000)
+          if (nvmlHasCuda11NvmlFunctions()) {
+            CUDA_CALL(nvmlDeviceGetCpuAffinityWithinScope(device, cpu_set_size, nvml_mask,
+                                                              NVML_AFFINITY_SCOPE_SOCKET));
+          } else {
+            CUDA_CALL(nvmlDeviceGetCpuAffinity(device, cpu_set_size, nvml_mask));
+          }
+        #else
+          CUDA_CALL(nvmlDeviceGetCpuAffinity(device, cpu_set_size, nvml_mask));
+        #endif
 
-    // Convert it to cpu_set_t
-    cpu_set_t nvml_set;
-    CPU_ZERO(&nvml_set);
-    const size_t n_bits = sizeof(unsigned long) * 8;  // NOLINT(runtime/int)
-    for (size_t i = 0; i < num_cpus; ++i) {
-      const size_t position = i % n_bits;
-      const size_t index = i / n_bits;
-      const unsigned long current_mask = 1ul << position;  // NOLINT(runtime/int)
-      const bool cpu_is_set = (nvml_mask[index] & current_mask) != 0;
-      if (cpu_is_set) {
-          CPU_SET(i, &nvml_set);
-      }
-    }
+        // Convert it to cpu_set_t
+        cpu_set_t nvml_set;
+        CPU_ZERO(&nvml_set);
+        const size_t n_bits = sizeof(unsigned long) * 8;  // NOLINT(runtime/int)
+        for (size_t i = 0; i < num_cpus; ++i) {
+          const size_t position = i % n_bits;
+          const size_t index = i / n_bits;
+          const unsigned long current_mask = 1ul << position;  // NOLINT(runtime/int)
+          const bool cpu_is_set = (nvml_mask[index] & current_mask) != 0;
+          if (cpu_is_set) {
+            CPU_SET(i, &nvml_set);
+          }
+        }
 
-    // Get the current affinity mask
-    cpu_set_t current_set;
-    CPU_ZERO(&current_set);
-    pthread_getaffinity_np(pthread_self(), sizeof(current_set), &current_set);
+        // Get the current affinity mask
+        cpu_set_t current_set;
+        CPU_ZERO(&current_set);
+        pthread_getaffinity_np(pthread_self(), sizeof(current_set), &current_set);
 
-    // AND masks
-    CPU_AND(mask, &nvml_set, &current_set);
-  } catch (const NvmlError &e) {
-    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
-      if (supported.exchange(false)) {
-        DALI_WARN("nvmlDeviceGetCpuAffinityWithinScope/nvmlDeviceGetCpuAffinity is not supported"
-                  " on this platform, skipping CPU affinity setting.");
-      }
-      return;
-    }
-    throw;
-  }
+        // AND masks
+        CPU_AND(mask, &nvml_set, &current_set);
+      });
 }
 
 void SetCPUAffinity(int core) {

--- a/dali/util/nvml.h
+++ b/dali/util/nvml.h
@@ -17,6 +17,7 @@
 
 #include <nvml.h>
 #include <cuda_runtime_api.h>
+#include <atomic>
 #include <mutex>
 #include <string>
 #include "dali/util/nvml_wrap.h"
@@ -259,13 +260,25 @@ inline DeviceProperties GetDeviceInfo(int device_idx) {
  * @throws std::runtime_error
  */
 inline bool HasHwDecoder(int device_idx) {
-  if (!nvmlIsInitialized()) {
+  static std::atomic<bool> supported{true};
+  if (!supported || !nvmlIsInitialized()) {
     return false;
   }
-  auto info = GetDeviceInfo(device_idx);
-  return info.type == NVML_BRAND_TESLA &&
-         (info.cap_major == 8 || info.cap_major == 9) &&
-         info.cap_minor == 0;
+  try {
+    auto info = GetDeviceInfo(device_idx);
+    return info.type == NVML_BRAND_TESLA &&
+           (info.cap_major == 8 || info.cap_major == 9) &&
+           info.cap_minor == 0;
+  } catch (const NvmlError &e) {
+    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
+      if (supported.exchange(false)) {
+        DALI_WARN("nvmlDeviceGetBrand/nvmlDeviceGetCudaComputeCapability is not supported"
+                  " on this platform, skipping HW decoder detection.");
+      }
+      return false;
+    }
+    throw;
+  }
 }
 
 /**
@@ -274,11 +287,23 @@ inline bool HasHwDecoder(int device_idx) {
  * @throws std::runtime_error
  */
 inline bool HasHwDecoder() {
-  if (!nvmlIsInitialized()) {
+  static std::atomic<bool> supported{true};
+  if (!supported || !nvmlIsInitialized()) {
     return false;
   }
   unsigned int device_count;
-  CUDA_CALL(nvmlDeviceGetCount_v2(&device_count));
+  try {
+    CUDA_CALL(nvmlDeviceGetCount_v2(&device_count));
+  } catch (const NvmlError &e) {
+    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
+      if (supported.exchange(false)) {
+        DALI_WARN("nvmlDeviceGetCount_v2 is not supported on this platform,"
+                  " skipping HW decoder detection.");
+      }
+      return false;
+    }
+    throw;
+  }
   for (unsigned int device_idx = 0; device_idx < device_count; device_idx++) {
     if (HasHwDecoder(device_idx)) return true;
   }

--- a/dali/util/nvml.h
+++ b/dali/util/nvml.h
@@ -228,6 +228,49 @@ inline int GetCudaDriverVersion() {
 }
 
 
+namespace detail {
+
+/**
+ * Calls fn(), gracefully handling NVML_ERROR_NOT_SUPPORTED.
+ * On the first NOT_SUPPORTED result the supported flag is cleared and a one-time warning
+ * is emitted; subsequent calls return default_val immediately without touching NVML.
+ */
+template <typename T, typename F>
+T NvmlCall(std::atomic<bool> &supported, const char *what, T default_val, F &&fn) {
+  if (!supported || !nvmlIsInitialized())
+    return default_val;
+  try {
+    return fn();
+  } catch (const NvmlError &e) {
+    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
+      if (supported.exchange(false))
+        DALI_WARN(what);
+      return default_val;
+    }
+    throw;
+  }
+}
+
+/** Void overload — same semantics, no return value. */
+template <typename F>
+void NvmlCall(std::atomic<bool> &supported, const char *what, F &&fn) {
+  if (!supported || !nvmlIsInitialized())
+    return;
+  try {
+    fn();
+  } catch (const NvmlError &e) {
+    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
+      if (supported.exchange(false))
+        DALI_WARN(what);
+      return;
+    }
+    throw;
+  }
+}
+
+}  // namespace detail
+
+
 #if (CUDART_VERSION >= 11000)
 
 /**
@@ -261,24 +304,15 @@ inline DeviceProperties GetDeviceInfo(int device_idx) {
  */
 inline bool HasHwDecoder(int device_idx) {
   static std::atomic<bool> supported{true};
-  if (!supported || !nvmlIsInitialized()) {
-    return false;
-  }
-  try {
-    auto info = GetDeviceInfo(device_idx);
-    return info.type == NVML_BRAND_TESLA &&
-           (info.cap_major == 8 || info.cap_major == 9) &&
-           info.cap_minor == 0;
-  } catch (const NvmlError &e) {
-    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
-      if (supported.exchange(false)) {
-        DALI_WARN("nvmlDeviceGetBrand/nvmlDeviceGetCudaComputeCapability is not supported"
-                  " on this platform, skipping HW decoder detection.");
-      }
-      return false;
-    }
-    throw;
-  }
+  return detail::NvmlCall(supported,
+      "nvmlDeviceGetBrand/nvmlDeviceGetCudaComputeCapability is not supported"
+      " on this platform, skipping HW decoder detection.",
+      false, [&]() -> bool {
+        auto info = GetDeviceInfo(device_idx);
+        return info.type == NVML_BRAND_TESLA &&
+               (info.cap_major == 8 || info.cap_major == 9) &&
+               info.cap_minor == 0;
+      });
 }
 
 /**
@@ -288,26 +322,17 @@ inline bool HasHwDecoder(int device_idx) {
  */
 inline bool HasHwDecoder() {
   static std::atomic<bool> supported{true};
-  if (!supported || !nvmlIsInitialized()) {
-    return false;
-  }
-  unsigned int device_count;
-  try {
-    CUDA_CALL(nvmlDeviceGetCount_v2(&device_count));
-  } catch (const NvmlError &e) {
-    if (e.result() == NVML_ERROR_NOT_SUPPORTED) {
-      if (supported.exchange(false)) {
-        DALI_WARN("nvmlDeviceGetCount_v2 is not supported on this platform,"
-                  " skipping HW decoder detection.");
-      }
-      return false;
-    }
-    throw;
-  }
-  for (unsigned int device_idx = 0; device_idx < device_count; device_idx++) {
-    if (HasHwDecoder(device_idx)) return true;
-  }
-  return false;
+  return detail::NvmlCall(supported,
+      "nvmlDeviceGetCount_v2 is not supported on this platform,"
+      " skipping HW decoder detection.",
+      false, [&]() -> bool {
+        unsigned int device_count;
+        CUDA_CALL(nvmlDeviceGetCount_v2(&device_count));
+        for (unsigned int device_idx = 0; device_idx < device_count; device_idx++) {
+          if (HasHwDecoder(device_idx)) return true;
+        }
+        return false;
+      });
 }
 
 inline bool isHWDecoderSupported() {


### PR DESCRIPTION
On platforms like WSL2, NVML initialises successfully but individual
queries (e.g. nvmlDeviceGetCpuAffinityWithinScope) return
NVML_ERROR_NOT_SUPPORTED. Previously this propagated as an unhandled
exception.

* Each affected call site now carries a static per-function
  supported flag (std::atomic<bool>).
* On the first NOT_SUPPORTED result the flag is cleared and a
  one-time warning is emitted; subsequent calls to that function
  return a safe default without touching NVML.
* Unrelated NVML functions that work correctly are not affected.

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
  Bug fix (*non-breaking change which fixes an issue*)

  ## Description:
  On platforms like WSL2, NVML initialises successfully but individual
  queries (e.g. `nvmlDeviceGetCpuAffinityWithinScope`) return
  `NVML_ERROR_NOT_SUPPORTED`. Previously this propagated as an unhandled
  exception, crashing DALI at thread-pool creation time.

  The existing `DALI_DISABLE_NVML=1` workaround was too broad — it also
  disables driver version queries, HW decoder detection and other NVML
  functionality that works correctly on the same platform.

  Instead, each call site that may encounter `NOT_SUPPORTED` now carries
  its own `static std::atomic<bool> supported{true}` flag. On the first
  failure the flag is atomically cleared and a one-time warning is emitted
  (`exchange` acts as the warn-once guard). Subsequent calls to that
  specific function return a safe default without touching NVML. All other
  NVML functions that succeed on the platform continue working normally.

  ## Additional information:

  ### Affected modules and functionalities:
  - `dali/util/nvml.cc` — `GetNVMLAffinityMask`, `GetDriverVersion`, `GetCudaDriverVersion`
  - `dali/util/nvml.h` — `HasHwDecoder`, `HasHwDecoder(int)`

  ### Key points relevant for the review:
  - No global disable state is introduced; each function degrades independently.
  - `std::atomic<bool>::exchange` provides a lock-free warn-once guarantee across threads.
  - `nvmlIsInitialized()` and `nvml_wrap.*` are unchanged.

  ### Tests:
  - [ ] Existing tests apply
  - [ ] New tests added
    - [ ] Python tests
    - [ ] GTests
    - [ ] Benchmark
    - [ ] Other
  - [x] N/A

  ## Checklist

  ### Documentation
  - [ ] Existing documentation applies
  - [ ] Documentation updated
    - [ ] Docstring
    - [ ] Doxygen
    - [ ] RST
    - [ ] Jupyter
    - [ ] Other
  - [x] N/A

  ### DALI team only

  #### Requirements
  - [ ] Implements new requirements
  - [ ] Affects existing requirements
  - [x] N/A

  **REQ IDs**: N/A

  **JIRA TASK**: N/A