### PR TITLE
Surface dlerror() per attempted path in nvimgcodec wrap

### DIFF
--- a/dali/nvimgcodec/nvimgcodec_wrap.cc
+++ b/dali/nvimgcodec/nvimgcodec_wrap.cc
@@ -51,10 +51,19 @@ NVIMGCODECDRIVER loadNvimgcodecLibrary() {
                                 nvimgcodecLibDefaultPathMajorVer,
                                 nvimgcodecLibDefaultPath};
   NVIMGCODECDRIVER ret = nullptr;
+  std::string attempts;
+  // Clear any pending dlerror() before the loop so the first dlerror() call
+  // we make corresponds to our own dlopen failure, not a prior unrelated one.
+  dlerror();
   for (const char *path : paths) {
     ret = dlopen(path, RTLD_NOW);
     if (ret)
       break;
+    const char *err = dlerror();
+    attempts += "\n  ";
+    attempts += path;
+    attempts += ": ";
+    attempts += err ? err : "(no dlerror)";
   }
 
   if (!ret) {
@@ -62,7 +71,8 @@ NVIMGCODECDRIVER loadNvimgcodecLibrary() {
     throw std::runtime_error(
         "dlopen libnvimgcodec.so failed!. Please install nvimagecodec: See "
         "https://developer.nvidia.com/nvimgcodec-downloads or simply do `pip install "
-        "nvidia-nvimgcodec-cu" + std::to_string(cuda_version_major) + "`.");
+        "nvidia-nvimgcodec-cu" + std::to_string(cuda_version_major) + "`."
+        "\nAttempted paths:" + attempts);
   }
   return ret;
 }

--- a/dali/nvimgcodec/nvimgcodec_wrap.cc
+++ b/dali/nvimgcodec/nvimgcodec_wrap.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 #include <string>
 #include <unordered_map>
 #include <stdexcept>
+
+#include "dali/core/format.h"
 
 #define STR_IMPL_(x) #x
 #define STR(x) STR_IMPL_(x)
@@ -54,7 +56,7 @@ NVIMGCODECDRIVER loadNvimgcodecLibrary() {
   std::string attempts;
   // Clear any pending dlerror() before the loop so the first dlerror() call
   // we make corresponds to our own dlopen failure, not a prior unrelated one.
-  dlerror();
+  (void)dlerror();
   for (const char *path : paths) {
     ret = dlopen(path, RTLD_NOW);
     if (ret)
@@ -63,16 +65,16 @@ NVIMGCODECDRIVER loadNvimgcodecLibrary() {
     attempts += "\n  ";
     attempts += path;
     attempts += ": ";
-    attempts += err ? err : "(no dlerror)";
+    attempts += err ? err : "(unknown dlerror)";
   }
 
   if (!ret) {
     int cuda_version_major = CUDA_VERSION / 1000;  // 11020 -> 11, 12000 -> 12
-    throw std::runtime_error(
+    throw std::runtime_error(dali::make_string(
         "dlopen libnvimgcodec.so failed!. Please install nvimagecodec: See "
         "https://developer.nvidia.com/nvimgcodec-downloads or simply do `pip install "
-        "nvidia-nvimgcodec-cu" + std::to_string(cuda_version_major) + "`."
-        "\nAttempted paths:" + attempts);
+        "nvidia-nvimgcodec-cu", cuda_version_major, "`."
+        "\nAttempted paths:", attempts));
   }
   return ret;
 }


### PR DESCRIPTION
## Summary
- `loadNvimgcodecLibrary()` in `dali/nvimgcodec/nvimgcodec_wrap.cc` currently throws a generic `dlopen libnvimgcodec.so failed\!` and discards `dlerror()`, leaving CI logs without a usable diagnostic.
- This blocks investigation of intermittent failures on the CPU-only sanitizer test job (`L0_TL0_cpu_only--py310--CPU_CUDA13`), where every `dlopen` candidate path fails but the actual reason (TLS-block exhaustion under preloaded `libasan`/`libstdc++`, RTLD_NOW symbol resolution, inner-dlopen failure from a codec extension, etc.) is invisible.
- This PR captures `dlerror()` after each failed `dlopen` candidate and appends an `Attempted paths:` block to the thrown message. The existing install-instruction text is preserved unchanged.

Example new message:

```
dlopen libnvimgcodec.so failed\!. Please install nvimagecodec: See https://developer.nvidia.com/nvimgcodec-downloads or simply do `pip install nvidia-nvimgcodec-cu13`.
Attempted paths:
  libnvimgcodec.so.0.8.0: libnvimgcodec.so.0.8.0: cannot open shared object file: No such file or directory
  libnvimgcodec.so.0:     <real reason here>
  ...
```

This is a diagnostic-only change. No behavior change on the success path; on failure the existing string still matches grep / docs.

## Test plan
- [ ] Sanitizer pipeline (`L0_TL0_cpu_only--py310--CPU_CUDA13`) reaches the throw path and the new message contains the per-path `dlerror()` text.
- [ ] Non-sanitizer CPU build still loads nvimgcodec normally — no behavioral regression on the success path.