### PR TITLE
Add static type inference to arithmetic ops.

### DIFF
--- a/dali/operators/math/expressions/arithmetic.cc
+++ b/dali/operators/math/expressions/arithmetic.cc
@@ -27,7 +27,16 @@ std::optional<DALIDataType> PropagateTypes(
   }
   if (expr.GetNodeType() == NodeType::Tensor) {
     auto &e = dynamic_cast<ExprTensor &>(expr);
-    if (!input_types[e.GetInputIndex()])
+    int idx = e.GetInputIndex();
+    if (idx < 0)
+      throw std::out_of_range("Negative input index encountered.");
+
+    if (idx >= input_types.size()) {
+      throw std::out_of_range(make_string(
+        "Input index ", idx, " is out of range. "
+        "Only ", input_types.size(), " inputs are present."));
+    }
+    if (!input_types[idx])
       return std::nullopt;
 
     expr.SetTypeId(*input_types[e.GetInputIndex()]);

--- a/dali/operators/math/expressions/arithmetic.cc
+++ b/dali/operators/math/expressions/arithmetic.cc
@@ -155,7 +155,7 @@ Examples::
         if (!ex)
           return std::nullopt;
         return PropagateTypes(*ex, spec);
-      } catch (std::exception) {
+      } catch (const std::exception &) {
         return std::nullopt;
       }
     })

--- a/dali/operators/math/expressions/arithmetic.cc
+++ b/dali/operators/math/expressions/arithmetic.cc
@@ -69,7 +69,7 @@ DALIDataType PropagateTypes(ExprNode &expr, const Workspace &ws) {
 
 std::optional<DALIDataType> PropagateTypes(ExprNode &expr, const OpSpec &spec) {
   SmallVector<std::optional<DALIDataType>, 8> input_types;
-  for (int i = 0; i < spec.NumInput(); i++)
+  for (int i = 0; i < spec.NumRegularInput(); i++)
     input_types.push_back(spec.InputDesc(i).dtype);
   return PropagateTypes(expr, make_cspan(input_types));
 }

--- a/dali/operators/math/expressions/arithmetic.cc
+++ b/dali/operators/math/expressions/arithmetic.cc
@@ -20,6 +20,52 @@
 namespace dali {
 namespace expr {
 
+std::optional<DALIDataType> PropagateTypes(
+      ExprNode &expr, span<const std::optional<DALIDataType>> input_types) {
+  if (expr.GetNodeType() == NodeType::Constant) {
+    return expr.GetTypeId();
+  }
+  if (expr.GetNodeType() == NodeType::Tensor) {
+    auto &e = dynamic_cast<ExprTensor &>(expr);
+    if (!input_types[e.GetInputIndex()])
+      return std::nullopt;
+
+    expr.SetTypeId(*input_types[e.GetInputIndex()]);
+    return expr.GetTypeId();
+  }
+  auto &func = dynamic_cast<ExprFunc &>(expr);
+  int subexpression_count = func.GetSubexpressionCount();
+  DALI_ENFORCE(0 < subexpression_count && subexpression_count <= kMaxArity,
+               "Only unary, binary and ternary expressions are supported");
+
+  SmallVector<DALIDataType, kMaxArity> types;
+  types.resize(subexpression_count);
+  for (int i = 0; i < subexpression_count; i++) {
+    auto subexpr_type = PropagateTypes(func[i], input_types);
+    if (!subexpr_type)
+      return std::nullopt;
+    types[i] = *subexpr_type;
+  }
+  expr.SetTypeId(TypePromotion(NameToOp(func.GetFuncName()), make_span(types)));
+  return expr.GetTypeId();
+}
+
+
+DALIDataType PropagateTypes(ExprNode &expr, const Workspace &ws) {
+  SmallVector<std::optional<DALIDataType>, 8> input_types;
+  for (int i = 0; i < ws.NumInput(); i++)
+    input_types.push_back(ws.GetInputDataType(i));
+  return PropagateTypes(expr, make_cspan(input_types)).value();
+}
+
+std::optional<DALIDataType> PropagateTypes(ExprNode &expr, const OpSpec &spec) {
+  SmallVector<std::optional<DALIDataType>, 8> input_types;
+  for (int i = 0; i < spec.NumInput(); i++)
+    input_types.push_back(spec.InputDesc(i).dtype);
+  return PropagateTypes(expr, make_cspan(input_types));
+}
+
+
 template <>
 void ArithmeticGenericOp<CPUBackend>::RunImpl(Workspace &ws) {
   PrepareSamplesPerTask<CPUBackend>(samples_per_task_, exec_order_, ws, constant_storage_, spec_);
@@ -103,7 +149,16 @@ Examples::
       }
       return ndim;
     })
-    .OutputDType(0, std::nullopt)  // TODO(michalz): factor out dtype inference and use it here
+    .OutputDType(0, [](const OpSpec &spec)->std::optional<DALIDataType> {
+      try {
+        auto ex = expr::ParseExpressionString(spec.GetArgument<std::string>("expression_desc"));
+        if (!ex)
+          return std::nullopt;
+        return PropagateTypes(*ex, spec);
+      } catch (std::exception) {
+        return std::nullopt;
+      }
+    })
     .OutputLayout(0, [](const OpSpec &spec)->std::optional<TensorLayout> {
       // Layouts must match or be suffixes (when broadcasting), e.g.:
       // HWC + WC

--- a/dali/operators/math/expressions/arithmetic.h
+++ b/dali/operators/math/expressions/arithmetic.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -138,29 +138,12 @@ DLL_PUBLIC TensorLayout GetCommonLayout(ExprNode &expr, const Workspace &ws) {
 /**
  * @brief Recurse over expression tree, fill the missing types of TensorInputs
  */
-template <typename Backend>
-DLL_PUBLIC DALIDataType PropagateTypes(ExprNode &expr, const Workspace &ws) {
-  if (expr.GetNodeType() == NodeType::Constant) {
-    return expr.GetTypeId();
-  }
-  if (expr.GetNodeType() == NodeType::Tensor) {
-    auto &e = dynamic_cast<ExprTensor &>(expr);
-    expr.SetTypeId(ws.Input<Backend>(e.GetInputIndex()).type());
-    return expr.GetTypeId();
-  }
-  auto &func = dynamic_cast<ExprFunc &>(expr);
-  int subexpression_count = func.GetSubexpressionCount();
-  DALI_ENFORCE(0 < subexpression_count && subexpression_count <= kMaxArity,
-               "Only unary, binary and ternary expressions are supported");
+DLL_PUBLIC std::optional<DALIDataType> PropagateTypes(
+      ExprNode &expr, span<const std::optional<DALIDataType>> input_types);
 
-  SmallVector<DALIDataType, kMaxArity> types;
-  types.resize(subexpression_count);
-  for (int i = 0; i < subexpression_count; i++) {
-    types[i] = PropagateTypes<Backend>(func[i], ws);
-  }
-  expr.SetTypeId(TypePromotion(NameToOp(func.GetFuncName()), make_span(types)));
-  return expr.GetTypeId();
-}
+DLL_PUBLIC DALIDataType PropagateTypes(ExprNode &expr, const Workspace &ws);
+
+DLL_PUBLIC std::optional<DALIDataType> PropagateTypes(ExprNode &expr, const OpSpec &spec);
 
 /**
  * @brief Helper for recursively filling vector of tasks to execute
@@ -345,7 +328,7 @@ class ArithmeticGenericOp : public StatelessOperator<Backend> {
     PropagateShapes<Backend>(result_shape_, *expr_, ws, curr_batch_size);
 
     if (!types_layout_inferred_) {
-      result_type_id_ = PropagateTypes<Backend>(*expr_, ws);
+      result_type_id_ = PropagateTypes(*expr_, ws);
       result_layout_ = GetCommonLayout<Backend>(*expr_, ws);
       // sample_ndim is assumed to be constant between iterations.
       if (result_layout_.size() != result_shape_.sample_dim()) {

--- a/dali/operators/math/expressions/arithmetic_test.cc
+++ b/dali/operators/math/expressions/arithmetic_test.cc
@@ -45,7 +45,7 @@ TEST(ArithmeticOpsTest, TreePropagation) {
   ws.AddInput(in[0]);
   ws.AddInput(in[1]);
 
-  auto result_type = PropagateTypes<CPUBackend>(expr_ref, ws);
+  auto result_type = PropagateTypes(expr_ref, ws);
   TensorListShape<> result_shape;
   PropagateShapes<CPUBackend>(result_shape, expr_ref, ws, 2);
   auto result_layout = GetCommonLayout<CPUBackend>(expr_ref, ws);

--- a/dali/test/python/experimental_mode/test_output_metadata.py
+++ b/dali/test/python/experimental_mode/test_output_metadata.py
@@ -120,6 +120,33 @@ def test_slice():
     assert_correct_metadata(input.slice[1:, 1:, 1:])
 
 
+# --- Arithm ---
+
+
+@eval_modes(ndd.EvalMode.deferred)
+def test_arithm():
+    a = ndd.as_batch(
+        [
+            ndd.zeros(shape=(2, 3, 4), dtype=ndd.int8),
+            ndd.zeros(shape=(3, 2, 5), dtype=ndd.int8),
+        ],
+        layout="XYZ",
+    ).evaluate()
+    b = ndd.as_batch(
+        [
+            ndd.zeros(shape=(2, 3, 4), dtype=ndd.float32),
+            ndd.zeros(shape=(3, 2, 5), dtype=ndd.float32),
+        ],
+        layout="XYZ",
+    ).evaluate()
+
+    assert_correct_metadata(a + b)
+    assert_correct_metadata(a << 3)
+    assert_correct_metadata(~a)
+    assert_correct_metadata(a * 5.0)
+    assert_correct_metadata(a * 5)
+
+
 # --- New dimensions ---
 
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)


## Description:
This PR adds static DType inference for arithmetic operators, that was left out.
The code was refactored so that the same function infers the dtype at run-time and build-time.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Metadata test checks that the metadata is actually there.
Existing tests cover metadata agreement between run-time and static analysis as well as checks for possible regressions.
- [X] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
