### PR TITLE
Fix a race condition when querying op metadata

### DIFF
--- a/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
@@ -133,34 +133,38 @@ class Invocation:
 
     def ndim(self, result_index: int) -> int:
         if self._results is None:
-            if init_spec := getattr(self._operator, "_init_spec", None):
-                init_spec(self._inputs, self._args)
-                ndim = self._operator._op_spec.OutputDesc(result_index)[2]
-                if ndim is not None:
-                    return ndim
+            ndim = self._try_get_metadata(result_index, 2)
+            if ndim is not None:
+                return ndim
             self.run(self._eval_context)
         return self._results[result_index].ndim()
 
     def dtype(self, result_index: int) -> DType:
         if self._results is None:
-            if init_spec := getattr(self._operator, "_init_spec", None):
-                init_spec(self._inputs, self._args)
-                dtype = self._operator._op_spec.OutputDesc(result_index)[3]
-                if dtype is not None:
-                    return dtype
+            if dtype := self._try_get_metadata(result_index, 3):
+                return dtype
             self.run(self._eval_context)
         return self._results[result_index].dtype
 
-    def layout(self, result_index: int) -> str:
+    def layout(self, result_index: int) -> str | None:
         if self._results is None:
-            if init_spec := getattr(self._operator, "_init_spec", None):
-                init_spec(self._inputs, self._args)
-                layout = self._operator._op_spec.OutputDesc(result_index)[4]
-                if layout is not None:
-                    layout = str(layout)
-                    return None if layout == "" else layout
+            layout = self._try_get_metadata(result_index, 4)
+            if layout is not None:
+                layout = str(layout)
+                return None if layout == "" else layout
             self.run(self._eval_context)
         return self._results[result_index].layout()
+
+    def _try_get_metadata(self, result_index: int, desc_index: int):
+        # Capture the operator first to guard from a race condition
+        operator = self._operator
+        if self._results is None:
+            assert operator is not None
+            if init_spec := getattr(operator, "_init_spec", None):
+                init_spec(self._inputs, self._args)
+                if output_desc := operator._op_spec.OutputDesc(result_index):
+                    return output_desc[desc_index]
+        return None
 
     def __iter__(self):
         for index in range(len(self)):

--- a/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
@@ -38,9 +38,6 @@ class Invocation:
     It binds the operator instance and the call arguments.
     It also tracks the order of invocations of stateful operators, which is important for
     lazy evaluation of stateful operators or operators with side-effects.
-
-    NOTE:  This class is not thread safe. Subsequent invocations of the same operator instance
-           must be synchronized by the caller.
     """
 
     def __init__(
@@ -141,7 +138,8 @@ class Invocation:
 
     def dtype(self, result_index: int) -> DType:
         if self._results is None:
-            if dtype := self._try_get_metadata(result_index, 3):
+            dtype = self._try_get_metadata(result_index, 3)
+            if dtype is not None:
                 return dtype
             self.run(self._eval_context)
         return self._results[result_index].dtype

--- a/dali/test/python/experimental_mode/test_multithreading.py
+++ b/dali/test/python/experimental_mode/test_multithreading.py
@@ -252,3 +252,19 @@ def test_error_parallel_eval_contexts():
 
     with assert_raises(RuntimeError, glob="*EvalContext*"):
         run_parallel(worker)
+
+
+def test_parallel_op_metadata_query():
+    layouts = ["ABC", "XYZ", None]
+    dtypes = [ndd.int32, ndd.float32, ndd.uint8]
+
+    def worker(thread_id: int):
+        layout = layouts[thread_id % len(layouts)]
+        dtype = dtypes[thread_id % len(dtypes)]
+        for _ in range(1_000):
+            batch = ndd.zeros(batch_size=8, shape=[64, 64, 3], layout=layout, dtype=dtype)
+            assert batch.layout == layout
+            assert batch.dtype == dtype
+            assert batch.ndim == 3
+
+    run_parallel(worker)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:

When getting the `ndim`, `dtype` or `layout` of an operator in dynamic mode, the invocation first checks that it has no result and if that's the case uses the operator to infer metadata statically. This can cause a race condition if another thread is executing the operator because the `_operator` attribute of the invocation is set to `None` when running is complete.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

Dynamic mode.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4668
<!--- DALI-XXXX or NA --->
