### PR TITLE
ci: exclude py/unsafe-cyclic-import from CodeQL reporting

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - exclude:
+      id: py/unsafe-cyclic-import

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          queries: +security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
- Adds .github/codeql/codeql-config.yml with a query-filter to suppress
  the py/unsafe-cyclic-import rule, and update codeql.yml to use the
  config file instead of the inline queries parameter.

## Category:
Other (*Configuration*)


## Description:
CodeQL currently reports `py/unsafe-cyclic-import` alerts across the codebase.
These are false positives for our use case (DALI's Python modules use deferred /
conditional imports intentionally to break circular dependencies at import time).
This PR suppresses that specific rule via a CodeQL config file rather than
silencing it inline in every affected file.


## Additional information:

### Affected modules and functionalities:
- `.github/codeql/codeql-config.yml` — new file; declares the `security-and-quality`
  query suite and adds a `query-filters` entry to exclude `py/unsafe-cyclic-import`.
- `.github/workflows/codeql.yml` — replaces the inline `queries: +security-and-quality`
  parameter with `config-file: ./.github/codeql/codeql-config.yml` so the workflow
  delegates query selection and filtering to the config file.


### Key points relevant for the review:
- Moving from `queries:` to `config-file:` is the standard CodeQL approach for
  per-repo query customisation; the effective query suite (`security-and-quality`)
  is unchanged — only `py/unsafe-cyclic-import` is filtered out.
- The filter uses `id:` matching, which is the stable, version-independent way to
  exclude a rule (as opposed to path-based exclusions).


### Tests:
- [x] N/A


## Checklist

### Documentation
- [x] N/A

### DALI team only

#### Requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A