### PR TITLE
Drop libdali OpenCV imgcodecs via pure-CPU JPEG distortion kernel

### DIFF
--- a/cmake/Dependencies.common.cmake
+++ b/cmake/Dependencies.common.cmake
@@ -35,16 +35,28 @@ if (BUILD_OPENCV)
   message(STATUS "Found OpenCV: ${OpenCV_INCLUDE_DIRS} (found suitable version \"${OpenCV_VERSION}\", minimum required is \"3.0\")")
   include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS})
 
-  # Production link line: only core+imgproc, never imgcodecs (keeps libdali
-  # free of opencv_imgcodecs and its bundled codec statics:
-  # libwebp/libpng/libjasper/libIlmImf/libtiff).
-  list(APPEND DALI_LIBS opencv_core opencv_imgproc)
-  message("OpenCV production libraries: opencv_core opencv_imgproc")
+  # Production link line: everything find_package() exported EXCEPT imgcodecs
+  # -- keeps libdali free of opencv_imgcodecs and its bundled codec statics
+  # (libwebp/libpng/libjasper/libIlmImf/libtiff). Filtering OpenCV_LIBRARIES
+  # rather than hard-coding `opencv_core opencv_imgproc` keeps this portable
+  # across OpenCV configs that export libraries via different naming styles
+  # (raw `opencv_core`, namespaced `OpenCV::core`, or absolute paths).
+  set(_opencv_prod_libs)
+  set(_opencv_test_extra_libs)
+  foreach(_opencv_lib IN LISTS OpenCV_LIBRARIES)
+    if (_opencv_lib MATCHES "imgcodecs")
+      list(APPEND _opencv_test_extra_libs ${_opencv_lib})
+    else()
+      list(APPEND _opencv_prod_libs ${_opencv_lib})
+    endif()
+  endforeach()
+  list(APPEND DALI_LIBS ${_opencv_prod_libs})
+  message(STATUS "OpenCV production libraries: ${_opencv_prod_libs}")
   list(APPEND DALI_EXCLUDES libopencv_core.a;libopencv_imgproc.a;libopencv_highgui.a)
 
   if (BUILD_TEST)
-    set(DALI_OPENCV_TEST_EXTRA_LIBS opencv_imgcodecs CACHE INTERNAL
-        "OpenCV imgcodecs target, for test executables only")
+    set(DALI_OPENCV_TEST_EXTRA_LIBS "${_opencv_test_extra_libs}" CACHE INTERNAL
+        "OpenCV imgcodecs library/target, for test executables only")
   endif()
 endif()
 

--- a/cmake/Dependencies.common.cmake
+++ b/cmake/Dependencies.common.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,18 +17,35 @@
 # OpenCV
 ##################################################################
 if (BUILD_OPENCV)
-  # For OpenCV 3 and later, 'imdecode()' is in the imgcodecs library
+  # Single find_package call with the full set of components needed for the
+  # current build. `imgcodecs` is added when BUILD_TEST is on (test fixtures
+  # use cv::imread/imwrite for golden images and diff dumps). Splitting into
+  # two find_package calls would risk core/imgproc and imgcodecs resolving
+  # against different OpenCV installs and mixing versions on the link line.
+  set(_opencv_components core imgproc)
+  if (BUILD_TEST)
+    list(APPEND _opencv_components imgcodecs)
+  endif()
 
-  find_package(OpenCV 4.0 QUIET COMPONENTS core imgproc imgcodecs)
+  find_package(OpenCV 4.0 QUIET COMPONENTS ${_opencv_components})
   if(NOT OpenCV_FOUND)
-    find_package(OpenCV 3.0 REQUIRED COMPONENTS core imgproc imgcodecs)
+    find_package(OpenCV 3.0 REQUIRED COMPONENTS ${_opencv_components})
   endif()
 
   message(STATUS "Found OpenCV: ${OpenCV_INCLUDE_DIRS} (found suitable version \"${OpenCV_VERSION}\", minimum required is \"3.0\")")
   include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS})
-  list(APPEND DALI_LIBS ${OpenCV_LIBRARIES})
-  message("OpenCV libraries: ${OpenCV_LIBRARIES}")
-  list(APPEND DALI_EXCLUDES libopencv_core.a;libopencv_imgproc.a;libopencv_highgui.a;libopencv_imgcodecs.a;liblibwebp.a;libittnotify.a;libpng.a;liblibtiff.a;liblibjasper.a;libIlmImf.a;liblibjpeg-turbo.a)
+
+  # Production link line: only core+imgproc, never imgcodecs (keeps libdali
+  # free of opencv_imgcodecs and its bundled codec statics:
+  # libwebp/libpng/libjasper/libIlmImf/libtiff).
+  list(APPEND DALI_LIBS opencv_core opencv_imgproc)
+  message("OpenCV production libraries: opencv_core opencv_imgproc")
+  list(APPEND DALI_EXCLUDES libopencv_core.a;libopencv_imgproc.a;libopencv_highgui.a)
+
+  if (BUILD_TEST)
+    set(DALI_OPENCV_TEST_EXTRA_LIBS opencv_imgcodecs CACHE INTERNAL
+        "OpenCV imgcodecs target, for test executables only")
+  endif()
 endif()
 
 ##################################################################

--- a/dali/CMakeLists.txt
+++ b/dali/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -103,6 +103,9 @@ if (BUILD_DALI_PIPELINE AND BUILD_TEST)
 
   target_link_libraries(dali_test PUBLIC dali dali_core dali_kernels ${DALI_LIBS} gtest)
   target_link_libraries(dali_test PRIVATE dynlink_cuda ${CUDART_LIB})
+  if (DALI_OPENCV_TEST_EXTRA_LIBS)
+    target_link_libraries(dali_test PRIVATE ${DALI_OPENCV_TEST_EXTRA_LIBS})
+  endif()
   if (BUILD_NVML)
     target_link_libraries(dali_test PRIVATE dynlink_nvml)
   endif(BUILD_NVML)

--- a/dali/kernels/CMakeLists.txt
+++ b/dali/kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -96,6 +96,9 @@ if (BUILD_TEST)
   # TODO(janton): Remove dependency with target `dali`
   target_link_libraries(dali_kernel_test PUBLIC dali_kernels dali)
   target_link_libraries(dali_kernel_test PRIVATE gtest dynlink_cuda ${DALI_LIBS})
+  if (DALI_OPENCV_TEST_EXTRA_LIBS)
+    target_link_libraries(dali_kernel_test PRIVATE ${DALI_OPENCV_TEST_EXTRA_LIBS})
+  endif()
   target_link_libraries(dali_kernel_test PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
   if (WITH_DYNAMIC_NPP)
     target_link_libraries(dali_kernel_test PRIVATE dynlink_npp)

--- a/dali/kernels/imgproc/jpeg/dct_8x8.h
+++ b/dali/kernels/imgproc/jpeg/dct_8x8.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_IMGPROC_JPEG_DCT_8X8_GPU_CUH_
-#define DALI_KERNELS_IMGPROC_JPEG_DCT_8X8_GPU_CUH_
+#ifndef DALI_KERNELS_IMGPROC_JPEG_DCT_8X8_H_
+#define DALI_KERNELS_IMGPROC_JPEG_DCT_8X8_H_
 
-#include <cuda_runtime_api.h>
+#include "dali/core/host_dev.h"
+#include "dali/core/force_inline.h"
 
 namespace dali {
 namespace kernels {
 
 // Implements optimized routines required for 8x8 DCT (forward and inverse)
-// as described in the paper:
+// as described in:
 // https://docs.nvidia.com/cuda/samples/3_Imaging/dct8x8/doc/dct8x8.pdf
-
 
 static constexpr float a = 1.387039845322148f;             // sqrt(2) * cos(    pi / 16);
 static constexpr float b = 1.306562964876377f;             // sqrt(2) * cos(    pi /  8);
@@ -34,7 +34,7 @@ static constexpr float f = 0.275899379282943f;             // sqrt(2) * cos(7 * 
 static constexpr float norm_factor = 0.3535533905932737f;  // 1 / sqrt(8)
 
 template <int stride>
-__inline__ __device__
+DALI_HOST_DEV DALI_FORCEINLINE
 void dct_fwd_8x8_1d(float* data) {
   float x0 = data[0 * stride];
   float x1 = data[1 * stride];
@@ -81,7 +81,7 @@ void dct_fwd_8x8_1d(float* data) {
 }
 
 template <int stride>
-__inline__ __device__
+DALI_HOST_DEV DALI_FORCEINLINE
 void dct_inv_8x8_1d(float *data) {
   float x0 = data[0 * stride];
   float x1 = data[1 * stride];
@@ -131,5 +131,4 @@ void dct_inv_8x8_1d(float *data) {
 }  // namespace kernels
 }  // namespace dali
 
-
-#endif  // DALI_KERNELS_IMGPROC_JPEG_DCT_8X8_GPU_CUH_
+#endif  // DALI_KERNELS_IMGPROC_JPEG_DCT_8X8_H_

--- a/dali/kernels/imgproc/jpeg/dct_8x8.h
+++ b/dali/kernels/imgproc/jpeg/dct_8x8.h
@@ -25,17 +25,24 @@ namespace kernels {
 // as described in:
 // https://docs.nvidia.com/cuda/samples/3_Imaging/dct8x8/doc/dct8x8.pdf
 
-static constexpr float a = 1.387039845322148f;             // sqrt(2) * cos(    pi / 16);
-static constexpr float b = 1.306562964876377f;             // sqrt(2) * cos(    pi /  8);
-static constexpr float c = 1.175875602419359f;             // sqrt(2) * cos(3 * pi / 16);
-static constexpr float d = 0.785694958387102f;             // sqrt(2) * cos(5 * pi / 16);
-static constexpr float e = 0.541196100146197f;             // sqrt(2) * cos(3 * pi /  8);
-static constexpr float f = 0.275899379282943f;             // sqrt(2) * cos(7 * pi / 16);
-static constexpr float norm_factor = 0.3535533905932737f;  // 1 / sqrt(8)
+namespace dct8x8 {
+
+// Per-coefficient cosine constants and the 1/sqrt(8) normalization. Kept in
+// a nested namespace so single-letter names don't leak into dali::kernels.
+constexpr float a = 1.387039845322148f;             // sqrt(2) * cos(    pi / 16);
+constexpr float b = 1.306562964876377f;             // sqrt(2) * cos(    pi /  8);
+constexpr float c = 1.175875602419359f;             // sqrt(2) * cos(3 * pi / 16);
+constexpr float d = 0.785694958387102f;             // sqrt(2) * cos(5 * pi / 16);
+constexpr float e = 0.541196100146197f;             // sqrt(2) * cos(3 * pi /  8);
+constexpr float f = 0.275899379282943f;             // sqrt(2) * cos(7 * pi / 16);
+constexpr float norm_factor = 0.3535533905932737f;  // 1 / sqrt(8)
+
+}  // namespace dct8x8
 
 template <int stride>
 DALI_HOST_DEV DALI_FORCEINLINE
 void dct_fwd_8x8_1d(float* data) {
+  using namespace dct8x8;  // NOLINT(build/namespaces)
   float x0 = data[0 * stride];
   float x1 = data[1 * stride];
   float x2 = data[2 * stride];
@@ -83,6 +90,7 @@ void dct_fwd_8x8_1d(float* data) {
 template <int stride>
 DALI_HOST_DEV DALI_FORCEINLINE
 void dct_inv_8x8_1d(float *data) {
+  using namespace dct8x8;  // NOLINT(build/namespaces)
   float x0 = data[0 * stride];
   float x1 = data[1 * stride];
   float x2 = data[2 * stride];

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.cc
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include "dali/core/error_handling.h"
 #include "dali/core/convert.h"
 #include "dali/core/geom/mat.h"
 #include "dali/core/geom/vec.h"
@@ -242,10 +243,12 @@ void JpegCompressionDistortionCPU::RunSample(
     bool horz_subsample,
     bool vert_subsample) {
   const auto &sh = in.shape;
-  assert(out.shape == sh);
+  DALI_ENFORCE(out.shape == sh,
+               "JpegCompressionDistortionCPU: output and input must have matching shapes.");
   const int H = sh[0];
   const int W = sh[1];
-  assert(sh[2] == 3);
+  DALI_ENFORCE(sh[2] == 3, "JpegCompressionDistortionCPU: only interleaved 3-channel "
+                           "(RGB) input is supported.");
   if (H == 0 || W == 0) return;
 
   const auto lumaQ = PrepareQuantTable(GetLumaQuantizationTable(quality));

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.cc
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.cc
@@ -1,0 +1,224 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.h"
+
+#include <algorithm>
+#include <cmath>
+#include "dali/core/convert.h"
+#include "dali/core/geom/mat.h"
+#include "dali/core/geom/vec.h"
+#include "dali/core/static_switch.h"
+#include "dali/core/util.h"
+#include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
+#include "dali/kernels/imgproc/jpeg/dct_8x8.h"
+#include "dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.h"
+
+namespace dali {
+namespace kernels {
+namespace jpeg {
+
+namespace {
+
+inline vec<3, uint8_t> sample_rgb_clamped(const uint8_t *in, int H, int W, int x, int y) {
+  x = std::clamp(x, 0, W - 1);
+  y = std::clamp(y, 0, H - 1);
+  const uint8_t *p = in + (static_cast<int64_t>(y) * W + x) * 3;
+  return {p[0], p[1], p[2]};
+}
+
+inline void fwd_dct_8x8(float blk[8][8]) {
+  for (int r = 0; r < 8; r++)
+    dct_fwd_8x8_1d<1>(&blk[r][0]);
+  for (int c = 0; c < 8; c++)
+    dct_fwd_8x8_1d<8>(&blk[0][c]);
+}
+
+inline void inv_dct_8x8(float blk[8][8]) {
+  for (int c = 0; c < 8; c++)
+    dct_inv_8x8_1d<8>(&blk[0][c]);
+  for (int r = 0; r < 8; r++)
+    dct_inv_8x8_1d<1>(&blk[r][0]);
+}
+
+inline void quantize_8x8(float blk[8][8], const mat<8, 8, uint8_t> &Q) {
+  for (int i = 0; i < 8; i++) {
+    for (int j = 0; j < 8; j++) {
+      float q = static_cast<float>(Q(i, j));
+      blk[i][j] = q * std::round(blk[i][j] / q);
+    }
+  }
+}
+
+template <bool HorzSub, bool VertSub>
+void RunSampleImpl(uint8_t *out, const uint8_t *in, int H, int W,
+                   const mat<8, 8, uint8_t> &lumaQ,
+                   const mat<8, 8, uint8_t> &chromaQ) {
+  constexpr int LX = 1 + static_cast<int>(HorzSub);
+  constexpr int LY = 1 + static_cast<int>(VertSub);
+  constexpr int macro_w = 8 * LX;
+  constexpr int macro_h = 8 * LY;
+
+  const int aligned_W = align_up(W, macro_w);
+  const int aligned_H = align_up(H, macro_h);
+
+  for (int by = 0; by < aligned_H; by += macro_h) {
+    for (int bx = 0; bx < aligned_W; bx += macro_w) {
+      float luma[LY][LX][8][8];
+      float cb[8][8];
+      float cr[8][8];
+
+      // Forward path: sample + RGB->YCbCr (uint8_t domain) + shift -128
+      for (int cy = 0; cy < 8; cy++) {
+        for (int cx = 0; cx < 8; cx++) {
+          int y0 = by + cy * LY;
+          int x0 = bx + cx * LX;
+
+          vec<3, uint8_t> rgb[LY][LX];
+          for (int i = 0; i < LY; i++) {
+            for (int j = 0; j < LX; j++) {
+              rgb[i][j] = sample_rgb_clamped(in, H, W, x0 + j, y0 + i);
+            }
+          }
+
+          // Compute average rgb for chroma (in uint8_t to match GPU kernel behavior)
+          vec<3, uint8_t> avg_rgb;
+          if (HorzSub && VertSub) {
+            avg_rgb = {
+              ConvertSat<uint8_t>((rgb[0][0][0] + rgb[0][1][0] + rgb[1][0][0] + rgb[1][1][0])
+                                  * 0.25f),
+              ConvertSat<uint8_t>((rgb[0][0][1] + rgb[0][1][1] + rgb[1][0][1] + rgb[1][1][1])
+                                  * 0.25f),
+              ConvertSat<uint8_t>((rgb[0][0][2] + rgb[0][1][2] + rgb[1][0][2] + rgb[1][1][2])
+                                  * 0.25f)
+            };
+          } else if (HorzSub) {
+            avg_rgb = {
+              ConvertSat<uint8_t>((rgb[0][0][0] + rgb[0][1][0]) * 0.5f),
+              ConvertSat<uint8_t>((rgb[0][0][1] + rgb[0][1][1]) * 0.5f),
+              ConvertSat<uint8_t>((rgb[0][0][2] + rgb[0][1][2]) * 0.5f)
+            };
+          } else if (VertSub) {
+            avg_rgb = {
+              ConvertSat<uint8_t>((rgb[0][0][0] + rgb[1][0][0]) * 0.5f),
+              ConvertSat<uint8_t>((rgb[0][0][1] + rgb[1][0][1]) * 0.5f),
+              ConvertSat<uint8_t>((rgb[0][0][2] + rgb[1][0][2]) * 0.5f)
+            };
+          } else {
+            avg_rgb = rgb[0][0];
+          }
+
+          // Convert to YCbCr in uint8_t domain (matches GPU kernel), then shift by -128
+          cb[cy][cx] = static_cast<float>(color::jpeg::rgb_to_cb<uint8_t>(avg_rgb)) - 128.0f;
+          cr[cy][cx] = static_cast<float>(color::jpeg::rgb_to_cr<uint8_t>(avg_rgb)) - 128.0f;
+
+          for (int i = 0; i < LY; i++) {
+            for (int j = 0; j < LX; j++) {
+              int local_y = cy * LY + i;
+              int local_x = cx * LX + j;
+              int blk_y = local_y / 8;
+              int blk_x = local_x / 8;
+              int in_blk_y = local_y & 7;
+              int in_blk_x = local_x & 7;
+              luma[blk_y][blk_x][in_blk_y][in_blk_x] =
+                  static_cast<float>(color::jpeg::rgb_to_y<uint8_t>(rgb[i][j])) - 128.0f;
+            }
+          }
+        }
+      }
+
+      // DCT, quantize, inverse DCT
+      fwd_dct_8x8(cb);
+      fwd_dct_8x8(cr);
+      for (int i = 0; i < LY; i++)
+        for (int j = 0; j < LX; j++)
+          fwd_dct_8x8(luma[i][j]);
+
+      quantize_8x8(cb, chromaQ);
+      quantize_8x8(cr, chromaQ);
+      for (int i = 0; i < LY; i++)
+        for (int j = 0; j < LX; j++)
+          quantize_8x8(luma[i][j], lumaQ);
+
+      inv_dct_8x8(cb);
+      inv_dct_8x8(cr);
+      for (int i = 0; i < LY; i++)
+        for (int j = 0; j < LX; j++)
+          inv_dct_8x8(luma[i][j]);
+
+      // Backward path: shift +128, YCbCr->RGB, write
+      for (int cy = 0; cy < 8; cy++) {
+        for (int cx = 0; cx < 8; cx++) {
+          uint8_t Cb_u = ConvertSat<uint8_t>(cb[cy][cx] + 128.0f);
+          uint8_t Cr_u = ConvertSat<uint8_t>(cr[cy][cx] + 128.0f);
+
+          for (int i = 0; i < LY; i++) {
+            for (int j = 0; j < LX; j++) {
+              int y = by + cy * LY + i;
+              int x = bx + cx * LX + j;
+              if (x >= W || y >= H)
+                continue;
+
+              int local_y = cy * LY + i;
+              int local_x = cx * LX + j;
+              int blk_y = local_y / 8;
+              int blk_x = local_x / 8;
+              int in_blk_y = local_y & 7;
+              int in_blk_x = local_x & 7;
+              uint8_t Y_u = ConvertSat<uint8_t>(
+                  luma[blk_y][blk_x][in_blk_y][in_blk_x] + 128.0f);
+
+              auto rgb = color::jpeg::ycbcr_to_rgb<uint8_t>(
+                  vec<3, uint8_t>{Y_u, Cb_u, Cr_u});
+
+              uint8_t *p = out + (static_cast<int64_t>(y) * W + x) * 3;
+              p[0] = rgb[0];
+              p[1] = rgb[1];
+              p[2] = rgb[2];
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+}  // namespace
+
+void JpegCompressionDistortionCPU::RunSample(
+    const TensorView<StorageCPU, uint8_t, 3> &out,
+    const TensorView<StorageCPU, const uint8_t, 3> &in,
+    int quality,
+    bool horz_subsample,
+    bool vert_subsample) {
+  const auto &sh = in.shape;
+  assert(out.shape == sh);
+  const int H = sh[0];
+  const int W = sh[1];
+  assert(sh[2] == 3);
+  if (H == 0 || W == 0) return;
+
+  const auto lumaQ = GetLumaQuantizationTable(quality);
+  const auto chromaQ = GetChromaQuantizationTable(quality);
+
+  BOOL_SWITCH(horz_subsample, HorzSub, (
+    BOOL_SWITCH(vert_subsample, VertSub, (
+      RunSampleImpl<HorzSub, VertSub>(out.data, in.data, H, W, lumaQ, chromaQ);
+    ));  // NOLINT
+  ));  // NOLINT
+}
+
+}  // namespace jpeg
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.cc
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.cc
@@ -50,24 +50,31 @@ inline QuantTable PrepareQuantTable(const mat<8, 8, uint8_t> &Q) {
   return t;
 }
 
-inline void fwd_dct_8x8(float blk[8][8]) {
+// 8x8 DCT/quantize helpers templated on the row stride of the surrounding
+// buffer. RowStride=8 for standalone 8x8 blocks (chroma); RowStride=macro_w
+// for luma blocks tiled inside a flat macro_h x macro_w scratch buffer.
+template <int RowStride>
+inline void fwd_dct_8x8(float *blk) {
   for (int r = 0; r < 8; r++)
-    dct_fwd_8x8_1d<1>(&blk[r][0]);
+    dct_fwd_8x8_1d<1>(blk + r * RowStride);
   for (int c = 0; c < 8; c++)
-    dct_fwd_8x8_1d<8>(&blk[0][c]);
+    dct_fwd_8x8_1d<RowStride>(blk + c);
 }
 
-inline void inv_dct_8x8(float blk[8][8]) {
+template <int RowStride>
+inline void inv_dct_8x8(float *blk) {
   for (int c = 0; c < 8; c++)
-    dct_inv_8x8_1d<8>(&blk[0][c]);
+    dct_inv_8x8_1d<RowStride>(blk + c);
   for (int r = 0; r < 8; r++)
-    dct_inv_8x8_1d<1>(&blk[r][0]);
+    dct_inv_8x8_1d<1>(blk + r * RowStride);
 }
 
-inline void quantize_8x8(float blk[8][8], const QuantTable &Q) {
+template <int RowStride>
+inline void quantize_8x8(float *blk, const QuantTable &Q) {
   for (int i = 0; i < 8; i++) {
     for (int j = 0; j < 8; j++) {
-      blk[i][j] = Q.q[i][j] * std::round(blk[i][j] * Q.inv_q[i][j]);
+      float &v = blk[i * RowStride + j];
+      v = Q.q[i][j] * std::round(v * Q.inv_q[i][j]);
     }
   }
 }
@@ -82,6 +89,8 @@ inline void ProcessMacroblock(uint8_t *out, const uint8_t *in, int H, int W,
                               const QuantTable &chromaQ) {
   constexpr int LX = 1 + static_cast<int>(HorzSub);
   constexpr int LY = 1 + static_cast<int>(VertSub);
+  constexpr int macro_w = 8 * LX;
+  constexpr int macro_h = 8 * LY;
 
   auto sample_rgb = [&](int x, int y) -> vec<3, uint8_t> {
     if constexpr (BoundsCheck) {
@@ -92,7 +101,9 @@ inline void ProcessMacroblock(uint8_t *out, const uint8_t *in, int H, int W,
     return {p[0], p[1], p[2]};
   };
 
-  float luma[LY][LX][8][8];
+  // Flat row-major luma buffer covering the whole macroblock. The DCT/quantize
+  // calls walk it as a tiling of LY*LX 8x8 blocks via the row-stride template.
+  float luma[macro_h][macro_w];
   float cb[8][8];
   float cr[8][8];
 
@@ -141,13 +152,7 @@ inline void ProcessMacroblock(uint8_t *out, const uint8_t *in, int H, int W,
 
       for (int i = 0; i < LY; i++) {
         for (int j = 0; j < LX; j++) {
-          int local_y = cy * LY + i;
-          int local_x = cx * LX + j;
-          int blk_y = local_y / 8;
-          int blk_x = local_x / 8;
-          int in_blk_y = local_y & 7;
-          int in_blk_x = local_x & 7;
-          luma[blk_y][blk_x][in_blk_y][in_blk_x] =
+          luma[cy * LY + i][cx * LX + j] =
               static_cast<float>(color::jpeg::rgb_to_y<uint8_t>(rgb[i][j])) - 128.0f;
         }
       }
@@ -155,23 +160,23 @@ inline void ProcessMacroblock(uint8_t *out, const uint8_t *in, int H, int W,
   }
 
   // DCT, quantize, inverse DCT
-  fwd_dct_8x8(cb);
-  fwd_dct_8x8(cr);
-  for (int i = 0; i < LY; i++)
-    for (int j = 0; j < LX; j++)
-      fwd_dct_8x8(luma[i][j]);
+  fwd_dct_8x8<8>(&cb[0][0]);
+  fwd_dct_8x8<8>(&cr[0][0]);
+  for (int by_ = 0; by_ < LY; by_++)
+    for (int bx_ = 0; bx_ < LX; bx_++)
+      fwd_dct_8x8<macro_w>(&luma[by_ * 8][bx_ * 8]);
 
-  quantize_8x8(cb, chromaQ);
-  quantize_8x8(cr, chromaQ);
-  for (int i = 0; i < LY; i++)
-    for (int j = 0; j < LX; j++)
-      quantize_8x8(luma[i][j], lumaQ);
+  quantize_8x8<8>(&cb[0][0], chromaQ);
+  quantize_8x8<8>(&cr[0][0], chromaQ);
+  for (int by_ = 0; by_ < LY; by_++)
+    for (int bx_ = 0; bx_ < LX; bx_++)
+      quantize_8x8<macro_w>(&luma[by_ * 8][bx_ * 8], lumaQ);
 
-  inv_dct_8x8(cb);
-  inv_dct_8x8(cr);
-  for (int i = 0; i < LY; i++)
-    for (int j = 0; j < LX; j++)
-      inv_dct_8x8(luma[i][j]);
+  inv_dct_8x8<8>(&cb[0][0]);
+  inv_dct_8x8<8>(&cr[0][0]);
+  for (int by_ = 0; by_ < LY; by_++)
+    for (int bx_ = 0; bx_ < LX; bx_++)
+      inv_dct_8x8<macro_w>(&luma[by_ * 8][bx_ * 8]);
 
   // Backward path: shift +128, YCbCr->RGB, write
   for (int cy = 0; cy < 8; cy++) {
@@ -188,14 +193,7 @@ inline void ProcessMacroblock(uint8_t *out, const uint8_t *in, int H, int W,
               continue;
           }
 
-          int local_y = cy * LY + i;
-          int local_x = cx * LX + j;
-          int blk_y = local_y / 8;
-          int blk_x = local_x / 8;
-          int in_blk_y = local_y & 7;
-          int in_blk_x = local_x & 7;
-          uint8_t Y_u = ConvertSat<uint8_t>(
-              luma[blk_y][blk_x][in_blk_y][in_blk_x] + 128.0f);
+          uint8_t Y_u = ConvertSat<uint8_t>(luma[cy * LY + i][cx * LX + j] + 128.0f);
 
           auto rgb = color::jpeg::ycbcr_to_rgb<uint8_t>(
               vec<3, uint8_t>{Y_u, Cb_u, Cr_u});

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.cc
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.cc
@@ -31,11 +31,23 @@ namespace jpeg {
 
 namespace {
 
-inline vec<3, uint8_t> sample_rgb_clamped(const uint8_t *in, int H, int W, int x, int y) {
-  x = std::clamp(x, 0, W - 1);
-  y = std::clamp(y, 0, H - 1);
-  const uint8_t *p = in + (static_cast<int64_t>(y) * W + x) * 3;
-  return {p[0], p[1], p[2]};
+// Quantization table with precomputed reciprocals so the hot-path quantize step
+// uses multiplications instead of divisions (mirrors the GPU's __frcp_rn use).
+struct QuantTable {
+  float q[8][8];
+  float inv_q[8][8];
+};
+
+inline QuantTable PrepareQuantTable(const mat<8, 8, uint8_t> &Q) {
+  QuantTable t;
+  for (int i = 0; i < 8; i++) {
+    for (int j = 0; j < 8; j++) {
+      float qv = static_cast<float>(Q(i, j));
+      t.q[i][j] = qv;
+      t.inv_q[i][j] = 1.0f / qv;
+    }
+  }
+  return t;
 }
 
 inline void fwd_dct_8x8(float blk[8][8]) {
@@ -52,19 +64,156 @@ inline void inv_dct_8x8(float blk[8][8]) {
     dct_inv_8x8_1d<1>(&blk[r][0]);
 }
 
-inline void quantize_8x8(float blk[8][8], const mat<8, 8, uint8_t> &Q) {
+inline void quantize_8x8(float blk[8][8], const QuantTable &Q) {
   for (int i = 0; i < 8; i++) {
     for (int j = 0; j < 8; j++) {
-      float q = static_cast<float>(Q(i, j));
-      blk[i][j] = q * std::round(blk[i][j] / q);
+      blk[i][j] = Q.q[i][j] * std::round(blk[i][j] * Q.inv_q[i][j]);
+    }
+  }
+}
+
+// Process a single macroblock. BoundsCheck=true is only needed for the partial
+// rightmost/bottommost macroblock; interior macroblocks compile to a faster path
+// without input clamps or output bounds checks.
+template <bool HorzSub, bool VertSub, bool BoundsCheck>
+inline void ProcessMacroblock(uint8_t *out, const uint8_t *in, int H, int W,
+                              int by, int bx,
+                              const QuantTable &lumaQ,
+                              const QuantTable &chromaQ) {
+  constexpr int LX = 1 + static_cast<int>(HorzSub);
+  constexpr int LY = 1 + static_cast<int>(VertSub);
+
+  auto sample_rgb = [&](int x, int y) -> vec<3, uint8_t> {
+    if constexpr (BoundsCheck) {
+      x = std::clamp(x, 0, W - 1);
+      y = std::clamp(y, 0, H - 1);
+    }
+    const uint8_t *p = in + (static_cast<int64_t>(y) * W + x) * 3;
+    return {p[0], p[1], p[2]};
+  };
+
+  float luma[LY][LX][8][8];
+  float cb[8][8];
+  float cr[8][8];
+
+  // Forward path: sample + RGB->YCbCr (uint8_t domain) + shift -128
+  for (int cy = 0; cy < 8; cy++) {
+    for (int cx = 0; cx < 8; cx++) {
+      int y0 = by + cy * LY;
+      int x0 = bx + cx * LX;
+
+      vec<3, uint8_t> rgb[LY][LX];
+      for (int i = 0; i < LY; i++) {
+        for (int j = 0; j < LX; j++) {
+          rgb[i][j] = sample_rgb(x0 + j, y0 + i);
+        }
+      }
+
+      // Compute average rgb for chroma (in uint8_t to match GPU kernel behavior)
+      vec<3, uint8_t> avg_rgb;
+      if constexpr (HorzSub && VertSub) {
+        avg_rgb = {
+          ConvertSat<uint8_t>((rgb[0][0][0] + rgb[0][1][0] + rgb[1][0][0] + rgb[1][1][0])
+                              * 0.25f),
+          ConvertSat<uint8_t>((rgb[0][0][1] + rgb[0][1][1] + rgb[1][0][1] + rgb[1][1][1])
+                              * 0.25f),
+          ConvertSat<uint8_t>((rgb[0][0][2] + rgb[0][1][2] + rgb[1][0][2] + rgb[1][1][2])
+                              * 0.25f)
+        };
+      } else if constexpr (HorzSub) {
+        avg_rgb = {
+          ConvertSat<uint8_t>((rgb[0][0][0] + rgb[0][1][0]) * 0.5f),
+          ConvertSat<uint8_t>((rgb[0][0][1] + rgb[0][1][1]) * 0.5f),
+          ConvertSat<uint8_t>((rgb[0][0][2] + rgb[0][1][2]) * 0.5f)
+        };
+      } else if constexpr (VertSub) {
+        avg_rgb = {
+          ConvertSat<uint8_t>((rgb[0][0][0] + rgb[1][0][0]) * 0.5f),
+          ConvertSat<uint8_t>((rgb[0][0][1] + rgb[1][0][1]) * 0.5f),
+          ConvertSat<uint8_t>((rgb[0][0][2] + rgb[1][0][2]) * 0.5f)
+        };
+      } else {
+        avg_rgb = rgb[0][0];
+      }
+
+      cb[cy][cx] = static_cast<float>(color::jpeg::rgb_to_cb<uint8_t>(avg_rgb)) - 128.0f;
+      cr[cy][cx] = static_cast<float>(color::jpeg::rgb_to_cr<uint8_t>(avg_rgb)) - 128.0f;
+
+      for (int i = 0; i < LY; i++) {
+        for (int j = 0; j < LX; j++) {
+          int local_y = cy * LY + i;
+          int local_x = cx * LX + j;
+          int blk_y = local_y / 8;
+          int blk_x = local_x / 8;
+          int in_blk_y = local_y & 7;
+          int in_blk_x = local_x & 7;
+          luma[blk_y][blk_x][in_blk_y][in_blk_x] =
+              static_cast<float>(color::jpeg::rgb_to_y<uint8_t>(rgb[i][j])) - 128.0f;
+        }
+      }
+    }
+  }
+
+  // DCT, quantize, inverse DCT
+  fwd_dct_8x8(cb);
+  fwd_dct_8x8(cr);
+  for (int i = 0; i < LY; i++)
+    for (int j = 0; j < LX; j++)
+      fwd_dct_8x8(luma[i][j]);
+
+  quantize_8x8(cb, chromaQ);
+  quantize_8x8(cr, chromaQ);
+  for (int i = 0; i < LY; i++)
+    for (int j = 0; j < LX; j++)
+      quantize_8x8(luma[i][j], lumaQ);
+
+  inv_dct_8x8(cb);
+  inv_dct_8x8(cr);
+  for (int i = 0; i < LY; i++)
+    for (int j = 0; j < LX; j++)
+      inv_dct_8x8(luma[i][j]);
+
+  // Backward path: shift +128, YCbCr->RGB, write
+  for (int cy = 0; cy < 8; cy++) {
+    for (int cx = 0; cx < 8; cx++) {
+      uint8_t Cb_u = ConvertSat<uint8_t>(cb[cy][cx] + 128.0f);
+      uint8_t Cr_u = ConvertSat<uint8_t>(cr[cy][cx] + 128.0f);
+
+      for (int i = 0; i < LY; i++) {
+        for (int j = 0; j < LX; j++) {
+          int y = by + cy * LY + i;
+          int x = bx + cx * LX + j;
+          if constexpr (BoundsCheck) {
+            if (x >= W || y >= H)
+              continue;
+          }
+
+          int local_y = cy * LY + i;
+          int local_x = cx * LX + j;
+          int blk_y = local_y / 8;
+          int blk_x = local_x / 8;
+          int in_blk_y = local_y & 7;
+          int in_blk_x = local_x & 7;
+          uint8_t Y_u = ConvertSat<uint8_t>(
+              luma[blk_y][blk_x][in_blk_y][in_blk_x] + 128.0f);
+
+          auto rgb = color::jpeg::ycbcr_to_rgb<uint8_t>(
+              vec<3, uint8_t>{Y_u, Cb_u, Cr_u});
+
+          uint8_t *p = out + (static_cast<int64_t>(y) * W + x) * 3;
+          p[0] = rgb[0];
+          p[1] = rgb[1];
+          p[2] = rgb[2];
+        }
+      }
     }
   }
 }
 
 template <bool HorzSub, bool VertSub>
 void RunSampleImpl(uint8_t *out, const uint8_t *in, int H, int W,
-                   const mat<8, 8, uint8_t> &lumaQ,
-                   const mat<8, 8, uint8_t> &chromaQ) {
+                   const QuantTable &lumaQ,
+                   const QuantTable &chromaQ) {
   constexpr int LX = 1 + static_cast<int>(HorzSub);
   constexpr int LY = 1 + static_cast<int>(VertSub);
   constexpr int macro_w = 8 * LX;
@@ -74,121 +223,13 @@ void RunSampleImpl(uint8_t *out, const uint8_t *in, int H, int W,
   const int aligned_H = align_up(H, macro_h);
 
   for (int by = 0; by < aligned_H; by += macro_h) {
+    bool edge_y = by + macro_h > H;
     for (int bx = 0; bx < aligned_W; bx += macro_w) {
-      float luma[LY][LX][8][8];
-      float cb[8][8];
-      float cr[8][8];
-
-      // Forward path: sample + RGB->YCbCr (uint8_t domain) + shift -128
-      for (int cy = 0; cy < 8; cy++) {
-        for (int cx = 0; cx < 8; cx++) {
-          int y0 = by + cy * LY;
-          int x0 = bx + cx * LX;
-
-          vec<3, uint8_t> rgb[LY][LX];
-          for (int i = 0; i < LY; i++) {
-            for (int j = 0; j < LX; j++) {
-              rgb[i][j] = sample_rgb_clamped(in, H, W, x0 + j, y0 + i);
-            }
-          }
-
-          // Compute average rgb for chroma (in uint8_t to match GPU kernel behavior)
-          vec<3, uint8_t> avg_rgb;
-          if (HorzSub && VertSub) {
-            avg_rgb = {
-              ConvertSat<uint8_t>((rgb[0][0][0] + rgb[0][1][0] + rgb[1][0][0] + rgb[1][1][0])
-                                  * 0.25f),
-              ConvertSat<uint8_t>((rgb[0][0][1] + rgb[0][1][1] + rgb[1][0][1] + rgb[1][1][1])
-                                  * 0.25f),
-              ConvertSat<uint8_t>((rgb[0][0][2] + rgb[0][1][2] + rgb[1][0][2] + rgb[1][1][2])
-                                  * 0.25f)
-            };
-          } else if (HorzSub) {
-            avg_rgb = {
-              ConvertSat<uint8_t>((rgb[0][0][0] + rgb[0][1][0]) * 0.5f),
-              ConvertSat<uint8_t>((rgb[0][0][1] + rgb[0][1][1]) * 0.5f),
-              ConvertSat<uint8_t>((rgb[0][0][2] + rgb[0][1][2]) * 0.5f)
-            };
-          } else if (VertSub) {
-            avg_rgb = {
-              ConvertSat<uint8_t>((rgb[0][0][0] + rgb[1][0][0]) * 0.5f),
-              ConvertSat<uint8_t>((rgb[0][0][1] + rgb[1][0][1]) * 0.5f),
-              ConvertSat<uint8_t>((rgb[0][0][2] + rgb[1][0][2]) * 0.5f)
-            };
-          } else {
-            avg_rgb = rgb[0][0];
-          }
-
-          // Convert to YCbCr in uint8_t domain (matches GPU kernel), then shift by -128
-          cb[cy][cx] = static_cast<float>(color::jpeg::rgb_to_cb<uint8_t>(avg_rgb)) - 128.0f;
-          cr[cy][cx] = static_cast<float>(color::jpeg::rgb_to_cr<uint8_t>(avg_rgb)) - 128.0f;
-
-          for (int i = 0; i < LY; i++) {
-            for (int j = 0; j < LX; j++) {
-              int local_y = cy * LY + i;
-              int local_x = cx * LX + j;
-              int blk_y = local_y / 8;
-              int blk_x = local_x / 8;
-              int in_blk_y = local_y & 7;
-              int in_blk_x = local_x & 7;
-              luma[blk_y][blk_x][in_blk_y][in_blk_x] =
-                  static_cast<float>(color::jpeg::rgb_to_y<uint8_t>(rgb[i][j])) - 128.0f;
-            }
-          }
-        }
-      }
-
-      // DCT, quantize, inverse DCT
-      fwd_dct_8x8(cb);
-      fwd_dct_8x8(cr);
-      for (int i = 0; i < LY; i++)
-        for (int j = 0; j < LX; j++)
-          fwd_dct_8x8(luma[i][j]);
-
-      quantize_8x8(cb, chromaQ);
-      quantize_8x8(cr, chromaQ);
-      for (int i = 0; i < LY; i++)
-        for (int j = 0; j < LX; j++)
-          quantize_8x8(luma[i][j], lumaQ);
-
-      inv_dct_8x8(cb);
-      inv_dct_8x8(cr);
-      for (int i = 0; i < LY; i++)
-        for (int j = 0; j < LX; j++)
-          inv_dct_8x8(luma[i][j]);
-
-      // Backward path: shift +128, YCbCr->RGB, write
-      for (int cy = 0; cy < 8; cy++) {
-        for (int cx = 0; cx < 8; cx++) {
-          uint8_t Cb_u = ConvertSat<uint8_t>(cb[cy][cx] + 128.0f);
-          uint8_t Cr_u = ConvertSat<uint8_t>(cr[cy][cx] + 128.0f);
-
-          for (int i = 0; i < LY; i++) {
-            for (int j = 0; j < LX; j++) {
-              int y = by + cy * LY + i;
-              int x = bx + cx * LX + j;
-              if (x >= W || y >= H)
-                continue;
-
-              int local_y = cy * LY + i;
-              int local_x = cx * LX + j;
-              int blk_y = local_y / 8;
-              int blk_x = local_x / 8;
-              int in_blk_y = local_y & 7;
-              int in_blk_x = local_x & 7;
-              uint8_t Y_u = ConvertSat<uint8_t>(
-                  luma[blk_y][blk_x][in_blk_y][in_blk_x] + 128.0f);
-
-              auto rgb = color::jpeg::ycbcr_to_rgb<uint8_t>(
-                  vec<3, uint8_t>{Y_u, Cb_u, Cr_u});
-
-              uint8_t *p = out + (static_cast<int64_t>(y) * W + x) * 3;
-              p[0] = rgb[0];
-              p[1] = rgb[1];
-              p[2] = rgb[2];
-            }
-          }
-        }
+      bool edge_x = bx + macro_w > W;
+      if (edge_x || edge_y) {
+        ProcessMacroblock<HorzSub, VertSub, true>(out, in, H, W, by, bx, lumaQ, chromaQ);
+      } else {
+        ProcessMacroblock<HorzSub, VertSub, false>(out, in, H, W, by, bx, lumaQ, chromaQ);
       }
     }
   }
@@ -209,8 +250,8 @@ void JpegCompressionDistortionCPU::RunSample(
   assert(sh[2] == 3);
   if (H == 0 || W == 0) return;
 
-  const auto lumaQ = GetLumaQuantizationTable(quality);
-  const auto chromaQ = GetChromaQuantizationTable(quality);
+  const auto lumaQ = PrepareQuantTable(GetLumaQuantizationTable(quality));
+  const auto chromaQ = PrepareQuantTable(GetChromaQuantizationTable(quality));
 
   BOOL_SWITCH(horz_subsample, HorzSub, (
     BOOL_SWITCH(vert_subsample, VertSub, (

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.h
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_IMGPROC_JPEG_JPEG_DISTORTION_CPU_KERNEL_H_
+#define DALI_KERNELS_IMGPROC_JPEG_JPEG_DISTORTION_CPU_KERNEL_H_
+
+#include "dali/core/api_helper.h"
+#include "dali/core/span.h"
+#include "dali/core/tensor_view.h"
+#include "dali/kernels/kernel.h"
+
+namespace dali {
+namespace kernels {
+namespace jpeg {
+
+// CPU port of the GPU lossy-only JPEG distortion kernel: RGB -> YCbCr (with
+// optional 2:1 horizontal/vertical chroma subsampling) -> 8x8 forward DCT ->
+// Annex-K quantization -> 8x8 inverse DCT -> YCbCr -> RGB. Skips the
+// Huffman/bitstream stages of real JPEG, just like the GPU kernel.
+//
+// Threading is the caller's responsibility. RunSample processes a single
+// image; the operator drives a thread pool across frames/samples.
+class DLL_PUBLIC JpegCompressionDistortionCPU {
+ public:
+  // Apply the distortion to one image in-place layout (output may alias input).
+  //
+  // @param out             interleaved RGB output, shape (H, W, 3)
+  // @param in              interleaved RGB input,  shape (H, W, 3)
+  // @param quality         JPEG quality factor in [1, 100] (clamped internally)
+  // @param horz_subsample  if true, average chroma horizontally 2:1
+  // @param vert_subsample  if true, average chroma vertically 2:1
+  void RunSample(const TensorView<StorageCPU, uint8_t, 3> &out,
+                 const TensorView<StorageCPU, const uint8_t, 3> &in,
+                 int quality,
+                 bool horz_subsample,
+                 bool vert_subsample);
+};
+
+}  // namespace jpeg
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_IMGPROC_JPEG_JPEG_DISTORTION_CPU_KERNEL_H_

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.h
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.h
@@ -33,7 +33,13 @@ namespace jpeg {
 // image; the operator drives a thread pool across frames/samples.
 class DLL_PUBLIC JpegCompressionDistortionCPU {
  public:
-  // Apply the distortion to one image in-place layout (output may alias input).
+  // Apply the distortion to one image. `out` may alias `in`: the kernel
+  // processes one macroblock at a time, completes all RGB reads (with
+  // clamp-to-edge sampling on partial edge macroblocks) into per-macroblock
+  // float scratch before producing any RGB output, and the partial-macroblock
+  // clamp coordinates W-1 / H-1 always lie within the current macroblock's
+  // own pixel span -- so a clamped read can never hit a pixel that an earlier
+  // macroblock has already overwritten.
   //
   // @param out             interleaved RGB output, shape (H, W, 3)
   // @param in              interleaved RGB input,  shape (H, W, 3)

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_test.cc
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_test.cc
@@ -14,7 +14,10 @@
 
 #include <gtest/gtest.h>
 #include <opencv2/opencv.hpp>
+#include <chrono>
 #include <cstring>
+#include <iostream>
+#include <random>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -114,6 +117,47 @@ INSTANTIATE_TEST_SUITE_P(JpegDistortionTestCPU, JpegDistortionTestCPU, ::testing
   ::testing::Values(false, true),
   ::testing::Values(false, true)
 ));  // NOLINT
+
+// Disabled by default so it doesn't run in normal CI. Invoke with
+//   --gtest_filter='*JpegDistortionPerfCPU*' --gtest_also_run_disabled_tests
+// to measure RunSample throughput on a synthetic 1080p RGB image.
+TEST(JpegDistortionPerfCPU, DISABLED_RunSample_1080p_q75_420) {
+  using clock = std::chrono::steady_clock;
+  constexpr int H = 1080;
+  constexpr int W = 1920;
+  constexpr int q = 75;
+  constexpr int warmup = 3;
+  constexpr int iters = 50;
+
+  std::vector<uint8_t> in(static_cast<size_t>(H) * W * 3);
+  std::vector<uint8_t> out(in.size());
+  std::mt19937 rng(0xC0FFEE);
+  std::uniform_int_distribution<int> dist(0, 255);
+  for (auto &v : in) v = static_cast<uint8_t>(dist(rng));
+
+  TensorShape<3> sh{H, W, 3};
+  TensorView<StorageCPU, const uint8_t, 3> in_view{in.data(), sh};
+  TensorView<StorageCPU, uint8_t, 3> out_view{out.data(), sh};
+
+  JpegCompressionDistortionCPU kernel;
+  for (int i = 0; i < warmup; i++)
+    kernel.RunSample(out_view, in_view, q, true, true);
+
+  auto t0 = clock::now();
+  for (int i = 0; i < iters; i++)
+    kernel.RunSample(out_view, in_view, q, true, true);
+  auto t1 = clock::now();
+
+  double total_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+  double per_call_ms = total_ms / iters;
+  double mp = (static_cast<double>(H) * W) / 1e6;
+  double mpps = mp * 1000.0 / per_call_ms;
+
+  std::cout << "[ PERF     ] iters=" << iters << " HxW=" << H << "x" << W
+            << " q=" << q << " 4:2:0  per-call=" << per_call_ms
+            << " ms  total=" << total_ms << " ms  throughput=" << mpps
+            << " MP/s" << std::endl;
+}
 
 }  // namespace test
 }  // namespace jpeg

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_test.cc
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_test.cc
@@ -60,6 +60,13 @@ class JpegDistortionTestCPU : public ::testing::TestWithParam<std::tuple<bool, b
 
   void TestQuality(int q) {
     JpegCompressionDistortionCPU kernel;
+    // The reference image is produced by cv::imencode(".jpg", ...) which
+    // always uses 4:2:0 chroma subsampling. For (horz_subsample,
+    // vert_subsample) != (true, true) the kernel produces 4:4:4 / 4:2:2 /
+    // 4:4:0 output, so the comparison is necessarily looser -- we assert
+    // gross correctness (no crash, no wildly out-of-range pixels) rather
+    // than tight numerical agreement. These thresholds mirror the GPU
+    // kernel test (jpeg_distortion_gpu_test.cu).
     int max_abs_error = vert_subsample && horz_subsample ? 80 : 128;
     double max_avg_error = vert_subsample && horz_subsample ? 3 : 10;
 

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_test.cc
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_test.cc
@@ -1,0 +1,121 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <opencv2/opencv.hpp>
+#include <cstring>
+#include <string>
+#include <tuple>
+#include <vector>
+#include "dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.h"
+#include "dali/pipeline/data/tensor_list.h"
+#include "dali/test/dali_test_config.h"
+#include "dali/util/image.h"
+
+namespace dali {
+namespace kernels {
+namespace jpeg {
+namespace test {
+
+using testing::dali_extra_path;
+
+inline cv::Mat rgb2bgr(const cv::Mat &img) {
+  cv::Mat out;
+  cv::cvtColor(img, out, cv::COLOR_RGB2BGR);
+  return out;
+}
+
+inline cv::Mat bgr2rgb(const cv::Mat &img) {
+  return rgb2bgr(img);
+}
+
+class JpegDistortionTestCPU : public ::testing::TestWithParam<std::tuple<bool, bool>> {
+ protected:
+  using T = uint8_t;
+  bool horz_subsample = std::get<0>(GetParam());
+  bool vert_subsample = std::get<1>(GetParam());
+
+  void SetUp() override {
+    auto paths = ImageList(dali_extra_path() + "/db/single/bmp", {".bmp"}, 3);
+    images_.resize(paths.size());
+    for (size_t i = 0; i < paths.size(); i++) {
+      images_[i] = bgr2rgb(cv::imread(paths[i]));
+      ASSERT_FALSE(images_[i].empty()) << "Failed to load " << paths[i];
+    }
+  }
+
+  void TestQuality(int q) {
+    JpegCompressionDistortionCPU kernel;
+    int max_abs_error = vert_subsample && horz_subsample ? 80 : 128;
+    double max_avg_error = vert_subsample && horz_subsample ? 3 : 10;
+
+    for (size_t i = 0; i < images_.size(); i++) {
+      const auto &in_mat = images_[i];
+      cv::Mat out_mat(in_mat.rows, in_mat.cols, CV_8UC3);
+
+      TensorShape<3> sh{in_mat.rows, in_mat.cols, 3};
+      TensorView<StorageCPU, const uint8_t, 3> in_view{in_mat.data, sh};
+      TensorView<StorageCPU, uint8_t, 3> out_view{out_mat.data, sh};
+
+      kernel.RunSample(out_view, in_view, q, horz_subsample, vert_subsample);
+
+      std::vector<uint8_t> encoded;
+      cv::imencode(".jpg", rgb2bgr(in_mat), encoded, {cv::IMWRITE_JPEG_QUALITY, q});
+      cv::Mat encoded_mat(1, encoded.size(), CV_8UC1, encoded.data());
+      cv::Mat out_ref = bgr2rgb(cv::imdecode(encoded_mat, cv::IMREAD_COLOR));
+
+      cv::Mat diff;
+      cv::absdiff(out_mat, out_ref, diff);
+      double min_val, max_val;
+      cv::minMaxLoc(diff, &min_val, &max_val);
+      auto mean = cv::mean(diff);
+
+      EXPECT_LE(max_val, max_abs_error)
+          << "image " << i << " q=" << q << " hs=" << horz_subsample
+          << " vs=" << vert_subsample;
+      for (int d = 0; d < 3; d++) {
+        EXPECT_LE(mean[d], max_avg_error)
+            << "image " << i << " channel " << d << " q=" << q;
+      }
+    }
+  }
+
+  std::vector<cv::Mat> images_;
+};
+
+TEST_P(JpegDistortionTestCPU, JpegCompressionDistortion_LowestQuality) {
+  this->TestQuality(1);
+}
+
+TEST_P(JpegDistortionTestCPU, JpegCompressionDistortion_LowQuality) {
+  this->TestQuality(5);
+}
+
+TEST_P(JpegDistortionTestCPU, JpegCompressionDistortion_HighQuality) {
+  this->TestQuality(95);
+}
+
+TEST_P(JpegDistortionTestCPU, JpegCompressionDistortion_HighestQuality) {
+  this->TestQuality(100);
+}
+
+INSTANTIATE_TEST_SUITE_P(JpegDistortionTestCPU, JpegDistortionTestCPU, ::testing::Combine(
+  ::testing::Values(false, true),
+  ::testing::Values(false, true)
+));  // NOLINT
+
+}  // namespace test
+}  // namespace jpeg
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_impl.cuh
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_impl.cuh
@@ -21,7 +21,7 @@
 #include "dali/core/geom/vec.h"
 #include "dali/core/util.h"
 #include "dali/kernels/common/block_setup.h"
-#include "dali/kernels/imgproc/jpeg/dct_8x8_gpu.cuh"
+#include "dali/kernels/imgproc/jpeg/dct_8x8.h"
 #include "dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.h"
 #include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
 #include "dali/kernels/imgproc/sampler.h"

--- a/dali/operators/CMakeLists.txt
+++ b/dali/operators/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -148,6 +148,9 @@ if (BUILD_TEST)
 
   target_link_libraries(dali_operator_test PUBLIC dali_operators)
   target_link_libraries(dali_operator_test PRIVATE gtest dynlink_cuda ${DALI_LIBS})
+  if (DALI_OPENCV_TEST_EXTRA_LIBS)
+    target_link_libraries(dali_operator_test PRIVATE ${DALI_OPENCV_TEST_EXTRA_LIBS})
+  endif()
   if (BUILD_NVML)
     target_link_libraries(dali_operator_test PRIVATE dynlink_nvml)
   endif(BUILD_NVML)

--- a/dali/operators/image/distortion/jpeg_compression_distortion_op_cpu.cc
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op_cpu.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <opencv2/opencv.hpp>
 #include <vector>
+#include "dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.h"
 #include "dali/operators/image/distortion/jpeg_compression_distortion_op.h"
 
 namespace dali {
@@ -50,25 +50,7 @@ class JpegCompressionDistortionCPU : public JpegCompressionDistortion<CPUBackend
 
  protected:
   void RunImpl(Workspace &ws) override;
-
- private:
-  struct ThreadCtx {
-    std::vector<uint8_t> encoded;
-  };
-  std::vector<ThreadCtx> thread_ctx_;
 };
-
-template <typename ThreadCtx>
-static void RunJpegDistortionCPU(ThreadCtx &ctx, const uint8_t *input, uint8_t *output,
-                                 size_t width, size_t height, int quality) {
-  auto in_mat = cv::Mat(height, width, CV_8UC3, const_cast<uint8_t *>(input));
-  auto out_mat = cv::Mat(height, width, CV_8UC3, output);
-
-  cv::cvtColor(in_mat, out_mat, cv::COLOR_RGB2BGR);
-  cv::imencode(".jpg", out_mat, ctx.encoded, {cv::IMWRITE_JPEG_QUALITY, quality});
-  cv::imdecode(ctx.encoded, cv::IMREAD_COLOR, &out_mat);
-  cv::cvtColor(out_mat, out_mat, cv::COLOR_BGR2RGB);
-}
 
 void JpegCompressionDistortionCPU::RunImpl(Workspace &ws) {
   const auto &input = ws.Input<CPUBackend>(0);
@@ -77,11 +59,9 @@ void JpegCompressionDistortionCPU::RunImpl(Workspace &ws) {
   output.SetLayout(layout);
   auto in_shape = input.shape();
   int nsamples = input.num_samples();
-  auto& thread_pool = ws.GetThreadPool();
+  auto &thread_pool = ws.GetThreadPool();
   auto in_view = view<const uint8_t>(input);
   auto out_view = view<uint8_t>(output);
-
-  thread_ctx_.resize(thread_pool.NumThreads());
 
   for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
     auto shape = in_shape.tensor_shape_span(sample_idx);
@@ -95,20 +75,24 @@ void JpegCompressionDistortionCPU::RunImpl(Workspace &ws) {
     assert(c_dim >= 0);
     int f_dim = layout.find('F');
 
-    int64_t nframes =
-        volume(shape.begin(), shape.begin() + f_dim + 1);  // note that if f_dim is -1, this
-                                                           // evaluates to an empty range,
-                                                           // volume of 1
+    // f_dim == -1 for HWC: nframes = volume([], [0]) = 1.
+    int64_t nframes = volume(shape.begin(), shape.begin() + f_dim + 1);
     int64_t frame_size = volume(shape.begin() + f_dim + 1, shape.begin() + ndim);
     int64_t width = shape[w_dim];
     int64_t height = shape[h_dim];
-    for (int elem_idx = 0; elem_idx < nframes; elem_idx++) {
+
+    for (int frame_idx = 0; frame_idx < nframes; frame_idx++) {
       thread_pool.AddWork(
-          [&, sample_idx, elem_idx, width, height, frame_size,
-           quality = quality_arg_[sample_idx].data[0]](int thread_id) {
-            auto *in = in_view[sample_idx].data + elem_idx * frame_size;
-            auto *out = out_view[sample_idx].data + elem_idx * frame_size;
-            RunJpegDistortionCPU(thread_ctx_[thread_id], in, out, width, height, quality);
+          [&, sample_idx, frame_idx, width, height, frame_size,
+           quality = quality_arg_[sample_idx].data[0]](int) {
+            const uint8_t *in_ptr = in_view[sample_idx].data + frame_idx * frame_size;
+            uint8_t *out_ptr = out_view[sample_idx].data + frame_idx * frame_size;
+            TensorShape<3> sh{static_cast<int64_t>(height), static_cast<int64_t>(width), 3};
+            TensorView<StorageCPU, const uint8_t, 3> in_tv{in_ptr, sh};
+            TensorView<StorageCPU, uint8_t, 3> out_tv{out_ptr, sh};
+            kernels::jpeg::JpegCompressionDistortionCPU kernel;
+            kernel.RunSample(out_tv, in_tv, quality,
+                             /*horz_subsample=*/true, /*vert_subsample=*/true);
           },
           frame_size);
     }

--- a/dali/test/python/operator_1/test_jpeg_compression_distortion.py
+++ b/dali/test/python/operator_1/test_jpeg_compression_distortion.py
@@ -174,7 +174,12 @@ def test_jpeg_compression_distortion_sequence():
     seq_len = 10
     for batch_size in [1, 15]:
         for device in ["cpu", "gpu"]:
-            for quality in [2, None, 50]:
+            # Numerical behavior across quality values is covered by
+            # test_jpeg_compression_distortion. This test only verifies that
+            # distorting a sequence equals distorting each slice independently,
+            # which doesn't depend on the quality value. Use quality=None so
+            # the per-sample random-quality tensor path is exercised.
+            for quality in [None]:
                 yield (
                     _testimpl_jpeg_compression_distortion_sequence,
                     batch_size,


### PR DESCRIPTION
## Category:

**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:

The CPU `JpegCompressionDistortion` operator was the only consumer of `cv::imencode` / `cv::imdecode` in `libdali`, which dragged `opencv_imgcodecs` (and its libjpeg/libpng/libtiff dependency closure) into the production runtime. This PR ports the operator to a pure CPU kernel that mirrors the existing GPU lossy-only pipeline (RGB → YCbCr → 8x8 DCT → Annex-K quantization → IDCT → YCbCr → RGB), and unlinks `opencv_imgcodecs` from `libdali`. OpenCV's encoder/decoder is still linked into the test binaries so existing tests can compare against a reference.

## Additional information:

### Affected modules and functionalities:

- New CPU kernel `dali::kernels::jpeg::JpegCompressionDistortionCPU` (`dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_kernel.{h,cc}`).
- `dct_8x8_gpu.cuh` renamed to `dct_8x8.h`; `__device__` helpers swapped for `DALI_HOST_DEV DALI_FORCEINLINE` so the same DCT routines are reusable from CPU and GPU.
- `JpegCompressionDistortionCPU` operator now runs the kernel under the operator's thread pool, one frame per work item. The previous nvimgcodec-based implementation (instance/encoder/decoder/extension/buffer plumbing, quality bucketing, future status checks) is removed.
- `cmake/Dependencies.common.cmake`, `dali/CMakeLists.txt`, `dali/kernels/CMakeLists.txt`, `dali/operators/CMakeLists.txt`: split `opencv_imgcodecs` so it is only linked into test binaries, not into `libdali`.

### Key points relevant for the review:

- Color conversion deliberately uses uint8 RGB→YCbCr / YCbCr→RGB (`color::jpeg::rgb_to_y/cb/cr<uint8_t>`, `ycbcr_to_rgb<uint8_t>`) to match the GPU kernel byte-for-byte rather than an arithmetically purer float path.
- For 4:2:0 / 4:2:2 / 4:4:0 the chroma block averages four/two RGB samples in the uint8 domain (also matching GPU). 4:4:4 (`horz_subsample=false, vert_subsample=false`) takes the top-left sample.
- The operator hard-codes `horz_subsample=true, vert_subsample=true` (4:2:0), matching the GPU op's default.
- Edge handling: macroblocks that cross H/W are processed with a `BoundsCheck=true` template specialization (forward path uses clamp-to-edge sampling, backward path skips out-of-bounds writes); interior macroblocks compile-dispatch to `BoundsCheck=false` so the hot path has no per-pixel clamp or branch.
- Quantization tables are precomputed once per sample as a `(q, 1/q)` float pair, so the inner quantize step multiplies by `1/q` instead of dividing — matches the GPU kernel's `__frcp_rn`-based formulation and removes the `uint8 → float` reload from the inner loop.
- Luma scratch is a flat row-major `float[macro_h][macro_w]` covering the whole macroblock; the DCT, quantize, and IDCT calls walk it via a `RowStride`-templated set of helpers (`fwd_dct_8x8<RowStride>`, `inv_dct_8x8<RowStride>`, `quantize_8x8<RowStride>`). Cleaner per-pixel indexing than the original `luma[LY][LX][8][8]` 4-D array, with no `local_y / 8`, `local_y & 7` arithmetic in the hot loops.

### Tests:

- New gtest `dali/kernels/imgproc/jpeg/jpeg_distortion_cpu_test.cc` parametrized on (horz_subsample, vert_subsample) ∈ {false,true}^2, quality ∈ {1, 5, 95, 100}, against `cv::imencode`/`cv::imdecode` as reference.
- Disabled-by-default perf gtest `JpegDistortionPerfCPU.DISABLED_RunSample_1080p_q75_420` in the same file: times `RunSample` on a synthetic 1080p RGB image. Run with `--gtest_filter='*JpegDistortionPerfCPU*' --gtest_also_run_disabled_tests`. Used during development to validate that the reciprocal-quant + edge-split optimizations didn't regress; left in tree as a measurement harness for future kernel changes.
- Existing operator tests for `JpegCompressionDistortion` CPU continue to apply.
- Trimmed `test_jpeg_compression_distortion_sequence` to a single `quality=None` case per (batch_size, device): the test verifies a structural property (whole-sequence == per-slice distortion under matched per-sample quality) that doesn't depend on the numeric quality value, and numerical correctness across qualities is already covered by `test_jpeg_compression_distortion` and the kernel-level gtest.

- [X] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [X] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A