### PR TITLE
Fix leaked PyLong refs in pointer bindings

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -156,6 +156,10 @@ static string TensorLayoutRepr(const TensorLayout &tl) {
   return ss.str();
 }
 
+static py::object PyLongFromVoidPtr(void *ptr) {
+  return py::reinterpret_steal<py::object>(PyLong_FromVoidPtr(ptr));
+}
+
 template<typename Backend>
 py::dict ArrayInterfaceRepr(Tensor<Backend> &t) {
   py::dict d;
@@ -164,7 +168,7 @@ py::dict ArrayInterfaceRepr(Tensor<Backend> &t) {
   // __array_interface__ expects shape to be a tuple
   d["shape"] = py::tuple(py_shape<Backend>(t));
   // tuple of (raw_data_pointer, if_data_is_read_only)
-  tup[0] = py::reinterpret_borrow<py::object>(PyLong_FromVoidPtr(t.raw_mutable_data()));
+  tup[0] = PyLongFromVoidPtr(t.raw_mutable_data());
   // if we make it readonly, it prevents us from sharing memory with PyTorch tensor
   tup[1] = false;
   d["data"] = tup;
@@ -918,7 +922,7 @@ void ExposeTensor(py::module &m) {
             Destination of the copy.
       )code")
     .def("data_ptr", [](Tensor<CPUBackend> &t) {
-          return py::reinterpret_borrow<py::object>(PyLong_FromVoidPtr(t.raw_mutable_data()));
+          return PyLongFromVoidPtr(t.raw_mutable_data());
         },
       R"code(
       Returns the address of the first element of tensor.
@@ -1139,13 +1143,13 @@ void ExposeTensor(py::module &m) {
       )code")
     .def_property_readonly("stream", [](const Tensor<GPUBackend> &t)->py::object {
       if (t.order().is_device())
-        return py::reinterpret_borrow<py::object>(PyLong_FromVoidPtr(t.order().stream()));
+        return PyLongFromVoidPtr(t.order().stream());
       else
         return py::none();
     })
     .def("data_ptr",
         [](Tensor<GPUBackend> &t) {
-          return py::reinterpret_borrow<py::object>(PyLong_FromVoidPtr(t.raw_mutable_data()));
+          return PyLongFromVoidPtr(t.raw_mutable_data());
         },
       R"code(
       Returns the address of the first element of tensor.
@@ -1571,8 +1575,7 @@ void ExposeTensorListCPU(py::module &m) {
       )code")
     .def("data_ptr",
         [](TensorList<CPUBackend> &tl) {
-          return py::reinterpret_borrow<py::object>(
-              PyLong_FromVoidPtr(contiguous_raw_mutable_data(tl)));
+          return PyLongFromVoidPtr(contiguous_raw_mutable_data(tl));
         },
       R"code(
       Returns the address of the first element of TensorList.
@@ -1814,8 +1817,7 @@ void ExposeTesorListGPU(py::module &m) {
       )code")
     .def("data_ptr",
         [](TensorList<GPUBackend> &tl) {
-          return py::reinterpret_borrow<py::object>(
-              PyLong_FromVoidPtr(contiguous_raw_mutable_data(tl)));
+          return PyLongFromVoidPtr(contiguous_raw_mutable_data(tl));
         },
       R"code(
       Returns the address of the first element of TensorList.
@@ -1833,7 +1835,7 @@ void ExposeTesorListGPU(py::module &m) {
     })
     .def_property_readonly("stream", [](const TensorList<GPUBackend> &t)->py::object {
       if (t.order().is_device())
-        return py::reinterpret_borrow<py::object>(PyLong_FromVoidPtr(t.order().stream()));
+        return PyLongFromVoidPtr(t.order().stream());
       else
         return py::none();
     })

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -124,16 +124,13 @@ def test_data_ptr_tensor_list_cpu():
     assert np.array_equal(arr, from_tensor_list)
 
 
-def _assert_pointer_int_has_no_extra_refs(name, get_value):
+def _assert_pointer_int_has_no_extra_refs(name, get_value, allow_none=False):
     value = get_value()
+    if value is None:
+        assert allow_none, f"{name} returned None instead of int"
+        return
     assert isinstance(value, int), f"{name} returned {type(value)} instead of int"
-    refcount = sys.getrefcount(value)
-    assert refcount == 2, f"{name} returned an int with refcount {refcount}, expected 2"
-
-
-def _assert_optional_pointer_int_has_no_extra_refs(name, get_value):
-    value = get_value()
-    if value is None or -5 <= value <= 256:
+    if -5 <= value <= 256:
         return
     refcount = sys.getrefcount(value)
     assert refcount == 2, f"{name} returned an int with refcount {refcount}, expected 2"
@@ -159,9 +156,11 @@ def test_pointer_returning_bindings_do_not_leak_python_int_refs():
         lambda: tensor_gpu.__cuda_array_interface__["data"][0],
     )
     _assert_pointer_int_has_no_extra_refs("TensorListGPU.data_ptr()", tensorlist_gpu.data_ptr)
-    _assert_optional_pointer_int_has_no_extra_refs("TensorGPU.stream", lambda: tensor_gpu.stream)
-    _assert_optional_pointer_int_has_no_extra_refs(
-        "TensorListGPU.stream", lambda: tensorlist_gpu.stream
+    _assert_pointer_int_has_no_extra_refs(
+        "TensorGPU.stream", lambda: tensor_gpu.stream, allow_none=True
+    )
+    _assert_pointer_int_has_no_extra_refs(
+        "TensorListGPU.stream", lambda: tensorlist_gpu.stream, allow_none=True
     )
 
 
@@ -169,6 +168,7 @@ def _traced_current_memory_after_calls(get_value, iterations):
     gc.collect()
     tracemalloc.start()
     try:
+        value = None
         for _ in range(iterations):
             value = get_value()
         del value

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
+import sys
+import tracemalloc
+import warnings
+
 import numpy as np
 import nvidia.dali.fn as fn
 import nvidia.dali.types as types
-import warnings
 from numpy.testing import assert_array_equal
 from nvidia.dali import pipeline_def
 from nvidia.dali.backend_impl import TensorCPU, TensorGPU, TensorListCPU, TensorListGPU, GetSchema
@@ -118,6 +122,95 @@ def test_data_ptr_tensor_list_cpu():
         tensorlist.data_ptr(), tensor.shape(), types.to_numpy_type(tensor.dtype)
     )
     assert np.array_equal(arr, from_tensor_list)
+
+
+def _assert_pointer_int_has_no_extra_refs(name, get_value):
+    value = get_value()
+    assert isinstance(value, int), f"{name} returned {type(value)} instead of int"
+    refcount = sys.getrefcount(value)
+    assert refcount == 2, f"{name} returned an int with refcount {refcount}, expected 2"
+
+
+def _assert_optional_pointer_int_has_no_extra_refs(name, get_value):
+    value = get_value()
+    if value is None or -5 <= value <= 256:
+        return
+    refcount = sys.getrefcount(value)
+    assert refcount == 2, f"{name} returned an int with refcount {refcount}, expected 2"
+
+
+def test_pointer_returning_bindings_do_not_leak_python_int_refs():
+    arr = np.arange(6, dtype=np.uint8).reshape(2, 3)
+    tensor_cpu = TensorCPU(arr, "HW")
+    tensorlist_cpu = TensorListCPU(arr, "W")
+
+    _assert_pointer_int_has_no_extra_refs("TensorCPU.data_ptr()", tensor_cpu.data_ptr)
+    _assert_pointer_int_has_no_extra_refs(
+        'TensorCPU.__array_interface__["data"][0]',
+        lambda: tensor_cpu.__array_interface__["data"][0],
+    )
+    _assert_pointer_int_has_no_extra_refs("TensorListCPU.data_ptr()", tensorlist_cpu.data_ptr)
+
+    tensor_gpu = tensor_cpu._as_gpu()
+    tensorlist_gpu = tensorlist_cpu._as_gpu()
+    _assert_pointer_int_has_no_extra_refs("TensorGPU.data_ptr()", tensor_gpu.data_ptr)
+    _assert_pointer_int_has_no_extra_refs(
+        'TensorGPU.__cuda_array_interface__["data"][0]',
+        lambda: tensor_gpu.__cuda_array_interface__["data"][0],
+    )
+    _assert_pointer_int_has_no_extra_refs("TensorListGPU.data_ptr()", tensorlist_gpu.data_ptr)
+    _assert_optional_pointer_int_has_no_extra_refs("TensorGPU.stream", lambda: tensor_gpu.stream)
+    _assert_optional_pointer_int_has_no_extra_refs(
+        "TensorListGPU.stream", lambda: tensorlist_gpu.stream
+    )
+
+
+def _traced_current_memory_after_calls(get_value, iterations):
+    gc.collect()
+    tracemalloc.start()
+    try:
+        for _ in range(iterations):
+            value = get_value()
+        del value
+        gc.collect()
+        current, _ = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    return current
+
+
+def _assert_no_traced_memory_leak(name, get_value, iterations=10000):
+    current = _traced_current_memory_after_calls(get_value, iterations)
+    assert current < 64 * 1024, f"{name} retained {current} bytes after {iterations} calls"
+
+
+@params(
+    ("TensorCPU.data_ptr()", lambda t: t["tensor_cpu"].data_ptr()),
+    (
+        'TensorCPU.__array_interface__["data"][0]',
+        lambda t: t["tensor_cpu"].__array_interface__["data"][0],
+    ),
+    ("TensorListCPU.data_ptr()", lambda t: t["tensorlist_cpu"].data_ptr()),
+    ("TensorGPU.data_ptr()", lambda t: t["tensor_gpu"].data_ptr()),
+    (
+        'TensorGPU.__cuda_array_interface__["data"][0]',
+        lambda t: t["tensor_gpu"].__cuda_array_interface__["data"][0],
+    ),
+    ("TensorListGPU.data_ptr()", lambda t: t["tensorlist_gpu"].data_ptr()),
+    ("TensorGPU.stream", lambda t: t["tensor_gpu"].stream),
+    ("TensorListGPU.stream", lambda t: t["tensorlist_gpu"].stream),
+)
+def test_pointer_returning_bindings_do_not_leak_python_int_allocations(name, get_from_tensors):
+    arr = np.array([[1]], dtype=np.uint8)
+    tensor_cpu = TensorCPU(arr, "")
+    tensorlist_cpu = TensorListCPU(arr, "")
+    tensors = {
+        "tensor_cpu": tensor_cpu,
+        "tensorlist_cpu": tensorlist_cpu,
+        "tensor_gpu": tensor_cpu._as_gpu(),
+        "tensorlist_gpu": tensorlist_cpu._as_gpu(),
+    }
+    _assert_no_traced_memory_leak(name, lambda: get_from_tensors(tensors))
 
 
 def test_array_interface_tensor_cpu():


### PR DESCRIPTION
- PyLong_FromVoidPtr returns a new reference, so wrapping it
  with py::reinterpret_borrow leaves an extra reference alive
  after Python drops the object. Add a small helper that steals
  the new reference and use it for data_ptr, array-interface
  data pointers, and stream pointer bindings.
- Adds backend_impl regression coverage for pointer-returning bindings:
  a direct refcount check and a tracemalloc allocation-retention check
  covering CPU/GPU data_ptr, array-interface data pointers,
  and stream properties.
- fixes https://github.com/NVIDIA/DALI/issues/6320

## Category:
  **Bug fix** (*non-breaking change which fixes an issue*)

  ## Description:
  Fixes #6320.

  `PyLong_FromVoidPtr` returns a new Python reference. The Python bindings wrapped those values with `py::reinterpret_borrow`, which incremented the refcount and leaked one Python `int` object reference per call after Python discarded the result.

  This change adds a helper that wraps `PyLong_FromVoidPtr` with `py::reinterpret_steal` and uses it for pointer-returning bindings such as `data_ptr`, array interface data pointers, and GPU stream properties.

  ## Additional information:

  ### Affected modules and functionalities:
  - Python backend bindings in `dali/python/backend_impl.cc`
  - `TensorCPU.data_ptr()`
  - `TensorGPU.data_ptr()`
  - `TensorListCPU.data_ptr()`
  - `TensorListGPU.data_ptr()`
  - `TensorGPU.stream`
  - `TensorListGPU.stream`
  - `__array_interface__["data"]`
  - `__cuda_array_interface__["data"]`

  ### Key points relevant for the review:
 Python reference ownership for `PyLong_FromVoidPtr` results. The helper steals the new reference returned by the Python C API instead of borrowing it and incrementing the refcount.

  The tests cover this in two ways:
  - A direct `sys.getrefcount` check for pointer-returning bindings.
  - A tracemalloc allocation-retention regression modeled after the issue reproducer, parametrized over the affected pointer-returning calls.

  ### Tests:
  - [ ] Existing tests apply
  - [x] New tests added
    - [x] Python tests
    - [ ] GTests
    - [ ] Benchmark
    - [ ] Other
  - [ ] N/A

  ## Checklist

  ### Documentation
  - [x] Existing documentation applies
  - [ ] Documentation updated
    - [ ] Docstring
    - [ ] Doxygen
    - [ ] RST
    - [ ] Jupyter
    - [ ] Other
  - [ ] N/A

  ### DALI team only

  #### Requirements
  - [ ] Implements new requirements
  - [ ] Affects existing requirements
  - [x] N/A

  **REQ IDs**: N/A

  **JIRA TASK**: N/A
