### PR TITLE
Clarify DeviceGuard null-context behavior

### DIFF
--- a/dali/core/device_guard_test.cc
+++ b/dali/core/device_guard_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,47 @@ TEST(DeviceGuard, ConstructorWithDevice) {
   }
   CUDA_CALL(cudaGetDevice(&current_device));
   EXPECT_EQ(current_device, test_device);
+}
+
+TEST(DeviceGuard, ConstructorWithDeviceRestoresNullContextMultiGPU) {
+  int test_device = 0;
+  int guard_device = 1;
+  int current_device = 0;
+  int count = 0;
+  CUcontext current_context = NULL;
+
+  ASSERT_TRUE(cuInitChecked());
+  CUDA_CALL(cudaGetDeviceCount(&count));
+  if (count < 2) {
+    GTEST_SKIP() << "Test requires at least two CUDA devices";
+  }
+
+  // Restore the state that was current when this test entered.
+  DeviceGuard restore_guard;
+  CUDA_CALL(cudaSetDevice(test_device));
+  CUDA_CALL(cuCtxSetCurrent(NULL));
+  CUDA_CALL(cudaGetDevice(&current_device));
+  ASSERT_EQ(current_device, test_device);
+  CUDA_CALL(cuCtxGetCurrent(&current_context));
+  ASSERT_EQ(current_context, nullptr);
+
+  {
+    DeviceGuard g(guard_device);
+    CUDA_CALL(cudaGetDevice(&current_device));
+    EXPECT_EQ(current_device, guard_device);
+
+    void *ptr = nullptr;
+    CUDA_CALL(cudaMalloc(&ptr, 1));
+    CUDA_CALL(cudaFree(ptr));
+    CUDA_CALL(cuCtxGetCurrent(&current_context));
+    EXPECT_NE(current_context, nullptr);
+  }
+
+  // If there were no primary context at construction, DeviceGuard will create a new one
+  CUDA_CALL(cuCtxGetCurrent(&current_context));
+  EXPECT_NE(current_context, nullptr);
+  CUDA_CALL(cudaGetDevice(&current_device));
+  EXPECT_NE(current_device, test_device);
 }
 
 TEST(DeviceGuard, ConstructorNoArgs) {
@@ -90,7 +131,73 @@ struct CUDAContext : UniqueHandle<CUcontext, CUDAContext> {
 
 }  // namespace
 
-TEST(DeviceGuard, Checkcontext) {
+TEST(DeviceGuard, ConstructorNoArgsRestoresNullContextMultiGPU) {
+  int test_device = 0;
+  CUdevice cu_guard_device = 0;
+  int guard_device = 1;
+  int current_device = 0;
+  int count = 0;
+  CUcontext current_context = NULL;
+
+  ASSERT_TRUE(cuInitChecked());
+  CUDA_CALL(cudaGetDeviceCount(&count));
+  if (count < 2) {
+    GTEST_SKIP() << "Test requires at least two CUDA devices";
+  }
+
+  // Restore the state that was current when this test entered.
+  DeviceGuard restore_guard;
+  CUDA_CALL(cudaSetDevice(test_device));
+  CUDA_CALL(cuCtxSetCurrent(NULL));
+  CUDA_CALL(cudaGetDevice(&current_device));
+  ASSERT_EQ(current_device, test_device);
+  CUDA_CALL(cuCtxGetCurrent(&current_context));
+  ASSERT_EQ(current_context, nullptr);
+
+  CUDA_CALL(cuDeviceGet(&cu_guard_device, guard_device));
+  CUDAContext guard_context;
+  {
+    DeviceGuard g;
+    guard_context = CUDAContext::Create(0, cu_guard_device);
+    CUDA_CALL(cudaGetDevice(&current_device));
+    EXPECT_EQ(current_device, guard_device);
+    CUDA_CALL(cuCtxGetCurrent(&current_context));
+    EXPECT_EQ(current_context, guard_context);
+  }
+
+  // If there were no primary context at construction, DeviceGuard will create a new one
+  CUDA_CALL(cuCtxGetCurrent(&current_context));
+  EXPECT_NE(current_context, nullptr);
+  CUDA_CALL(cudaGetDevice(&current_device));
+  EXPECT_NE(current_device, test_device);
+}
+
+TEST(DeviceGuard, NegativeDeviceIsNoOp) {
+  CUdevice cu_test_device = 0;
+  CUdevice cu_current_device = 0;
+  CUcontext current_context = nullptr;
+
+  ASSERT_TRUE(cuInitChecked());
+
+  // Restore the state that was current when this test entered.
+  DeviceGuard restore_guard;
+  CUDA_CALL(cuDeviceGet(&cu_test_device, 0));
+  auto test_context = CUDAContext::Create(0, cu_test_device);
+  CUDA_CALL(cuCtxSetCurrent(test_context));
+  CUDA_CALL(cuCtxGetCurrent(&current_context));
+  ASSERT_EQ(current_context, test_context);
+
+  {
+    DeviceGuard g(-1);
+  }
+
+  CUDA_CALL(cuCtxGetCurrent(&current_context));
+  EXPECT_EQ(current_context, test_context);
+  CUDA_CALL(cuCtxGetDevice(&cu_current_device));
+  EXPECT_EQ(cu_current_device, cu_test_device);
+}
+
+TEST(DeviceGuard, CheckcontextMultiGPU) {
   int test_device = 0;
   CUdevice cu_test_device = 0;
   int guard_device = 0;
@@ -125,7 +232,7 @@ TEST(DeviceGuard, Checkcontext) {
   EXPECT_EQ(cu_current_device, cu_test_device);
 }
 
-TEST(DeviceGuard, CheckcontextNoArgs) {
+TEST(DeviceGuard, CheckcontextNoArgsMultiGPU) {
   int test_device = 0;
   CUdevice cu_test_device = 0;
   CUcontext cu_current_ctx = nullptr;

--- a/include/dali/core/device_guard.h
+++ b/include/dali/core/device_guard.h
@@ -33,6 +33,8 @@ class DLL_PUBLIC DeviceGuard {
   /// @brief Saves current device id, sets a new one and switches back
   ///        to the original device upon object destruction.
   //         for device id < 0 it is no-op
+  //         if no primary context was current at construction, a new one will be created
+  //         and the new device will be made the primary context
   explicit DeviceGuard(int new_device);
   ~DeviceGuard();
  private:


### PR DESCRIPTION
- Documents and tests the current DeviceGuard behavior when it is constructed
  without an active CUDA driver context. In this state, switching devices through
  the runtime can create or keep a primary context for the scoped device instead
  of restoring the original no-context state.
- Adds multi-GPU coverage for the explicit-device and no-arg constructors in
  this null-context path, and cover the DeviceGuard(-1) no-op contract with an
  active driver context. Renames the driver-context tests with a MultiGPU suffix
  to make their requirements explicit.

## Category:
  **Bug fix**


  ## Description:
  Clarify and test `DeviceGuard` behavior when it is constructed while no CUDA
  driver context is current.

  In this state, switching devices through the CUDA runtime can create or keep a
  primary context for the scoped device instead of restoring the original
  no-current-context state. This PR documents that behavior for
  `DeviceGuard(int)` and adds focused regression coverage for the affected paths.


  ## Additional information:

  ### Affected modules and functionalities:
  - `dali/core/device_guard`
  - CUDA runtime device and driver context handling


  ### Key points relevant for the review:
  - Adds multi-GPU coverage for `DeviceGuard(int)` in the no-current-context path.
  - Adds multi-GPU coverage for no-arg `DeviceGuard()` in the same path.
  - Adds coverage that `DeviceGuard(-1)` remains a no-op with an active driver
    context.
  - Renames existing driver-context tests with a `MultiGPU` suffix to make their
    requirements explicit.

  ### Tests:
  - [ ] Existing tests apply
  - [x] New tests added
    - [ ] Python tests
    - [x] GTests
    - [ ] Benchmark
    - [ ] Other
  - [ ] N/A

  Tested with:
  - `compile/dali/python/nvidia/dali/test/dali_core_test.bin --gtest_filter=DeviceGuard.*`


  ## Checklist

  ### Documentation
  - [ ] Existing documentation applies
  - [ ] Documentation updated
    - [ ] Docstring
    - [ ] Doxygen
    - [ ] RST
    - [ ] Jupyter
    - [ ] Other
  - [x] N/A

  ### DALI team only

  #### Requirements
  - [ ] Implements new requirements
  - [ ] Affects existing requirements
  - [x] N/A

  **REQ IDs**: N/A

  **JIRA TASK**: N/A