### PR TITLE
Fix handling of empty layouts in ndd.Invocation

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -26,13 +26,20 @@
 namespace dali {
 
 inline std::optional<int> ReshapeNDimFunc(const OpSpec &spec) {
+  // run-time shape is no-go
+  if (spec.NumRegularInput() > 1)
+    return std::nullopt;
+  if (spec.HasTensorArgument("shape") || spec.HasTensorArgument("rel_shape"))
+    return std::nullopt;
+
   std::vector<int> shape;
   if (spec.TryGetRepeatedArgument(shape, "shape"))
     return shape.size();
   std::vector<float> rel_shape;
   if (spec.TryGetRepeatedArgument(rel_shape, "rel_shape"))
     return rel_shape.size();
-  return std::nullopt;
+
+  return spec.InputDesc(0).ndim;
 }
 
 DALI_SCHEMA(Reshape)

--- a/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
@@ -160,7 +160,9 @@ class Invocation:
                     layout = str(layout)
                     return None if layout == "" else layout
             self.run(self._eval_context)
-        return self._results[result_index].layout()
+
+        layout = self._results[result_index].layout()
+        return None if layout == "" else layout
 
     def __iter__(self):
         for index in range(len(self)):

--- a/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
@@ -162,7 +162,7 @@ class Invocation:
             self.run(self._eval_context)
 
         layout = self._results[result_index].layout()
-        return None if layout == "" else layout
+        return layout or None  # this will override "" with None
 
     def __iter__(self):
         for index in range(len(self)):

--- a/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
@@ -151,7 +151,7 @@ class Invocation:
             self.run(self._eval_context)
         return self._results[result_index].dtype
 
-    def layout(self, result_index: int) -> str:
+    def layout(self, result_index: int) -> str | None:
         if self._results is None:
             if init_spec := getattr(self._operator, "_init_spec", None):
                 init_spec(self._inputs, self._args)

--- a/dali/test/python/experimental_mode/test_output_metadata.py
+++ b/dali/test/python/experimental_mode/test_output_metadata.py
@@ -56,6 +56,7 @@ def assert_correct_metadata(
     (ndd.brightness_contrast, dict(brightness=1.2)),
     (ndd.crop_mirror_normalize, dict(crop=(2, 2))),
     (ndd.crop_mirror_normalize, dict(crop=(2, 2), dtype=ndd.float32)),
+    (ndd.reshape, dict(layout="")),
 )
 def test_image_ops(func, kwargs):
     tensor = ndd.zeros(shape=(4, 4, 3), dtype=ndd.uint8, layout="HWC")
@@ -206,3 +207,15 @@ def test_gaussian_blur_fchw():
     sigmas = ndd.per_frame(sigmas)
 
     assert_correct_metadata(ndd.gaussian_blur(input, sigma=sigmas))
+
+
+# --- Empty layout handling ---
+
+
+@eval_modes(ndd.EvalMode.deferred)
+def test_empty_layout():
+    input = ndd.as_batch([ndd.zeros(shape=(3, 3)), ndd.zeros(shape=(4, 4))])
+    reshaped = ndd.reshape(input, layout="")
+    assert reshaped._invocation_result.layout is None
+    reshaped.evaluate()
+    assert reshaped._invocation_result.layout is None


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
This PR fixes a minor inconsistency in handling empty layouts. Empty layouts obtained from metadata were returned as `None` but as empty string if evaluation was required. Now `None` is returned across the board, consistent with the behavior of Tensor and Batch.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
