### PR TITLE
Improve device guard.

### DIFF
--- a/dali/core/device_guard.cc
+++ b/dali/core/device_guard.cc
@@ -33,7 +33,9 @@ namespace {
 
 struct PrimaryContext {
   ~PrimaryContext() {
-    CUDA_DTOR_CALL(cuDevicePrimaryCtxRelease(device));
+    if (handle.load(std::memory_order::acquire) != nullptr) {
+      CUDA_DTOR_CALL(cuDevicePrimaryCtxRelease(device));
+    }
   }
 
   CUdevice device{};

--- a/dali/core/device_guard.cc
+++ b/dali/core/device_guard.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <atomic>
+#include <vector>
+#include <stdexcept>
 #include "dali/core/device_guard.h"
 #include "dali/core/cuda_error.h"
 

--- a/dali/core/device_guard.cc
+++ b/dali/core/device_guard.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,32 +12,76 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
 #include "dali/core/device_guard.h"
 #include "dali/core/cuda_error.h"
 
 namespace dali {
 
+// This makes restoring NULL context possible
+#define INVALID_CONTEXT ((CUcontext)(intptr_t)-1)  // NOLINT
+
 DeviceGuard::DeviceGuard() :
-  old_context_(NULL) {
+  old_context_(INVALID_CONTEXT) {
   DALI_ENFORCE(cuInitChecked(),
     "Failed to load libcuda.so. "
     "Check your library paths and if the driver is installed correctly.");
   CUDA_CALL(cuCtxGetCurrent(&old_context_));
 }
 
+namespace {
+
+struct PrimaryContext {
+  ~PrimaryContext() {
+    CUDA_DTOR_CALL(cuDevicePrimaryCtxRelease(device));
+  }
+
+  CUdevice device{};
+  std::atomic<CUcontext> handle{nullptr};
+
+  CUcontext Get() {
+    CUcontext ctx = handle.load();
+    if (ctx)
+      return ctx;
+    CUDA_CALL(cuDevicePrimaryCtxRetain(&ctx, device));
+    CUcontext expected = nullptr;
+    if (handle.compare_exchange_strong(expected, ctx)) {
+      return ctx;
+    } else {
+      CUDA_CALL(cuDevicePrimaryCtxRelease(device));
+      return expected;
+    }
+  }
+};
+
+
+
+}  // namespace
+
 DeviceGuard::DeviceGuard(int new_device) :
-  old_context_(NULL) {
+  old_context_(INVALID_CONTEXT) {
   if (new_device >= 0) {
     DALI_ENFORCE(cuInitChecked(),
       "Failed to load libcuda.so. "
       "Check your library paths and if the driver is installed correctly.");
     CUDA_CALL(cuCtxGetCurrent(&old_context_));
-    CUDA_CALL(cudaSetDevice(new_device));
+    static auto default_contexts = []() {
+      int ndevs = 0;
+      CUDA_CALL(cudaGetDeviceCount(&ndevs));
+      std::vector<PrimaryContext> ctxs(ndevs);
+      for (int i = 0; i < ndevs; i++)
+        ctxs[i].device = i;
+      return ctxs;
+    }();
+    if (new_device < 0 || new_device >= static_cast<int>(default_contexts.size()))
+      throw std::out_of_range(make_string("Invalid device ordinal: ", new_device));
+    auto *ctx = default_contexts[new_device].Get();
+    CUDA_CALL(cuCtxSetCurrent(ctx));
   }
 }
 
 DeviceGuard::~DeviceGuard() {
-  if (old_context_ != NULL) {
+  if (old_context_ != INVALID_CONTEXT) {
     CUresult err = cuCtxSetCurrent(old_context_);
     if (err != CUDA_SUCCESS) {
       std::cerr << "Failed to recover from DeviceGuard: " << err << std::endl;

--- a/dali/core/device_guard.cc
+++ b/dali/core/device_guard.cc
@@ -73,7 +73,7 @@ DeviceGuard::DeviceGuard(int new_device) :
         ctxs[i].device = i;
       return ctxs;
     }();
-    if (new_device < 0 || new_device >= static_cast<int>(default_contexts.size()))
+    if (new_device >= static_cast<int>(default_contexts.size()))
       throw std::out_of_range(make_string("Invalid device ordinal: ", new_device));
     auto *ctx = default_contexts[new_device].Get();
     CUDA_CALL(cuCtxSetCurrent(ctx));

--- a/dali/core/device_guard_test.cc
+++ b/dali/core/device_guard_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,34 @@
 #include "dali/core/device_guard.h"
 #include "dali/core/cuda_error.h"
 #include "dali/core/unique_handle.h"
+#include "dali/test/timing.h"
 
 namespace dali {
+
+TEST(DeviceGuard, RestoreUninit0) {
+  ASSERT_TRUE(cuInitChecked());
+  int count = 0;
+  CUDA_CALL(cudaGetDeviceCount(&count));
+  if (count < 2) {
+    GTEST_SKIP() << "This test requires at least 2 CUDA devices.";
+  }
+
+  unsigned flags = 0;
+  int active = 0;
+  CUDA_CALL(cuDevicePrimaryCtxGetState(0, &flags, &active));
+  if (active) {
+    GTEST_SKIP() << "This test cannot be run with a primary context already active for device 0";
+  }
+
+  int curr = -1;
+  {
+    DeviceGuard dg(1);
+    CUDA_CALL(cudaGetDevice(&curr));
+    EXPECT_EQ(curr, 1);
+  }
+  CUDA_CALL(cudaGetDevice(&curr));
+  EXPECT_EQ(curr, 0);
+}
 
 TEST(DeviceGuard, ConstructorWithDevice) {
   int test_device = 0;
@@ -159,6 +185,43 @@ TEST(DeviceGuard, CheckcontextNoArgs) {
   CUDA_CALL(cuCtxGetDevice(&cu_current_device));
   EXPECT_EQ(cu_current_ctx, cu_test_ctx);
   EXPECT_EQ(cu_current_device, cu_test_device);
+}
+
+TEST(DeviceGuard, SwitchPerf) {
+  ASSERT_TRUE(cuInitChecked());
+  int count = 0;
+  CUDA_CALL(cudaGetDeviceCount(&count));
+  if (count < 2) {
+    GTEST_SKIP() << "This test requires at least 2 CUDA devices.";
+  }
+
+  {
+    DeviceGuard dg0(0);
+    DeviceGuard dg1(1);
+  }
+
+  auto start = test::perf_timer::now();
+  int iters = 100000;
+  for (int i = 0; i < iters; i++) {
+    DeviceGuard dg0(0);
+    DeviceGuard dg1(1);
+  }
+  auto end = test::perf_timer::now();
+  std::cout << test::format_time(test::seconds(end - start) / (2 * iters)) << std::endl;
+}
+
+TEST(DeviceGuard, SameDevPerf) {
+  ASSERT_TRUE(cuInitChecked());
+  int count = 0;
+  DeviceGuard dg0(0);
+
+  auto start = test::perf_timer::now();
+  int iters = 100000;
+  for (int i = 0; i < iters; i++) {
+    DeviceGuard dg0(0);
+  }
+  auto end = test::perf_timer::now();
+  std::cout << test::format_time(test::seconds(end - start) / iters) << std::endl;
 }
 
 }  // namespace dali

--- a/dali/core/device_guard_test.cc
+++ b/dali/core/device_guard_test.cc
@@ -228,7 +228,7 @@ TEST(DeviceGuard, CheckContext) {
     CUDA_CALL(cuCtxSetCurrent(cu_test_ctx1));
   }
   CUDA_CALL(cuCtxGetCurrent(&ctx));
-  EXPECT_EQ(ctx, cu_test_ctx0.get()) << "Context not restored upon construction";
+  EXPECT_EQ(ctx, cu_test_ctx0.get()) << "Context not restored upon destruction";
 }
 
 

--- a/dali/core/device_guard_test.cc
+++ b/dali/core/device_guard_test.cc
@@ -68,12 +68,13 @@ int DoTestPrimaryContextInitMultithreaded() {
   int active = 0;
   CUDA_CALL(cuDevicePrimaryCtxGetState(0, &flags, &active));
   if (active) {
-    std::cout << "This test cannot be run with a primary context already active for device 0";
+    std::cout << "This test cannot be run with a primary context already active for device 0"
+              << std::endl;
     return 0xbad;
   }
 
   std::atomic<bool> start{false};
-  bool failure = false;
+  std::atomic<bool> failure{false};
 
   std::vector<std::thread> threads;
   for (int i = 0; i < 10; i++) {
@@ -212,6 +213,9 @@ struct CUDAContext : UniqueHandle<CUcontext, CUDAContext> {
 TEST(DeviceGuard, CheckContext) {
   ASSERT_TRUE(cuInitChecked());
 
+  int ndevs = 0;
+  CUDA_CALL(cudaGetDeviceCount(&ndevs));
+  int test_dev = ndevs - 1;
   CUcontext old = nullptr;
   CUDA_CALL(cuCtxGetCurrent(&old));
   auto restore = AtScopeExit([old]() {
@@ -225,6 +229,17 @@ TEST(DeviceGuard, CheckContext) {
     DeviceGuard g;
     CUDA_CALL(cuCtxGetCurrent(&ctx));
     EXPECT_EQ(ctx, cu_test_ctx0.get());
+    CUDA_CALL(cuCtxSetCurrent(cu_test_ctx1));
+  }
+  CUDA_CALL(cuCtxGetCurrent(&ctx));
+  EXPECT_EQ(ctx, cu_test_ctx0.get()) << "Context not restored upon destruction";
+  {
+    DeviceGuard g(test_dev);
+    CUDA_CALL(cuCtxGetCurrent(&ctx));
+    EXPECT_NE(ctx, cu_test_ctx0.get());
+    int dev = -1;
+    CUDA_CALL(cuCtxGetDevice(&dev));
+    EXPECT_EQ(dev, test_dev);
     CUDA_CALL(cuCtxSetCurrent(cu_test_ctx1));
   }
   CUDA_CALL(cuCtxGetCurrent(&ctx));
@@ -268,7 +283,7 @@ TEST(DeviceGuard, CheckContextNoArgs) {
   EXPECT_EQ(cu_current_device, cu_test_device);
 }
 
-TEST(DeviceGuard, NegativeDevicNoOp) {
+TEST(DeviceGuard, NegativeDeviceNoOp) {
   // This test creates a DeviceGuard with a negative device ID and destroys it out-of-order
   // to verify that it's really no-op, even with valid CUDA context present.
 

--- a/dali/core/device_guard_test.cc
+++ b/dali/core/device_guard_test.cc
@@ -210,7 +210,7 @@ struct CUDAContext : UniqueHandle<CUcontext, CUDAContext> {
 
 }  // namespace
 
-TEST(DeviceGuard, CheckContext) {
+TEST(DeviceGuard, CheckContext_MultiGPU) {
   ASSERT_TRUE(cuInitChecked());
 
   int ndevs = 0;
@@ -283,7 +283,7 @@ TEST(DeviceGuard, CheckContextNoArgs) {
   EXPECT_EQ(cu_current_device, cu_test_device);
 }
 
-TEST(DeviceGuard, NegativeDeviceNoOp) {
+TEST(DeviceGuard, NegativeDeviceNoOp_MultiGPU) {
   // This test creates a DeviceGuard with a negative device ID and destroys it out-of-order
   // to verify that it's really no-op, even with valid CUDA context present.
 

--- a/dali/core/device_guard_test.cc
+++ b/dali/core/device_guard_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include "dali/core/call_at_exit.h"
 #include "dali/core/dynlink_cuda.h"
 #include "dali/core/device_guard.h"
 #include "dali/core/cuda_error.h"
@@ -209,39 +210,27 @@ struct CUDAContext : UniqueHandle<CUcontext, CUDAContext> {
 }  // namespace
 
 TEST(DeviceGuard, CheckContext) {
-  int test_device = 0;
-  CUdevice cu_test_device = 0;
-  int guard_device = 0;
-  int current_device;
-  CUdevice cu_current_device = 0;
-  CUcontext cu_current_ctx = nullptr;
-  int count = 1;
-
   ASSERT_TRUE(cuInitChecked());
-  CUDA_CALL(cudaGetDeviceCount(&count));
-  if (count > 1) {
-    guard_device = 1;
-  }
 
-  CUDA_CALL(cuDeviceGet(&cu_test_device, test_device));
-  auto cu_test_ctx = CUDAContext::Create(0, cu_test_device);
-  CUDA_CALL(cuCtxSetCurrent(cu_test_ctx));
-  CUDA_CALL(cuCtxGetCurrent(&cu_current_ctx));
-  CUDA_CALL(cuCtxGetDevice(&cu_current_device));
-  EXPECT_EQ(cu_current_ctx, cu_test_ctx);
-  EXPECT_EQ(cu_current_device, cu_test_device);
+  CUcontext old = nullptr;
+  CUDA_CALL(cuCtxGetCurrent(&old));
+  auto restore = AtScopeExit([old]() {
+    CUDA_DTOR_CALL(cuCtxSetCurrent(old));
+  });
+  auto cu_test_ctx0 = CUDAContext::Create(0, 0);
+  auto cu_test_ctx1 = CUDAContext::Create(0, 0);
+  CUDA_CALL(cuCtxSetCurrent(cu_test_ctx0));
+  CUcontext ctx = nullptr;
   {
-    DeviceGuard g(guard_device);
-    CUDA_CALL(cudaGetDevice(&current_device));
-    EXPECT_EQ(current_device, guard_device);
-    CUDA_CALL(cuCtxGetCurrent(&cu_current_ctx));
-    EXPECT_NE(cu_current_ctx, cu_test_ctx);
+    DeviceGuard g;
+    CUDA_CALL(cuCtxGetCurrent(&ctx));
+    EXPECT_EQ(ctx, cu_test_ctx0.get());
+    CUDA_CALL(cuCtxSetCurrent(cu_test_ctx1));
   }
-  CUDA_CALL(cuCtxGetCurrent(&cu_current_ctx));
-  CUDA_CALL(cuCtxGetDevice(&cu_current_device));
-  EXPECT_EQ(cu_current_ctx, cu_test_ctx);
-  EXPECT_EQ(cu_current_device, cu_test_device);
+  CUDA_CALL(cuCtxGetCurrent(&ctx));
+  EXPECT_EQ(ctx, cu_test_ctx0.get()) << "Context not restored upon construction";
 }
+
 
 TEST(DeviceGuard, CheckContextNoArgs) {
   int test_device = 0;
@@ -316,7 +305,7 @@ TEST(DeviceGuard, CheckOutOfRange) {
   EXPECT_THROW(DeviceGuard{ndevs}, std::out_of_range);
 }
 
-TEST(DeviceGuard, SwitchPerf) {
+TEST(DeviceGuard, SwitchPerf_MultiGPU) {
   ASSERT_TRUE(cuInitChecked());
   int count = 0;
   CUDA_CALL(cudaGetDeviceCount(&count));

--- a/dali/core/device_guard_test.cc
+++ b/dali/core/device_guard_test.cc
@@ -122,7 +122,7 @@ void TestPrimaryContextInitMultithreaded() {
   _exit(DoTestPrimaryContextInitMultithreaded());
 }
 
-TEST(DeviceGuard, RestoreUninit0) {
+TEST(DeviceGuard, RestoreUninit0_MultiGPU) {
   int count = 0;
   CUDA_CALL(cudaGetDeviceCount(&count));
   if (count < 2) {

--- a/dali/core/device_guard_test.cc
+++ b/dali/core/device_guard_test.cc
@@ -21,29 +21,121 @@
 
 namespace dali {
 
-TEST(DeviceGuard, RestoreUninit0) {
-  ASSERT_TRUE(cuInitChecked());
-  int count = 0;
-  CUDA_CALL(cudaGetDeviceCount(&count));
-  if (count < 2) {
-    GTEST_SKIP() << "This test requires at least 2 CUDA devices.";
+int DoTestUninit0() {
+  if (!cuInitChecked()) {
+    std::cout << "Cannot initialize CUDA." << std::endl;
+    return 0xdead;
   }
 
   unsigned flags = 0;
   int active = 0;
   CUDA_CALL(cuDevicePrimaryCtxGetState(0, &flags, &active));
   if (active) {
-    GTEST_SKIP() << "This test cannot be run with a primary context already active for device 0";
+    std::cout << "This test cannot be run with a primary context already active for device 0"
+              << std::endl;
+    return 0xbad;
   }
 
   int curr = -1;
   {
     DeviceGuard dg(1);
     CUDA_CALL(cudaGetDevice(&curr));
-    EXPECT_EQ(curr, 1);
+    if (curr != 1) {
+      std::cout << "Device not switched properly." << std::endl;
+      return 1;
+    }
   }
   CUDA_CALL(cudaGetDevice(&curr));
-  EXPECT_EQ(curr, 0);
+  if (curr != 0) {
+    std::cout << "Device not restored properly." << std::endl;
+    return 2;
+  }
+  return 0;
+}
+
+void TestUninit0() {
+  _exit(DoTestUninit0());
+}
+
+int DoTestPrimaryContextInitMultithreaded() {
+  if (!cuInitChecked()) {
+    std::cout << "Cannot initialize CUDA." << std::endl;
+    return 0xdead;
+  }
+
+  unsigned flags = 0;
+  int active = 0;
+  CUDA_CALL(cuDevicePrimaryCtxGetState(0, &flags, &active));
+  if (active) {
+    std::cout << "This test cannot be run with a primary context already active for device 0";
+    return 0xbad;
+  }
+
+  std::atomic<bool> start{false};
+  bool failure = false;
+
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 10; i++) {
+    threads.emplace_back([&]() {
+      while (!start.load()) {}
+      DeviceGuard dg(0);
+      unsigned flags = 0;
+      int active = 0;
+      if (cuDevicePrimaryCtxGetState(0, &flags, &active) != CUDA_SUCCESS) {
+        std::cout << "Cannot get primary context for device 0." << std::endl;
+        failure = true;
+      }
+      if (!active) {
+        std::cout << "Primary context not active" << std::endl;
+        failure = true;
+      }
+    });
+  }
+
+  start.store(true);
+  for (auto &t : threads)
+    t.join();
+
+  if (failure) {
+    std::cout << "A failure was detected in one of the worker threads." << std::endl;
+    return 1;
+  }
+
+  {
+    unsigned flags = 0;
+    int active = 0;
+    if (cuDevicePrimaryCtxGetState(0, &flags, &active) != CUDA_SUCCESS) {
+      std::cout << "Cannot get primary context for device 0." << std::endl;
+      return 2;
+    }
+
+    if (!active) {
+      std::cout << "Primary context should be active as a side-effect" << std::endl;
+      return 3;
+    }
+  }
+
+  return 0;
+}
+
+void TestPrimaryContextInitMultithreaded() {
+  _exit(DoTestPrimaryContextInitMultithreaded());
+}
+
+TEST(DeviceGuard, RestoreUninit0) {
+  int count = 0;
+  CUDA_CALL(cudaGetDeviceCount(&count));
+  if (count < 2) {
+    GTEST_SKIP() << "This test requires at least 2 CUDA devices.";
+  }
+
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  EXPECT_EXIT(TestUninit0(), testing::ExitedWithCode(0), "");
+}
+
+TEST(DeviceGuard, Multithreaded) {
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  EXPECT_EXIT(TestPrimaryContextInitMultithreaded(), testing::ExitedWithCode(0), "");
 }
 
 TEST(DeviceGuard, ConstructorWithDevice) {
@@ -116,7 +208,7 @@ struct CUDAContext : UniqueHandle<CUcontext, CUDAContext> {
 
 }  // namespace
 
-TEST(DeviceGuard, Checkcontext) {
+TEST(DeviceGuard, CheckContext) {
   int test_device = 0;
   CUdevice cu_test_device = 0;
   int guard_device = 0;
@@ -151,7 +243,7 @@ TEST(DeviceGuard, Checkcontext) {
   EXPECT_EQ(cu_current_device, cu_test_device);
 }
 
-TEST(DeviceGuard, CheckcontextNoArgs) {
+TEST(DeviceGuard, CheckContextNoArgs) {
   int test_device = 0;
   CUdevice cu_test_device = 0;
   CUcontext cu_current_ctx = nullptr;
@@ -185,6 +277,43 @@ TEST(DeviceGuard, CheckcontextNoArgs) {
   CUDA_CALL(cuCtxGetDevice(&cu_current_device));
   EXPECT_EQ(cu_current_ctx, cu_test_ctx);
   EXPECT_EQ(cu_current_device, cu_test_device);
+}
+
+TEST(DeviceGuard, NegativeDevicNoOp) {
+  // This test creates a DeviceGuard with a negative device ID and destroys it out-of-order
+  // to verify that it's really no-op, even with valid CUDA context present.
+
+  ASSERT_TRUE(cuInitChecked());
+  int count = 0;
+  CUDA_CALL(cudaGetDeviceCount(&count));
+  if (count < 2) {
+    GTEST_SKIP() << "This test requires at least 2 CUDA devices.";
+  }
+
+  int dev = -1;
+  {
+    DeviceGuard dg0(0);
+    std::optional<DeviceGuard> dgneg;
+    {
+      DeviceGuard dg1(1);
+      dgneg.emplace(-1);  // this will outlive the scope
+      CUDA_CALL(cudaGetDevice(&dev));
+      EXPECT_EQ(dev, 1);
+    }
+    CUDA_CALL(cudaGetDevice(&dev));
+    EXPECT_EQ(dev, 0);
+    dgneg.reset();  // shouldn't change anything
+    CUDA_CALL(cudaGetDevice(&dev));
+    EXPECT_EQ(dev, 0);
+  }
+  CUDA_CALL(cudaGetDevice(&dev));
+  EXPECT_EQ(dev, 0);
+}
+
+TEST(DeviceGuard, CheckOutOfRange) {
+  int ndevs = 0;
+  CUDA_CALL(cudaGetDeviceCount(&ndevs));
+  EXPECT_THROW(DeviceGuard{ndevs}, std::out_of_range);
 }
 
 TEST(DeviceGuard, SwitchPerf) {

--- a/dali/core/device_guard_test.cc
+++ b/dali/core/device_guard_test.cc
@@ -330,7 +330,6 @@ TEST(DeviceGuard, SwitchPerf_MultiGPU) {
 
 TEST(DeviceGuard, SameDevPerf) {
   ASSERT_TRUE(cuInitChecked());
-  int count = 0;
   DeviceGuard dg0(0);
 
   auto start = test::perf_timer::now();


### PR DESCRIPTION
## Category:
**Bug fix** / **Refactoring** (performance improvement and correctness fix)

## Description:
Improves `DeviceGuard` in two ways:

1. **Faster device switching.** Replaces the `cudaSetDevice` call with a direct `cuCtxSetCurrent` on the device's primary context. The primary contexts are retained once (lazily, on first use) into a static, per-process table and reused on every `DeviceGuard` construction. This avoids the runtime-API lookup overhead and the implicit primary-context retain that `cudaSetDevice` performs on every call.

2. **Correct restoration of an uninitialized context.** The old code used `NULL` both as the "uninitialized old context" sentinel and as a legitimate captured value, so a `DeviceGuard` constructed when no CUDA context was current would silently *not* restore the (NULL) context on destruction. A dedicated `INVALID_CONTEXT` sentinel (`(CUcontext)-1`) is now used, so `NULL` can be restored faithfully.

Out-of-range device ordinals now throw `std::out_of_range` instead of relying on a `cudaSetDevice` error.

## Additional information:

### Affected modules and functionalities:
- `dali/core/device_guard.cc` — primary-context cache, atomic lazy init, sentinel-based restoration, range check.
- `dali/core/device_guard_test.cc` — new correctness and perf tests.

### Key points relevant for the review:
- Lazy initialization of `default_contexts` uses a function-local `static` (thread-safe under C++11). Each `PrimaryContext` retains the device's primary context on first `Get()` via `cuDevicePrimaryCtxRetain` and stores the handle atomically with `compare_exchange_strong`, releasing the redundant retain if another thread won the race.
- The destructor of `PrimaryContext` calls `cuDevicePrimaryCtxRelease` once at process shutdown via `CUDA_DTOR_CALL` — note the lifetime is process-wide, matching how the CUDA runtime itself manages primary contexts.
- The `INVALID_CONTEXT == (CUcontext)-1` sentinel is a value the driver will never return; it is only ever compared, never dereferenced or passed to the driver.
- `cuCtxSetCurrent` is used in place of `cudaSetDevice`; verify this is acceptable for downstream code paths that may have relied on runtime-API state being updated as a side effect.

### Tests:
- [x] Existing tests apply
- [x] New tests added
  - [x] GTests
    - `DeviceGuard.RestoreUninit0` — verifies restoration of a NULL/uninitialized old context (requires ≥2 GPUs and no primary context active on device 0).
    - `DeviceGuard.SwitchPerf` — microbenchmark for cross-device guard pairs (requires ≥2 GPUs).
    - `DeviceGuard.SameDevPerf` — microbenchmark for same-device guard.

## Checklist

### Documentation
- [x] N/A (no public API change)

#### Requirements
- [x] N/A

**REQ IDs**: N/A
**JIRA TASK**: N/A
