### PR TITLE
Coverity static analysis fixes - May 2026

### DIFF
--- a/dali/c_api_2/op_test/complex_pipeline_test.cc
+++ b/dali/c_api_2/op_test/complex_pipeline_test.cc
@@ -280,14 +280,14 @@ void RunCheckpointingTest(Pipeline &ref, daliPipeline_h pipe1, daliPipeline_h pi
   ext.pipeline_data.data = pipeline_data;
   ext.pipeline_data.size = strlen(ext.pipeline_data.data);
 
-  daliCheckpoint_h checkpoint_h{};
+  daliCheckpoint_h checkpoint1_h{};
   // Take a checkpoint from pipe1...
-  CHECK_DALI(daliPipelineGetCheckpoint(pipe1, &checkpoint_h, &ext));
-  CheckpointHandle checkpoint(checkpoint_h);
+  CHECK_DALI(daliPipelineGetCheckpoint(pipe1, &checkpoint1_h, &ext));
+  CheckpointHandle checkpoint1(checkpoint1_h);
 
   const char *data = nullptr;
   size_t size = 0;
-  CHECK_DALI(daliPipelineSerializeCheckpoint(pipe1, checkpoint, &data, &size));
+  CHECK_DALI(daliPipelineSerializeCheckpoint(pipe1, checkpoint1, &data, &size));
   ASSERT_NE(data, nullptr);
 
   // ...restore into ref...
@@ -299,9 +299,10 @@ void RunCheckpointingTest(Pipeline &ref, daliPipeline_h pipe1, daliPipeline_h pi
   auto chk_str = ref.GetSerializedCheckpoint({ ext.pipeline_data.data, ext.iterator_data.data });
 
   // ...deserialize into pipe2...
+  daliCheckpoint_h checkpoint2_h{};
   CHECK_DALI(daliPipelineDeserializeCheckpoint(
-        pipe2, &checkpoint_h, chk_str.data(), chk_str.length()));
-  CheckpointHandle checkpoint2(checkpoint_h);
+        pipe2, &checkpoint2_h, chk_str.data(), chk_str.length()));
+  CheckpointHandle checkpoint2(checkpoint2_h);
 
   daliCheckpointExternalData_t ext2{};
   CHECK_DALI(daliCheckpointGetExternalData(checkpoint2, &ext2));

--- a/dali/c_api_2/pipeline.cc
+++ b/dali/c_api_2/pipeline.cc
@@ -420,8 +420,9 @@ daliResult_t daliPipelineGetOutputDesc(
 
 daliResult_t daliPipelinePopOutputs(daliPipeline_h pipeline, daliPipelineOutputs_h *out) {
   DALI_PROLOG();
-  auto pipe = ToPointer(pipeline);
   CHECK_OUTPUT(out);
+  *out = nullptr;
+  auto pipe = ToPointer(pipeline);
   *out = pipe->PopOutputs().release();
   DALI_EPILOG();
 }
@@ -431,8 +432,9 @@ daliResult_t daliPipelinePopOutputsAsync(
         daliPipelineOutputs_h *out,
         cudaStream_t stream) {
   DALI_PROLOG();
-  auto pipe = ToPointer(pipeline);
   CHECK_OUTPUT(out);
+  *out = nullptr;
+  auto pipe = ToPointer(pipeline);
   *out = pipe->PopOutputs(stream).release();
   DALI_EPILOG();
 }

--- a/dali/c_api_2/pipeline.cc
+++ b/dali/c_api_2/pipeline.cc
@@ -420,9 +420,8 @@ daliResult_t daliPipelineGetOutputDesc(
 
 daliResult_t daliPipelinePopOutputs(daliPipeline_h pipeline, daliPipelineOutputs_h *out) {
   DALI_PROLOG();
-  CHECK_OUTPUT(out);
-  *out = nullptr;
   auto pipe = ToPointer(pipeline);
+  CHECK_OUTPUT(out);
   *out = pipe->PopOutputs().release();
   DALI_EPILOG();
 }
@@ -432,9 +431,8 @@ daliResult_t daliPipelinePopOutputsAsync(
         daliPipelineOutputs_h *out,
         cudaStream_t stream) {
   DALI_PROLOG();
-  CHECK_OUTPUT(out);
-  *out = nullptr;
   auto pipe = ToPointer(pipeline);
+  CHECK_OUTPUT(out);
   *out = pipe->PopOutputs(stream).release();
   DALI_EPILOG();
 }

--- a/dali/c_api_2/pipeline_test_utils.h
+++ b/dali/c_api_2/pipeline_test_utils.h
@@ -38,13 +38,13 @@ inline TensorListHandle GetOutput(daliPipelineOutputs_h h, int idx) {
 }
 
 inline PipelineOutputsHandle PopOutputs(daliPipeline_h h) {
-  daliPipelineOutputs_h raw_out_h;
+  daliPipelineOutputs_h raw_out_h = nullptr;
   CHECK_DALI(daliPipelinePopOutputs(h, &raw_out_h));
   return PipelineOutputsHandle(raw_out_h);
 }
 
 inline PipelineOutputsHandle PopOutputsAsync(daliPipeline_h h, cudaStream_t stream) {
-  daliPipelineOutputs_h raw_out_h;
+  daliPipelineOutputs_h raw_out_h = nullptr;
   CHECK_DALI(daliPipelinePopOutputsAsync(h, &raw_out_h, stream));
   return PipelineOutputsHandle(raw_out_h);
 }

--- a/dali/pipeline/operator/operator_factory.h
+++ b/dali/pipeline/operator/operator_factory.h
@@ -44,7 +44,7 @@ class OperatorRegistry {
 
   template <typename Backend>
   void Register(std::string name, Creator creator) {
-    Register(name, std::move(creator), BackendDeviceName<Backend>);
+    Register(std::move(name), std::move(creator), BackendDeviceName<Backend>);
   }
 
   void Register(
@@ -100,11 +100,11 @@ class OperatorRegistry {
 template <typename OpType>
 class Registerer {
  public:
-  Registerer(const std::string &name,
+  Registerer(std::string name,
       OperatorRegistry<OpType> *registry,
       typename OperatorRegistry<OpType>::Creator creator,
       std::string_view devName = "") {
-    registry->Register(name, creator, devName);
+    registry->Register(std::move(name), std::move(creator), devName);
   }
 
   // Standard creator function used by all operators


### PR DESCRIPTION
## Summary

Three changes:

- **`complex_pipeline_test.cc`** — Coverity-flagged use-after-free in `RunCheckpointingTest`. Split `checkpoint_h` into distinct `checkpoint1_h` / `checkpoint2_h` locals so there is no apparent reuse of a handle after a RAII transfer. The test keeps using the raw C API for output handles (it is intentionally a C API test).
- **`pipeline_test_utils.h`** — initialize `daliPipelineOutputs_h raw_out_h = nullptr` in the `PopOutputs` and `PopOutputsAsync` test helpers. `CHECK_DALI` here is `EXPECT_EQ` (non-fatal), so on a failing call the helpers were wrapping an *uninitialized* handle in `PipelineOutputsHandle` and the destructor would call `daliPipelineOutputsDestroy` on garbage. With this init the destructor sees nullptr on the failure path and the original `EXPECT_EQ` failure stays visible. The C API itself is unchanged: per the convention shared with the CUDA runtime, output parameters are not modified on non-success returns (only `DALI_NO_DATA` writes nullptr, which these functions do not return), so initialization is the caller's responsibility.
- **`operator_factory.h`** — Coverity-flagged copy-when-could-move in `Registerer`. Take `Registerer::name` by value and `std::move` both `name` and `creator` into `OperatorRegistry::Register`, eliminating two copies on each operator registration. Also `std::move(name)` in the `Register<Backend>` template overload so the name reaches the inner `Register` without an extra copy.

The remaining Coverity findings from the same snapshot (an unchecked-return-value in `FileLabelLoaderBase` and an uncaught-exception in vendored `third_party/pybind11`) are intentionally not addressed here.

## Test plan

- [ ] DALI CI green (build + tests) on this branch
- [ ] No new regressions in `CAPI2_SerializedPipelineTest.Checkpointing` / `CAPI2_PipelineBuilderTest.Checkpointing`
- [ ] Next Coverity scan no longer flags the use-after-free in `RunCheckpointingTest` or the copy-when-could-move in `Registerer`