### PR TITLE
Add schema aliases. Use aliases in rename-only deprecations.

### DIFF
--- a/dali/operators/audio/resample.cc
+++ b/dali/operators/audio/resample.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,18 +97,14 @@ type. Example::
     nullptr, false);
 
 // Deprecated alias
-DALI_SCHEMA(experimental__AudioResample)
-    .AddParent("AudioResample")
-    .DocStr("Legacy alias for :meth:`audio_resample`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .MakeDocHidden()
+DALI_SCHEMA_ALIAS(experimental__AudioResample, AudioResample)
     .Deprecate(
         "1.18",
         "AudioResample",
         "This operator was moved out from the experimental phase, "
-        "and is now a regular DALI operator. This is just an deprecated "
-        "alias kept for backward compatibility.");
+        "and is now a regular DALI operator. This is just a deprecated "
+        "alias kept for backward compatibility.")
+    .MakeDocHidden();
 
 namespace audio {
 

--- a/dali/operators/decoder/inflate/inflate.cc
+++ b/dali/operators/decoder/inflate/inflate.cc
@@ -89,10 +89,7 @@ The value is ignored if the `layout` is not specified or the input is not a sequ
     .OutputLayout(0, std::nullopt)
     .OutputNDim(0, std::nullopt);
 
-DALI_SCHEMA(experimental__Inflate)
-    .AddParent("decoders__Inflate")
-    .NumInput(1)
-    .NumOutput(1)
+DALI_SCHEMA_ALIAS(experimental__Inflate, decoders__Inflate)
     .Deprecate("2.0", "decoders__Inflate")
     .MakeDocHidden();
 

--- a/dali/operators/decoder/inflate/inflate.cc
+++ b/dali/operators/decoder/inflate/inflate.cc
@@ -95,10 +95,7 @@ The value is ignored if the `layout` is not specified or the input is not a sequ
     .OutputLayout(0, std::nullopt)
     .OutputNDim(0, std::nullopt);
 
-DALI_SCHEMA(experimental__Inflate)
-    .AddParent("decoders__Inflate")
-    .NumInput(1)
-    .NumOutput(1)
+DALI_SCHEMA_ALIAS(experimental__Inflate, decoders__Inflate)
     .Deprecate("2.0", "decoders__Inflate")
     .MakeDocHidden();
 

--- a/dali/operators/generic/resize/tensor_resize_cpu.cc
+++ b/dali/operators/generic/resize/tensor_resize_cpu.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,20 +46,14 @@ DALI_SCHEMA(TensorResize)
     .AddParent("TensorResizeAttr");
 
 // Deprecated alias
-DALI_SCHEMA(experimental__TensorResize)
-    .AddParent("TensorResize")
-    .DocStr("Legacy alias for :meth:`tensor_resize`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .MakeDocHidden()
-    .SupportVolumetric()
-    .AllowSequences()
+DALI_SCHEMA_ALIAS(experimental__TensorResize, TensorResize)
     .Deprecate(
         "2.0",
         "TensorResize",
         "This operator was moved out from the experimental phase, "
         "and is now a regular DALI operator. This is just a deprecated "
-        "alias kept for backward compatibility.");
+        "alias kept for backward compatibility.")
+    .MakeDocHidden();
 
 // Kept for backwards compatibility
 DALI_REGISTER_OPERATOR(experimental__TensorResize, tensor_resize::TensorResizeCPU, CPU);

--- a/dali/operators/reader/file_reader_op.cc
+++ b/dali/operators/reader/file_reader_op.cc
@@ -146,17 +146,13 @@ case-sensitively, otherwise case-insensitively.)", false)
 // Deprecated alias
 DALI_REGISTER_OPERATOR(FileReader, FileReader, CPU);
 
-DALI_SCHEMA(FileReader)
-    .DocStr("Legacy alias for :meth:`readers.file`.")
-    .NumInput(0)
-    .NumOutput(2)  // (Images, Labels)
-    .AddParent("readers__File")
-    .MakeDocHidden()
+DALI_SCHEMA_ALIAS(FileReader, readers__File)
     .Deprecate(
         "1.0",
         "readers__File",
         R"code(In DALI 1.0 all readers were moved into a dedicated :mod:`~nvidia.dali.fn.readers`
 submodule and renamed to follow a common pattern. This is a placeholder operator with identical
-functionality to allow for backward compatibility.)code");
+functionality to allow for backward compatibility.)code")
+    .MakeDocHidden();
 
 }  // namespace dali

--- a/dali/operators/reader/mxnet_reader_op.cc
+++ b/dali/operators/reader/mxnet_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -64,17 +64,13 @@ properties.
 // Deprecated alias
 DALI_REGISTER_OPERATOR(MXNetReader, MXNetReader, CPU);
 
-DALI_SCHEMA(MXNetReader)
-    .DocStr("Legacy alias for :meth:`readers.mxnet`.")
-    .NumInput(0)
-    .NumOutput(2)
-    .AddParent("readers__MXNet")
-    .MakeDocHidden()
+DALI_SCHEMA_ALIAS(MXNetReader, readers__MXNet)
     .Deprecate(
         "1.0",
         "readers__MXNet",
         R"code(In DALI 1.0 all readers were moved into a dedicated :mod:`~nvidia.dali.fn.readers`
 submodule and renamed to follow a common pattern. This is a placeholder operator with identical
-functionality to allow for backward compatibility.)code");
+functionality to allow for backward compatibility.)code")
+    .MakeDocHidden();
 
 }  // namespace dali

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -238,18 +238,14 @@ Mutually exclusive with ``dont_use_mmap=False``.)code",
 // Deprecated alias
 DALI_REGISTER_OPERATOR(NumpyReader, NumpyReaderCPU, CPU);
 
-DALI_SCHEMA(NumpyReader)
-    .DocStr("Legacy alias for :meth:`readers.numpy`.")
-    .NumInput(0)
-    .NumOutput(1)  // (Arrays)
-    .AddParent("readers__Numpy")
-    .MakeDocHidden()
+DALI_SCHEMA_ALIAS(NumpyReader, readers__Numpy)
     .Deprecate(
         "1.0",
         "readers__Numpy",
         R"code(In DALI 1.0 all readers were moved into a dedicated :mod:`~nvidia.dali.fn.readers`
 submodule and renamed to follow a common pattern. This is a placeholder operator with identical
-functionality to allow for backward compatibility.)code");
+functionality to allow for backward compatibility.)code")
+    .MakeDocHidden();
 
 NumpyReaderCPU::~NumpyReaderCPU() {
   // Stop the prefetch thread as it uses the thread pool from this class. So before we can

--- a/dali/operators/reader/sequence_reader_op.cc
+++ b/dali/operators/reader/sequence_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,18 +90,13 @@ For reading video sequences, one of :meth:`nvidia.dali.fn.readers.video`,
 // Deprecated alias
 DALI_REGISTER_OPERATOR(SequenceReader, SequenceReader, CPU);
 
-DALI_SCHEMA(SequenceReader)
-    .DocStr("Legacy alias for :meth:`readers.sequence`.")
-    .NumInput(0)
-    .NumOutput(1)  // ([Frames])
-    .AllowSequences()
-    .AddParent("readers__Sequence")
-    .MakeDocHidden()
+DALI_SCHEMA_ALIAS(SequenceReader, readers__Sequence)
     .Deprecate(
         "1.0",
         "readers__Sequence",
         R"code(In DALI 1.0 all readers were moved into a dedicated :mod:`~nvidia.dali.fn.readers`
 submodule and renamed to follow a common pattern. This is a placeholder operator with identical
-functionality to allow for backward compatibility.)code");
+functionality to allow for backward compatibility.)code")
+    .MakeDocHidden();
 
 }  // namespace dali

--- a/dali/operators/reader/tfrecord_reader_op.cc
+++ b/dali/operators/reader/tfrecord_reader_op.cc
@@ -134,16 +134,14 @@ functionality to allow for backward compatibility.)code");
 
 
 // Deprecated alias
-DALI_SCHEMA(TFRecordReader)
-    .DocStr("Legacy alias for :meth:`readers.tfrecord`.")
-    .AddParent("readers__TFRecord")
-    .MakeDocHidden()
+DALI_SCHEMA_ALIAS(TFRecordReader, readers__TFRecord)
     .Deprecate(
         "1.0",
         "readers__TFRecord",
         R"code(In DALI 1.0 all readers were moved into a dedicated :mod:`~nvidia.dali.fn.readers`
 submodule and renamed to follow a common pattern. This is a placeholder operator with identical
-functionality to allow for backward compatibility.)code");
+functionality to allow for backward compatibility.)code")
+    .MakeDocHidden();
 
 void TFRecordReader::Prefetch() {
   // We actually prepare the next batch

--- a/dali/operators/video/decoder/video_decoder_cpu.cc
+++ b/dali/operators/video/decoder/video_decoder_cpu.cc
@@ -198,18 +198,14 @@ apart or starting playback from a frame deep into the video.)code",
     .OutputDType(0, DALI_UINT8)
     .OutputLayout(0, "FHWC");
 
-DALI_SCHEMA(experimental__decoders__Video)
-    .AddParent("decoders__Video")
-    .DocStr("Legacy alias for :meth:`decoders.video`.")
-    .NumInput(1)
-    .NumOutput(1)
-    .MakeDocHidden()
+DALI_SCHEMA_ALIAS(experimental__decoders__Video, decoders__Video)
     .Deprecate(
         "2.0",
         "decoders__Video",
         "This operator was moved out from the experimental phase, "
         "and is now a regular DALI operator. This is just a deprecated "
-        "alias kept for backward compatibility.");
+        "alias kept for backward compatibility.")
+    .MakeDocHidden();
 
 class VideoDecoderCpu : public VideoDecoderBase<CPUBackend, FramesDecoderCpu> {
  public:

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -27,10 +27,19 @@
 
 namespace dali {
 
-std::map<string, OpSchema, std::less<>> &SchemaRegistry::registry() {
+namespace {
+
+std::map<string, OpSchema, std::less<>> &registry() {
   static std::map<string, OpSchema, std::less<>> schema_map;
   return schema_map;
 }
+
+std::map<string, string, std::less<>> &aliases() {
+  static std::map<string, string, std::less<>> alias_map;
+  return alias_map;
+}
+
+}  // namespace
 
 OpSchema &SchemaRegistry::RegisterSchema(std::string_view name) {
   auto &schema_map = registry();
@@ -41,19 +50,51 @@ OpSchema &SchemaRegistry::RegisterSchema(std::string_view name) {
 }
 
 const OpSchema &SchemaRegistry::GetSchema(std::string_view name) {
-  auto &schema_map = registry();
-  auto it = schema_map.find(name);
-  if (it == schema_map.end())
+  if (auto *schema = TryGetSchema(name))
+    return *schema;
+  else
     throw invalid_key("Schema for operator '" + std::string(name) + "' not registered");
-
-  return it->second;
 }
 
 const OpSchema *SchemaRegistry::TryGetSchema(std::string_view name) {
   auto &schema_map = registry();
   auto it = schema_map.find(name);
-  return it != schema_map.end() ? &it->second : nullptr;
+  if (it == schema_map.end() || !it->second.AliasFor().empty()) {
+    auto &alias_map = aliases();
+    auto alias_it = alias_map.find(name);
+    if (alias_it != alias_map.end()) {
+      name = alias_it->second;
+      it = schema_map.find(name);
+    }
+  }
+
+  if (it == schema_map.end())
+    return nullptr;
+
+  return &it->second;
 }
+
+void SchemaRegistry::AddAlias(std::string_view alias_name, std::string_view actual_name) {
+  if (alias_name == actual_name)
+    throw std::invalid_argument("Schema name self-aliasing is forbidden");
+
+  auto &alias_map = aliases();
+  auto previous_target_it = alias_map.find(alias_name);
+  if (previous_target_it != alias_map.end())
+    throw std::invalid_argument(make_string("\"", alias_name,
+        "\" is already used as a schema alias name for \"", previous_target_it->second, "\""));
+
+  for (;;) {
+    auto redir = alias_map.find(actual_name);
+    if (redir == alias_map.end())
+      break;
+    if (redir->second == alias_name)
+      throw std::invalid_argument("Cycle detected while adding schema alias.");
+    actual_name = redir->second;
+  }
+  alias_map[std::string(alias_name)] = actual_name;
+}
+
 
 const OpSchema &OpSchema::Default() {
   static OpSchema default_schema(DefaultSchemaTag{});
@@ -391,6 +432,14 @@ OpSchema &OpSchema::Deprecate(std::string version, std::string in_favor_of,
   return *this;
 }
 
+OpSchema &OpSchema::AliasFor(std::string_view actual_name) {
+  DALI_ENFORCE(alias_for_.empty(), make_string(
+      "The schema \"", name_, "\" is already an alias for \"", alias_for_, "\""));
+
+  alias_for_ = actual_name;
+  SchemaRegistry::AddAlias(name_, actual_name);
+  return *this;
+}
 
 OpSchema &OpSchema::Unserializable() {
   serializable_ = false;
@@ -847,6 +896,9 @@ const std::string &OpSchema::DeprecatedInFavorOf() const {
   return deprecated_in_favor_of_;
 }
 
+const std::string &OpSchema::AliasFor() const {
+  return alias_for_;
+}
 
 const std::string &OpSchema::DeprecationMessage() const {
   return deprecation_message_;

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -439,6 +439,9 @@ class DLL_PUBLIC OpSchema {
                       std::string in_favor_of = "",
                       std::string explanation = "");
 
+  /** Marks that this schema is actually just an alias */
+  OpSchema &AliasFor(std::string_view actual_name);
+
   /** Notes that this operator cannot be serialized */
   OpSchema &Unserializable();
 
@@ -774,6 +777,9 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   /** What operator replaced the current one. */
   const std::string &DeprecatedInFavorOf() const;
 
+  /** Whether this schema is just an alias for another one */
+  const std::string &AliasFor() const;
+
   /** Additional deprecation message */
   const std::string &DeprecationMessage() const;
 
@@ -1056,6 +1062,7 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   std::string deprecated_in_favor_of_;
   std::string deprecation_message_;
   std::string deprecation_version_;
+  std::string alias_for_;
 };
 
 
@@ -1065,10 +1072,9 @@ class SchemaRegistry {
   DLL_PUBLIC static const OpSchema &GetSchema(std::string_view name);
   DLL_PUBLIC static const OpSchema *TryGetSchema(std::string_view name);
 
- private:
-  inline SchemaRegistry() {}
+  DLL_PUBLIC static void AddAlias(std::string_view alias_name, std::string_view actual_name);
 
-  DLL_PUBLIC static std::map<string, OpSchema, std::less<>> &registry();
+  SchemaRegistry() = delete;
 };
 
 template <typename T>
@@ -1108,6 +1114,8 @@ inline T OpSchema::GetDefaultValueForArgument(std::string_view name) const {
 #else
 #define DALI_SCHEMA(OpName) DALI_DEFINE_SCHEMA(OpName)
 #endif
+
+#define DALI_SCHEMA_ALIAS(AliasName, OpName) DALI_SCHEMA(AliasName).AliasFor(#OpName)
 
 }  // namespace dali
 

--- a/dali/pipeline/operator/operator_factory.h
+++ b/dali/pipeline/operator/operator_factory.h
@@ -67,14 +67,27 @@ class OperatorRegistry {
   std::unique_ptr<OpType> Create(
         std::string_view name,
         const OpSpec &spec,
-        std::optional<std::string_view> device_name = {}) {
+        std::optional<std::string_view> devName = {}) {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto creator_it = registry_.find(name);
-    DALI_ENFORCE(creator_it != registry_.end(), make_string(
+    auto it = registry_.find(name);
+    std::string_view lookup_name = name;
+    while (it == registry_.end()) {
+      // Maybe we got an alias? Check the schema's actual name.
+      if (auto *schema = SchemaRegistry::TryGetSchema(lookup_name)) {
+        std::string_view new_name = schema->name();
+        if (new_name == lookup_name)
+          break;  // no alias found
+        lookup_name = new_name;
+        it = registry_.find(lookup_name);
+      } else {
+        break;
+      }
+    }
+    DALI_ENFORCE(it != registry_.end(), make_string(
         "Operator \"", name, "\" not registered",
-        (device_name? make_string(" for \"", *device_name, "\"") : "")));
-
-    return creator_it->second(spec);
+        (devName ? make_string(" for ", *devName) : ""),
+        "."));
+    return it->second(spec);
   }
 
   vector<std::string> RegisteredNames(bool internal_ops) {
@@ -119,12 +132,12 @@ class Registerer {
 #define DALI_DECLARE_OPTYPE_REGISTRY(RegistryName, OpType)            \
   class DLL_PUBLIC RegistryName##Registry {                           \
    public:                                                            \
-    DLL_PUBLIC static ::dali::OperatorRegistry<OpType>& Registry();     \
+    DLL_PUBLIC static ::dali::OperatorRegistry<OpType>& Registry();   \
   };
 
 #define DALI_DEFINE_OPTYPE_REGISTRY(RegistryName, OpType)               \
   dali::OperatorRegistry<OpType>& RegistryName##Registry::Registry() {  \
-    static ::dali::OperatorRegistry<OpType> registry;                     \
+    static ::dali::OperatorRegistry<OpType> registry;                   \
     return registry;                                                    \
   }
 

--- a/dali/pipeline/operator/operator_factory.h
+++ b/dali/pipeline/operator/operator_factory.h
@@ -67,7 +67,7 @@ class OperatorRegistry {
   std::unique_ptr<OpType> Create(
         std::string_view name,
         const OpSpec &spec,
-        std::optional<std::string_view> devName = {}) {
+        std::optional<std::string_view> device_name = {}) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = registry_.find(name);
     std::string_view lookup_name = name;
@@ -85,7 +85,7 @@ class OperatorRegistry {
     }
     DALI_ENFORCE(it != registry_.end(), make_string(
         "Operator \"", name, "\" not registered",
-        (devName ? make_string(" for ", *devName) : ""),
+        (device_name ? make_string(" for ", *device_name) : ""),
         "."));
     return it->second(spec);
   }
@@ -116,8 +116,8 @@ class Registerer {
   Registerer(std::string name,
       OperatorRegistry<OpType> *registry,
       typename OperatorRegistry<OpType>::Creator creator,
-      std::string_view devName = "") {
-    registry->Register(std::move(name), std::move(creator), devName);
+      std::optional<std::string_view> device_name = {}) {
+    registry->Register(std::move(name), std::move(creator), device_name);
   }
 
   // Standard creator function used by all operators


### PR DESCRIPTION
## Category:
**New feature** (*non-breaking change which adds functionality*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
This change introduces a new mechanism of schema aliases. This mechanism causes the target schema to be selected, removing the need to add parent and risking incomplete schema inheritance. It also makes the code shorter and helps with serialized pipelines - newly serialized pipelines will store the actual operator name, opening the door for future removal of deprecated operators.

## Additional information:

### Affected modules and functionalities:
Deprecated operators.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
There's no explicit test for aliases. Tests involving deprecated operators will suffice.
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4666
<!--- DALI-XXXX or NA --->
