### PR TITLE
Update torch and torchvision package versions for CUDA 13.x

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -597,18 +597,18 @@ all_packages = [
     CudaPackageExtraIndex(
         "torch",
         {
-            "120": [PckgVer("2.7.1", python_min_ver="3.9", python_max_ver="3.13")],
-            "130": [PckgVer("2.8.0", python_min_ver="3.9", python_max_ver="3.13")],
+            "120": [PckgVer("2.8.0+cu128", python_min_ver="3.9", python_max_ver="3.13")],
+            "130": [PckgVer("2.10.0+cu130", python_min_ver="3.10", python_max_ver="3.14")],
         },
-        extra_index="https://download.pytorch.org/whl/cu128/",
+        extra_index="https://download.pytorch.org/whl/",
     ),
     CudaPackageExtraIndex(
         "torchvision",
         {
-            "120": [PckgVer("0.22.1", python_min_ver="3.9", python_max_ver="3.13")],
-            "130": [PckgVer("0.23.0", python_min_ver="3.9", python_max_ver="3.13")],
+            "120": [PckgVer("0.23.0+cu128", python_min_ver="3.9", python_max_ver="3.13")],
+            "130": [PckgVer("0.26.0+cu130", python_min_ver="3.10", python_max_ver="3.14")],
         },
-        extra_index="https://download.pytorch.org/whl/cu128/",
+        extra_index="https://download.pytorch.org/whl/",
     ),
     CudaPackageExtraIndex(
         "paddlepaddle-gpu",

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -598,7 +598,7 @@ all_packages = [
         "torch",
         {
             "120": [PckgVer("2.8.0+cu128", python_min_ver="3.9", python_max_ver="3.13")],
-            "130": [PckgVer("2.10.0+cu130", python_min_ver="3.10", python_max_ver="3.14")],
+            "130": [PckgVer("2.11.0+cu130", python_min_ver="3.10", python_max_ver="3.14")],
         },
         extra_index="https://download.pytorch.org/whl/",
     ),

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -597,7 +597,7 @@ all_packages = [
     CudaPackageExtraIndex(
         "torch",
         {
-            "120": [PckgVer("2.8.0+cu128", python_min_ver="3.9", python_max_ver="3.13")],
+            "120": [PckgVer("2.7.1+cu128", python_min_ver="3.9", python_max_ver="3.13")],
             "130": [PckgVer("2.11.0+cu130", python_min_ver="3.10", python_max_ver="3.14")],
         },
         extra_index="https://download.pytorch.org/whl/",
@@ -605,7 +605,7 @@ all_packages = [
     CudaPackageExtraIndex(
         "torchvision",
         {
-            "120": [PckgVer("0.23.0+cu128", python_min_ver="3.9", python_max_ver="3.13")],
+            "120": [PckgVer("0.22.1+cu128", python_min_ver="3.9", python_max_ver="3.13")],
             "130": [PckgVer("0.26.0+cu130", python_min_ver="3.10", python_max_ver="3.14")],
         },
         extra_index="https://download.pytorch.org/whl/",


### PR DESCRIPTION
- torch: 2.11.0+cu130 (CUDA 13.x)
- torchvision: 0.26.0+cu130 (CUDA 13.x)
- Broadened extra_index URL to https://download.pytorch.org/whl/
   to support both CUDA variants
- Updated python_max_ver to 3.14 for CUDA 13.x packages

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
  **Other** (*Configuration*)

  ## Description:
  Updates the torch and torchvision package versions used in QA setup to the latest available releases, and broadens the PyTorch extra index URL so it can serve packages for CUDA 13.x builds.

  ## Additional information:

  ### Affected modules and functionalities:
  - `qa/setup_packages.py`: Updated torch and torchvision versions and their extra index URL.
    - torch: 2.11.0+cu130 (CUDA 13.x)
    - torchvision: 0.26.0+cu130 (CUDA 13.x)
    - `extra_index`: `https://download.pytorch.org/whl/cu128/` -> `https://download.pytorch.org/whl/` (unified index for all CUDA variants)
    - Updated `python_max_ver` to `3.14` for CUDA 13.x torch/torchvision packages

  ### Key points relevant for the review:
  - The extra index URL was changed from the CUDA-128-specific path to the base PyTorch wheel index, which serves version-suffixed wheels (e.g. `+cu128`, `+cu130`) correctly for both CUDA variants.
  - `python_max_ver` for CUDA 13.x packages bumped to `3.14` to align with the new torch 2.10.0 support matrix.

  ### Tests:
  - [ ] Existing tests apply
  - [ ] New tests added
  - [x] N/A

  ## Checklist

  ### Documentation
  - [ ] Existing documentation applies
  - [ ] Documentation updated
  - [x] N/A

  ### DALI team only

  #### Requirements
  - [ ] Implements new requirements
  - [ ] Affects existing requirements
  - [x] N/A

  **REQ IDs**: N/A

  **JIRA TASK**: N/A