### PR TITLE
Adjust handling of scalar-like values with new NumPy.

### DIFF
--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -247,11 +247,13 @@ class ScalarConstant(object):
         if value_dtype is not None:
             dali_type = to_dali_type(value.dtype)
             if dali_type in _int_types:
-                value = int(value)
+                value = int(value.item())
             elif dali_type in _float_types:
-                value = float(value)
+                value = float(value.item())
             elif dali_type in _bool_types:
-                value = bool(value)
+                value = bool(value.item())
+            else:
+                value = value.item()
             if dtype is None:
                 dtype = dali_type
 

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -125,6 +125,8 @@ def _type_name_convert_to_string(dtype, allow_tensors, api="fn"):
 def _type_convert_value(dtype, val):
     if dtype not in _known_types:
         raise RuntimeError(str(dtype) + " does not correspond to a known type.")
+    if item := getattr(val, "item", None):
+        val = item()
     return _known_types[dtype][1](val)
 
 

--- a/dali/test/python/test_functional_api.py
+++ b/dali/test/python/test_functional_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -124,6 +124,32 @@ def test_scalar_constant():
     inputs = fn.external_source(lambda: batches, 2, layout="HWC")
     rotated = fn.rotate(inputs, angle=types.ScalarConstant(90))
     pipe.set_outputs(*rotated, types.ScalarConstant(90))
+
+    outs = pipe.run()
+    arr1 = outs[0].at(0)
+    arr2 = outs[1].at(0)
+    arr3 = outs[2].at(0)
+    ref1 = np.array([[4, 8, 12], [3, 7, 11], [2, 6, 10], [1, 5, 9]])[:, :, np.newaxis]
+    ref2 = np.array([[20, 40, 60], [10, 30, 50]], dtype=np.uint8)[:, :, np.newaxis]
+    ref3 = np.array(90)
+    assert np.array_equal(arr1, ref1)
+    assert np.array_equal(arr2, ref2)
+    assert np.array_equal(arr3, ref3)
+
+
+def test_pseudoscalar():
+    pipe = Pipeline(batch_size=1, num_threads=1, device_id=0)
+
+    image1 = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], dtype=np.uint8)[
+        :, :, np.newaxis
+    ]
+    image2 = np.array([[10, 20], [30, 40], [50, 60]], dtype=np.uint8)[:, :, np.newaxis]
+    batches = [[image1], [image2]]
+
+    inputs = fn.external_source(lambda: batches, 2, layout="HWC")
+    rotated = fn.rotate(inputs, angle=np.array([90]))  # demoted to a scalar
+    assert rotated[0].source.spec.NumInput() == 1  # verify that `angle` is not an input
+    pipe.set_outputs(*rotated, types.ScalarConstant(np.array([90])))  # demoted to 0D
 
     outs = pipe.run()
     arr1 = outs[0].at(0)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
This PR fixes handling of scalar-like NumPy tensors in Numpy 2.4, where converting a one-element (but non-0D) tensor to a number is illegal.



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
