### PR TITLE
Move Philox RNG to dali_core

### DIFF
--- a/dali/core/CMakeLists.txt
+++ b/dali/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ project(dali_core CUDA CXX C)
 add_subdirectory(mm)
 add_subdirectory(os)
 add_subdirectory(exec)
+add_subdirectory(random)
 
 # Get all the source files
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)

--- a/dali/core/random/CMakeLists.txt
+++ b/dali/core/random/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Get all the source files
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_CORE_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_CORE_TEST_SRCS PARENT_SCOPE)

--- a/dali/core/random/philox.cc
+++ b/dali/core/random/philox.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/operators/random/philox.h"
+#include "dali/core/random/philox.h"
 #include <string>
 #include <string_view>
 #include <tuple>

--- a/dali/core/random/philox_test.cu
+++ b/dali/core/random/philox_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 #include <random>
 #include <string>
 #include <vector>
-#include "dali/operators/random/philox.h"
+#include "dali/core/random/philox.h"
 #include "dali/core/dev_buffer.h"
 #include "dali/core/cuda_stream.h"
 

--- a/dali/operators/image/crop/random_crop_generator_util.h
+++ b/dali/operators/image/crop/random_crop_generator_util.h
@@ -21,7 +21,7 @@
 #include <utility>
 #include "dali/core/common.h"
 #include "dali/util/crop_window.h"
-#include "dali/operators/random/philox.h"
+#include "dali/core/random/philox.h"
 
 namespace dali {
 

--- a/dali/operators/random/random_dist_test.cc
+++ b/dali/operators/random/random_dist_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include <numeric>
 #include <random>
 #include <vector>
-#include "dali/operators/random/philox.h"
+#include "dali/core/random/philox.h"
 #include "dali/core/int_literals.h"
 #include "dali/core/span.h"
 #include "dali/operators/random/random_dist_test.h"

--- a/dali/operators/random/random_dist_test.cu
+++ b/dali/operators/random/random_dist_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 #include <vector>
 #include "dali/core/cuda_stream.h"
 #include "dali/core/dev_buffer.h"
-#include "dali/operators/random/philox.h"
+#include "dali/core/random/philox.h"
 #include "dali/operators/random/random_dist_test.h"
 
 namespace dali {

--- a/dali/operators/random/rng_base.h
+++ b/dali/operators/random/rng_base.h
@@ -28,7 +28,7 @@
 #include "dali/pipeline/operator/operator.h"
 #include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 #include "dali/core/static_switch.h"
-#include "dali/operators/random/philox.h"
+#include "dali/core/random/philox.h"
 
 namespace dali {
 namespace rng {

--- a/dali/operators/random/rng_util.cuh
+++ b/dali/operators/random/rng_util.cuh
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 #include "dali/core/host_dev.h"
 #include "dali/core/force_inline.h"
 #include "dali/core/int_literals.h"
-#include "dali/operators/random/philox.h"
+#include "dali/core/random/philox.h"
 #include <curand_kernel.h>  // NOLINT
 
 namespace dali {

--- a/include/dali/core/random/philox.h
+++ b/include/dali/core/random/philox.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_OPERATORS_RANDOM_PHILOX_H_
-#define DALI_OPERATORS_RANDOM_PHILOX_H_
+#ifndef DALI_CORE_RANDOM_PHILOX_H_
+#define DALI_CORE_RANDOM_PHILOX_H_
 
 #include <cassert>
 #include <cstdint>
@@ -157,4 +157,4 @@ inline std::istream &operator>>(std::istream &is, Philox4x32_10::State &state) {
 
 }  // namespace dali
 
-#endif  // DALI_OPERATORS_RANDOM_PHILOX_H_
+#endif  // DALI_CORE_RANDOM_PHILOX_H_


### PR DESCRIPTION
## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)                                                           
                                                                                                                                          
## Description:                                                                                                                           
Promote the Philox4x32-10 RNG from `dali/operators/random` into `dali/core/random` so it can be reused outside of `dali_operators` (e.g., from `dali_kernels` or `dali_core` consumers) without introducing dependency on dali_operators library. The implementation is unchanged; only the location, header guard, include path, and CMake wiring move.

## Additional information:                                                                                                              

### Affected modules and functionalities:
- New layout:
  - `include/dali/core/random/philox.h` (was `dali/operators/random/philox.h`)
  - `dali/core/random/philox.cc` (was `dali/operators/random/philox.cc`)                                                                  
  - `dali/core/random/philox_test.cu` (was `dali/operators/random/philox_test.cu`)                                                        
  - `dali/core/random/CMakeLists.txt` (new, mirrors `dali/core/{mm,exec,os}` pattern)                                                     
- Header guard renamed `DALI_OPERATORS_RANDOM_PHILOX_H_` → `DALI_CORE_RANDOM_PHILOX_H_`.                                                  
- `dali/core/CMakeLists.txt` now `add_subdirectory(random)`.                                                                              
- All call sites updated to `#include "dali/core/random/philox.h"`:                                                                       
  - `dali/operators/random/{rng_base.h, rng_util.cuh, random_dist_test.cc, random_dist_test.cu}`                                          
  - `dali/operators/image/crop/random_crop_generator_util.h`                                                                              
- `philox.cc` is now compiled into `libdali_core.so`; `philox_test.cu` runs as part of `dali_core_test.bin` (was previously linked into   
`dali_operator_test.bin`).                                                                                                                
                                                                                                                                          
### Key points relevant for the review:                                                                                                   
- No code/behavior changes inside the Philox implementation or the tests — pure file move + include-path rewrite.
- `Philox4x32_10::recalc_output`, `state_to_string`, and `state_from_string` keep their `DLL_PUBLIC` markings; they are now exported via  
`libdali_core.so` instead of `libdali_operators.so`. Verify no downstream caller relied on the old symbol location.                       
- `philox_test.cu` includes `<curand_kernel.h>`; `dali_core_test` already links against the CUDA toolkit, so no extra link flags were     
needed.                                                                                                                                   
                                                          
### Tests:                                                                                                                                
- [X] Existing tests apply                                
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other                                                                                                                             
- [ ] N/A
                                                                                                                                          
The 6 `TestPhilox.*` cases (`CurandSkipaheadSanityCheck`, `VersusCurandSeq`, `VersusCurandInitSeqOffset`, `VersusCurandInitCtrPhase`,     
`VersusCurandRandomSkipahead`, `StringSerialization`) now run from `dali_core_test.bin` and pass locally. `dali_operator_test` continues to build and exercise `random_dist_test.{cc,cu}` (which use Philox via the new include path).                                             
                                                          
## Checklist

### Documentation
- [X] Existing documentation applies
- [ ] Documentation updated                                                                                                               
- [ ] N/A
                                                                                                                                          
### DALI team only                                        

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements                                                                                                       
- [X] N/A
                                                                                                                                          
**REQ IDs**: N/A                                          

**JIRA TASK**: N/A
