### PR TITLE
Add conda build option and CUDA target includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,6 @@ if(BUILD_FOR_CONDA AND DEFINED CUDAToolkit_TARGET_DIR AND
                  "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
 endif()
 
-# more recent CMake puts both cuda/targets/x86_64-linux/include and cuda/targets/x86_64-linux/include/cccl into the path
-# while we usually need only the former
-string(FIND "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}" ";" SEMICOLON_POS)
-
 parse_cuda_version(${CUDA_VERSION} CUDA_VERSION_MAJOR CUDA_VERSION_MINOR CUDA_VERSION_PATCH CUDA_VERSION_SHORT CUDA_VERSION_SHORT_DIGIT_ONLY)
 # CUDA_utils.cmake uses CUDA_VERSION_MAJOR value to determine the content of CUDA_known_archs and CUDA_TARGET_ARCHS
 include(cmake/CUDA_utils.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,17 +30,23 @@ endif()
 
 project(DALI CUDA CXX C)
 
+find_package(CUDAToolkit REQUIRED)
+
+option(BUILD_FOR_CONDA "Enable build adjustments used by conda-forge packaging" OFF)
+
 set(DALI_ROOT ${PROJECT_SOURCE_DIR})
 set(CUDA_VERSION "${CMAKE_CUDA_COMPILER_VERSION}")
+
+if(BUILD_FOR_CONDA AND DEFINED CUDAToolkit_TARGET_DIR AND
+   NOT "${CUDAToolkit_TARGET_DIR}" STREQUAL "")
+  set(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES "${CUDAToolkit_TARGET_DIR}/include")
+  message(STATUS "BUILD_FOR_CONDA -- using CUDA target include directory: "
+                 "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
+endif()
 
 # more recent CMake puts both cuda/targets/x86_64-linux/include and cuda/targets/x86_64-linux/include/cccl into the path
 # while we usually need only the former
 string(FIND "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}" ";" SEMICOLON_POS)
-if(NOT "${SEMICOLON_POS}" EQUAL -1)
-    list(GET CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES 0 CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY)
-else()
-    set(CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
-endif()
 
 parse_cuda_version(${CUDA_VERSION} CUDA_VERSION_MAJOR CUDA_VERSION_MINOR CUDA_VERSION_PATCH CUDA_VERSION_SHORT CUDA_VERSION_SHORT_DIGIT_ONLY)
 # CUDA_utils.cmake uses CUDA_VERSION_MAJOR value to determine the content of CUDA_known_archs and CUDA_TARGET_ARCHS
@@ -230,12 +236,22 @@ foreach(rpath IN ITEMS
   "$ORIGIN/../cufft/lib"
   "$ORIGIN/../npp/lib"
   "$ORIGIN/../nvjpeg/lib"
-  "$ORIGIN/../nvimgcodec"
-  "${NVIMGCODEC_DEFAULT_INSTALL_PATH}/lib64")
+  "$ORIGIN/../nvimgcodec")
   message(STATUS "Add to rpath: ${rpath}")
   list(APPEND CMAKE_BUILD_RPATH ${rpath})
   list(APPEND CMAKE_INSTALL_RPATH ${rpath})
 endforeach()
+
+if (BUILD_FOR_CONDA)
+  set(NVIMGCODEC_DEFAULT_LIBRARY_DIR "lib")
+else()
+  set(NVIMGCODEC_DEFAULT_LIBRARY_DIR "lib64")
+endif()
+set(nvimgcodec_default_rpath
+    "${NVIMGCODEC_DEFAULT_INSTALL_PATH}/${NVIMGCODEC_DEFAULT_LIBRARY_DIR}")
+message(STATUS "Add to rpath: ${nvimgcodec_default_rpath}")
+list(APPEND CMAKE_BUILD_RPATH ${nvimgcodec_default_rpath})
+list(APPEND CMAKE_INSTALL_RPATH ${nvimgcodec_default_rpath})
 
 get_dali_version(${PROJECT_SOURCE_DIR}/VERSION DALI_VERSION)
 
@@ -332,6 +348,7 @@ propagate_option(BUILD_NVML)
 propagate_option(BUILD_CUFILE)
 propagate_option(BUILD_NVIMAGECODEC)
 propagate_option(BUILD_AWSSDK)
+propagate_option(BUILD_FOR_CONDA)
 propagate_option(LINK_DRIVER)
 propagate_option(WITH_DYNAMIC_CUFFT)
 propagate_option(WITH_DYNAMIC_NPP)

--- a/cmake/Dependencies.common.cmake
+++ b/cmake/Dependencies.common.cmake
@@ -119,8 +119,13 @@ endif()
 # libtar
 ##################################################################
 if(BUILD_LIBTAR)
+  if(BUILD_FOR_CONDA)
+    set(libtar_NAMES tar libtar)
+  else()
+    set(libtar_NAMES libtar.a tar libtar)
+  endif()
   find_library(libtar_LIBS
-          NAMES libtar.a tar libtar
+          NAMES ${libtar_NAMES}
           PATHS ${LIBTAR_ROOT_DIR} "/usr/local" ${CMAKE_SYSTEM_PREFIX_PATH}
           PATH_SUFFIXES lib lib64)
   if(${libtar_LIBS} STREQUAL libtar_LIBS-NOTFOUND)
@@ -216,7 +221,7 @@ include_directories(${PROJECT_SOURCE_DIR}/third_party/rapidjson/include)
 ##################################################################
 # FFTS
 ##################################################################
-if (BUILD_FFTS)
+if (BUILD_FFTS AND NOT PREBUILD_DALI_LIBS)
   set(GENERATE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "-fPIC")
   set(ENABLE_SHARED OFF CACHE BOOL "shared library target")
   set(ENABLE_STATIC ON CACHE BOOL "static library target")
@@ -247,11 +252,13 @@ include_directories(SYSTEM third_party/cutlass/tools/util/include)
 ##################################################################
 # CocoAPI
 ##################################################################
-set(SOURCE_FILES third_party/cocoapi/common/maskApi.c)
-add_library(cocoapi STATIC ${SOURCE_FILES})
-set_target_properties(cocoapi PROPERTIES POSITION_INDEPENDENT_CODE ON)
-list(APPEND DALI_LIBS cocoapi)
-list(APPEND DALI_EXCLUDES libcocoapi.a)
+if(NOT PREBUILD_DALI_LIBS)
+  set(SOURCE_FILES third_party/cocoapi/common/maskApi.c)
+  add_library(cocoapi STATIC ${SOURCE_FILES})
+  set_target_properties(cocoapi PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  list(APPEND DALI_LIBS cocoapi)
+  list(APPEND DALI_EXCLUDES libcocoapi.a)
+endif()
 
 ##################################################################
 # cfitsio

--- a/conda/dali_native_libs/recipe/build.sh
+++ b/conda/dali_native_libs/recipe/build.sh
@@ -64,6 +64,7 @@ cmake -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda \
       -DBUILD_BENCHMARK=${BUILD_BENCHMARK:-ON}            \
       -DBUILD_NVTX=${BUILD_NVTX}                          \
       -DBUILD_PYTHON=OFF                                  \
+      -DBUILD_FOR_CONDA=ON                                \
       -DPREBUILD_DALI_LIBS=OFF                            \
       -DPYTHON_STUBGEN_INTERPRETER=${PYTHON}              \
       -DBUILD_LMDB=${BUILD_LMDB:-ON}                      \

--- a/conda/dali_python_bindings/recipe/build.sh
+++ b/conda/dali_python_bindings/recipe/build.sh
@@ -70,6 +70,7 @@ cmake -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda \
       -DBUILD_BENCHMARK=${BUILD_BENCHMARK:-ON}            \
       -DBUILD_NVTX=${BUILD_NVTX}                          \
       -DBUILD_PYTHON=ON                                   \
+      -DBUILD_FOR_CONDA=ON                                \
       -DPREBUILD_DALI_LIBS=ON                             \
       -DPYTHON_STUBGEN_INTERPRETER=${PYTHON}              \
       -DBUILD_LMDB=${BUILD_LMDB:-ON}                      \

--- a/dali/core/CMakeLists.txt
+++ b/dali/core/CMakeLists.txt
@@ -53,15 +53,14 @@ if (NOT LINK_DRIVER)
       OUTPUT ${CUDA_GENERATED_STUB}
       COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py --unique_prefix=Cuda --
                   "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/cuda.json" ${CUDA_GENERATED_STUB}
-                  "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/cuda.h"
-                  ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES_DIRECTIVE}
+                  "${CUDAToolkit_TARGET_DIR}/include/cuda.h" "-I${CUDAToolkit_TARGET_DIR}/include"
                   # for some reason QNX fails with 'too many errors emitted' is this is not set
                   "-ferror-limit=0"
                   # let clang know which architecutre we compile for
                   "--target=${CMAKE_SYSTEM_PROCESSOR}-linux-gnu"
                   ${DEFAULT_COMPILER_INCLUDE}
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py
-              "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/cuda.h"
+              "${CUDAToolkit_TARGET_DIR}/include/cuda.h"
               "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/cuda.json"
       COMMENT "Running cuda.h stub generator"
       VERBATIM)
@@ -80,15 +79,14 @@ if (BUILD_CUFILE)
       OUTPUT ${CUFILE_GENERATED_STUB}
       COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py --unique_prefix=Cufile --
                   "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/cufile.json" ${CUFILE_GENERATED_STUB}
-                  "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/cufile.h"
-                  ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES_DIRECTIVE}
+                  "${CUDAToolkit_TARGET_DIR}/include/cufile.h" "-I${CUDAToolkit_TARGET_DIR}/include"
                   # for some reason QNX fails with 'too many errors emitted' is this is not set
                   "-ferror-limit=0"
                   # let clang know which architecutre we compile for
                   "--target=${CMAKE_SYSTEM_PROCESSOR}-linux-gnu"
                   ${DEFAULT_COMPILER_INCLUDE}
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py
-              "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/cufile.h"
+              "${CUDAToolkit_TARGET_DIR}/include/cufile.h"
               "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/cufile.json"
       COMMENT "Running cufile.h stub generator"
       VERBATIM)
@@ -127,7 +125,7 @@ list(FILTER DALI_CORE_SRCS EXCLUDE REGEX ".*dynlink_nvcomp.cc")
 
 adjust_source_file_language_property("${DALI_CORE_SRCS}")
 add_library(dali_core ${LIBTYPE} ${DALI_CORE_SRCS})
-target_include_directories(dali_core SYSTEM PUBLIC ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+target_include_directories(dali_core SYSTEM PUBLIC "${CUDAToolkit_TARGET_DIR}/include")
 target_link_libraries(dali_core PRIVATE dynlink_cuda ${CUDART_LIB})
 if (BUILD_CUFILE)
     target_link_libraries(dali_core PRIVATE dynlink_cufile)

--- a/dali/core/dynlink_cufile.cc
+++ b/dali/core/dynlink_cufile.cc
@@ -35,8 +35,13 @@ CUFILE loadCufileLibrary() {
     ret = dlopen(__CufileLibName, RTLD_NOW);
 
     if (!ret) {
+#if FOR_CONDA_ENABLED
+      fprintf(stderr, "dlopen libcufile.so failed with error %s!. Please install libcufile: "
+              "`conda install -c conda-forge libcufile`.\n", dlerror());
+#else
       fprintf(stderr, "dlopen libcufile.so failed with error %s!. Please install libcufile.\n",
               dlerror());
+#endif
     }
   }
   return ret;

--- a/dali/core/dynlink_nvcomp.cc
+++ b/dali/core/dynlink_nvcomp.cc
@@ -35,8 +35,13 @@ NVCOMP loadNvCompFileLibrary() {
     ret = dlopen(__nvCompfileLibName, RTLD_NOW);
 
     if (!ret) {
+#if FOR_CONDA_ENABLED
+      fprintf(stderr, "dlopen libnvcomp.so failed with error %s!. Please install libnvcomp: "
+              "`conda install -c conda-forge libnvcomp`.\n", dlerror());
+#else
       fprintf(stderr, "dlopen libnvcomp.so failed with error %s!. Please install libnvcomp.\n",
               dlerror());
+#endif
     }
   }
   return ret;

--- a/dali/kernels/signal/fft/CMakeLists.txt
+++ b/dali/kernels/signal/fft/CMakeLists.txt
@@ -42,15 +42,14 @@ if (WITH_DYNAMIC_CUFFT)
         OUTPUT ${CUFFT_GENERATED_STUB}
         COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../../../internal_tools/stub_generator/stub_codegen.py --unique_prefix=Cufft --
                     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../internal_tools/stub_generator/cufft.json" ${CUFFT_GENERATED_STUB}
-                    "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/cufft.h"
-                    ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES_DIRECTIVE}
+                    "${CUDAToolkit_TARGET_DIR}/include/cufft.h" "-I${CUDAToolkit_TARGET_DIR}/include"
                     # for some reason QNX fails with 'too many errors emitted' is this is not set
                     "-ferror-limit=0"
                     # let clang know which architecutre we compile for
                     "--target=${CMAKE_SYSTEM_PROCESSOR}-linux-gnu"
                     ${DEFAULT_COMPILER_INCLUDE}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../../../internal_tools/stub_generator/stub_codegen.py
-                "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/cufft.h"
+                "${CUDAToolkit_TARGET_DIR}/include/cufft.h"
                 "${CMAKE_CURRENT_SOURCE_DIR}/../../../../internal_tools/stub_generator/cufft.json"
         COMMENT "Running cufft.h stub generator"
         VERBATIM)

--- a/dali/kernels/signal/fft/cufft_wrap.cc
+++ b/dali/kernels/signal/fft/cufft_wrap.cc
@@ -42,8 +42,13 @@ CUFFTDIVER loadCufftLibrary() {
   if (!ret) {
     ret = dlopen(__CufftLibName, RTLD_NOW);
     if (!ret) {
+#if FOR_CONDA_ENABLED
+      throw std::runtime_error("dlopen libcufft.so failed!. Please install "
+                               "libcufft: `conda install -c conda-forge libcufft`.");
+#else
       throw std::runtime_error("dlopen libcufft.so failed!. Please install "
                                 "CUDA toolkit or cuFFT python wheel.");
+#endif
     }
   }
   return ret;

--- a/dali/npp/CMakeLists.txt
+++ b/dali/npp/CMakeLists.txt
@@ -44,15 +44,14 @@ if (WITH_DYNAMIC_NPP)
         OUTPUT ${NPP_GENERATED_STUB}
         COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py --unique_prefix=Npp --
                     "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/npp.json" ${NPP_GENERATED_STUB}
-                    "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/npp.h"
-                    ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES_DIRECTIVE}
+                    "${CUDAToolkit_TARGET_DIR}/include/npp.h" "-I${CUDAToolkit_TARGET_DIR}/include"
                     # for some reason QNX fails with 'too many errors emitted' is this is not set
                     "-ferror-limit=0"
                     # let clang know which architecutre we compile for
                     "--target=${CMAKE_SYSTEM_PROCESSOR}-linux-gnu"
                     ${DEFAULT_COMPILER_INCLUDE}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py
-                "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/npp.h"
+                "${CUDAToolkit_TARGET_DIR}/include/npp.h"
                 "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/npp.json"
         COMMENT "Running npp.h stub generator"
         VERBATIM)

--- a/dali/npp/npp_wrap.cc
+++ b/dali/npp/npp_wrap.cc
@@ -55,8 +55,13 @@ NPPCDRIVER loadNppcLibrary() {
   if (!ret) {
     ret = dlopen(__NppcLibName, RTLD_NOW);
     if (!ret) {
+#if FOR_CONDA_ENABLED
+      throw std::runtime_error("dlopen libnppc.so failed!. Please install "
+          "libnpp: `conda install -c conda-forge libnpp`.");
+#else
       throw std::runtime_error("dlopen libnppc.so failed!. Please install "
           "CUDA toolkit or NPP python wheel.");
+#endif
     }
   }
   return ret;
@@ -69,8 +74,13 @@ NPPICCDRIVER loadNppiccLibrary() {
   if (!ret) {
     ret = dlopen(__NppiccLibName, RTLD_NOW);
     if (!ret) {
+#if FOR_CONDA_ENABLED
+      throw std::runtime_error("dlopen libnppicc.so failed!. Please install "
+          "libnpp: `conda install -c conda-forge libnpp`.");
+#else
       throw std::runtime_error("dlopen libnppicc.so failed!. Please install "
           "CUDA toolkit or NPP python wheel.");
+#endif
     }
   }
   return ret;
@@ -83,8 +93,13 @@ NPPIGDRIVER loadNppigLibrary() {
   if (!ret) {
     ret = dlopen(__NppigLibName, RTLD_NOW);
     if (!ret) {
+#if FOR_CONDA_ENABLED
+      throw std::runtime_error("dlopen libnppig.so failed!. Please install "
+          "libnpp: `conda install -c conda-forge libnpp`.");
+#else
       throw std::runtime_error("dlopen libnppig.so failed!. Please install "
           "CUDA toolkit or NPP python wheel.");
+#endif
     }
   }
   return ret;

--- a/dali/nvimgcodec/CMakeLists.txt
+++ b/dali/nvimgcodec/CMakeLists.txt
@@ -44,8 +44,7 @@ if(WITH_DYNAMIC_NVIMGCODEC)
     OUTPUT ${NVIMGCODEC_GENERATED_STUB}
     COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py --unique_prefix=Nvimgcodec --
     "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/nvimgcodec.json" ${NVIMGCODEC_GENERATED_STUB}
-    "${nvimgcodec_INCLUDE_DIR}/nvimgcodec.h" "-I${nvimgcodec_INCLUDE_DIR}"
-    ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES_DIRECTIVE}
+    "${nvimgcodec_INCLUDE_DIR}/nvimgcodec.h" "-I${nvimgcodec_INCLUDE_DIR}" "-I${CUDAToolkit_TARGET_DIR}/include"
     # for some reason QNX fails with 'too many errors emitted' if this is not set
     "-ferror-limit=0"
     # let clang know which architecutre we compile for

--- a/dali/nvimgcodec/nvimgcodec_wrap.cc
+++ b/dali/nvimgcodec/nvimgcodec_wrap.cc
@@ -31,6 +31,12 @@
   "." STR(NVIMGCODEC_VER_MINOR) "." STR(NVIMGCODEC_VER_PATCH)
 #define MAJOR_VER_STR STR(NVIMGCODEC_VER_MAJOR)
 
+#if FOR_CONDA_ENABLED
+#define NVIMGCODEC_DEFAULT_LIBRARY_DIR "lib"
+#else
+#define NVIMGCODEC_DEFAULT_LIBRARY_DIR "lib64"
+#endif
+
 namespace {
 
 typedef void *NVIMGCODECDRIVER;
@@ -39,11 +45,13 @@ const char nvimgcodecLibNameFullVer[] = "libnvimgcodec.so." FULL_VER_STR;
 const char nvimgcodecLibNameMajorVer[] = "libnvimgcodec.so." MAJOR_VER_STR;
 const char nvimgcodecLibName[] = "libnvimgcodec.so";
 const char nvimgcodecLibDefaultPathFullVer[] =
-    NVIMGCODEC_DEFAULT_INSTALL_PATH "/lib64/libnvimgcodec.so." FULL_VER_STR;
+    NVIMGCODEC_DEFAULT_INSTALL_PATH "/" NVIMGCODEC_DEFAULT_LIBRARY_DIR
+    "/libnvimgcodec.so." FULL_VER_STR;
 const char nvimgcodecLibDefaultPathMajorVer[] =
-    NVIMGCODEC_DEFAULT_INSTALL_PATH "/lib64/libnvimgcodec.so." MAJOR_VER_STR;
+    NVIMGCODEC_DEFAULT_INSTALL_PATH "/" NVIMGCODEC_DEFAULT_LIBRARY_DIR
+    "/libnvimgcodec.so." MAJOR_VER_STR;
 const char nvimgcodecLibDefaultPath[] =
-    NVIMGCODEC_DEFAULT_INSTALL_PATH "/lib64/libnvimgcodec.so";
+    NVIMGCODEC_DEFAULT_INSTALL_PATH "/" NVIMGCODEC_DEFAULT_LIBRARY_DIR "/libnvimgcodec.so";
 
 NVIMGCODECDRIVER loadNvimgcodecLibrary() {
   static const char *paths[] = {nvimgcodecLibNameFullVer,
@@ -69,12 +77,18 @@ NVIMGCODECDRIVER loadNvimgcodecLibrary() {
   }
 
   if (!ret) {
+#if FOR_CONDA_ENABLED
+    throw std::runtime_error(
+        "dlopen libnvimgcodec.so failed!. Please install "
+        "libnvimgcodec: `conda install -c conda-forge libnvimgcodec`.");
+#else
     int cuda_version_major = CUDA_VERSION / 1000;  // 11020 -> 11, 12000 -> 12
     throw std::runtime_error(dali::make_string(
         "dlopen libnvimgcodec.so failed!. Please install nvimagecodec: See "
         "https://developer.nvidia.com/nvimgcodec-downloads or simply do `pip install "
         "nvidia-nvimgcodec-cu", cuda_version_major, "`."
         "\nAttempted paths:", attempts));
+#endif
   }
   return ret;
 }

--- a/dali/operators/operators.cc
+++ b/dali/operators/operators.cc
@@ -66,16 +66,22 @@ DLL_PUBLIC void EnforceMinimumNvimgcodecVersion() {
   int minor = NVIMGCODEC_MINOR_FROM_SEMVER(version);
   int patch = NVIMGCODEC_PATCH_FROM_SEMVER(version);
 
-  int cuda_version_major = CUDA_VERSION / 1000;  // 11020 -> 11, 12000 -> 12
   if (version < NVIMGCODEC_VER) {
     std::stringstream ss;
     ss << "DALI requires nvImageCodec at minimum version " << NVIMGCODEC_VER_MAJOR << "."
        << NVIMGCODEC_VER_MINOR << "." << NVIMGCODEC_VER_PATCH << ", but got " << major << "."
-       << minor << "." << patch
-       << ". Please upgrade: See https://developer.nvidia.com/nvimgcodec-downloads or simply do "
-          "`pip install nvidia-nvimgcodec-cu" + std::to_string(cuda_version_major) + "~="
+       << minor << "." << patch;
+#if FOR_CONDA_ENABLED
+    ss << ". Please upgrade: `conda install -c conda-forge 'libnvimgcodec"
+       << ">=" << NVIMGCODEC_VER_MAJOR << "." << NVIMGCODEC_VER_MINOR << "."
+       << NVIMGCODEC_VER_PATCH << ",==" << NVIMGCODEC_VER_MAJOR << "." << NVIMGCODEC_VER_MINOR
+       << ".*'`.";
+#else
+    ss << ". Please upgrade: See https://developer.nvidia.com/nvimgcodec-downloads or simply do "
+          "`pip install nvidia-nvimgcodec-cu" + std::to_string(CUDA_VERSION / 1000) + "~="
        << NVIMGCODEC_VER_MAJOR << "." << NVIMGCODEC_VER_MINOR << "." << NVIMGCODEC_VER_PATCH
        << "`.";
+#endif
     throw std::runtime_error(ss.str());
   }
 #endif

--- a/dali/operators/video/dynlink_nvcuvid/CMakeLists.txt
+++ b/dali/operators/video/dynlink_nvcuvid/CMakeLists.txt
@@ -41,8 +41,7 @@ add_custom_command(
     OUTPUT ${NVCUVID_GENERATED_STUB}
     COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../../../internal_tools/stub_generator/stub_codegen.py --unique_prefix=Nvcuvid --
                 "${CMAKE_CURRENT_SOURCE_DIR}/../../../../internal_tools/stub_generator/nvcuvid.json" ${NVCUVID_GENERATED_STUB}
-                "${CMAKE_CURRENT_SOURCE_DIR}/nvcuvid.h"
-                ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES_DIRECTIVE}
+                "${CMAKE_CURRENT_SOURCE_DIR}/nvcuvid.h" "-I${CUDAToolkit_TARGET_DIR}/include"
                 "-I${CMAKE_SOURCE_DIR}/include" "-I${CMAKE_SOURCE_DIR}"
                 # for some reason QNX fails with 'too many errors emitted' is this is not set
                 "-ferror-limit=0"

--- a/dali/util/CMakeLists.txt
+++ b/dali/util/CMakeLists.txt
@@ -103,15 +103,14 @@ if(BUILD_NVML)
         OUTPUT ${NVML_GENERATED_STUB}
         COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py --unique_prefix=Nvml --
                     "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/nvml.json" ${NVML_GENERATED_STUB}
-                    "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/nvml.h"
-                    ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES_DIRECTIVE}
+                    "${CUDAToolkit_TARGET_DIR}/include/nvml.h" "-I${CUDAToolkit_TARGET_DIR}/include"
                     # for some reason QNX fails with 'too many errors emitted' is this is not set
                     "-ferror-limit=0"
                     # let clang know which architecutre we compile for
                     "--target=${CMAKE_SYSTEM_PROCESSOR}-linux-gnu"
                     ${DEFAULT_COMPILER_INCLUDE}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/stub_codegen.py
-                "${CUDA_TOOLKIT_INCLUDE_MAJOR_DIRECTORY}/nvml.h"
+                "${CUDAToolkit_TARGET_DIR}/include/nvml.h"
                 "${CMAKE_CURRENT_SOURCE_DIR}/../../internal_tools/stub_generator/nvml.json"
         COMMENT "Running nvml.h stub generator"
         VERBATIM)

--- a/dali/util/nvml_wrap.cc
+++ b/dali/util/nvml_wrap.cc
@@ -38,7 +38,7 @@ NVMLRIVER loadNvmlLibrary() {
     ret = dlopen(__NvmlLibName, RTLD_NOW);
 
     if (!ret) {
-      fprintf(stderr, "dlopen libnvidia-ml.so failed!. Please install GPU dirver");
+      fprintf(stderr, "dlopen libnvidia-ml.so failed!. Please install GPU driver");
     }
   }
   return ret;


### PR DESCRIPTION
Adds a conda packaging build option and switches CUDA-header consumers to
the CMake CUDAToolkit target directory.

It absorbs https://github.com/conda-forge/nvidia-dali-python-feedstock/tree/main/recipe/patches.

## Category:

Other (Build / Configuration)

## Description:

This change adds `BUILD_FOR_CONDA`, enables it from the conda native-libs and
Python-bindings recipes, and keeps the default source and wheel build behavior
unchanged when the option is disabled.

When `BUILD_FOR_CONDA=ON`, the build:

- uses conda's `lib` layout for nvImageCodec runtime lookup and RPATH;
- prefers the shared `libtar` library instead of forcing `libtar.a`;
- emits conda install guidance for dynamically loaded CUDA toolkit libraries;
- keeps conda-provided CUDA architecture settings intact.

The change also requires CMake's `CUDAToolkit` package and uses
`CUDAToolkit_TARGET_DIR/include` directly for CUDA-family generated stubs and
include directories. This covers the CUDA, cuFile, cuFFT, NPP, nvImageCodec,
NVML, and nvCUVID stub generation paths without depending on the trimmed
`CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES` value.

For the split conda package build, bundled FFTS and cocoapi static targets are
not rebuilt when `PREBUILD_DALI_LIBS=ON`.

## Additional information:

### Affected modules and functionalities:

- CMake configuration: `CMakeLists.txt`
- Dependency lookup: `cmake/Dependencies.common.cmake`
- Conda recipes:
  - `conda/dali_native_libs/recipe/build.sh`
  - `conda/dali_python_bindings/recipe/build.sh`
- CUDA-header stub generation and include paths:
  - `dali/core/CMakeLists.txt`
  - `dali/kernels/signal/fft/CMakeLists.txt`
  - `dali/npp/CMakeLists.txt`
  - `dali/nvimgcodec/CMakeLists.txt`
  - `dali/operators/video/dynlink_nvcuvid/CMakeLists.txt`
  - `dali/util/CMakeLists.txt`
- Dynamic loader diagnostics:
  - `dali/core/dynlink_cufile.cc`
  - `dali/core/dynlink_nvcomp.cc`
  - `dali/kernels/signal/fft/cufft_wrap.cc`
  - `dali/npp/npp_wrap.cc`
  - `dali/nvimgcodec/nvimgcodec_wrap.cc`
  - `dali/operators/operators.cc`
- Minor typo fix in `dali/util/nvml_wrap.cc`

### Key points relevant for the review:

- `BUILD_FOR_CONDA` defaults to `OFF`; default builds should retain existing
  behavior.
- The option is propagated through `propagate_option(BUILD_FOR_CONDA)`, which
  produces `FOR_CONDA_ENABLED` for the C++ loader diagnostics.
- `find_package(CUDAToolkit REQUIRED)` is now used so the build can consistently
  reference `CUDAToolkit_TARGET_DIR/include`.
- The obsolete nvJPEG2K conda-forge patch was intentionally not carried over.

### Tests:

- [x] Existing tests apply
- [ ] New tests added
    - [ ] Python tests
    - [ ] GTests
    - [ ] Benchmark
    - [ ] Other
- [ ] N/A

Previously configured successfully with:

- default reduced CMake configuration
- `BUILD_FOR_CONDA=ON`
- `BUILD_FOR_CONDA=ON` with explicit `CUDAToolkit_TARGET_DIR`

For this metadata refresh, `git diff --check upstream/main...HEAD` passes.

## Checklist

### Documentation

- [x] Existing documentation applies
- [ ] Documentation updated
    - [ ] Docstring
    - [ ] Doxygen
    - [ ] RST
    - [ ] Jupyter
    - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements

- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

REQ IDs: N/A

JIRA TASK: DALI-4681
