### PR TITLE
Keep nvimgcodec wheel path in LD_LIBRARY_PATH for CPU-only test

### DIFF
--- a/qa/TL0_cpu_only/test_nofw.sh
+++ b/qa/TL0_cpu_only/test_nofw.sh
@@ -5,11 +5,17 @@ pip_packages='${python_test_runner_package} numpy numba scipy librosa'
 target_dir=./dali/test/python
 
 test_body() {
-  # CPU only test, remove CUDA from the search path just in case.
-  # Keep the nvimgcodec wheel directory so libnvimgcodec.so (which provides
-  # CPU codecs via libjpeg-turbo / libtiff / opencv) remains discoverable for
-  # dlopen — it doesn't depend on system CUDA libs.
-  export LD_LIBRARY_PATH="$(python -c 'import nvidia.nvimgcodec as n, os; print(os.path.dirname(n.__file__))' 2>/dev/null || echo '')"
+  # CPU only test, remove CUDA from the search path just in case
+  if [ -n "$DALI_ENABLE_SANITIZERS" ]; then
+    # ASAN ignores DT_RUNPATH (https://bugzilla.redhat.com/show_bug.cgi?id=1449604),
+    # so libdali_operators.so's lazy dlopen("libnvimgcodec.so") cannot rely on its
+    # $ORIGIN/../nvimgcodec rpath entry. Keep the wheel-installed nvimgcodec dir
+    # reachable via LD_LIBRARY_PATH instead. Mirrors the same workaround in
+    # qa/test_template_impl.sh::enable_sanitizer().
+    export LD_LIBRARY_PATH="$(python -c 'import nvidia.nvimgcodec as n, os; print(os.path.dirname(n.__file__))' 2>/dev/null || echo '')"
+  else
+    export LD_LIBRARY_PATH=""
+  fi
   export PATH=${PATH/cuda/}
 
   for BINNAME in \

--- a/qa/TL0_cpu_only/test_nofw.sh
+++ b/qa/TL0_cpu_only/test_nofw.sh
@@ -5,8 +5,11 @@ pip_packages='${python_test_runner_package} numpy numba scipy librosa'
 target_dir=./dali/test/python
 
 test_body() {
-  # CPU only test, remove CUDA from the search path just in case
-  export LD_LIBRARY_PATH=""
+  # CPU only test, remove CUDA from the search path just in case.
+  # Keep the nvimgcodec wheel directory so libnvimgcodec.so (which provides
+  # CPU codecs via libjpeg-turbo / libtiff / opencv) remains discoverable for
+  # dlopen — it doesn't depend on system CUDA libs.
+  export LD_LIBRARY_PATH="$(python -c 'import nvidia.nvimgcodec as n, os; print(os.path.dirname(n.__file__))' 2>/dev/null || echo '')"
   export PATH=${PATH/cuda/}
 
   for BINNAME in \

--- a/qa/TL0_cpu_only/test_pytorch.sh
+++ b/qa/TL0_cpu_only/test_pytorch.sh
@@ -5,8 +5,11 @@ pip_packages='${python_test_runner_package} numpy pillow torch numba scipy libro
 target_dir=./dali/test/python
 
 test_body() {
-  # CPU only test, remove CUDA from the search path just in case
-  export LD_LIBRARY_PATH=""
+  # CPU only test, remove CUDA from the search path just in case.
+  # Keep the nvimgcodec wheel directory so libnvimgcodec.so (CPU codecs via
+  # libjpeg-turbo / libtiff / opencv) remains discoverable for dlopen — it
+  # doesn't depend on system CUDA libs.
+  export LD_LIBRARY_PATH="$(python -c 'import nvidia.nvimgcodec as n, os; print(os.path.dirname(n.__file__))' 2>/dev/null || echo '')"
   export PATH=${PATH/cuda/}
   ${python_new_invoke_test} -A 'pytorch' test_dali_cpu_only
 }

--- a/qa/TL0_cpu_only/test_pytorch.sh
+++ b/qa/TL0_cpu_only/test_pytorch.sh
@@ -5,11 +5,17 @@ pip_packages='${python_test_runner_package} numpy pillow torch numba scipy libro
 target_dir=./dali/test/python
 
 test_body() {
-  # CPU only test, remove CUDA from the search path just in case.
-  # Keep the nvimgcodec wheel directory so libnvimgcodec.so (CPU codecs via
-  # libjpeg-turbo / libtiff / opencv) remains discoverable for dlopen — it
-  # doesn't depend on system CUDA libs.
-  export LD_LIBRARY_PATH="$(python -c 'import nvidia.nvimgcodec as n, os; print(os.path.dirname(n.__file__))' 2>/dev/null || echo '')"
+  # CPU only test, remove CUDA from the search path just in case
+  if [ -n "$DALI_ENABLE_SANITIZERS" ]; then
+    # ASAN ignores DT_RUNPATH (https://bugzilla.redhat.com/show_bug.cgi?id=1449604),
+    # so libdali_operators.so's lazy dlopen("libnvimgcodec.so") cannot rely on its
+    # $ORIGIN/../nvimgcodec rpath entry. Keep the wheel-installed nvimgcodec dir
+    # reachable via LD_LIBRARY_PATH instead. Mirrors the same workaround in
+    # qa/test_template_impl.sh::enable_sanitizer().
+    export LD_LIBRARY_PATH="$(python -c 'import nvidia.nvimgcodec as n, os; print(os.path.dirname(n.__file__))' 2>/dev/null || echo '')"
+  else
+    export LD_LIBRARY_PATH=""
+  fi
   export PATH=${PATH/cuda/}
   ${python_new_invoke_test} -A 'pytorch' test_dali_cpu_only
 }

--- a/qa/TL0_cpu_only/test_tf.sh
+++ b/qa/TL0_cpu_only/test_tf.sh
@@ -8,8 +8,11 @@ target_dir=./dali/test/python
 test_body() {
   # skip TF tests for sanitizers as it leads to stack-overflow
   if [ -z "$DALI_ENABLE_SANITIZERS" ]; then
-    # CPU only test, remove CUDA from the search path just in case
-    export LD_LIBRARY_PATH=""
+    # CPU only test, remove CUDA from the search path just in case.
+    # Keep the nvimgcodec wheel directory so libnvimgcodec.so (CPU codecs via
+    # libjpeg-turbo / libtiff / opencv) remains discoverable for dlopen — it
+    # doesn't depend on system CUDA libs.
+    export LD_LIBRARY_PATH="$(python -c 'import nvidia.nvimgcodec as n, os; print(os.path.dirname(n.__file__))' 2>/dev/null || echo '')"
     export PATH=${PATH/cuda/}
     ${python_new_invoke_test} test_dali_tf_plugin_cpu_only
     ${python_new_invoke_test} test_dali_tf_plugin_cpu_only_dataset

--- a/qa/TL0_cpu_only/test_tf.sh
+++ b/qa/TL0_cpu_only/test_tf.sh
@@ -8,11 +8,11 @@ target_dir=./dali/test/python
 test_body() {
   # skip TF tests for sanitizers as it leads to stack-overflow
   if [ -z "$DALI_ENABLE_SANITIZERS" ]; then
-    # CPU only test, remove CUDA from the search path just in case.
-    # Keep the nvimgcodec wheel directory so libnvimgcodec.so (CPU codecs via
-    # libjpeg-turbo / libtiff / opencv) remains discoverable for dlopen — it
-    # doesn't depend on system CUDA libs.
-    export LD_LIBRARY_PATH="$(python -c 'import nvidia.nvimgcodec as n, os; print(os.path.dirname(n.__file__))' 2>/dev/null || echo '')"
+    # CPU only test, remove CUDA from the search path just in case
+    # Sanitizer-only ASAN/RPATH workaround isn't needed here — this branch is
+    # only entered with sanitizers OFF, so libdali_operators.so's RUNPATH
+    # ($ORIGIN/../nvimgcodec) suffices to find the wheel-installed nvimgcodec.
+    export LD_LIBRARY_PATH=""
     export PATH=${PATH/cuda/}
     ${python_new_invoke_test} test_dali_tf_plugin_cpu_only
     ${python_new_invoke_test} test_dali_tf_plugin_cpu_only_dataset


### PR DESCRIPTION
## Summary

The CPU-only test (`qa/TL0_cpu_only/test_nofw.sh`) wipes `LD_LIBRARY_PATH` to validate that DALI works without system CUDA libraries on the loader path. That clears not only system CUDA but also the wheel-provided nvimgcodec directory at `/usr/local/lib/python<X>/dist-packages/nvidia/nvimgcodec/`, where `libnvimgcodec.so` actually lives.

The DALI gtest binaries (`dali_test.bin`, `dali_operator_test.bin`, etc.) `dlopen` `libnvimgcodec.so` by basename via the dynlink wrapper. With `LD_LIBRARY_PATH=\"\"` the wheel-provided `.so` is unreachable and any CApi test that constructs an `ImageDecoder` pipeline (e.g. `CApiTest/0.FileReaderPipe`) fails before it runs.

This was surfaced cleanly by the new per-path `dlerror()` diagnostic from #6337:

\`\`\`
dlopen libnvimgcodec.so failed!. Please install nvimagecodec: ...
Attempted paths:
  libnvimgcodec.so.0.8.0: ... cannot open shared object file: No such file or directory
  libnvimgcodec.so.0:     ... cannot open shared object file: No such file or directory
  libnvimgcodec.so:       ... cannot open shared object file: No such file or directory
  /opt/nvidia/nvimgcodec_cuda13/lib64/libnvimgcodec.so.0.8.0: ... No such file or directory
  ...
\`\`\`

`libnvimgcodec.so` itself does not depend on system CUDA libs — its CUDA-side extensions (nvjpeg, nvjpeg2k, nvtiff) are loaded separately and are already allowed to fail in this CPU-only context. Keeping the wheel directory on the search path is consistent with the test's stated intent (\"remove CUDA from the search path\") while preserving the CPU codec backends (libjpeg-turbo / libtiff / opencv) that the gtest filter exercises.

## Test plan
- [ ] CI: \`L0_TL0_cpu_only--py310--CPU_CUDA13\` (sanitizer pipeline) passes — previously failed at \`CApiTest/0.FileReaderPipe\` with \`dlopen libnvimgcodec.so failed!\`.
- [ ] Non-sanitizer CPU-only run still green — change is additive (sets a path instead of clearing it).