### PR TITLE
Disable default metadata policy for Python-based operators.

### DIFF
--- a/dali/operators/numba_function/numba_func.cc
+++ b/dali/operators/numba_function/numba_func.cc
@@ -136,9 +136,7 @@ When `batch_processing` is set to ``True``, the function processes the whole bat
 function has to perform cross-sample operations and may be beneficial if significant part of the work can
 be reused. For other use cases, specifying False and using per-sample processing function allows the operator
 to process samples in parallel.)code", false)
-  .OutputDType(0, std::nullopt)
-  .OutputNDim(0, std::nullopt)
-  .OutputLayout(0, std::nullopt);
+  .UseDefaultMetadataPolicy(false);  // It's user-defined in Python, we don't know anything.
 
 DALI_SCHEMA(NumbaFuncImpl)
   .DocStr("")
@@ -162,9 +160,7 @@ block used to execute a CUDA kernel)code", DALI_INT_VEC, {})
 This function is invoked once per batch.)code", 0)
   .AddOptionalArg("batch_processing", R"code(Determines whether the function is invoked once per batch or
 separately for each sample in the batch.)code", false)
-  .OutputDType(0, std::nullopt)
-  .OutputNDim(0, std::nullopt)
-  .OutputLayout(0, std::nullopt);
+  .UseDefaultMetadataPolicy(false);  // It's user-defined in Python, we don't know anything.
 
 template <>
 NumbaFuncImpl<CPUBackend>::NumbaFuncImpl(const OpSpec &spec) : Base(spec) {

--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -39,9 +39,7 @@ outputs have no layout assigned.)code", nullptr)
     .NoPrune()
     .Unserializable()
     .MakeInternal()
-    .OutputLayout(0, std::nullopt)
-    .OutputDType(0, std::nullopt)
-    .OutputNDim(0, std::nullopt);
+    .UseDefaultMetadataPolicy(false);  // It's user-defined in Python, we don't know anything.
 
 
 DALI_SCHEMA(DLTensorPythonFunction)
@@ -75,9 +73,8 @@ If set to True, the function will receive its arguments as lists of DLPack tenso
     .SupportVolumetric()
     .NoPrune()
     .AddParent("PythonFunctionBase")
-    .OutputLayout(0, std::nullopt)
-    .OutputDType(0, std::nullopt)
-    .OutputNDim(0, std::nullopt);
+    .UseDefaultMetadataPolicy(false);  // It's user-defined in Python, we don't know anything.
+
 
 namespace detail {
 

--- a/dali/operators/python_function/jax_function.cc
+++ b/dali/operators/python_function/jax_function.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +54,8 @@ from the input to the output.)code",
                                                nullptr)
     .Unserializable()
     .MakeInternal()
-    .MakeDocHidden();
+    .MakeDocHidden()
+    .UseDefaultMetadataPolicy(false);  // It's user-defined in Python, we don't know anything.
 
 
 DALI_REGISTER_OPERATOR(_JaxFunction, JaxFunction<CPUBackend>, CPU);

--- a/dali/operators/python_function/python_function.cc
+++ b/dali/operators/python_function/python_function.cc
@@ -35,9 +35,8 @@ fewer than num_outputs elements, only the first outputs have the layout set and 
 outputs have no layout assigned.)code", nullptr)
     .MakeStateful()  // The python function may have some state
     .MakeInternal()
-    .OutputLayout(0, std::nullopt)
-    .OutputDType(0, std::nullopt)
-    .OutputNDim(0, std::nullopt);
+    .UseDefaultMetadataPolicy(false);  // It's user-defined in Python, we don't know anything.
+
 
 DALI_SCHEMA(PythonFunction)
         .DocStr(R"code(Executes a Python function.
@@ -75,9 +74,8 @@ once per batch or separately for every sample in the batch.
 
 If set to True, the function will receive its arguments as lists of NumPy or CuPy arrays,
 for CPU and GPU backend, respectively.)code", false)
-        .OutputLayout(0, std::nullopt)
-        .OutputDType(0, std::nullopt)
-        .OutputNDim(0, std::nullopt);
+        .UseDefaultMetadataPolicy(false);  // It's user-defined in Python, we don't know anything.
+
 
 DALI_SCHEMA(TorchPythonFunction)
         .DocStr(R"code(Executes a function that is operating on Torch tensors.
@@ -91,8 +89,6 @@ as PyTorch tensors.)code")
         .AddParent("PythonFunctionBase")
         .AddOptionalArg("batch_processing", R"code(Determines whether the function gets
 an entire batch as an input.)code", true)
-        .OutputLayout(0, std::nullopt)
-        .OutputDType(0, std::nullopt)
-        .OutputNDim(0, std::nullopt);
+        .UseDefaultMetadataPolicy(false);  // It's user-defined in Python, we don't know anything.
 
 }  // namespace dali


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)



## Description:
This change disables the default metadata inference policy for JAX function. It also refactors other Python-based operators by disabling the default policy instead of just setting `nullopt` metadata.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
L1 JAX, L0 others
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
