### PR TITLE
Expose Philox4x32_10 to Python and use it in dynamic mode RNG. Fix cloning semantics.

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2421,7 +2421,7 @@ std::shared_ptr<TensorList<Backend>> CloneTL(const TensorList<Backend> &tl) {
 }
 
 void ExposePhilox(py::module &m) {
-  auto philox = py::class_<Philox4x32_10>(m, "Philox4x32_10");
+  auto philox = py::class_<Philox4x32_10>(m, "_Philox4x32_10");
 
   py::class_<Philox4x32_10::State>(philox, "State")
     .def(py::init([](uint64_t key, uint64_t sequence, uint64_t offset) {
@@ -2458,11 +2458,19 @@ void ExposePhilox(py::module &m) {
     .def(py::init([](const Philox4x32_10::State &state) {
       return std::make_unique<Philox4x32_10>(state);
     }), "state"_a)
+    .def(py::init([](std::string_view state_str) {
+      Philox4x32_10::State state;
+      Philox4x32_10::state_from_string(state, state_str);
+      return std::make_unique<Philox4x32_10>(state);
+    }), "state"_a)
     .def("next", &Philox4x32_10::next)
     .def("skipahead", &Philox4x32_10::skipahead, "n"_a)
     .def("skipahead_sequence", &Philox4x32_10::skipahead_sequence, "n"_a)
     .def("get_state", &Philox4x32_10::get_state)
-    .def("set_state", &Philox4x32_10::set_state, "state"_a);
+    .def("set_state", &Philox4x32_10::set_state, "state"_a)
+    .def("set_state", [](Philox4x32_10 &self, std::string_view state) {
+      self.state_from_string(state);
+    }, "state"_a);
 }
 
 void ExposeStream(py::module &m) {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2421,7 +2421,8 @@ std::shared_ptr<TensorList<Backend>> CloneTL(const TensorList<Backend> &tl) {
 }
 
 void ExposePhilox(py::module &m) {
-  auto philox = py::class_<Philox4x32_10>(m, "_Philox4x32_10");
+  // Declare, but do not populate it yet; we need to define the nested class first.
+  py::class_<Philox4x32_10> philox(m, "_Philox4x32_10");
 
   py::class_<Philox4x32_10::State>(philox, "State")
     .def(py::init([](uint64_t key, uint64_t sequence, uint64_t offset) {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -28,6 +28,7 @@
 #include "dali/core/os/shared_mem.h"
 #endif
 #include "dali/core/python_util.h"
+#include "dali/core/random/philox.h"
 #include "dali/core/mm/default_resources.h"
 #include "dali/operators.h"
 #include "dali/kernels/kernel.h"
@@ -2419,6 +2420,52 @@ std::shared_ptr<TensorList<Backend>> CloneTL(const TensorList<Backend> &tl) {
   return tl_clone;
 }
 
+void ExposePhilox(py::module &m) {
+  auto philox = py::class_<Philox4x32_10>(m, "Philox4x32_10");
+
+  py::class_<Philox4x32_10::State>(philox, "State")
+    .def(py::init([](uint64_t key, uint64_t sequence, uint64_t offset) {
+      return Philox4x32_10::State(key, sequence, offset);
+    }), "key"_a, "sequence"_a, "offset"_a)
+    .def(py::init([](uint64_t key, uint64_t ctr_hi, uint64_t ctr_lo, unsigned phase) {
+      if (phase > 3)
+        throw py::value_error("phase must be in [0, 3]");
+      return Philox4x32_10::State(key, ctr_hi, ctr_lo, phase);
+    }), "key"_a, "ctr_hi"_a, "ctr_lo"_a, "phase"_a)
+    .def(py::init([](std::string_view str) {
+      Philox4x32_10::State s;
+      Philox4x32_10::state_from_string(s, str);
+      return s;
+    }),
+    "str"_a)
+    .def("__str__", [](const Philox4x32_10::State &s) {
+      return Philox4x32_10::state_to_string(s);
+    })
+    .def("__repr__", [](const Philox4x32_10::State &s) {
+      return make_string("Philox.State('", Philox4x32_10::state_to_string(s), "')");
+    })
+    .def_static("parse", [](std::string_view str) {
+      Philox4x32_10::State s;
+      Philox4x32_10::state_from_string(s, str);
+      return s;
+    }, "str"_a);
+
+  philox
+    .def(py::init([](uint64_t key, uint64_t sequence, uint64_t offset) {
+      auto p = std::make_unique<Philox4x32_10>();
+      p->init(key, sequence, offset);
+      return p;
+    }), "key"_a, "sequence"_a, "offset"_a)
+    .def(py::init([](const Philox4x32_10::State &state) {
+      return std::make_unique<Philox4x32_10>(state);
+    }), "state"_a)
+    .def("next", &Philox4x32_10::next)
+    .def("skipahead", &Philox4x32_10::skipahead, "n"_a)
+    .def("skipahead_sequence", &Philox4x32_10::skipahead_sequence, "n"_a)
+    .def("get_state", &Philox4x32_10::get_state)
+    .def("set_state", &Philox4x32_10::set_state, "state"_a);
+}
+
 void ExposeStream(py::module &m) {
   py::class_<dali::CUDAStreamLease>(m, "Stream")
     .def(py::init([](std::optional<int> device_id) {
@@ -2938,6 +2985,8 @@ PYBIND11_MODULE(backend_impl, m, py::mod_gil_not_used()) {
         [](ExternalContextCheckpoint &self, const std::string &new_data) {
           self.iterator_data = new_data;
         });
+
+  ExposePhilox(m);
 
   // Pipeline class and parameters
   ExposeStream(m);

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2442,7 +2442,7 @@ void ExposePhilox(py::module &m) {
       return Philox4x32_10::state_to_string(s);
     })
     .def("__repr__", [](const Philox4x32_10::State &s) {
-      return make_string("Philox.State('", Philox4x32_10::state_to_string(s), "')");
+      return make_string("Philox4x32_10.State('", Philox4x32_10::state_to_string(s), "')");
     })
     .def_static("parse", [](std::string_view str) {
       Philox4x32_10::State s;

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2436,8 +2436,7 @@ void ExposePhilox(py::module &m) {
       Philox4x32_10::State s;
       Philox4x32_10::state_from_string(s, str);
       return s;
-    }),
-    "str"_a)
+    }), "str"_a)
     .def("__str__", [](const Philox4x32_10::State &s) {
       return Philox4x32_10::state_to_string(s);
     })

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -57,12 +57,12 @@ class RNG:
         if seed is not None:
             if state is not None:
                 raise ValueError("Cannot specify both `seed` and `state`")
-            self._rng = _b.Philox4x32_10(seed & 0xFFFFFFFFFFFFFFFF, 0, 0)
+            self._rng = _b._Philox4x32_10(seed & 0xFFFFFFFFFFFFFFFF, 0, 0)
         elif state is not None:
-            self._rng = _b.Philox4x32_10(state)
+            self._rng = _b._Philox4x32_10(state)
         else:
             seed = _random.randint(0, 0xFFFFFFFFFFFFFFFF)
-            self._rng = _b.Philox4x32_10(seed, 0, 0)
+            self._rng = _b._Philox4x32_10(seed, 0, 0)
 
     def __call__(self):
         """Generate a random uint32 value.
@@ -74,11 +74,16 @@ class RNG:
         """
         return self._rng.next()
 
+    @property
+    def seed(self):
+        raise AttributeError("seed is write-only")
+
+    @seed.setter
     def seed(self, value):
         """Set the seed for this RNG and reset its random sequence.
         The seed is truncated to 64 bits.
         """
-        self._rng = _b.Philox4x32_10(value & 0xFFFFFFFFFFFFFFFF, 0, 0)
+        self._rng = _b._Philox4x32_10(value & 0xFFFFFFFFFFFFFFFF, 0, 0)
 
     def clone(self):
         """Create a new RNG with the same state
@@ -110,13 +115,25 @@ class RNG:
 
     @property
     def state(self):
-        """Returns the internal state of the generator."""
+        """Returns the internal state of the generator.
+
+        Returns
+        -------
+        Opaque state object. This object can be converted to a string and that string can be used
+        later to set the state or construct an RNG.
+        """
         return self._rng.get_state()
 
     @state.setter
     def state(self, value):
-        """Sets the internal state of the generator."""
-        return self._rng.set_state(value)
+        """Sets the internal state of the generator.
+
+        Parameters
+        ----------
+        value : object | str
+            Either a state object obtained from another RNG instance of its string representation
+        """
+        self._rng.set_state(value)
 
 
 # Thread-local storage for the default RNG
@@ -168,4 +185,4 @@ def set_seed(seed):
     >>> result2 = ndd.random.uniform(range=(-1, 1), shape=[10])
     >>> # result1 and result2 should be identical
     """
-    get_default_rng().seed(seed)
+    get_default_rng().seed = seed

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -36,6 +36,7 @@ class RNG:
     ----------
     seed : int, optional
         Seed for the random number generator. If not provided, a random seed is used.
+        Values that are out of range of uint64 are wrapped.
 
     Examples
     --------

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -106,7 +106,7 @@ class RNG:
         return RNG(state=self.state)
 
     def __repr__(self):
-        return f"RNG(seed={self._seed})"
+        return f"RNG(state={self.state})"
 
     @property
     def state(self):

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ that are dynamically added during module initialization.
 
 import random as _random
 import threading as _threading
+
+import nvidia.dali.backend_impl as _b
 
 # Note: __all__ is intentionally not defined here to allow help() to show
 # dynamically added random operator functions (uniform, normal, etc.)
@@ -48,10 +50,9 @@ class RNG:
 
     def __init__(self, seed=None):
         if seed is None:
-            # Use Python's random to generate a random seed
-            seed = _random.randint(0, 2**31 - 1)
-        self._rng = _random.Random(seed)
+            seed = _random.randint(0, 2**63 - 1)
         self._seed = seed
+        self._rng = _b.Philox4x32_10(seed & 0xFFFFFFFFFFFFFFFF, 0, 0)
 
     def __call__(self):
         """Generate a random uint32 value.
@@ -61,9 +62,7 @@ class RNG:
         int
             A random uint32 value (as Python int, but in range [0, 2^32-1]).
         """
-        # Generate a random value in the uint32 range [0, 2^32-1]
-        # Return as Python int (numpy will convert it when creating the array)
-        return self._rng.randint(0, 0xFFFFFFFF)
+        return self._rng.next()
 
     @property
     def seed(self):
@@ -74,7 +73,7 @@ class RNG:
     def seed(self, value):
         """Set the seed for this RNG and reset its random sequence."""
         self._seed = value
-        self._rng = _random.Random(value)
+        self._rng = _b.Philox4x32_10(value, 0, 0)
 
     def clone(self):
         """Create a new RNG with the same seed.

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -106,7 +106,7 @@ class RNG:
         return RNG(state=self.state)
 
     def __repr__(self):
-        return f"RNG(state={self.state})"
+        return f"RNG(state='{self.state}')"
 
     @property
     def state(self):

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -36,7 +36,7 @@ class RNG:
     ----------
     seed : int, optional
         Seed for the random number generator. If not provided, a random seed is used.
-        Values that are out of range of uint64 are wrapped.
+        The seed is truncated to 64 bits.
 
     Examples
     --------
@@ -72,9 +72,11 @@ class RNG:
 
     @seed.setter
     def seed(self, value):
-        """Set the seed for this RNG and reset its random sequence."""
+        """Set the seed for this RNG and reset its random sequence.
+        The seed is truncated to 64 bits.
+        """
         self._seed = value
-        self._rng = _b.Philox4x32_10(value, 0, 0)
+        self._rng = _b.Philox4x32_10(value & 0xFFFFFFFFFFFFFFFF, 0, 0)
 
     def clone(self):
         """Create a new RNG with the same seed.

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -37,6 +37,10 @@ class RNG:
     seed : int, optional
         Seed for the random number generator. If not provided, a random seed is used.
         The seed is truncated to 64 bits.
+        Mutually exclusive with `state`.
+    state : State object, optional
+        The state object as returned RNG.state property.
+        Mutually exclusive with `seed`.
 
     Examples
     --------
@@ -49,11 +53,16 @@ class RNG:
     >>> result = ndd.random.uniform(range=(-1, 1), shape=[10], rng=my_rng, device="cpu")
     """
 
-    def __init__(self, seed=None):
-        if seed is None:
-            seed = _random.randint(0, 2**63 - 1)
-        self._seed = seed
-        self._rng = _b.Philox4x32_10(seed & 0xFFFFFFFFFFFFFFFF, 0, 0)
+    def __init__(self, seed=None, state=None):
+        if seed is not None:
+            if state is not None:
+                raise ValueError("Cannot specify both `seed` and `state`")
+            self._rng = _b.Philox4x32_10(seed & 0xFFFFFFFFFFFFFFFF, 0, 0)
+        elif state is not None:
+            self._rng = _b.Philox4x32_10(state)
+        else:
+            seed = _random.randint(0, 0xFFFFFFFFFFFFFFFF)
+            self._rng = _b.Philox4x32_10(seed, 0, 0)
 
     def __call__(self):
         """Generate a random uint32 value.
@@ -65,28 +74,19 @@ class RNG:
         """
         return self._rng.next()
 
-    @property
-    def seed(self):
-        """Get the seed used to initialize this RNG."""
-        return self._seed
-
-    @seed.setter
     def seed(self, value):
         """Set the seed for this RNG and reset its random sequence.
         The seed is truncated to 64 bits.
         """
-        self._seed = value
         self._rng = _b.Philox4x32_10(value & 0xFFFFFFFFFFFFFFFF, 0, 0)
 
     def clone(self):
-        """Create a new RNG with the same seed.
+        """Create a new RNG with the same state
 
         Returns
         -------
         RNG
-            A new RNG instance initialized with the same seed as this one.
-            This allows creating independent RNG streams that produce the same
-            sequence of random numbers.
+            A new RNG which will continue the same sequence as this one.
 
         Examples
         --------
@@ -94,6 +94,7 @@ class RNG:
         >>>
         >>> # Create an RNG
         >>> rng1 = ndd.random.RNG(seed=1234)
+        >>> _ = rng1()  # change the state of the generator
         >>>
         >>> # Clone it to create an independent copy
         >>> rng2 = rng1.clone()
@@ -102,10 +103,20 @@ class RNG:
         >>> for i in range(10):
         >>>     assert rng1() == rng2()
         """
-        return RNG(seed=self._seed)
+        return RNG(state=self.state)
 
     def __repr__(self):
         return f"RNG(seed={self._seed})"
+
+    @property
+    def state(self):
+        """Returns the internal state of the generator."""
+        return self._rng.get_state()
+
+    @state.setter
+    def state(self, value):
+        """Sets the internal state of the generator."""
+        return self._rng.set_state(value)
 
 
 # Thread-local storage for the default RNG
@@ -157,4 +168,4 @@ def set_seed(seed):
     >>> result2 = ndd.random.uniform(range=(-1, 1), shape=[10])
     >>> # result1 and result2 should be identical
     """
-    get_default_rng().seed = seed
+    get_default_rng().seed(seed)

--- a/dali/test/python/experimental_mode/test_random.py
+++ b/dali/test/python/experimental_mode/test_random.py
@@ -15,6 +15,7 @@
 import nvidia.dali.experimental.dynamic as ndd
 import numpy as np
 from nose2.tools import cartesian_params, params
+from nose_utils import raises
 
 
 def asnumpy(tensor_or_batch):
@@ -142,6 +143,11 @@ def test_rng_clone():
     assert np.array_equal(
         result1_np, result2_np
     ), "Cloned RNGs should produce identical operator results"
+
+
+@raises(ValueError, glob="both")
+def test_rng_init_seed_and_state_error():
+    ndd.random.RNG(seed=0, state="")
 
 
 def test_rng_set_seed():

--- a/dali/test/python/experimental_mode/test_random.py
+++ b/dali/test/python/experimental_mode/test_random.py
@@ -107,9 +107,15 @@ def test_rng_clone():
     """Test that RNG.clone() creates an independent copy with the same seed."""
     # Create an RNG with a specific seed
     rng1 = ndd.random.RNG(seed=5678)
+    _ = rng1()  # advance
+    _ = rng1()  # advance some more
 
     # Clone it
     rng2 = rng1.clone()
+
+    # set state - effectively clone
+    rng3 = ndd.random.RNG(seed=12345)  # different seed
+    rng3.state = rng2.state
 
     # Verify they are different objects
     assert rng1 is not rng2, "Clone should create a new object"
@@ -118,16 +124,18 @@ def test_rng_clone():
     for i in range(10):
         val1 = rng1()
         val2 = rng2()
+        val3 = rng3()
         assert val1 == val2, f"Value {i} doesn't match: {val1} != {val2}"
+        assert val1 == val3, f"Value {i} doesn't match: {val1} != {val3}"
 
     # Verify cloned RNG works with operators
-    rng3 = ndd.random.RNG(seed=9999)
-    rng4 = rng3.clone()
+    rng4 = ndd.random.RNG(seed=9999)
+    rng5 = rng4.clone()
 
-    result1 = ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng3)
+    result1 = ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng4)
     result1_np = asnumpy(result1)
 
-    result2 = ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng4)
+    result2 = ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng5)
     result2_np = asnumpy(result2)
 
     # Results should be identical since clones have the same seed
@@ -140,20 +148,20 @@ def test_rng_set_seed():
     # Explicit RNG instance
     rng = ndd.random.RNG(seed=1234)
     values1 = [rng() for _ in range(5)]
-    rng.seed(1234)
+    rng.seed = 1234
     values2 = [rng() for _ in range(5)]
     assert values1 == values2
-    rng.seed(5678)  # Different seed should produce different values
+    rng.seed = 5678  # Different seed should produce different values
     values3 = [rng() for _ in range(5)]
     assert values1 != values3
 
     # Explicit RNG instance with operators
-    rng.seed(1234)
+    rng.seed = 1234
     result1_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng))
-    rng.seed(1234)
+    rng.seed = 1234
     result2_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng))
     assert np.array_equal(result1_np, result2_np)
-    rng.seed(5678)  # Different seed
+    rng.seed = 5678  # Different seed
     result3_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng))
     assert not np.array_equal(result1_np, result3_np)
 

--- a/dali/test/python/experimental_mode/test_random.py
+++ b/dali/test/python/experimental_mode/test_random.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -111,9 +111,6 @@ def test_rng_clone():
     # Clone it
     rng2 = rng1.clone()
 
-    # Verify they have the same seed
-    assert rng1.seed == rng2.seed, f"Seeds don't match: {rng1.seed} != {rng2.seed}"
-
     # Verify they are different objects
     assert rng1 is not rng2, "Clone should create a new object"
 
@@ -143,26 +140,25 @@ def test_rng_set_seed():
     # Explicit RNG instance
     rng = ndd.random.RNG(seed=1234)
     values1 = [rng() for _ in range(5)]
-    rng.seed = 1234
+    rng.seed(1234)
     values2 = [rng() for _ in range(5)]
     assert values1 == values2
-    rng.seed = 5678  # Different seed should produce different values
+    rng.seed(5678)  # Different seed should produce different values
     values3 = [rng() for _ in range(5)]
     assert values1 != values3
 
     # Explicit RNG instance with operators
-    rng.seed = 1234
+    rng.seed(1234)
     result1_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng))
-    rng.seed = 1234
+    rng.seed(1234)
     result2_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng))
     assert np.array_equal(result1_np, result2_np)
-    rng.seed = 5678  # Different seed
+    rng.seed(5678)  # Different seed
     result3_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng))
     assert not np.array_equal(result1_np, result3_np)
 
     # Default RNG
     ndd.random.set_seed(9876)
-    assert ndd.random.get_default_rng().seed == 9876
     values1 = [ndd.random.get_default_rng()() for _ in range(5)]
     ndd.random.set_seed(9876)
     values2 = [ndd.random.get_default_rng()() for _ in range(5)]

--- a/dali/test/python/experimental_mode/test_random.py
+++ b/dali/test/python/experimental_mode/test_random.py
@@ -131,6 +131,8 @@ def test_rng_clone():
 
     # Verify cloned RNG works with operators
     rng4 = ndd.random.RNG(seed=9999)
+    for _ in range(10):
+        _ = rng4()  # advance by 10 iterations
     rng5 = rng4.clone()
 
     result1 = ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng4)


### PR DESCRIPTION
Adds pybind11 bindings for Philox4x32_10 and its nested State type in backend_impl, and replaces the Python random.Random backing of nvidia.dali.experimental.dynamic.random.RNG with the now-core Philox generator so the dynamic mode RNG matches the operator-side Philox stream.

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix**
**Breaking change**
**New feature** (*non-breaking change which adds functionality*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
This PR exposes Philox generator in Python and changes the RNG used in Dynamic Mode to Philox counter-based generator.
This change is a prerequisite for portable RNG checkpoints.

The RNG API is also changed. The `seed` is now write-only. This is done because reading the seed doesn't make much sense after the generator has advanced. Instead, `state` is exposed (both get and set) so the generator can be placed at an exact position.

`RNG.clone` is fixed and now returns the copy of the RNG at any given instant - not initialized the same way, but the exact copy _now_, as was intended and as is necessary for checkpointing.

## Additional information:

### Affected modules and functionalities:
Python bindings.
Dynamic mode random number generators.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
The existing tests for random operators cover the refactored RNG.
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
Mostly applies. Added information about seed handling.
- [X] Existing documentation applies
- [X] Documentation updated
  - [X] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
