### PR TITLE
Ndd perf regression fixes

### DIFF
--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -364,6 +364,10 @@ class Batch:
     def _is_external(self) -> bool:
         return self._wraps_external_data
 
+    _nvtx_to_numpy_and_stack = NVTXRange("broadcast: to numpy and stack", category="batch")
+    _nvtx_to_backend = NVTXRange("broadcast: to backend", category="batch")
+    _nvtx_create_batch = NVTXRange("broadcast: create batch", category="batch")
+
     @staticmethod
     @NVTXRange("broadcast", category="batch")
     def broadcast(
@@ -394,7 +398,7 @@ class Batch:
             return Batch(tl_type.broadcast(t._storage, batch_size))
         import numpy as np
 
-        with NVTXRange("to numpy and stack", category="batch"):
+        with Batch._nvtx_to_numpy_and_stack:
             arr = np.array(sample)
             converted_dtype_id = None
             if arr.dtype == np.float64:
@@ -409,11 +413,11 @@ class Batch:
                 arr = arr.astype(_dali_types.to_numpy_type(dtype.type_id))
             arr = np.repeat(arr[np.newaxis], batch_size, axis=0)
 
-        with NVTXRange("to backend", category="batch"):
+        with Batch._nvtx_to_backend:
             tl = _backend.TensorListCPU(arr)
             if converted_dtype_id is not None:
                 tl.reinterpret(converted_dtype_id)
-        with NVTXRange("create batch", category="batch"):
+        with Batch._nvtx_create_batch:
             return Batch(tl, device=device, dtype=dtype)
 
     @property

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -35,7 +35,7 @@ from ._type import dtype as _dtype
 
 def _backend_device(backend: _backend.TensorListCPU | _backend.TensorListGPU) -> Device:
     if isinstance(backend, _backend.TensorListCPU):
-        return Device("cpu")
+        return Device.CPU
     elif isinstance(backend, _backend.TensorListGPU):
         return Device("gpu", backend.device_id())
     else:
@@ -305,7 +305,7 @@ class Batch:
                     assert len(self._tensors) == 0
                     raise ValueError("Element type must be specified if the list is empty")
                 if device is None:
-                    device = Device("cpu")
+                    device = Device.CPU
                 if layout is None:
                     layout = ""
                 self._device = device
@@ -521,7 +521,7 @@ class Batch:
         """
         Returns the batch on the CPU. If it's already there, this function returns `self`.
         """
-        return self.to_device(Device("cpu"))
+        return self.to_device(Device.CPU)
 
     def gpu(self, index: int | None = None) -> "Batch":
         """

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch2tensor.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch2tensor.py
@@ -34,6 +34,8 @@ class BatchToTensor:
     Only a minimal required subset of ``Operator`` interface is implemented.
     """
 
+    _nvtx_construct_invocation = NVTXRange("__call__: construct Invocation", category="op_builder")
+
     @mark_transparent
     @NVTXRange("__call__: Batch2Tensor", category="op_builder")
     def __call__(
@@ -49,7 +51,7 @@ class BatchToTensor:
     ):
         if not isinstance(batch, Batch):
             batch = _op_builder._to_batch(batch, batch_size)
-        with NVTXRange("__call__: construct Invocation", category="op_builder"):
+        with BatchToTensor._nvtx_construct_invocation:
             invocation = _invocation.Invocation(
                 self,
                 None,

--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -521,22 +521,20 @@ def _compile_intercept(
 
     @mark_transparent
     def wrapper(*inputs, batch_size=None, device=None, **raw_kwargs):
-        @mark_transparent
-        def _call():
-            return fn_call(
-                *inputs, batch_size=batch_size, device=device, _backend=backend, **raw_kwargs
-            )
-
         device, backend = _resolve_backend(op_class, device, inputs, raw_kwargs, op_name=op_name)
         compile_ctx = CompileContext.current()
         if compile_ctx is None:
-            return _call()
+            return fn_call(
+                *inputs, batch_size=batch_size, device=device, _backend=backend, **raw_kwargs
+            )
 
         # Resolves past transparent frames (this wrapper, makefun, NVTXRange, fn_call)
         # to the user's call site.
         frame = resolve_callsite_frame()
         if frame is None:
-            return _call()
+            return fn_call(
+                *inputs, batch_size=batch_size, device=device, _backend=backend, **raw_kwargs
+            )
 
         if compile_ctx.state is State.COMPILED:
             if batch_size is not None and batch_size != compile_ctx.batch_size:
@@ -547,10 +545,14 @@ def _compile_intercept(
                 )
             if result := compile_ctx.get_compiled_result(frame, inputs, raw_kwargs, device=device):
                 return result
-            return _call()
+            return fn_call(
+                *inputs, batch_size=batch_size, device=device, _backend=backend, **raw_kwargs
+            )
 
         # Run first, classify after, we need the result before we can inspect it
-        result = _call()
+        result = fn_call(
+            *inputs, batch_size=batch_size, device=device, _backend=backend, **raw_kwargs
+        )
 
         if op_class._is_stateful:
             return result

--- a/dali/python/nvidia/dali/experimental/dynamic/_device.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_device.py
@@ -218,6 +218,9 @@ class Device:
             _backend.SetCUDACurrentDevice(dev.device_id)
 
 
+Device.CPU = Device("cpu")
+
+
 def device(obj: DeviceLike, id: int | None = None) -> Device:
     """
     Returns a Device object from various input types.

--- a/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
@@ -215,10 +215,13 @@ class Invocation:
             if stream is not None:  # If the stream is None, there's no GPU
                 stream.synchronize()
 
+    _nvtx_wait = NVTXRange("Invocation.wait", category="invocation")
+    _nvtx_run = NVTXRange("Invocation.run", category="invocation")
+
     def run(self, ctx: Optional[_EvalContext] = None):
         """Executes the operator immediately."""
         if future := self._future:
-            with NVTXRange("Invocation.wait", category="invocation"):
+            with Invocation._nvtx_wait:
                 future.wait()
             self._future = None
         else:
@@ -270,7 +273,7 @@ class Invocation:
         if self._results is not None:
             return
 
-        with NVTXRange("Invocation.run", category="invocation"):
+        with Invocation._nvtx_run:
             # If the invocation was created with a GPU device, validate that
             # the evaluation context matches.
             if (

--- a/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_invocation.py
@@ -320,7 +320,7 @@ class Invocation:
                 if isinstance(x, (_b.TensorGPU, _b.TensorListGPU)):
                     return Device("gpu", x.device_id())
                 else:
-                    return Device("cpu")
+                    return Device.CPU
 
             if self._output_devices is None:
                 self._output_devices = [output_device(r) for r in self._results]

--- a/dali/python/nvidia/dali/experimental/dynamic/_nvtx.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_nvtx.py
@@ -13,29 +13,53 @@
 # limitations under the License.
 
 import contextlib
-
+import os
 import nvtx
 
 _DOMAIN = nvtx.get_domain("DALI")
 
+_NVTX_ENABLED = bool(
+    os.environ.get("NVTX_INJECTION64_PATH")
+    or os.environ.get("NSYS_INJECTION_PATH")
+    or os.environ.get("CUDA_INJECTION64_PATH")
+)
 
-class NVTXRange(contextlib.ContextDecorator):
-    """
-    NVTX range marker for the DALI domain. Can be used as a context manager or decorator.
-    Use categories to organize annotations.
-    """
+if _NVTX_ENABLED:
 
-    def __init__(self, message: str, color: int | str = 0x957DAD, category: str | None = None):
-        category_id = _DOMAIN.get_category_id(category)
-        self._attributes = _DOMAIN.get_event_attributes(
-            message=message,
-            color=color,
-            category=category_id,
-        )
+    class NVTXRange(contextlib.ContextDecorator):
+        """
+        NVTX range marker for the DALI domain. Can be used as a context manager or decorator.
+        Use categories to organize annotations.
+        """
 
-    def __enter__(self):
-        _DOMAIN.push_range(self._attributes)
-        return self
+        def __init__(self, message: str, color: int | str = 0x957DAD, category: str | None = None):
+            category_id = _DOMAIN.get_category_id(category)
+            self._attributes = _DOMAIN.get_event_attributes(
+                message=message,
+                color=color,
+                category=category_id,
+            )
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        _DOMAIN.pop_range()
+        def __enter__(self):
+            _DOMAIN.push_range(self._attributes)
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            _DOMAIN.pop_range()
+
+else:
+
+    class NVTXRange(contextlib.ContextDecorator):
+        """
+        NVTX range marker for the DALI domain. Can be used as a context manager or decorator.
+        Use categories to organize annotations.
+        """
+
+        def __init__(self, message: str, color: int | str = 0x957DAD, category: str | None = None):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False

--- a/dali/python/nvidia/dali/experimental/dynamic/_nvtx.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_nvtx.py
@@ -30,6 +30,8 @@ if _NVTX_ENABLED:
         """
         NVTX range marker for the DALI domain. Can be used as a context manager or decorator.
         Use categories to organize annotations.
+        Note that this class is used only if a profiler is detected; otherwise it's replaced with
+        a no-op stub.
         """
 
         def __init__(self, message: str, color: int | str = 0x957DAD, category: str | None = None):
@@ -52,7 +54,8 @@ else:
     class NVTXRange(contextlib.ContextDecorator):
         """
         NVTX range marker for the DALI domain. Can be used as a context manager or decorator.
-        Use categories to organize annotations.
+        Use categories to organize annotations. This variant is no-op and is used when profiling
+        is disabled.
         """
 
         def __init__(self, message: str, color: int | str = 0x957DAD, category: str | None = None):

--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -388,19 +388,14 @@ def _resolve_backend(
     if device is None:
 
         def infer_device():
-            for arg in inputs:
-                if arg is None:
-                    continue
-                dev = _ops._get_input_device(arg)
-                if dev is not None and dev.device_type == "gpu":
-                    return dev
-            for arg in raw_kwargs.values():
-                if arg is None:
-                    continue
-                dev = _ops._get_input_device(arg)
-                if dev is not None and dev.device_type == "gpu":
-                    return dev
-            return _device.Device("cpu")
+            for args in (inputs, raw_kwargs.values()):
+                for arg in args:
+                    if arg is None:
+                        continue
+                    dev = _ops._get_input_device(arg)
+                    if dev is not None and dev.device_type == "gpu":
+                        return dev
+            return _device.Device.CPU
 
         device = infer_device()
         device_inferred = True
@@ -497,7 +492,7 @@ def build_fn_wrapper(op, fn_name=None, add_to_module=True):
         call_args = {
             arg: _scalar_decay(value)
             for arg, value in raw_kwargs.items()
-            if value is not None and arg != "max_batch_size" and arg in tensor_args
+            if value is not None and arg in tensor_args
         }
 
         inputs, call_args = op._process_params(_backend, device, batch_size, *inputs, **call_args)

--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
 import copy
 
 import makefun
@@ -295,6 +294,9 @@ def build_call_function(schema, op_class):
 
     header = f"__call__({', '.join(['self'] + inputs + call_args + internal_args)})"
 
+    nvtx_arg_shallowcopy = NVTXRange("__call__: shallowcopy", category="op_builder")
+    nvtx_construct_invocation = NVTXRange("__call__: construct Invocation", category="op_builder")
+
     @mark_transparent
     @NVTXRange(f"__call__: {op_class._op_name}", category="op_builder")
     def call(self, *raw_args, batch_size=None, _process_params=True, **raw_kwargs):
@@ -310,7 +312,8 @@ def build_call_function(schema, op_class):
                 )
             raw_kwargs = {**raw_kwargs, **self._raw_tensor_args}
 
-        batch_size = _ops._infer_batch_size(batch_size, *raw_args, **raw_kwargs)
+        if batch_size is None:
+            batch_size = _ops._infer_batch_size(*raw_args, **raw_kwargs)
         is_batch = batch_size is not None
 
         if _process_params:
@@ -321,7 +324,7 @@ def build_call_function(schema, op_class):
             inputs = [inp for inp in raw_args if inp is not None]
             kwargs = {name: value for name, value in raw_kwargs.items() if value is not None}
 
-        with NVTXRange("__call__: shallowcopy", category="op_builder"):
+        with nvtx_arg_shallowcopy:
             inputs = [copy.copy(x) for x in inputs]
             kwargs = {k: copy.copy(v) for k, v in kwargs.items()}
 
@@ -330,7 +333,7 @@ def build_call_function(schema, op_class):
             self._call_id += 1
         else:
             call_id = None
-        with NVTXRange("__call__: construct Invocation", category="op_builder"):
+        with nvtx_construct_invocation:
             caller_frame = None
             if EvalMode.current().value <= EvalMode.eager.value:
                 caller_frame = resolve_callsite_frame()
@@ -478,26 +481,29 @@ def build_fn_wrapper(op, fn_name=None, add_to_module=True):
 
     header = f"{fn_name}({', '.join(inputs + signature_args)})"
 
+    nvtx_get_instance_range = NVTXRange(f"get instance {op._op_name}", category="op_builder")
+
     @mark_transparent
     @NVTXRange(f"{fn_name}()", category="op_builder")
     def fn_call(*inputs, batch_size=None, device=None, _backend=None, **raw_kwargs):
-        batch_size = _ops._infer_batch_size(batch_size, *inputs, **raw_kwargs)
+        if batch_size is None:
+            batch_size = _ops._infer_batch_size(*inputs, **raw_kwargs)
         max_batch_size = _next_pow2(batch_size or 1)
         init_args = {
-            arg: _scalar_decay(raw_kwargs[arg])
-            for arg in fixed_args
-            if arg != "max_batch_size" and arg in raw_kwargs and raw_kwargs[arg] is not None
+            arg: _scalar_decay(value)
+            for arg, value in raw_kwargs.items()
+            if value is not None and arg != "max_batch_size" and arg in fixed_args
         }
         call_args = {
-            arg: _scalar_decay(raw_kwargs[arg])
-            for arg in tensor_args
-            if arg in raw_kwargs and raw_kwargs[arg] is not None
+            arg: _scalar_decay(value)
+            for arg, value in raw_kwargs.items()
+            if value is not None and arg != "max_batch_size" and arg in tensor_args
         }
 
         inputs, call_args = op._process_params(_backend, device, batch_size, *inputs, **call_args)
 
         # Get or create the operator instance that matches the arguments
-        with NVTXRange(f"get instance {op._op_name}", category="op_builder"):
+        with nvtx_get_instance_range:
             op_inst = op._get(
                 max_batch_size=max_batch_size,
                 name=None,

--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -383,15 +383,23 @@ def _resolve_backend(
     Returns (resolved_device, backend).
     """
     if device is None:
-        for arg in itertools.chain(inputs, raw_kwargs.values()):
-            if arg is None:
-                continue
-            dev = _ops._get_input_device(arg)
-            if dev is not None and dev.device_type == "gpu":
-                device = dev
-                break
-        else:
-            device = _device.Device("cpu")
+
+        def infer_device():
+            for arg in inputs:
+                if arg is None:
+                    continue
+                dev = _ops._get_input_device(arg)
+                if dev is not None and dev.device_type == "gpu":
+                    return dev
+            for arg in raw_kwargs.values():
+                if arg is None:
+                    continue
+                dev = _ops._get_input_device(arg)
+                if dev is not None and dev.device_type == "gpu":
+                    return dev
+            return _device.Device("cpu")
+
+        device = infer_device()
         device_inferred = True
     else:
         if not isinstance(device, _device.Device):

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -25,9 +25,11 @@ from ._tensor import Tensor
 from ._nvtx import NVTXRange
 from threading import Lock
 
+_nvtx_to_tensor = NVTXRange("to_tensor", category="op_builder")
+
 
 def _to_tensor(x, device=None, dtype=None):
-    with NVTXRange("to_tensor", category="op_builder"):
+    with _nvtx_to_tensor:
         if x is None:
             return None
         if isinstance(x, Tensor):
@@ -96,11 +98,12 @@ def _get_input_device(x):
     return None
 
 
-def _infer_batch_size(explicit_batch_size, *raw_args, **raw_kwargs):
-    if explicit_batch_size is not None:
-        return explicit_batch_size
+_nvtx_infer_batch_size = NVTXRange("_infer_batch_size", category="op_builder")
+
+
+def _infer_batch_size(*raw_args, **raw_kwargs):
     batch_size = None
-    with NVTXRange("_infer_batch_size", category="op_builder"):
+    with _nvtx_infer_batch_size:
         for i, x in enumerate(list(raw_args) + list(raw_kwargs.values())):
             x_batch_size = _get_batch_size(x)
             if x_batch_size is not None:
@@ -285,6 +288,9 @@ class Operator:
 
         return Device(dev_type, dev_id)  # inherit the device id
 
+    _nvtx_convert_to_batches = NVTXRange("__call__: convert to batches", category="op_builder")
+    _nvtx_convert_to_tensors = NVTXRange("__call__: convert to tensors", category="op_builder")
+
     @classmethod
     def _process_params(cls, backend, op_device, batch_size, *raw_args, **raw_kwargs):
         """
@@ -322,7 +328,7 @@ class Operator:
         kwargs = {}
 
         if is_batch:
-            with NVTXRange("__call__: convert to batches", category="op_builder"):
+            with Operator._nvtx_convert_to_batches:
                 for i, inp in enumerate(raw_args):
                     if inp is None:
                         continue
@@ -335,7 +341,7 @@ class Operator:
                     dtype = cls._argument_conversion_map[k]
                     kwargs[k] = _to_batch(v, batch_size, device=_device.Device("cpu"), dtype=dtype)
         else:
-            with NVTXRange("__call__: convert to tensors", category="op_builder"):
+            with Operator._nvtx_convert_to_tensors:
                 for inp in raw_args:
                     if inp is None:
                         continue

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -78,7 +78,7 @@ def _get_input_device(x):
     if isinstance(x, Tensor):
         return x.device
     if isinstance(x, _b.TensorListCPU):
-        return _device.Device("cpu")
+        return _device.Device.CPU
     if isinstance(x, _b.TensorListGPU):
         return _device.Device("gpu")
     if hasattr(x, "__cuda_array_interface__"):
@@ -86,13 +86,13 @@ def _get_input_device(x):
     if hasattr(x, "__dlpack_device__"):
         dev = x.__dlpack_device__()
         if int(dev[0]) == 1 or int(dev[0]) == 3:  # CPU or CPU_PINNED
-            return _device.Device("cpu")
+            return _device.Device.CPU
         elif int(dev[0]) == 2:
             return _device.Device("gpu", dev[1])
         else:
             raise ValueError(f"Unknown DLPack device type: {dev.type}")
     if hasattr(x, "__dlpack__"):
-        return _device.Device("cpu")
+        return _device.Device.CPU
     if isinstance(x, list) and x:
         return _get_input_device(x[0])
     return None
@@ -339,7 +339,7 @@ class Operator:
                     if v is None:
                         continue
                     dtype = cls._argument_conversion_map[k]
-                    kwargs[k] = _to_batch(v, batch_size, device=_device.Device("cpu"), dtype=dtype)
+                    kwargs[k] = _to_batch(v, batch_size, device=_device.Device.CPU, dtype=dtype)
         else:
             with Operator._nvtx_convert_to_tensors:
                 for inp in raw_args:
@@ -465,7 +465,7 @@ class Operator:
 
     def _run(self, ctx, *inputs, batch_size=None, **args):
         device_id = ctx.device_id if ctx is not None else None
-        device_ctx = Device("gpu", device_id) if device_id is not None else Device("cpu")
+        device_ctx = Device("gpu", device_id) if device_id is not None else Device.CPU
         with device_ctx:
             if (
                 batch_size is not None

--- a/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
@@ -43,7 +43,7 @@ def _volume(shape: tuple[int, ...]) -> int:
 
 def _backend_device(backend: _backend.TensorCPU | _backend.TensorGPU) -> Device:
     if isinstance(backend, _backend.TensorCPU):
-        return Device("cpu")
+        return Device.CPU
     elif isinstance(backend, _backend.TensorGPU):
         return Device("gpu", backend.device_id())
     else:
@@ -265,7 +265,7 @@ class Tensor:
             else:
                 if self._device is None:
                     if device is None:
-                        device = Device("cpu")
+                        device = Device.CPU
                     self._device = device
                 else:
                     if device is None:
@@ -319,7 +319,7 @@ class Tensor:
         """
         Returns the tensor on the CPU. If it's already there, this function returns `self`.
         """
-        return self.to_device(Device("cpu"))
+        return self.to_device(Device.CPU)
 
     def gpu(self, index: int | None = None) -> "Tensor":
         """


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
  Cumulative micro-optimizations to the NDD (`nvidia.dali.experimental.dynamic`) hot path, where Python-side overhead per op invocation was a measurable share  
  of total time.                                                                                                                                                
                                                                                                                                                                
  - **Cache NVTX range objects** (`_batch.py`, `_batch2tensor.py`, `_invocation.py`, `_op_builder.py`, `_ops.py`). Instead of constructing a new `NVTXRange`    
  (and a fresh `EventAttributes`) for every call, allocate them once at class/module level and reuse. Hot paths now reference a class attribute instead of
  building NVTX state per call.                                                                                                                                 
  - **No-op NVTX when no profiler is attached** (`_nvtx.py`). Detect profilers via the standard env vars (`NVTX_INJECTION64_PATH`, `NSYS_INJECTION_PATH`,     
  `CUDA_INJECTION64_PATH`) at import time and swap in a stub `NVTXRange` whose `__init__`/`__enter__`/`__exit__` do nothing. Eliminates NVTX domain/category    
  lookups outside profiling runs.
  - **Drop nested closure in compile intercept** (`_compile.py`). The `_call()` closure inside `wrapper` allocated a function object on every invocation; inline
   `fn_call(...)` at each return site.                                                                                                                          
  - **Skip the redundant batch-size guard** (`_op_builder.py`, `_ops.py`). `_infer_batch_size` was always called and re-checked `explicit_batch_size`. Move the
  `if batch_size is None` check to the call site and have `_infer_batch_size` only do the inference.                                                            
  - **Avoid `itertools.chain` in device inference** (`_op_builder.py`). Replace the chained iteration with two explicit loops in a local helper — cheaper than
  building/iterating the chain object on every op.                                                                                                              
  - **Single-pass kwarg filtering in `build_fn_wrapper`** (`_op_builder.py`). Iterate `raw_kwargs.items()` once and test membership in
  `fixed_args`/`tensor_args`, instead of iterating those sets and looking up each key in `raw_kwargs`.     

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
