### PR TITLE
Dynamic Mode checkpointing

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2755,15 +2755,15 @@ void ExposeOperator(py::module &m) {
     .def("GetReaderMeta", [](OperatorBase &self) {
       return ReaderMetaToDict(self.GetReaderMeta());
     })
-    .def("SaveCheckpoint", [](OperatorBase &self) -> py::bytes {
+    .def("SaveCheckpoint", [](OperatorBase &self, py::object stream) -> py::bytes {
       // Saves the operator state, serializes it and returns the serialized representation.
       // Used by the dynamic API to expose stateful operator checkpointing to Python.
       // The returned blob may contain arbitrary bytes (e.g. protobuf-serialized loader
       // state), so it is returned as `py::bytes` to avoid UTF-8 conversion.
       OpCheckpoint cpt(self.GetSpec().SchemaName());
-      self.SaveState(cpt, AccessOrder{});
+      self.SaveState(cpt, AccessOrderFromPythonStreamObj(stream));
       return py::bytes(self.SerializeCheckpoint(cpt));
-    })
+    }, "stream"_a = py::none())
     .def("RestoreCheckpoint", [](OperatorBase &self, const std::string &data) {
       // Deserializes the operator state from a string/bytes blob and restores it.
       OpCheckpoint cpt(self.GetSpec().SchemaName());

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -39,6 +39,7 @@
 #include "dali/pipeline/data/tensor.h"
 #include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/init.h"
+#include "dali/pipeline/operator/checkpointing/op_checkpoint.h"
 #include "dali/pipeline/operator/error_reporting.h"
 #include "dali/pipeline/operator/op_schema.h"
 #include "dali/pipeline/operator/op_spec.h"
@@ -2753,7 +2754,22 @@ void ExposeOperator(py::module &m) {
     }, "ws"_a, "batch_size"_a = py::none())
     .def("GetReaderMeta", [](OperatorBase &self) {
       return ReaderMetaToDict(self.GetReaderMeta());
-    });
+    })
+    .def("SaveCheckpoint", [](OperatorBase &self) -> py::bytes {
+      // Saves the operator state, serializes it and returns the serialized representation.
+      // Used by the dynamic API to expose stateful operator checkpointing to Python.
+      // The returned blob may contain arbitrary bytes (e.g. protobuf-serialized loader
+      // state), so it is returned as `py::bytes` to avoid UTF-8 conversion.
+      OpCheckpoint cpt(self.GetSpec().SchemaName());
+      self.SaveState(cpt, AccessOrder{});
+      return py::bytes(self.SerializeCheckpoint(cpt));
+    })
+    .def("RestoreCheckpoint", [](OperatorBase &self, const std::string &data) {
+      // Deserializes the operator state from a string/bytes blob and restores it.
+      OpCheckpoint cpt(self.GetSpec().SchemaName());
+      self.DeserializeCheckpoint(cpt, data);
+      self.RestoreState(cpt);
+    }, "data"_a);
 }
 
 auto GetSupportedBackends(OpSchema &schema) {

--- a/dali/python/nvidia/dali/experimental/dynamic/__init__.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/__init__.py
@@ -29,6 +29,7 @@ from ._imread import imread  # noqa: F401
 from . import _ops
 from . import math  # noqa: F401
 from . import random  # noqa: F401
+from . import checkpoint  # noqa: F401
 from . import pytorch as pytorch  # noqa: F401
 
 _ops._initialize()

--- a/dali/python/nvidia/dali/experimental/dynamic/_eval_context.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_eval_context.py
@@ -118,6 +118,9 @@ class EvalContext:
         # Used to disallow the EvalContext to be active in two threads simultaneously
         self._lock = threading.RLock()
 
+        # Lazily-created Checkpoint bound to this context.
+        self._checkpoint = None
+
     def _purge_operator_cache(self):
         """Empties the operator instance cache"""
         self._instance_cache = {}
@@ -223,6 +226,21 @@ class EvalContext:
             return s
         else:
             return self._cuda_stream
+
+    @property
+    def checkpoint(self):
+        """The :class:`~nvidia.dali.experimental.dynamic.checkpoint.Checkpoint` bound
+        to this context.
+
+        Lazily created on first access. The same object is reused across
+        ``__enter__`` / ``__exit__`` of this context, so it is safe to register ops
+        once and refer to them across multiple iterations.
+        """
+        if self._checkpoint is None:
+            from . import checkpoint as _checkpoint_mod
+
+            self._checkpoint = _checkpoint_mod.Checkpoint()
+        return self._checkpoint
 
     @staticmethod
     def default() -> "EvalContext":

--- a/dali/python/nvidia/dali/experimental/dynamic/_eval_context.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_eval_context.py
@@ -118,8 +118,8 @@ class EvalContext:
         # Used to disallow the EvalContext to be active in two threads simultaneously
         self._lock = threading.RLock()
 
-        # Lazily-created Checkpoint bound to this context.
-        self._checkpoint = None
+        from . import checkpoint as _checkpoint_mod
+        self._checkpoint = _checkpoint_mod.Checkpoint()
 
     def _purge_operator_cache(self):
         """Empties the operator instance cache"""
@@ -236,10 +236,6 @@ class EvalContext:
         ``__enter__`` / ``__exit__`` of this context, so it is safe to register ops
         once and refer to them across multiple iterations.
         """
-        if self._checkpoint is None:
-            from . import checkpoint as _checkpoint_mod
-
-            self._checkpoint = _checkpoint_mod.Checkpoint()
         return self._checkpoint
 
     @staticmethod

--- a/dali/python/nvidia/dali/experimental/dynamic/_eval_context.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_eval_context.py
@@ -119,6 +119,7 @@ class EvalContext:
         self._lock = threading.RLock()
 
         from . import checkpoint as _checkpoint_mod
+
         self._checkpoint = _checkpoint_mod.Checkpoint()
 
     def _purge_operator_cache(self):

--- a/dali/python/nvidia/dali/experimental/dynamic/_eval_context.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_eval_context.py
@@ -233,9 +233,9 @@ class EvalContext:
         """The :class:`~nvidia.dali.experimental.dynamic.checkpoint.Checkpoint` bound
         to this context.
 
-        Lazily created on first access. The same object is reused across
-        ``__enter__`` / ``__exit__`` of this context, so it is safe to register ops
-        once and refer to them across multiple iterations.
+        When reusing a context (e.g. by using the default one), remember to call
+        ``clear`` on the checkpoint object before using the checkpoint in a new
+        processing pipeline.
         """
         return self._checkpoint
 

--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -186,6 +186,9 @@ def build_constructor(schema, op_class):
 
     if init_args:
         init_args = ["*"] + init_args
+    if is_reader:
+        init_args.append("enable_checkpointing=False")
+
     header_args = (
         [
             "self",

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -729,6 +729,14 @@ class Reader(Operator):
         loader. It can be passed back to :meth:`set_state` to resume processing
         from this point. The state is serialized to a string by ``str(state)``.
 
+        .. warning::
+            The methods ``get_state`` and ``set_state`` are not inherently thread-safe
+            with respect to running the reader. External synchronization is necessary.
+
+        .. note::
+            If there are any pending asynchronous or deferred calls to this operator,
+            the function will wait for them to finish before getting the state.
+
         Parameters
         ----------
         cuda_stream
@@ -755,6 +763,11 @@ class Reader(Operator):
                 f"The reader '{self._schema_name}' was initialized with checkpointing disabled. "
                 f"Pass `enable_checkpointing=True` to the reader's constructor."
             )
+
+        # Make sure that all pending invocations are done before we save the state
+        if self._last_invocation is not None:
+            self._last_invocation.run()
+
         # SaveCheckpoint returns a `bytes` blob (binary protobuf payload).
         # Wrap it as a base64 ASCII string so it round-trips through JSON / `str`.
         raw = self._op_backend.SaveCheckpoint(cuda_stream)
@@ -770,8 +783,14 @@ class Reader(Operator):
             Either a state object obtained from :meth:`get_state`, or its
             string representation (as produced by ``str(state)``).
 
-        Notes
-        -----
+        .. warning::
+            The methods ``get_state`` and ``set_state`` are not inherently thread-safe
+            with respect to running the reader. External synchronization is necessary.
+
+        .. note::
+            If there are any pending asynchronous or deferred calls to this operator,
+            the function will wait for them to finish before setting the state.
+
         If the reader's backend has not yet been initialized (i.e. no epoch has
         been started), the state is buffered and applied automatically the first
         time the backend is created.
@@ -798,6 +817,10 @@ class Reader(Operator):
         raw = base64.b64decode(serialized)
         self._enable_checkpointing()
         if self._op_backend is not None:
+            # if there was a previous invocation in flight, make sure it's finished before we
+            # try load the state
+            if self._last_invocation is not None:
+                self._last_invocation.run()
             self._op_backend.RestoreCheckpoint(raw)
         else:
             self._pending_state = raw

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -761,8 +761,7 @@ class Reader(Operator):
             serialized = state.decode("ascii")
         else:
             raise TypeError(
-                "state must be a ReaderState, str or bytes, "
-                f"got {type(state).__name__}."
+                "state must be a ReaderState, str or bytes, " f"got {type(state).__name__}."
             )
         # The C++ reader can only restore a snapshot before its prefetch thread
         # has started - i.e. before the first iteration. Reject late calls clearly

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -722,7 +722,7 @@ class Reader(Operator):
             self._op_backend.RestoreCheckpoint(self._pending_state)
             self._pending_state = None
 
-    def get_state(self, *, cuda_stream = None) -> "ReaderState":
+    def get_state(self, *, cuda_stream=None) -> "ReaderState":
         """Returns the current checkpoint state of this reader.
 
         The returned state object captures the iteration position of the underlying

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -647,6 +647,7 @@ class Reader(Operator):
         shard_id=_READER_SHARD_DEFAULTS["shard_id"],
         num_shards=_READER_SHARD_DEFAULTS["num_shards"],
         stick_to_shard=_READER_SHARD_DEFAULTS["stick_to_shard"],
+        enable_checkpointing=False,
         **kwargs,
     ):
         if name is None:
@@ -655,6 +656,7 @@ class Reader(Operator):
         self._batch_size = batch_size
         self._compiled_iter = None
         self._compile_mode: bool | None = None
+        self._checkpointing_enabled = enable_checkpointing
         device = _device.device(device)
         # _backend is forwarded via **kwargs, we don't need to touch it here
         self._shard_id = shard_id if shard_id is not None else _READER_SHARD_DEFAULTS["shard_id"]
@@ -688,7 +690,21 @@ class Reader(Operator):
         kwargs["shard_id"] = self._shard_id
         kwargs["num_shards"] = self._num_shards
         kwargs["stick_to_shard"] = self._stick_to_shard
+        kwargs["checkpointing"] = self._checkpointing_enabled
         super().__init__(self._actual_batch_size, name, device, **kwargs)
+
+    def _enable_checkpointing(self):
+        if self._checkpointing_enabled:
+            return
+        if self._compile_mode is True:
+            raise NotImplementedError("Checkpointing is currently not supported in compiled mode.")
+
+        if self._op_backend:
+            raise RuntimeError(
+                f"The operator '{self._schema_name}' was initialized with checkpointing disabled. "
+                f"Pass `enable_checkpointing=True` to the reader's constructor."
+            )
+        self._init_args["checkpointing"] = self._checkpointing_enabled = True
 
     @classmethod
     def _get(cls, *_, **__):
@@ -698,9 +714,6 @@ class Reader(Operator):
         if self._op_spec is not None:
             return
         super()._init_spec_no_lock(inputs, args)
-        # Enable checkpointing so the underlying loader maintains a snapshot queue.
-        # For readers that don't support checkpointing, this is a no-op at runtime.
-        self._op_spec.AddArg("checkpointing", True)
 
     def _init_backend(self, ctx, inputs, args):
         was_initialized = self._op_backend is not None
@@ -709,12 +722,17 @@ class Reader(Operator):
             self._op_backend.RestoreCheckpoint(self._pending_state)
             self._pending_state = None
 
-    def get_state(self) -> "ReaderState":
+    def get_state(self, *, cuda_stream = None) -> "ReaderState":
         """Returns the current checkpoint state of this reader.
 
         The returned state object captures the iteration position of the underlying
         loader. It can be passed back to :meth:`set_state` to resume processing
         from this point. The state is serialized to a string by ``str(state)``.
+
+        Parameters
+        ----------
+        cuda_stream
+            The CUDA stream on which the readers is running or None.
 
         Returns
         -------
@@ -732,9 +750,14 @@ class Reader(Operator):
                 "Cannot get the reader's state before its first iteration. "
                 "Call `next_epoch` once before calling `get_state`."
             )
+        if not self._checkpointing_enabled:
+            raise RuntimeError(
+                f"The reader '{self._schema_name}' was initialized with checkpointing disabled. "
+                f"Pass `enable_checkpointing=True` to the reader's constructor."
+            )
         # SaveCheckpoint returns a `bytes` blob (binary protobuf payload).
         # Wrap it as a base64 ASCII string so it round-trips through JSON / `str`.
-        raw = self._op_backend.SaveCheckpoint()
+        raw = self._op_backend.SaveCheckpoint(cuda_stream)
         serialized = base64.b64encode(raw).decode("ascii")
         return ReaderState(self, serialized)
 
@@ -773,6 +796,7 @@ class Reader(Operator):
                 "call to `next_epoch`, `samples`, `batches` or `__call__`."
             )
         raw = base64.b64decode(serialized)
+        self._enable_checkpointing()
         if self._op_backend is not None:
             self._op_backend.RestoreCheckpoint(raw)
         else:
@@ -853,6 +877,10 @@ class Reader(Operator):
             batch_size = self._batch_size
 
         if compile:
+            if self._checkpointing_enabled:
+                raise NotImplementedError(
+                    "Checkpointing is currently not supported in compiled mode."
+                )
             if self._compile_mode is False:
                 raise RuntimeError(
                     "This reader was previously used without compile=True "

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -808,7 +808,7 @@ class Reader(Operator):
         # The C++ reader can only restore a snapshot before its prefetch thread
         # has started - i.e. before the first iteration. Reject late calls clearly
         # rather than letting the underlying assertion fire.
-        if self._api_type is not None:
+        if self._op_backend is not None:
             raise RuntimeError(
                 "Cannot set the reader's state after iteration has begun. "
                 "Call `set_state` on a freshly constructed reader, before any "

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -14,6 +14,8 @@
 
 from typing import TypedDict
 
+import base64
+
 import nvidia.dali as dali
 import nvidia.dali.backend_impl as _b
 import math
@@ -598,6 +600,39 @@ class Operator:
 _READER_SHARD_DEFAULTS = {"shard_id": 0, "num_shards": 1, "stick_to_shard": False}
 
 
+class ReaderState:
+    """Serialized checkpoint state of a :class:`Reader`.
+
+    Wraps the serialized representation produced by the underlying operator's
+    :func:`SerializeCheckpoint`. It can be converted to a string with :func:`str`,
+    saved to disk, and later passed to :meth:`Reader.set_state` to restore the
+    reader to the captured iteration position.
+
+    The object also keeps a reference to the originating operator so that future
+    extensions can re-serialize the live state on demand.
+    """
+
+    def __init__(self, op: "Reader", serialized: str):
+        self._op = op
+        self._serialized = serialized
+
+    def __str__(self) -> str:
+        return self._serialized
+
+    def __repr__(self) -> str:
+        return f"ReaderState({self._serialized!r})"
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, ReaderState):
+            return self._serialized == other._serialized
+        if isinstance(other, str):
+            return self._serialized == other
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._serialized)
+
+
 class Reader(Operator):
     """Base class for reader operators. Extends Operator with iteration support via next_epoch().
 
@@ -638,6 +673,8 @@ class Reader(Operator):
         self._previous_batch_size: int | None = None
         # Used to make sure that args passed to the constructor are not repeated in __call__
         self._tensor_arg_names: set[str] = set()
+        # If set, the serialized checkpoint state to apply once the backend is constructed.
+        self._pending_state: str | None = None
 
         if self._num_shards < 1:
             raise ValueError(
@@ -656,6 +693,91 @@ class Reader(Operator):
     @classmethod
     def _get(cls, *_, **__):
         raise RuntimeError("Readers cannot be cached. Construct a new instance instead.")
+
+    def _init_spec_no_lock(self, inputs, args):
+        if self._op_spec is not None:
+            return
+        super()._init_spec_no_lock(inputs, args)
+        # Enable checkpointing so the underlying loader maintains a snapshot queue.
+        # For readers that don't support checkpointing, this is a no-op at runtime.
+        self._op_spec.AddArg("checkpointing", True)
+
+    def _init_backend(self, ctx, inputs, args):
+        was_initialized = self._op_backend is not None
+        super()._init_backend(ctx, inputs, args)
+        if not was_initialized and self._pending_state is not None:
+            self._op_backend.RestoreCheckpoint(self._pending_state)
+            self._pending_state = None
+
+    def get_state(self) -> "ReaderState":
+        """Returns the current checkpoint state of this reader.
+
+        The returned state object captures the iteration position of the underlying
+        loader. It can be passed back to :meth:`set_state` to resume processing
+        from this point. The state is serialized to a string by ``str(state)``.
+
+        Returns
+        -------
+        :class:`ReaderState`
+            An opaque state object that wraps a serialized checkpoint string.
+
+        Raises
+        ------
+        RuntimeError
+            If the reader has not started any epoch yet (the backend has not been
+            initialized) or if the underlying reader does not support checkpointing.
+        """
+        if self._op_backend is None:
+            raise RuntimeError(
+                "Cannot get the reader's state before its first iteration. "
+                "Call `next_epoch` once before calling `get_state`."
+            )
+        # SaveCheckpoint returns a `bytes` blob (binary protobuf payload).
+        # Wrap it as a base64 ASCII string so it round-trips through JSON / `str`.
+        raw = self._op_backend.SaveCheckpoint()
+        serialized = base64.b64encode(raw).decode("ascii")
+        return ReaderState(self, serialized)
+
+    def set_state(self, state) -> None:
+        """Restores the reader's iteration position from a saved state.
+
+        Parameters
+        ----------
+        state : :class:`ReaderState` or str
+            Either a state object obtained from :meth:`get_state`, or its
+            string representation (as produced by ``str(state)``).
+
+        Notes
+        -----
+        If the reader's backend has not yet been initialized (i.e. no epoch has
+        been started), the state is buffered and applied automatically the first
+        time the backend is created.
+        """
+        if isinstance(state, ReaderState):
+            serialized = state._serialized
+        elif isinstance(state, str):
+            serialized = state
+        elif isinstance(state, bytes):
+            serialized = state.decode("ascii")
+        else:
+            raise TypeError(
+                "state must be a ReaderState, str or bytes, "
+                f"got {type(state).__name__}."
+            )
+        # The C++ reader can only restore a snapshot before its prefetch thread
+        # has started - i.e. before the first iteration. Reject late calls clearly
+        # rather than letting the underlying assertion fire.
+        if self._api_type is not None:
+            raise RuntimeError(
+                "Cannot set the reader's state after iteration has begun. "
+                "Call `set_state` on a freshly constructed reader, before any "
+                "call to `next_epoch`, `samples`, `batches` or `__call__`."
+            )
+        raw = base64.b64decode(serialized)
+        if self._op_backend is not None:
+            self._op_backend.RestoreCheckpoint(raw)
+        else:
+            self._pending_state = raw
 
     def _shard_epoch_size(self):
         meta = self._op_backend.GetReaderMeta()

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -673,8 +673,8 @@ class Reader(Operator):
         self._previous_batch_size: int | None = None
         # Used to make sure that args passed to the constructor are not repeated in __call__
         self._tensor_arg_names: set[str] = set()
-        # If set, the serialized checkpoint state to apply once the backend is constructed.
-        self._pending_state: str | None = None
+        # If set, the checkpoint state to apply once the backend is constructed.
+        self._pending_state = None
 
         if self._num_shards < 1:
             raise ValueError(

--- a/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
@@ -198,7 +198,7 @@ class Checkpoint:
     # Registration / state access
     # ------------------------------------------------------------------
 
-    def register(self, op : Any, name : str | None = None) -> str:
+    def register(self, op: Any, name: str | None = None) -> str:
         """Adds a stateful op to the checkpoint.
 
         Parameters
@@ -278,9 +278,7 @@ class Checkpoint:
             )
         if self._loaded:
             if key not in self._states:
-                raise KeyError(
-                    f"Checkpoint was loaded but does not contain a state for {key!r}."
-                )
+                raise KeyError(f"Checkpoint was loaded but does not contain a state for {key!r}.")
         self._ops[key] = op
         self._reverse[id(op)] = key
         self._maybe_apply(key)
@@ -315,7 +313,7 @@ class Checkpoint:
             raise KeyError(f"No op registered under {key!r}.")
         return self._states.get(key)
 
-    def set_state(self, name : str, value : Any) -> None:
+    def set_state(self, name: str, value: Any) -> None:
         """Manually sets the state for an operator (registered or future)
 
         Parameters
@@ -395,8 +393,7 @@ class Checkpoint:
         missing = set(self._ops.keys()) - set(self._states.keys())
         if missing:
             raise RuntimeError(
-                "Checkpoint state is incomplete - missing entries for "
-                f"{sorted(missing)}."
+                "Checkpoint state is incomplete - missing entries for " f"{sorted(missing)}."
             )
         for key in list(self._dirty):
             self._ops[key].set_state(self._states[key])
@@ -416,12 +413,11 @@ class Checkpoint:
         """
         if not self._states:
             raise RuntimeError(
-                "Cannot serialize an empty checkpoint. Call `collect` (or "
-                "`set_state`) first."
+                "Cannot serialize an empty checkpoint. Call `collect` (or " "`set_state`) first."
             )
         payload = {
             "version": _CHECKPOINT_FORMAT_VERSION,
-            "states": { k : str(v) for k, v in self._states.items() },
+            "states": {k: str(v) for k, v in self._states.items()},
         }
         return json.dumps(payload)
 

--- a/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
@@ -1,0 +1,539 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checkpointing support for DALI dynamic mode.
+
+The dynamic mode pipelines are stateful by way of two operator categories:
+
+* :class:`~nvidia.dali.experimental.dynamic._ops.Reader` instances - they hold
+  the iteration position over the dataset.
+* :class:`~nvidia.dali.experimental.dynamic.random.RNG` instances - they hold
+  the random number generator state.
+
+The :class:`Checkpoint` class collects the state of a chosen subset of these
+objects so that processing can be resumed at the captured point. See
+:func:`current` for a thread-local, ``EvalContext``-bound default checkpoint.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import string
+from typing import Any, Optional
+
+from . import _eval_context
+
+__all__ = ["Checkpoint", "current"]
+
+
+# Format-string version. Bumped if the on-disk layout becomes incompatible.
+_CHECKPOINT_FORMAT_VERSION = 1
+
+
+class _Sentinel:
+    """A unique marker used to signal "no name was provided"."""
+
+
+_NO_NAME = _Sentinel()
+
+
+def _pattern_to_regex(pattern: str) -> re.Pattern:
+    """Translates a Python format string with a ``{seq}`` field into a regex.
+
+    The regex captures the value of ``seq`` as group ``seq``. Other format fields
+    are not supported.
+    """
+    parts = []
+    parts.append("^")
+    seq_seen = False
+    for literal, field_name, format_spec, _conv in string.Formatter().parse(pattern):
+        parts.append(re.escape(literal))
+        if field_name is None:
+            continue
+        if field_name != "seq":
+            raise ValueError(
+                f"Unsupported field {{{field_name}}} in checkpoint pattern. "
+                "Only `{seq}` (with an optional format spec) is allowed."
+            )
+        if seq_seen:
+            raise ValueError("`{seq}` may appear at most once in a checkpoint pattern.")
+        seq_seen = True
+        # Allow the digits to be padded as a numeric format spec might require, but
+        # we don't try to interpret the format spec - any sequence of digits matches.
+        parts.append(r"(?P<seq>\d+)")
+    parts.append("$")
+    if not seq_seen:
+        raise ValueError("Checkpoint pattern must include `{seq}`.")
+    return re.compile("".join(parts))
+
+
+def _matching_files(pattern: str):
+    """Yields ``(seq, path)`` pairs for paths in the filesystem matching pattern."""
+    # Build a glob equivalent by replacing `{seq...}` with `*`.
+    glob_parts = []
+    seq_seen = False
+    for literal, field_name, _format_spec, _conv in string.Formatter().parse(pattern):
+        glob_parts.append(literal)
+        if field_name is None:
+            continue
+        if field_name != "seq":
+            raise ValueError(
+                f"Unsupported field {{{field_name}}} in checkpoint pattern. "
+                "Only `{seq}` (with an optional format spec) is allowed."
+            )
+        if seq_seen:
+            raise ValueError("`{seq}` may appear at most once in a checkpoint pattern.")
+        seq_seen = True
+        glob_parts.append("*")
+    if not seq_seen:
+        raise ValueError("Checkpoint pattern must include `{seq}`.")
+    glob_pattern = "".join(glob_parts)
+    regex = _pattern_to_regex(pattern)
+    for path in glob.iglob(glob_pattern):
+        m = regex.match(path)
+        if m is None:
+            continue
+        yield int(m.group("seq")), path
+
+
+class Checkpoint:
+    """Aggregates the state of stateful objects (readers and RNGs) for resume.
+
+    A checkpoint stores a mapping from a key (operator name) to that operator's
+    serialized state. Objects can be added with :meth:`register`, after which
+    their state can be collected with :meth:`collect` or restored with
+    :meth:`restore`. The serialized representation can be persisted with
+    :meth:`save` and loaded back with :meth:`load`.
+
+    The supported objects are:
+
+    * :class:`~nvidia.dali.experimental.dynamic._ops.Reader` instances
+      (the ``ndd.readers.*`` operators)
+    * :class:`~nvidia.dali.experimental.dynamic.random.RNG` instances
+
+    Both expose ``get_state`` and ``set_state`` methods, which is the duck-typed
+    contract used by this class.
+
+    Examples
+    --------
+    >>> import nvidia.dali.experimental.dynamic as ndd
+    >>>
+    >>> reader = ndd.readers.File(file_root="...")
+    >>> rng = ndd.random.RNG(seed=42)
+    >>>
+    >>> ckpt = ndd.checkpoint.Checkpoint()
+    >>> ckpt.register(reader, "reader")
+    >>> ckpt.register(rng, "rng")
+    >>>
+    >>> # ... iterate for a while ...
+    >>>
+    >>> ckpt.collect()
+    >>> ckpt.save("ckpt_{seq:04d}.json")
+    """
+
+    def __init__(self):
+        # name -> registered op instance
+        self._ops: dict[str, Any] = {}
+        # name -> serialized state string (`str` for both readers and RNGs)
+        self._states: dict[str, str] = {}
+        # set of names whose state in `self._states` is "dirty" - has been set but
+        # not yet propagated to the corresponding op via `op.set_state`.
+        self._dirty: set[str] = set()
+        # True after a successful :meth:`collect` (and cleared by :meth:`load`).
+        self._complete: bool = False
+        # True after a successful :meth:`load` (and cleared by :meth:`collect`).
+        self._loaded: bool = False
+        # Counter for auto-generated keys.
+        self._seq_counter: int = 0
+        # Counter used by :meth:`save` to pick a sequential file name. Initialized
+        # lazily on first save by scanning the filesystem.
+        self._save_seq: Optional[int] = None
+
+    # ------------------------------------------------------------------
+    # State management
+    # ------------------------------------------------------------------
+
+    def clear(self) -> None:
+        """Resets the checkpoint to its initial state.
+
+        Drops all registered ops, all stored states, and resets the ``complete``
+        and ``loaded`` flags as well as the auto-generated key counter.
+        """
+        self._ops.clear()
+        self._states.clear()
+        self._dirty.clear()
+        self._complete = False
+        self._loaded = False
+        self._seq_counter = 0
+        self._save_seq = None
+
+    @property
+    def is_complete(self) -> bool:
+        """``True`` if :meth:`collect` was the last operation to populate the state."""
+        return self._complete
+
+    @property
+    def is_loaded(self) -> bool:
+        """``True`` if :meth:`load` (or :meth:`deserialize`) populated the state."""
+        return self._loaded
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Names of all currently registered ops."""
+        return tuple(self._ops.keys())
+
+    def __len__(self) -> int:
+        return len(self._ops)
+
+    def __contains__(self, name) -> bool:
+        return str(name) in self._ops
+
+    # ------------------------------------------------------------------
+    # Registration / state access
+    # ------------------------------------------------------------------
+
+    def register(self, op, name=_NO_NAME) -> str:
+        """Adds a stateful op to the checkpoint.
+
+        Parameters
+        ----------
+        op : Reader or RNG
+            The stateful object to register. Must expose ``get_state`` /
+            ``set_state`` methods.
+        name : str, optional
+            The key under which to store the op. If omitted, a sequential numeric
+            key is generated, unless ``op`` was already registered (under any
+            name), in which case its existing key is returned. If ``name`` is
+            provided, any existing op under that key is replaced.
+
+        Returns
+        -------
+        str
+            The key under which ``op`` is registered.
+
+        Notes
+        -----
+        If a state is currently associated with ``name`` and is marked dirty
+        (e.g. it came from a recent :meth:`load`), the state is immediately
+        applied to ``op`` via ``op.set_state`` and the entry is marked clean.
+        """
+        if name is _NO_NAME:
+            # Anonymous registration - reverse-lookup the op first so that
+            # registering the same op twice is a no-op.
+            for key, registered_op in self._ops.items():
+                if registered_op is op:
+                    self._maybe_apply(key)
+                    return key
+            if self._complete:
+                raise RuntimeError(
+                    "Cannot register a new op into a checkpoint that has been "
+                    "completed via `collect`. Call `clear` first."
+                )
+            # Pick the next free sequential key.
+            while True:
+                key = str(self._seq_counter)
+                self._seq_counter += 1
+                if key not in self._ops:
+                    break
+            if self._loaded and key not in self._states:
+                raise KeyError(
+                    f"Loaded checkpoint has no state for inferred key {key!r}. "
+                    "If your registration order changed since the checkpoint was "
+                    "saved, use the named form `register(op, name)` instead."
+                )
+            self._ops[key] = op
+            self._maybe_apply(key)
+            return key
+
+        key = str(name)
+        if key in self._ops:
+            # Existing entry - replace and apply pending state if any.
+            self._ops[key] = op
+            self._maybe_apply(key)
+            return key
+
+        # New named entry.
+        if self._complete:
+            raise RuntimeError(
+                f"Cannot register a new op {key!r} into a completed checkpoint. "
+                "Call `clear` first."
+            )
+        if self._loaded:
+            if key not in self._states:
+                raise KeyError(
+                    f"Checkpoint was loaded but does not contain a state for {key!r}."
+                )
+        self._ops[key] = op
+        self._maybe_apply(key)
+        return key
+
+    def _maybe_apply(self, key: str) -> None:
+        if key in self._dirty:
+            self._ops[key].set_state(self._states[key])
+            self._dirty.discard(key)
+
+    def get_state(self, name) -> Optional[str]:
+        """Returns the stored state for the op registered under ``name``.
+
+        Parameters
+        ----------
+        name : str
+            The key under which the op is registered.
+
+        Returns
+        -------
+        str or None
+            The serialized state string, or ``None`` if no state has been
+            collected/loaded for that key yet.
+
+        Raises
+        ------
+        KeyError
+            If no op is registered under ``name``.
+        """
+        key = str(name)
+        if key not in self._ops:
+            raise KeyError(f"No op registered under {key!r}.")
+        return self._states.get(key)
+
+    def set_state(self, name, value) -> None:
+        """Manually sets the state for an already-registered op.
+
+        Parameters
+        ----------
+        name : str
+            The key under which the op is registered.
+        value
+            The state value. Will be stringified via ``str(value)``. Strings are
+            stored verbatim.
+
+        Raises
+        ------
+        KeyError
+            If no op is registered under ``name``.
+
+        Notes
+        -----
+        The state is marked *dirty*. It is applied to the op the next time
+        :meth:`register` is called for that key, or when :meth:`restore` is
+        invoked.
+        """
+        key = str(name)
+        if key not in self._ops:
+            raise KeyError(f"No op registered under {key!r}.")
+        self._states[key] = value if isinstance(value, str) else str(value)
+        self._dirty.add(key)
+
+    # ------------------------------------------------------------------
+    # Collect / restore
+    # ------------------------------------------------------------------
+
+    def collect(self) -> None:
+        """Collects the state of every registered op into the checkpoint.
+
+        Sets the ``complete`` flag, clears the ``loaded`` flag, and marks all
+        states as clean. Verifies that the state dictionary does not contain any
+        keys without a corresponding registered op.
+        """
+        extra = set(self._states.keys()) - set(self._ops.keys())
+        if extra:
+            raise RuntimeError(
+                "Checkpoint state has entries with no corresponding registered "
+                f"ops: {sorted(extra)}."
+            )
+        new_states: dict[str, str] = {}
+        for key, op in self._ops.items():
+            state = op.get_state()
+            new_states[key] = state if isinstance(state, str) else str(state)
+        self._states = new_states
+        self._dirty.clear()
+        self._complete = True
+        self._loaded = False
+
+    def restore(self) -> None:
+        """Restores the state of every registered op from the checkpoint.
+
+        Intended for manual use - typically you'd register ops one by one and
+        rely on :meth:`register` to apply the state implicitly. This method
+        applies all dirty states at once.
+
+        Raises
+        ------
+        RuntimeError
+            If the state dictionary contains entries with no corresponding
+            registered ops, or if any registered op is missing a state in the
+            dictionary (unless the dictionary is empty, in which case this is a
+            no-op).
+        """
+        if not self._states:
+            return
+        extra = set(self._states.keys()) - set(self._ops.keys())
+        if extra:
+            raise RuntimeError(
+                "Checkpoint state has entries with no corresponding registered "
+                f"ops: {sorted(extra)}."
+            )
+        missing = set(self._ops.keys()) - set(self._states.keys())
+        if missing:
+            raise RuntimeError(
+                "Checkpoint state is incomplete - missing entries for "
+                f"{sorted(missing)}."
+            )
+        for key in list(self._dirty):
+            self._ops[key].set_state(self._states[key])
+        self._dirty.clear()
+
+    # ------------------------------------------------------------------
+    # (De)serialization and persistence
+    # ------------------------------------------------------------------
+
+    def serialize(self) -> str:
+        """Serializes the checkpoint state dictionary to a JSON string.
+
+        Raises
+        ------
+        RuntimeError
+            If the state dictionary is empty.
+        """
+        if not self._states:
+            raise RuntimeError(
+                "Cannot serialize an empty checkpoint. Call `collect` (or "
+                "`set_state`) first."
+            )
+        payload = {
+            "version": _CHECKPOINT_FORMAT_VERSION,
+            "states": self._states,
+        }
+        return json.dumps(payload)
+
+    def deserialize(self, data: str) -> None:
+        """Replaces the checkpoint state dictionary with a deserialized version.
+
+        Parameters
+        ----------
+        data : str
+            A string previously produced by :meth:`serialize`.
+
+        Notes
+        -----
+        Sets the ``loaded`` flag and clears the ``complete`` flag. Marks every
+        loaded entry as dirty so that subsequent :meth:`register` calls (or
+        :meth:`restore`) will apply the state.
+        """
+        payload = json.loads(data)
+        if not isinstance(payload, dict) or "states" not in payload:
+            raise ValueError("Invalid checkpoint payload.")
+        version = payload.get("version", 0)
+        if version != _CHECKPOINT_FORMAT_VERSION:
+            raise ValueError(
+                f"Unsupported checkpoint format version {version}; expected "
+                f"{_CHECKPOINT_FORMAT_VERSION}."
+            )
+        states = payload["states"]
+        if not isinstance(states, dict):
+            raise ValueError("Invalid checkpoint payload: `states` must be a dict.")
+        self._states = {str(k): str(v) for k, v in states.items()}
+        self._dirty = set(self._states.keys())
+        self._complete = False
+        self._loaded = True
+
+    def save(self, pattern: str) -> str:
+        """Serializes the checkpoint and writes it to a file.
+
+        Parameters
+        ----------
+        pattern : str
+            A Python format string containing ``{seq}`` (e.g. ``"ckpt_{seq:04d}.json"``).
+            The placeholder is replaced with a sequential number that does not
+            collide with any existing file.
+
+        Returns
+        -------
+        str
+            The path of the file that was written.
+
+        Raises
+        ------
+        RuntimeError
+            If the state dictionary is empty.
+        """
+        seq = self._next_save_seq(pattern)
+        path = pattern.format(seq=seq)
+        # Avoid overwriting an existing file - bump the counter if one appeared in
+        # the meantime.
+        while os.path.exists(path):
+            seq += 1
+            path = pattern.format(seq=seq)
+        data = self.serialize()
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(data)
+        self._save_seq = seq + 1
+        return path
+
+    def load(self, pattern: str) -> str:
+        """Reads a previously saved checkpoint from a file.
+
+        Parameters
+        ----------
+        pattern : str
+            A Python format string containing ``{seq}`` (e.g. ``"ckpt_{seq:04d}.json"``).
+            If multiple files match, the one with the highest sequence number
+            is loaded.
+
+        Returns
+        -------
+        str
+            The path of the file that was read.
+
+        Raises
+        ------
+        FileNotFoundError
+            If no file matching the pattern exists.
+
+        Notes
+        -----
+        Marks all loaded entries as dirty (see :meth:`deserialize`).
+        """
+        candidates = list(_matching_files(pattern))
+        if not candidates:
+            raise FileNotFoundError(f"No checkpoint file matches pattern {pattern!r}.")
+        candidates.sort(key=lambda x: x[0])
+        seq, path = candidates[-1]
+        with open(path, "r", encoding="utf-8") as f:
+            data = f.read()
+        self.deserialize(data)
+        self._save_seq = seq + 1
+        return path
+
+    def _next_save_seq(self, pattern: str) -> int:
+        """Returns the next sequence number to use for :meth:`save`."""
+        if self._save_seq is not None:
+            return self._save_seq
+        # First save - scan the filesystem so we don't clobber existing files.
+        max_existing = -1
+        for seq, _ in _matching_files(pattern):
+            if seq > max_existing:
+                max_existing = seq
+        return max_existing + 1
+
+
+def current() -> Checkpoint:
+    """Returns the :class:`Checkpoint` bound to the current :class:`EvalContext`."""
+    return _eval_context.EvalContext.current().checkpoint

--- a/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
@@ -29,11 +29,12 @@ objects so that processing can be resumed at the captured point. See
 from __future__ import annotations
 
 import glob
+import inspect
 import json
 import os
 import re
 import string
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 from . import _eval_context, _ops
 
@@ -41,7 +42,22 @@ __all__ = ["Checkpoint", "current"]
 
 
 # Format-string version. Bumped if the on-disk layout becomes incompatible.
-_CHECKPOINT_FORMAT_VERSION = 1
+_CHECKPOINT_FORMAT_VERSION = 2
+
+
+class _StateEntry(NamedTuple):
+    """Per-operator entry in the checkpoint state map.
+
+    ``state`` is the serialized state (as returned by ``op.get_state`` or, after
+    deserialization, its string form). ``type_name`` is the qualified name of the
+    operator's class - populated by :meth:`Checkpoint.collect`, by an explicit
+    :meth:`Checkpoint.set_state` ``type`` argument, or by a deserialized payload.
+    When set, it is verified against the actual operator's type before the state
+    is applied (see :meth:`Checkpoint._maybe_apply`).
+    """
+
+    state: Any
+    type_name: Optional[str] = None
 
 
 def _pattern_to_regex(pattern: str) -> re.Pattern:
@@ -143,8 +159,11 @@ class Checkpoint:
         self._ops: dict[str, Any] = {}
         # id -> name for reverse lookup of operator instances
         self._reverse: dict[int, str] = {}
-        # name -> serialized state string (`str` for both readers and RNGs)
-        self._states: dict[str, Any] = {}
+        # name -> entry holding the serialized state and the operator's
+        # (optional) type name. The type name is populated by `collect` or by an
+        # explicit `set_state(..., op_type=...)` call, and is verified in
+        # `_maybe_apply` when the state is propagated to the op.
+        self._states: dict[str, _StateEntry] = {}
         # set of names whose state in `self._states` is "dirty" - has been set but
         # not yet propagated to the corresponding op via `op.set_state`.
         self._dirty: set[str] = set()
@@ -268,6 +287,12 @@ class Checkpoint:
         if old_op := self._ops.get(key, None):
             # Existing entry - replace and apply pending state if any.
             if old_op is not op:
+                if type(old_op) is not type(op):
+                    raise TypeError(
+                        f"Cannot replace operator {key!r} of type "
+                        f"{type(old_op).__qualname__!r} with an operator of type "
+                        f"{type(op).__qualname__!r}."
+                    )
                 del self._reverse[id(old_op)]
                 self._ops[key] = op
                 self._reverse[id(op)] = key
@@ -290,7 +315,15 @@ class Checkpoint:
 
     def _maybe_apply(self, key: str) -> None:
         if key in self._dirty:
-            self._ops[key].set_state(self._states[key])
+            entry = self._states[key]
+            op = self._ops[key]
+            if entry.type_name is not None and type(op).__qualname__ != entry.type_name:
+                raise TypeError(
+                    f"Type mismatch for operator {key!r}: checkpoint stores state "
+                    f"for type {entry.type_name!r}, but the registered operator is "
+                    f"of type {type(op).__qualname__!r}."
+                )
+            op.set_state(entry.state)
             self._dirty.discard(key)
 
     def get_state(self, name):
@@ -315,9 +348,10 @@ class Checkpoint:
         key = str(name)
         if key not in self._ops:
             raise KeyError(f"No op registered under {key!r}.")
-        return self._states.get(key)
+        entry = self._states.get(key)
+        return None if entry is None else entry.state
 
-    def set_state(self, name: str, value: Any) -> None:
+    def set_state(self, name: str, value: Any, op_type: Optional[Any] = None) -> None:
         """Manually sets the state for an operator (registered or future)
 
         Parameters
@@ -327,11 +361,18 @@ class Checkpoint:
         value
             The state value. It can be of any type that the respective
             operator's ``set_state`` accepts.
+        op_type : class or str, optional
+            The class (or its qualified name) of the operator that this state
+            belongs to. When provided, the type name is stored alongside the
+            state and verified against the actual operator's type before the
+            state is applied (in :meth:`_maybe_apply`).
 
         Raises
         ------
         KeyError
             If the checkpoint is complete and no operator is registered under ``name``.
+        TypeError
+            If ``op_type`` is neither a type nor a string.
 
         Notes
         -----
@@ -342,7 +383,15 @@ class Checkpoint:
         key = str(name)
         if self._complete and key not in self._ops:
             raise KeyError(f"No operator registered under {key!r}.")
-        self._states[key] = value
+        if op_type is None:
+            type_name = None
+        elif isinstance(op_type, str):
+            type_name = op_type
+        elif isinstance(op_type, type):
+            type_name = op_type.__qualname__
+        else:
+            raise TypeError(f"`op_type` must be a class or a string, got {op_type!r}.")
+        self._states[key] = _StateEntry(state=value, type_name=type_name)
         self._dirty.add(key)
 
     # ------------------------------------------------------------------
@@ -362,13 +411,13 @@ class Checkpoint:
                 "Checkpoint state has entries with no corresponding registered "
                 f"ops: {sorted(extra)}."
             )
-        new_states: dict[str, str] = {}
+        new_states: dict[str, _StateEntry] = {}
         stream = None
         for key, op in self._ops.items():
             if stream is None and isinstance(op, _ops.Operator) and op._backend != "cpu":
                 stream = _eval_context.EvalContext.current().cuda_stream
-            state = op.get_state(cuda_stream = stream)
-            new_states[key] = state
+            state = op.get_state(cuda_stream=stream)
+            new_states[key] = _StateEntry(state=state, type_name=type(op).__qualname__)
         self._states = new_states
         self._dirty.clear()
         self._complete = True
@@ -403,8 +452,7 @@ class Checkpoint:
                 "Checkpoint state is incomplete - missing entries for " f"{sorted(missing)}."
             )
         for key in list(self._dirty):
-            self._ops[key].set_state(self._states[key])
-        self._dirty.clear()
+            self._maybe_apply(key)
 
     # ------------------------------------------------------------------
     # (De)serialization and persistence
@@ -424,7 +472,9 @@ class Checkpoint:
             )
         payload = {
             "version": _CHECKPOINT_FORMAT_VERSION,
-            "states": {k: str(v) for k, v in self._states.items()},
+            "states": {
+                k: {"state": str(v.state), "type": v.type_name} for k, v in self._states.items()
+            },
         }
         return json.dumps(payload)
 
@@ -454,7 +504,15 @@ class Checkpoint:
         states = payload["states"]
         if not isinstance(states, dict):
             raise ValueError("Invalid checkpoint payload: `states` must be a dict.")
-        self._states = {str(k): str(v) for k, v in states.items()}
+        new_states: dict[str, _StateEntry] = {}
+        for k, v in states.items():
+            if not isinstance(v, dict) or "state" not in v:
+                raise ValueError(f"Invalid checkpoint entry for {k!r}.")
+            type_name = v.get("type")
+            if type_name is not None and not isinstance(type_name, str):
+                raise ValueError(f"Invalid `type` for entry {k!r}: expected a string.")
+            new_states[str(k)] = _StateEntry(state=str(v["state"]), type_name=type_name)
+        self._states = new_states
         self._dirty = set(self._states.keys())
         self._complete = False  # we can (and likely will) register operators in this checkpoint
         self._loaded = True

--- a/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
@@ -169,6 +169,7 @@ class Checkpoint:
         self._ops.clear()
         self._states.clear()
         self._dirty.clear()
+        self._reverse.clear()
         self._complete = False
         self._loaded = False
         self._save_seq = None

--- a/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
@@ -35,7 +35,7 @@ import re
 import string
 from typing import Any, Optional
 
-from . import _eval_context
+from . import _eval_context, _ops
 
 __all__ = ["Checkpoint", "current"]
 
@@ -208,7 +208,7 @@ class Checkpoint:
             The stateful object to register. Must expose ``get_state`` /
             ``set_state`` methods.
         name : str, optional
-            The key under which to store the op. If omitted, a sequential numeric
+            The key under which to store the op. If omitted, a sequential
             key is generated, unless ``op`` was already registered (under any
             name), in which case its existing key is returned. If ``name`` is
             provided, any existing operator under that key is replaced.
@@ -227,6 +227,9 @@ class Checkpoint:
         applied to ``op`` via ``op.set_state`` and the entry is marked clean.
         """
         old_key = self._reverse.get(id(op), None)
+
+        if isinstance(op, _ops.Reader):
+            op._enable_checkpointing()
 
         if name is None:
             # Anonymous registration - reverse-lookup the op first so that
@@ -290,7 +293,7 @@ class Checkpoint:
             self._ops[key].set_state(self._states[key])
             self._dirty.discard(key)
 
-    def get_state(self, name) -> Optional[str]:
+    def get_state(self, name):
         """Returns the stored state for the op registered under ``name``.
 
         Parameters
@@ -328,7 +331,7 @@ class Checkpoint:
         Raises
         ------
         KeyError
-            If no operator is registered under ``name``.
+            If the checkpoint is complete and no operator is registered under ``name``.
 
         Notes
         -----
@@ -360,8 +363,11 @@ class Checkpoint:
                 f"ops: {sorted(extra)}."
             )
         new_states: dict[str, str] = {}
+        stream = None
         for key, op in self._ops.items():
-            state = op.get_state()
+            if stream is None and isinstance(op, _ops.Operator) and op._backend != "cpu":
+                stream = _eval_context.EvalContext.current().cuda_stream
+            state = op.get_state(cuda_stream = stream)
             new_states[key] = state
         self._states = new_states
         self._dirty.clear()

--- a/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
@@ -29,7 +29,6 @@ objects so that processing can be resumed at the captured point. See
 from __future__ import annotations
 
 import glob
-import inspect
 import json
 import os
 import re
@@ -92,11 +91,13 @@ def _pattern_to_regex(pattern: str) -> re.Pattern:
 
 def _matching_files(pattern: str):
     """Yields ``(seq, path)`` pairs for paths in the filesystem matching pattern."""
-    # Build a glob equivalent by replacing `{seq...}` with `*`.
+    # Build a glob equivalent by replacing `{seq...}` with `*`. The regex below uses
+    # `re.escape` on the same literals, so the two views must agree on bracket /
+    # `?` / `*` characters in the path - escape them on the glob side too.
     glob_parts = []
     seq_seen = False
     for literal, field_name, _format_spec, _conv in string.Formatter().parse(pattern):
-        glob_parts.append(literal)
+        glob_parts.append(glob.escape(literal))
         if field_name is None:
             continue
         if field_name != "seq":

--- a/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
@@ -44,13 +44,6 @@ __all__ = ["Checkpoint", "current"]
 _CHECKPOINT_FORMAT_VERSION = 1
 
 
-class _Sentinel:
-    """A unique marker used to signal "no name was provided"."""
-
-
-_NO_NAME = _Sentinel()
-
-
 def _pattern_to_regex(pattern: str) -> re.Pattern:
     """Translates a Python format string with a ``{seq}`` field into a regex.
 
@@ -148,8 +141,10 @@ class Checkpoint:
     def __init__(self):
         # name -> registered op instance
         self._ops: dict[str, Any] = {}
+        # id -> name for reverse lookup of operator instances
+        self._reverse: dict[int, str] = {}
         # name -> serialized state string (`str` for both readers and RNGs)
-        self._states: dict[str, str] = {}
+        self._states: dict[str, Any] = {}
         # set of names whose state in `self._states` is "dirty" - has been set but
         # not yet propagated to the corresponding op via `op.set_state`.
         self._dirty: set[str] = set()
@@ -157,8 +152,6 @@ class Checkpoint:
         self._complete: bool = False
         # True after a successful :meth:`load` (and cleared by :meth:`collect`).
         self._loaded: bool = False
-        # Counter for auto-generated keys.
-        self._seq_counter: int = 0
         # Counter used by :meth:`save` to pick a sequential file name. Initialized
         # lazily on first save by scanning the filesystem.
         self._save_seq: Optional[int] = None
@@ -178,7 +171,6 @@ class Checkpoint:
         self._dirty.clear()
         self._complete = False
         self._loaded = False
-        self._seq_counter = 0
         self._save_seq = None
 
     @property
@@ -206,7 +198,7 @@ class Checkpoint:
     # Registration / state access
     # ------------------------------------------------------------------
 
-    def register(self, op, name=_NO_NAME) -> str:
+    def register(self, op : Any, name : str | None = None) -> str:
         """Adds a stateful op to the checkpoint.
 
         Parameters
@@ -218,7 +210,9 @@ class Checkpoint:
             The key under which to store the op. If omitted, a sequential numeric
             key is generated, unless ``op`` was already registered (under any
             name), in which case its existing key is returned. If ``name`` is
-            provided, any existing op under that key is replaced.
+            provided, any existing operator under that key is replaced.
+            The key must not start with ``"__op_"`` - this prefix is reserved for
+            automatically generated names.
 
         Returns
         -------
@@ -231,38 +225,48 @@ class Checkpoint:
         (e.g. it came from a recent :meth:`load`), the state is immediately
         applied to ``op`` via ``op.set_state`` and the entry is marked clean.
         """
-        if name is _NO_NAME:
+        old_key = self._reverse.get(id(op), None)
+
+        if name is None:
             # Anonymous registration - reverse-lookup the op first so that
             # registering the same op twice is a no-op.
-            for key, registered_op in self._ops.items():
-                if registered_op is op:
-                    self._maybe_apply(key)
-                    return key
+            if old_key:
+                self._maybe_apply(old_key)
+                return old_key
             if self._complete:
                 raise RuntimeError(
-                    "Cannot register a new op into a checkpoint that has been "
+                    "Cannot register a new operator into a checkpoint that has been "
                     "completed via `collect`. Call `clear` first."
                 )
-            # Pick the next free sequential key.
-            while True:
-                key = str(self._seq_counter)
-                self._seq_counter += 1
-                if key not in self._ops:
-                    break
+            # Use a sequential key
+            key = f"__op_{len(self._ops)}"
             if self._loaded and key not in self._states:
                 raise KeyError(
-                    f"Loaded checkpoint has no state for inferred key {key!r}. "
+                    f"Loaded checkpoint has no state for the operator's key {key!r}. "
                     "If your registration order changed since the checkpoint was "
                     "saved, use the named form `register(op, name)` instead."
                 )
             self._ops[key] = op
+            self._reverse[id(op)] = key
             self._maybe_apply(key)
             return key
 
-        key = str(name)
-        if key in self._ops:
+        if name.startswith("__op_"):
+            raise ValueError("Manually assigned names must not start with '__op_'.")
+        if not name:
+            raise ValueError("The name must not be empty.")
+        key = name
+        if old_key is not None and old_key != key:
+            raise RuntimeError(
+                f"Cannot register the operator with a new key {key!r} "
+                f"when it's already been added with the key {old_key!r}."
+            )
+        if old_op := self._ops.get(key, None):
             # Existing entry - replace and apply pending state if any.
-            self._ops[key] = op
+            if old_op is not op:
+                del self._reverse[id(old_op)]
+                self._ops[key] = op
+                self._reverse[id(op)] = key
             self._maybe_apply(key)
             return key
 
@@ -278,6 +282,7 @@ class Checkpoint:
                     f"Checkpoint was loaded but does not contain a state for {key!r}."
                 )
         self._ops[key] = op
+        self._reverse[id(op)] = key
         self._maybe_apply(key)
         return key
 
@@ -296,9 +301,9 @@ class Checkpoint:
 
         Returns
         -------
-        str or None
-            The serialized state string, or ``None`` if no state has been
-            collected/loaded for that key yet.
+            The state object passed to ``set_state`` or obtained from the
+            operator during ``collect``. If the checkpoint was deserialized
+            or loaded from a file, it'll be stringified.
 
         Raises
         ------
@@ -310,21 +315,21 @@ class Checkpoint:
             raise KeyError(f"No op registered under {key!r}.")
         return self._states.get(key)
 
-    def set_state(self, name, value) -> None:
-        """Manually sets the state for an already-registered op.
+    def set_state(self, name : str, value : Any) -> None:
+        """Manually sets the state for an operator (registered or future)
 
         Parameters
         ----------
         name : str
             The key under which the op is registered.
         value
-            The state value. Will be stringified via ``str(value)``. Strings are
-            stored verbatim.
+            The state value. It can be of any type that the respective
+            operator's ``set_state`` accepts.
 
         Raises
         ------
         KeyError
-            If no op is registered under ``name``.
+            If no operator is registered under ``name``.
 
         Notes
         -----
@@ -333,9 +338,9 @@ class Checkpoint:
         invoked.
         """
         key = str(name)
-        if key not in self._ops:
-            raise KeyError(f"No op registered under {key!r}.")
-        self._states[key] = value if isinstance(value, str) else str(value)
+        if self._complete and key not in self._ops:
+            raise KeyError(f"No operator registered under {key!r}.")
+        self._states[key] = value
         self._dirty.add(key)
 
     # ------------------------------------------------------------------
@@ -358,7 +363,7 @@ class Checkpoint:
         new_states: dict[str, str] = {}
         for key, op in self._ops.items():
             state = op.get_state()
-            new_states[key] = state if isinstance(state, str) else str(state)
+            new_states[key] = state
         self._states = new_states
         self._dirty.clear()
         self._complete = True
@@ -416,7 +421,7 @@ class Checkpoint:
             )
         payload = {
             "version": _CHECKPOINT_FORMAT_VERSION,
-            "states": self._states,
+            "states": { k : str(v) for k, v in self._states.items() },
         }
         return json.dumps(payload)
 
@@ -448,18 +453,18 @@ class Checkpoint:
             raise ValueError("Invalid checkpoint payload: `states` must be a dict.")
         self._states = {str(k): str(v) for k, v in states.items()}
         self._dirty = set(self._states.keys())
-        self._complete = False
+        self._complete = False  # we can (and likely will) register operators in this checkpoint
         self._loaded = True
 
-    def save(self, pattern: str) -> str:
+    def save(self, filename: str) -> str:
         """Serializes the checkpoint and writes it to a file.
 
         Parameters
         ----------
-        pattern : str
-            A Python format string containing ``{seq}`` (e.g. ``"ckpt_{seq:04d}.json"``).
-            The placeholder is replaced with a sequential number that does not
-            collide with any existing file.
+        filename : str
+            A Python format string, optionally containing ``{seq}``
+            (e.g. ``"ckpt_{seq:04d}.json"``). The placeholder is replaced with a sequential number
+            that does not collide with any existing file.
 
         Returns
         -------
@@ -471,13 +476,13 @@ class Checkpoint:
         RuntimeError
             If the state dictionary is empty.
         """
-        seq = self._next_save_seq(pattern)
-        path = pattern.format(seq=seq)
+        seq = self._next_save_seq(filename)
+        path = filename.format(seq=seq)
         # Avoid overwriting an existing file - bump the counter if one appeared in
         # the meantime.
         while os.path.exists(path):
             seq += 1
-            path = pattern.format(seq=seq)
+            path = filename.format(seq=seq)
         data = self.serialize()
         directory = os.path.dirname(path)
         if directory:
@@ -487,13 +492,14 @@ class Checkpoint:
         self._save_seq = seq + 1
         return path
 
-    def load(self, pattern: str) -> str:
+    def load(self, filename: str) -> str:
         """Reads a previously saved checkpoint from a file.
 
         Parameters
         ----------
-        pattern : str
-            A Python format string containing ``{seq}`` (e.g. ``"ckpt_{seq:04d}.json"``).
+        filename : str
+            A Python format string, optionally containing
+            ``{seq}`` (e.g. ``"ckpt_{seq:04d}.json"``).
             If multiple files match, the one with the highest sequence number
             is loaded.
 
@@ -511,9 +517,9 @@ class Checkpoint:
         -----
         Marks all loaded entries as dirty (see :meth:`deserialize`).
         """
-        candidates = list(_matching_files(pattern))
+        candidates = list(_matching_files(filename))
         if not candidates:
-            raise FileNotFoundError(f"No checkpoint file matches pattern {pattern!r}.")
+            raise FileNotFoundError(f"No checkpoint file matches filename {filename!r}.")
         candidates.sort(key=lambda x: x[0])
         seq, path = candidates[-1]
         with open(path, "r", encoding="utf-8") as f:

--- a/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/checkpoint.py
@@ -548,8 +548,9 @@ class Checkpoint:
         directory = os.path.dirname(path)
         if directory:
             os.makedirs(directory, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
+        with open(path + ".tmp", "w", encoding="utf-8") as f:
             f.write(data)
+        os.replace(path + ".tmp", path)
         self._save_seq = seq + 1
         return path
 

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -135,6 +135,35 @@ class RNG:
         """
         self._rng.set_state(value)
 
+    def get_state(self):
+        """Returns the internal state of the generator.
+
+        Equivalent to :attr:`state`. Provided so that an :class:`RNG` exposes the same
+        ``get_state`` / ``set_state`` interface as a :class:`Reader`, which is the
+        contract used by the checkpointing API.
+
+        Returns
+        -------
+        Opaque state object. The object can be converted to a string with ``str(state)`` and
+        later used to set the state or construct an RNG.
+        """
+        return self._rng.get_state()
+
+    def set_state(self, value):
+        """Sets the internal state of the generator.
+
+        Equivalent to assigning to :attr:`state`. Provided so that an :class:`RNG` exposes
+        the same ``get_state`` / ``set_state`` interface as a :class:`Reader`, which is
+        the contract used by the checkpointing API.
+
+        Parameters
+        ----------
+        value : object | str
+            Either a state object obtained from :func:`get_state` (or the :attr:`state`
+            property) or its string representation.
+        """
+        self._rng.set_state(value)
+
 
 # Thread-local storage for the default RNG
 _thread_local = _threading.local()

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -135,12 +135,17 @@ class RNG:
         """
         self._rng.set_state(value)
 
-    def get_state(self):
+    def get_state(self, *, cuda_stream=None):
         """Returns the internal state of the generator.
 
         Equivalent to :attr:`state`. Provided so that an :class:`RNG` exposes the same
         ``get_state`` / ``set_state`` interface as a :class:`Reader`, which is the
         contract used by the checkpointing API.
+
+        Parameters
+        ----------
+        cuda_stream: Any
+            Not used.
 
         Returns
         -------

--- a/dali/test/python/experimental_mode/test_checkpoint.py
+++ b/dali/test/python/experimental_mode/test_checkpoint.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import tempfile
 
@@ -536,3 +537,156 @@ def test_checkpoint_mixed_reader_and_rng_end_to_end():
     got_rngs = [rng2() for _ in range(5)]
     assert got_labels == expected_labels
     assert got_rngs == expected_rngs
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint - operator type tracking
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_collect_records_type():
+    """collect stores the operator's qualified type name in each entry."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    reader = _make_reader(enable_checkpointing=True)
+    next(reader.next_epoch(batch_size=4))  # advance so get_state is valid
+    ckpt.register(rng, "rng")
+    ckpt.register(reader, "reader")
+    ckpt.collect()
+    assert ckpt._states["rng"].type_name == "RNG"
+    assert ckpt._states["reader"].type_name == "File"
+
+
+def test_checkpoint_serialize_includes_type():
+    """The serialized payload carries the operator type alongside the state."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+    payload = json.loads(ckpt.serialize())
+    assert payload["version"] == 2
+    assert payload["states"]["rng"]["type"] == "RNG"
+    assert isinstance(payload["states"]["rng"]["state"], str)
+
+
+def test_checkpoint_set_state_with_op_type_class():
+    """set_state accepts a class as op_type and stores its qualified name."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.set_state("rng", "some_state", op_type=ndd.random.RNG)
+    assert ckpt._states["rng"].type_name == "RNG"
+
+
+def test_checkpoint_set_state_with_op_type_string():
+    """set_state accepts a string as op_type and stores it verbatim."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.set_state("rng", "some_state", op_type="RNG")
+    assert ckpt._states["rng"].type_name == "RNG"
+
+
+def test_checkpoint_set_state_invalid_op_type_errors():
+    """set_state rejects an op_type that is neither a type nor a string."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    with assert_raises(TypeError, glob="op_type"):
+        ckpt.set_state("rng", "some_state", op_type=42)
+
+
+def test_checkpoint_set_state_op_type_mismatch_errors():
+    """Registering an op of the wrong type for a typed state raises TypeError."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    # Pretend a state for a File reader is buffered under "x".
+    ckpt.set_state("x", "irrelevant", op_type=ndd.readers.File)
+    rng = ndd.random.RNG(seed=1)
+    # Registering an RNG under "x" must trigger a type-mismatch error before
+    # the state is propagated.
+    with assert_raises(TypeError, glob="Type mismatch*'File'*'RNG'*"):
+        ckpt.register(rng, "x")
+
+
+def test_checkpoint_register_replace_different_type_errors():
+    """Replacing a registered op with one of a different type raises TypeError."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    reader = _make_reader()
+    ckpt.register(rng, "key")
+    with assert_raises(TypeError, glob="Cannot replace operator*'RNG'*'File'*"):
+        ckpt.register(reader, "key")
+
+
+def test_checkpoint_register_after_load_wrong_type_errors():
+    """Registering an op of a different type than the one in a loaded checkpoint errors."""
+    rng = ndd.random.RNG(seed=1)
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.register(rng, "x")
+    ckpt.collect()
+    payload = ckpt.serialize()
+
+    ckpt2 = ndd.checkpoint.Checkpoint()
+    ckpt2.deserialize(payload)
+    reader = _make_reader()
+    with assert_raises(TypeError, glob="Type mismatch*'RNG'*'File'*"):
+        ckpt2.register(reader, "x")
+
+
+def test_checkpoint_register_after_load_correct_type_ok():
+    """A loaded checkpoint with type info applies cleanly to a matching op."""
+    rng = ndd.random.RNG(seed=42)
+    for _ in range(3):
+        rng()
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+    expected = [rng() for _ in range(5)]
+    payload = ckpt.serialize()
+
+    ckpt2 = ndd.checkpoint.Checkpoint()
+    ckpt2.deserialize(payload)
+    rng2 = ndd.random.RNG(seed=999)
+    ckpt2.register(rng2, "rng")  # types match - no error
+    got = [rng2() for _ in range(5)]
+    assert got == expected
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint - deserialize payload validation
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_deserialize_format_version_mismatch_errors():
+    """deserialize rejects payloads with an unsupported version."""
+    payload = json.dumps({"version": 1, "states": {"rng": {"state": "x", "type": "RNG"}}})
+    ckpt = ndd.checkpoint.Checkpoint()
+    with assert_raises(ValueError, glob="version"):
+        ckpt.deserialize(payload)
+
+
+def test_checkpoint_deserialize_entry_not_a_dict_errors():
+    """deserialize rejects entries that are not dicts (legacy v1 inline strings)."""
+    payload = json.dumps({"version": 2, "states": {"rng": "raw_string_state"}})
+    ckpt = ndd.checkpoint.Checkpoint()
+    with assert_raises(ValueError, glob="Invalid checkpoint entry"):
+        ckpt.deserialize(payload)
+
+
+def test_checkpoint_deserialize_entry_missing_state_errors():
+    """deserialize rejects entries that lack the ``state`` field."""
+    payload = json.dumps({"version": 2, "states": {"rng": {"type": "RNG"}}})
+    ckpt = ndd.checkpoint.Checkpoint()
+    with assert_raises(ValueError, glob="Invalid checkpoint entry"):
+        ckpt.deserialize(payload)
+
+
+def test_checkpoint_deserialize_invalid_type_field_errors():
+    """deserialize rejects entries whose ``type`` is not a string."""
+    payload = json.dumps({"version": 2, "states": {"rng": {"state": "x", "type": 42}}})
+    ckpt = ndd.checkpoint.Checkpoint()
+    with assert_raises(ValueError, glob="Invalid `type`"):
+        ckpt.deserialize(payload)
+
+
+def test_checkpoint_deserialize_null_type_ok():
+    """deserialize accepts a null ``type`` (matches set_state without op_type)."""
+    payload = json.dumps({"version": 2, "states": {"rng": {"state": "x", "type": None}}})
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.deserialize(payload)
+    assert ckpt._states["rng"].type_name is None
+    assert ckpt._states["rng"].state == "x"

--- a/dali/test/python/experimental_mode/test_checkpoint.py
+++ b/dali/test/python/experimental_mode/test_checkpoint.py
@@ -690,3 +690,159 @@ def test_checkpoint_deserialize_null_type_ok():
     ckpt.deserialize(payload)
     assert ckpt._states["rng"].type_name is None
     assert ckpt._states["rng"].state == "x"
+
+
+# ---------------------------------------------------------------------------
+# Reader.set_state bytes branch
+# ---------------------------------------------------------------------------
+
+
+def test_reader_set_state_accepts_bytes():
+    """set_state accepts a raw ``bytes`` blob (ASCII-encoded serialized form)."""
+    ref = _make_reader(enable_checkpointing=True)
+    it_ref = ref.next_epoch(batch_size=4)
+    next(it_ref)
+    state_bytes = str(ref.get_state()).encode("ascii")
+    expected = _labels_of(next(it_ref))
+
+    restored = _make_reader()
+    restored.set_state(state_bytes)
+    got = _labels_of(next(restored.next_epoch(batch_size=4)))
+    assert got == expected, f"Restored reader produced {got} instead of {expected}."
+
+
+# ---------------------------------------------------------------------------
+# Failure during _maybe_apply
+# ---------------------------------------------------------------------------
+
+
+class _RaisingRNG:
+    """Stand-in op whose ``set_state`` raises. Used to test partial-restore behavior."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def get_state(self, *, cuda_stream=None):
+        return "state"
+
+    def set_state(self, value):
+        self.calls += 1
+        raise RuntimeError("simulated set_state failure")
+
+
+def test_checkpoint_register_after_load_set_state_failure_keeps_dirty():
+    """If ``op.set_state`` raises during register-after-load, the key stays dirty."""
+    payload = json.dumps(
+        {
+            "version": 2,
+            "states": {
+                "good": {"state": "x", "type": "_RaisingRNG"},
+                "bad": {"state": "x", "type": "_RaisingRNG"},
+            },
+        }
+    )
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.deserialize(payload)
+    assert ckpt._dirty == {"good", "bad"}
+
+    bad = _RaisingRNG()
+    with assert_raises(RuntimeError, glob="simulated set_state failure"):
+        ckpt.register(bad, "bad")
+    # Failed apply does not clear `_dirty` for the failed key, and the unrelated
+    # key remains dirty too - the caller can retry registration without losing state.
+    assert "bad" in ckpt._dirty
+    assert "good" in ckpt._dirty
+    assert bad.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via ndd.checkpoint.current()
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_current_end_to_end():
+    """A full save/load cycle going through ``ndd.checkpoint.current()``."""
+    ndd.checkpoint.current().clear()  # ensure no leftover registrations from prior tests
+    try:
+        reader = _make_reader(enable_checkpointing=True)
+        rng = ndd.random.RNG(seed=2026)
+        ckpt = ndd.checkpoint.current()
+        ckpt.register(reader, "reader")
+        ckpt.register(rng, "rng")
+
+        it = reader.next_epoch(batch_size=4)
+        next(it)
+        rng()
+
+        ckpt.collect()
+        with tempfile.TemporaryDirectory() as d:
+            path = ckpt.save(os.path.join(d, "ckpt_{seq:04d}.json"))
+            assert os.path.exists(path)
+
+            expected_labels = _labels_of(next(it))
+            expected_rngs = [rng() for _ in range(3)]
+
+            ndd.checkpoint.current().clear()
+            ckpt2 = ndd.checkpoint.current()
+            ckpt2.load(os.path.join(d, "ckpt_{seq:04d}.json"))
+
+            reader2 = _make_reader()
+            rng2 = ndd.random.RNG(seed=0)
+            ckpt2.register(reader2, "reader")
+            ckpt2.register(rng2, "rng")
+
+            got_labels = _labels_of(next(reader2.next_epoch(batch_size=4)))
+            got_rngs = [rng2() for _ in range(3)]
+            assert got_labels == expected_labels
+            assert got_rngs == expected_rngs
+    finally:
+        ndd.checkpoint.current().clear()
+
+
+# ---------------------------------------------------------------------------
+# Compiled mode is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_reader_checkpointing_rejects_compile_mode():
+    """``enable_checkpointing=True`` and ``next_epoch(compile=True)`` are mutually exclusive."""
+    reader = _make_reader(enable_checkpointing=True)
+    with assert_raises(NotImplementedError, glob="*compiled mode*"):
+        reader.next_epoch(batch_size=4, compile=True)
+
+
+def test_reader_enable_checkpointing_rejected_after_compile():
+    """A reader that has entered compiled mode cannot then opt in to checkpointing."""
+    reader = _make_reader()
+    next(reader.next_epoch(batch_size=4, compile=True))
+    ckpt = ndd.checkpoint.Checkpoint()
+    with assert_raises(NotImplementedError, glob="*compiled mode*"):
+        ckpt.register(reader, "reader")
+
+
+# ---------------------------------------------------------------------------
+# Filename pattern regression - bracket characters in literals
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_save_load_with_glob_metachars_in_literal():
+    """Bracket characters in the filename literal must not be expanded as glob classes.
+
+    Without escaping, ``glob.iglob`` would interpret ``[a-z]`` as a character class
+    and refuse to match a file actually named ``[a-z]_0.json``.
+    """
+    rng = ndd.random.RNG(seed=42)
+    for _ in range(3):
+        rng()
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+
+    with tempfile.TemporaryDirectory() as d:
+        pattern = os.path.join(d, "[a-z]_{seq}.json")
+        saved = ckpt.save(pattern)
+        assert os.path.basename(saved) == "[a-z]_0.json"
+
+        ckpt2 = ndd.checkpoint.Checkpoint()
+        loaded = ckpt2.load(pattern)
+        assert loaded == saved

--- a/dali/test/python/experimental_mode/test_checkpoint.py
+++ b/dali/test/python/experimental_mode/test_checkpoint.py
@@ -157,8 +157,8 @@ def test_checkpoint_register_anonymous_returns_sequential_keys():
     ckpt = ndd.checkpoint.Checkpoint()
     rng1 = ndd.random.RNG(seed=1)
     rng2 = ndd.random.RNG(seed=2)
-    assert ckpt.register(rng1) == "0"
-    assert ckpt.register(rng2) == "1"
+    assert ckpt.register(rng1) == "__op_0"
+    assert ckpt.register(rng2) == "__op_1"
 
 
 def test_checkpoint_register_anonymous_idempotent():
@@ -198,8 +198,11 @@ def test_checkpoint_get_state_no_state_yet_returns_none():
 def test_checkpoint_set_state_unregistered_errors():
     """set_state raises KeyError if the name was not registered."""
     ckpt = ndd.checkpoint.Checkpoint()
+    rng1 = ndd.random.RNG(seed=1)
+    ckpt.register(rng1)
+    ckpt.collect()  # it's complete now
     with assert_raises(KeyError):
-        ckpt.set_state("unknown", "...")
+        ckpt.set_state("unknown2", "...")
 
 
 # ---------------------------------------------------------------------------
@@ -384,7 +387,7 @@ def test_checkpoint_register_anonymous_after_load_extra_op_errors():
     ckpt2 = ndd.checkpoint.Checkpoint()
     ckpt2.deserialize(payload)
     ckpt2.register(ndd.random.RNG(seed=2))  # consumes "0"
-    with assert_raises(KeyError, glob="inferred key"):
+    with assert_raises(KeyError, glob="Loaded checkpoint has no state"):
         ckpt2.register(ndd.random.RNG(seed=3))
 
 

--- a/dali/test/python/experimental_mode/test_checkpoint.py
+++ b/dali/test/python/experimental_mode/test_checkpoint.py
@@ -82,7 +82,7 @@ def test_reader_get_state_before_iteration_errors():
 
 def test_reader_state_str_roundtrip():
     """The state object's __str__ is a serialized form usable with set_state."""
-    reader = _make_reader()
+    reader = _make_reader(enable_checkpointing=True)
     it = reader.next_epoch(batch_size=4)
     next(it)
     state = reader.get_state()
@@ -100,7 +100,7 @@ def test_reader_state_str_roundtrip():
 def test_reader_get_set_state_resume():
     """set_state on a fresh reader resumes from the captured iteration position."""
     # Reference reader, iterate through and capture state after the first batch.
-    ref = _make_reader()
+    ref = _make_reader(enable_checkpointing=True)
     it_ref = ref.next_epoch(batch_size=4)
     next(it_ref)  # discard first batch
     state = ref.get_state()
@@ -109,6 +109,7 @@ def test_reader_get_set_state_resume():
     # Restored reader: set_state before the first iteration so that the state
     # is buffered and applied on backend creation.
     restored = _make_reader()
+    # The backend hasn't been initialized - this should enable checkpointing
     restored.set_state(state)
     it_restored = restored.next_epoch(batch_size=4)
     got = _labels_of(next(it_restored))
@@ -122,7 +123,7 @@ def test_reader_set_state_after_iteration_errors():
     thread starts. Calling :meth:`set_state` after the first batch must therefore
     fail loudly rather than silently misbehave.
     """
-    reader = _make_reader()
+    reader = _make_reader(enable_checkpointing=True)
     next(reader.next_epoch(batch_size=4))
     state = reader.get_state()
     with assert_raises(RuntimeError, glob="after iteration has begun"):
@@ -280,10 +281,10 @@ def test_checkpoint_collect_restore_rng_roundtrip():
 def test_checkpoint_collect_restore_reader_roundtrip():
     """A captured Reader state can be restored to resume iteration."""
     ref = _make_reader()
-    it_ref = ref.next_epoch(batch_size=4)
-    next(it_ref)
     ckpt = ndd.checkpoint.Checkpoint()
     ckpt.register(ref, "reader")
+    it_ref = ref.next_epoch(batch_size=4)
+    next(it_ref)
     ckpt.collect()
     expected = _labels_of(next(it_ref))
 
@@ -399,13 +400,8 @@ def test_checkpoint_register_anonymous_after_load_extra_op_errors():
 def test_checkpoint_save_load_roundtrip(name_pattern):
     """save writes a file; load returns the most recent one."""
     rng = ndd.random.RNG(seed=42)
-    rng()
-    expected = [rng() for _ in range(5)]
-    rng.set_state(rng.get_state())  # reset to current state
-
-    # Recreate to capture state cleanly.
-    rng = ndd.random.RNG(seed=42)
-    rng()
+    for _ in range(10):
+        rng()  # advance
     ckpt = ndd.checkpoint.Checkpoint()
     ckpt.register(rng, "rng")
     ckpt.collect()
@@ -509,7 +505,7 @@ def test_checkpoint_current_returns_eval_context_checkpoint():
 
 def test_checkpoint_mixed_reader_and_rng_end_to_end():
     """Mixed reader + RNG round-trip through serialize/deserialize."""
-    reader = _make_reader()
+    reader = _make_reader(enable_checkpointing=True)
     rng = ndd.random.RNG(seed=2024)
 
     # Run a few iterations to advance state.

--- a/dali/test/python/experimental_mode/test_checkpoint.py
+++ b/dali/test/python/experimental_mode/test_checkpoint.py
@@ -21,7 +21,6 @@ from nose_utils import assert_raises
 from nose2.tools import params
 from test_utils import get_dali_extra_path
 
-
 _DALI_EXTRA = get_dali_extra_path()
 _FILE_ROOT = os.path.join(_DALI_EXTRA, "db", "single", "jpeg")
 _FILE_LIST = os.path.join(_FILE_ROOT, "image_list.txt")
@@ -355,7 +354,7 @@ def test_checkpoint_register_anonymous_after_load_replays_keys():
     ref_other = ndd.random.RNG(seed=99)
 
     ckpt = ndd.checkpoint.Checkpoint()
-    ckpt.register(ref_rng)            # gets "0"
+    ckpt.register(ref_rng)  # gets "0"
     ckpt.register(ref_other, "other")  # named
     ckpt.collect()
     payload = ckpt.serialize()
@@ -369,7 +368,7 @@ def test_checkpoint_register_anonymous_after_load_replays_keys():
     ckpt2 = ndd.checkpoint.Checkpoint()
     ckpt2.deserialize(payload)
     # Same registration order: anonymous first, then named.
-    ckpt2.register(new_rng)            # picks up sequential key "0"
+    ckpt2.register(new_rng)  # picks up sequential key "0"
     ckpt2.register(new_other, "other")
     got_rng = [new_rng() for _ in range(3)]
     got_other = [new_other() for _ in range(3)]

--- a/dali/test/python/experimental_mode/test_checkpoint.py
+++ b/dali/test/python/experimental_mode/test_checkpoint.py
@@ -1,0 +1,540 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+
+import numpy as np
+import nvidia.dali.experimental.dynamic as ndd
+from nose_utils import assert_raises
+from nose2.tools import params
+from test_utils import get_dali_extra_path
+
+
+_DALI_EXTRA = get_dali_extra_path()
+_FILE_ROOT = os.path.join(_DALI_EXTRA, "db", "single", "jpeg")
+_FILE_LIST = os.path.join(_FILE_ROOT, "image_list.txt")
+
+
+def _make_reader(**kwargs):
+    """Helper that constructs a deterministic File reader for the tests."""
+    return ndd.readers.File(
+        file_root=_FILE_ROOT,
+        file_list=_FILE_LIST,
+        random_shuffle=False,
+        **kwargs,
+    )
+
+
+def _labels_of(batch):
+    """Returns the integer labels of a (jpeg, label) batch as a list."""
+    _, lbl = batch
+    return [int(np.array(ndd.as_tensor(t, device="cpu"))[0]) for t in lbl.tensors]
+
+
+# ---------------------------------------------------------------------------
+# RNG manual get_state / set_state
+# ---------------------------------------------------------------------------
+
+
+def test_rng_get_set_state_methods():
+    """RNG exposes get_state/set_state mirroring the `state` property."""
+    rng = ndd.random.RNG(seed=1234)
+    state1 = rng.get_state()
+    # `state` and `get_state()` must agree.
+    assert str(state1) == str(rng.state)
+
+    # Advance.
+    v_pre = [rng() for _ in range(5)]
+
+    # Restore via set_state with a state object.
+    rng.set_state(state1)
+    v_post = [rng() for _ in range(5)]
+    assert v_pre == v_post
+
+    # Restore via set_state with the string representation.
+    rng.set_state(str(state1))
+    v_str = [rng() for _ in range(5)]
+    assert v_pre == v_str
+
+
+# ---------------------------------------------------------------------------
+# Reader manual get_state / set_state
+# ---------------------------------------------------------------------------
+
+
+def test_reader_get_state_before_iteration_errors():
+    """get_state must error if the reader has not been initialized yet."""
+    reader = _make_reader()
+    with assert_raises(RuntimeError, glob="before its first iteration"):
+        reader.get_state()
+
+
+def test_reader_state_str_roundtrip():
+    """The state object's __str__ is a serialized form usable with set_state."""
+    reader = _make_reader()
+    it = reader.next_epoch(batch_size=4)
+    next(it)
+    state = reader.get_state()
+    s = str(state)
+    assert isinstance(s, str)
+    assert len(s) > 0
+    # set_state must accept either the object or its string representation.
+    # It must be called on a fresh reader (before the first iteration).
+    reader2 = _make_reader()
+    reader2.set_state(state)
+    reader3 = _make_reader()
+    reader3.set_state(s)
+
+
+def test_reader_get_set_state_resume():
+    """set_state on a fresh reader resumes from the captured iteration position."""
+    # Reference reader, iterate through and capture state after the first batch.
+    ref = _make_reader()
+    it_ref = ref.next_epoch(batch_size=4)
+    next(it_ref)  # discard first batch
+    state = ref.get_state()
+    expected = _labels_of(next(it_ref))
+
+    # Restored reader: set_state before the first iteration so that the state
+    # is buffered and applied on backend creation.
+    restored = _make_reader()
+    restored.set_state(state)
+    it_restored = restored.next_epoch(batch_size=4)
+    got = _labels_of(next(it_restored))
+    assert got == expected, f"Restored reader produced {got} instead of {expected}."
+
+
+def test_reader_set_state_after_iteration_errors():
+    """set_state after iteration has begun raises a clear error.
+
+    The underlying C++ reader can only restore a checkpoint before its prefetch
+    thread starts. Calling :meth:`set_state` after the first batch must therefore
+    fail loudly rather than silently misbehave.
+    """
+    reader = _make_reader()
+    next(reader.next_epoch(batch_size=4))
+    state = reader.get_state()
+    with assert_raises(RuntimeError, glob="after iteration has begun"):
+        reader.set_state(state)
+
+
+def test_reader_set_state_invalid_type():
+    """set_state rejects unsupported argument types."""
+    reader = _make_reader()
+    with assert_raises(TypeError, glob="ReaderState"):
+        reader.set_state(42)
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint - registration semantics
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_register_named():
+    """Named registration returns the supplied key."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    key = ckpt.register(rng, "my_rng")
+    assert key == "my_rng"
+    assert "my_rng" in ckpt
+    assert ckpt.names == ("my_rng",)
+
+
+def test_checkpoint_register_anonymous_returns_sequential_keys():
+    """Anonymous registration returns "0", "1", ... ."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng1 = ndd.random.RNG(seed=1)
+    rng2 = ndd.random.RNG(seed=2)
+    assert ckpt.register(rng1) == "0"
+    assert ckpt.register(rng2) == "1"
+
+
+def test_checkpoint_register_anonymous_idempotent():
+    """Re-registering the same op anonymously returns the existing key."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    key = ckpt.register(rng)
+    assert ckpt.register(rng) == key
+    assert len(ckpt) == 1
+
+
+def test_checkpoint_register_named_replaces():
+    """Named registration replaces a previous entry at the same key."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng1 = ndd.random.RNG(seed=1)
+    rng2 = ndd.random.RNG(seed=2)
+    ckpt.register(rng1, "rng")
+    ckpt.register(rng2, "rng")
+    assert len(ckpt) == 1
+
+
+def test_checkpoint_get_state_unregistered_errors():
+    """get_state raises KeyError if the name was not registered."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    with assert_raises(KeyError):
+        ckpt.get_state("unknown")
+
+
+def test_checkpoint_get_state_no_state_yet_returns_none():
+    """get_state returns None if no state has been collected/loaded yet."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    ckpt.register(rng, "rng")
+    assert ckpt.get_state("rng") is None
+
+
+def test_checkpoint_set_state_unregistered_errors():
+    """set_state raises KeyError if the name was not registered."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    with assert_raises(KeyError):
+        ckpt.set_state("unknown", "...")
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint - collect / restore
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_collect_sets_complete():
+    """collect populates the state dictionary and sets is_complete."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+    assert ckpt.is_complete
+    assert not ckpt.is_loaded
+    assert ckpt.get_state("rng") is not None
+
+
+def test_checkpoint_collect_extra_state_errors():
+    """collect raises if the state dict has entries with no registered op."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    # Manually inject a stray key.
+    ckpt._states["ghost"] = "..."
+    with assert_raises(RuntimeError, glob="no corresponding registered ops"):
+        ckpt.collect()
+
+
+def test_checkpoint_restore_empty_is_noop():
+    """restore on an empty state dict is a no-op."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    ckpt.register(rng, "rng")
+    ckpt.restore()  # should not raise
+
+
+def test_checkpoint_restore_missing_state_errors():
+    """restore raises if a registered op has no state in the dictionary."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng1 = ndd.random.RNG(seed=1)
+    rng2 = ndd.random.RNG(seed=2)
+    ckpt.register(rng1, "a")
+    ckpt.register(rng2, "b")
+    # Manually populate state for only one of the two registered ops.
+    ckpt.set_state("a", str(rng1.get_state()))
+    with assert_raises(RuntimeError, glob="incomplete"):
+        ckpt.restore()
+
+
+def test_checkpoint_restore_extra_state_errors():
+    """restore raises if the state dict has entries with no matching op."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt._states["ghost"] = "..."
+    ckpt._dirty.add("ghost")
+    with assert_raises(RuntimeError, glob="no corresponding registered ops"):
+        ckpt.restore()
+
+
+def test_checkpoint_collect_restore_rng_roundtrip():
+    """A captured RNG state can be restored to reproduce its sequence."""
+    rng = ndd.random.RNG(seed=42)
+    rng()  # advance a bit
+    rng()
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+    expected = [rng() for _ in range(5)]
+
+    rng2 = ndd.random.RNG(seed=999)  # different seed - state will be overwritten
+    ckpt2 = ndd.checkpoint.Checkpoint()
+    ckpt2.deserialize(ckpt.serialize())
+    ckpt2.register(rng2, "rng")  # state applied implicitly here
+    got = [rng2() for _ in range(5)]
+    assert got == expected
+
+
+def test_checkpoint_collect_restore_reader_roundtrip():
+    """A captured Reader state can be restored to resume iteration."""
+    ref = _make_reader()
+    it_ref = ref.next_epoch(batch_size=4)
+    next(it_ref)
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.register(ref, "reader")
+    ckpt.collect()
+    expected = _labels_of(next(it_ref))
+
+    restored = _make_reader()
+    ckpt2 = ndd.checkpoint.Checkpoint()
+    ckpt2.deserialize(ckpt.serialize())
+    ckpt2.register(restored, "reader")
+    got = _labels_of(next(restored.next_epoch(batch_size=4)))
+    assert got == expected
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint - serialize / deserialize
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_serialize_empty_errors():
+    """serialize raises if the state dictionary is empty."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    with assert_raises(RuntimeError, glob="empty"):
+        ckpt.serialize()
+
+
+def test_checkpoint_deserialize_marks_loaded():
+    """deserialize sets is_loaded and clears is_complete; entries are dirty."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+    payload = ckpt.serialize()
+
+    ckpt2 = ndd.checkpoint.Checkpoint()
+    ckpt2.deserialize(payload)
+    assert ckpt2.is_loaded
+    assert not ckpt2.is_complete
+    assert "rng" in ckpt2._dirty
+
+
+def test_checkpoint_register_after_load_unknown_key_errors():
+    """Registering an op with an unknown key after load() raises KeyError."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+    payload = ckpt.serialize()
+
+    ckpt2 = ndd.checkpoint.Checkpoint()
+    ckpt2.deserialize(payload)
+    new_rng = ndd.random.RNG(seed=2)
+    with assert_raises(KeyError):
+        ckpt2.register(new_rng, "other")
+
+
+def test_checkpoint_register_anonymous_after_collect_errors():
+    """Anonymous registration after collect() raises RuntimeError."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+    new_rng = ndd.random.RNG(seed=2)
+    with assert_raises(RuntimeError, glob="completed"):
+        ckpt.register(new_rng)
+
+
+def test_checkpoint_register_anonymous_after_load_replays_keys():
+    """Anonymous registration after load() works as long as the order matches."""
+    ref_rng = ndd.random.RNG(seed=1)
+    ref_other = ndd.random.RNG(seed=99)
+
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.register(ref_rng)            # gets "0"
+    ckpt.register(ref_other, "other")  # named
+    ckpt.collect()
+    payload = ckpt.serialize()
+
+    expected_rng = [ref_rng() for _ in range(3)]
+    expected_other = [ref_other() for _ in range(3)]
+
+    new_rng = ndd.random.RNG(seed=12345)
+    new_other = ndd.random.RNG(seed=54321)
+
+    ckpt2 = ndd.checkpoint.Checkpoint()
+    ckpt2.deserialize(payload)
+    # Same registration order: anonymous first, then named.
+    ckpt2.register(new_rng)            # picks up sequential key "0"
+    ckpt2.register(new_other, "other")
+    got_rng = [new_rng() for _ in range(3)]
+    got_other = [new_other() for _ in range(3)]
+    assert got_rng == expected_rng
+    assert got_other == expected_other
+
+
+def test_checkpoint_register_anonymous_after_load_extra_op_errors():
+    """Anonymous registration of an extra op (no matching key) raises KeyError."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.register(ndd.random.RNG(seed=1))  # "0"
+    ckpt.collect()
+    payload = ckpt.serialize()
+
+    ckpt2 = ndd.checkpoint.Checkpoint()
+    ckpt2.deserialize(payload)
+    ckpt2.register(ndd.random.RNG(seed=2))  # consumes "0"
+    with assert_raises(KeyError, glob="inferred key"):
+        ckpt2.register(ndd.random.RNG(seed=3))
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint - save / load
+# ---------------------------------------------------------------------------
+
+
+@params("ckpt_{seq:04d}.json", "ckpt_{seq}.bin")
+def test_checkpoint_save_load_roundtrip(name_pattern):
+    """save writes a file; load returns the most recent one."""
+    rng = ndd.random.RNG(seed=42)
+    rng()
+    expected = [rng() for _ in range(5)]
+    rng.set_state(rng.get_state())  # reset to current state
+
+    # Recreate to capture state cleanly.
+    rng = ndd.random.RNG(seed=42)
+    rng()
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+
+    expected = [rng() for _ in range(5)]
+
+    with tempfile.TemporaryDirectory() as d:
+        pattern = os.path.join(d, name_pattern)
+        p1 = ckpt.save(pattern)
+        p2 = ckpt.save(pattern)
+        assert os.path.exists(p1)
+        assert os.path.exists(p2)
+        assert p1 != p2
+
+        # Load picks the most recent (highest seq) entry.
+        ckpt2 = ndd.checkpoint.Checkpoint()
+        loaded_path = ckpt2.load(pattern)
+        assert loaded_path == p2
+
+    rng2 = ndd.random.RNG(seed=999)
+    ckpt2.register(rng2, "rng")
+    got = [rng2() for _ in range(5)]
+    assert got == expected
+
+
+def test_checkpoint_save_avoids_overwrite_across_instances():
+    """Multiple checkpoint instances writing into the same dir produce distinct files."""
+    rng = ndd.random.RNG(seed=1)
+    ckpt1 = ndd.checkpoint.Checkpoint()
+    ckpt1.register(rng, "rng")
+    ckpt1.collect()
+
+    with tempfile.TemporaryDirectory() as d:
+        pattern = os.path.join(d, "ckpt_{seq:03d}.json")
+        p1 = ckpt1.save(pattern)
+        # A fresh checkpoint instance must scan the dir and avoid clobbering.
+        ckpt2 = ndd.checkpoint.Checkpoint()
+        ckpt2.register(rng, "rng")
+        ckpt2.collect()
+        p2 = ckpt2.save(pattern)
+        assert p1 != p2
+
+
+def test_checkpoint_load_no_match_errors():
+    """load raises FileNotFoundError when no file matches."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    with tempfile.TemporaryDirectory() as d:
+        pattern = os.path.join(d, "missing_{seq:03d}.json")
+        with assert_raises(FileNotFoundError):
+            ckpt.load(pattern)
+
+
+def test_checkpoint_pattern_requires_seq():
+    """save/load require a `{seq}` placeholder in the pattern."""
+    rng = ndd.random.RNG(seed=1)
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+    with assert_raises(ValueError, glob="seq"):
+        ckpt.save("/tmp/no_placeholder.json")
+    with assert_raises(ValueError, glob="seq"):
+        ckpt.load("/tmp/no_placeholder.json")
+
+
+def test_checkpoint_clear():
+    """clear resets the checkpoint to its empty state."""
+    ckpt = ndd.checkpoint.Checkpoint()
+    rng = ndd.random.RNG(seed=1)
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+    ckpt.clear()
+    assert len(ckpt) == 0
+    assert not ckpt.is_complete
+    assert not ckpt.is_loaded
+
+
+# ---------------------------------------------------------------------------
+# EvalContext-bound checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_eval_context_has_lazy_checkpoint():
+    """EvalContext.checkpoint returns a singleton Checkpoint per context."""
+    ctx = ndd.EvalContext.current()
+    c1 = ctx.checkpoint
+    c2 = ctx.checkpoint
+    assert c1 is c2
+    assert isinstance(c1, ndd.checkpoint.Checkpoint)
+
+
+def test_checkpoint_current_returns_eval_context_checkpoint():
+    """checkpoint.current() returns EvalContext.current().checkpoint."""
+    ctx = ndd.EvalContext.current()
+    assert ndd.checkpoint.current() is ctx.checkpoint
+
+
+# ---------------------------------------------------------------------------
+# Mixed reader + RNG end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_mixed_reader_and_rng_end_to_end():
+    """Mixed reader + RNG round-trip through serialize/deserialize."""
+    reader = _make_reader()
+    rng = ndd.random.RNG(seed=2024)
+
+    # Run a few iterations to advance state.
+    it = reader.next_epoch(batch_size=4)
+    next(it)
+    next(it)
+    rng()
+    rng()
+
+    ckpt = ndd.checkpoint.Checkpoint()
+    ckpt.register(reader, "reader")
+    ckpt.register(rng, "rng")
+    ckpt.collect()
+    payload = ckpt.serialize()
+
+    expected_labels = _labels_of(next(it))
+    expected_rngs = [rng() for _ in range(5)]
+
+    # Now reconstruct.
+    reader2 = _make_reader()
+    rng2 = ndd.random.RNG(seed=12345)  # different seed - will be overwritten
+    ckpt2 = ndd.checkpoint.Checkpoint()
+    ckpt2.deserialize(payload)
+    ckpt2.register(reader2, "reader")
+    ckpt2.register(rng2, "rng")
+
+    got_labels = _labels_of(next(reader2.next_epoch(batch_size=4)))
+    got_rngs = [rng2() for _ in range(5)]
+    assert got_labels == expected_labels
+    assert got_rngs == expected_rngs

--- a/dali/test/python/experimental_mode/test_public_api.py
+++ b/dali/test/python/experimental_mode/test_public_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ def test_ndd_reader_api():
     for reader in dir(ndd.readers):
         reader_cls = getattr(ndd.readers, reader)
         if isinstance(reader_cls, type) and issubclass(reader_cls, ndd._ops.Reader):
-            allowed_members = {"next_epoch", "get_metadata"}
+            allowed_members = {"next_epoch", "get_metadata", "get_state", "set_state"}
             for member in dir(reader_cls):
                 assert (
                     member.startswith("_") or member in allowed_members

--- a/docs/dali_dynamic/checkpointing.rst
+++ b/docs/dali_dynamic/checkpointing.rst
@@ -111,8 +111,9 @@ Restoring from disk is the symmetric operation:
 The convenience function :func:`checkpoint.current` returns the
 :class:`~checkpoint.Checkpoint` bound to the current
 :class:`EvalContext`. It is created lazily on first access, so the same instance
-is reused across the lifetime of the context:
-Using :func:`checkpoint.current`
+is reused across the lifetime of the context.
+
+Using :func:`checkpoint.current`:
 
 .. code-block:: python
 

--- a/docs/dali_dynamic/checkpointing.rst
+++ b/docs/dali_dynamic/checkpointing.rst
@@ -108,9 +108,13 @@ Restoring from disk is the symmetric operation:
    for batch in reader.next_epoch(batch_size=16):
        ...
 
+Current checkpoint
+^^^^^^^^^^^^^^^^^^
+
 The convenience function :func:`checkpoint.current` returns the
-:class:`~checkpoint.Checkpoint` bound to the current
-:class:`EvalContext`.
+:class:`~checkpoint.Checkpoint` bound to the current :class:`EvalContext`.
+This function allows the code hidden behind function calls to use checkpointing
+without modifying the API to pass the context explicitly.
 
 Using :func:`checkpoint.current`:
 

--- a/docs/dali_dynamic/checkpointing.rst
+++ b/docs/dali_dynamic/checkpointing.rst
@@ -1,0 +1,191 @@
+Checkpointing
+=============
+
+.. currentmodule:: nvidia.dali.experimental.dynamic
+
+Dynamic mode pipelines can produce *checkpoints* that capture the state of all
+stateful operators - readers and random number generators - so that processing
+can be resumed at the captured iteration. Operators that do not maintain
+user-observable state (decoders, resizes, normalizations, etc.) are conceptually
+stateless and are not part of a checkpoint.
+
+This page describes the two checkpointing layers that DALI Dynamic exposes:
+
+#. A :ref:`manual <ndd_checkpointing_manual>` ``get_state`` / ``set_state``
+   interface on individual readers and RNGs.
+#. A :ref:`semi-automatic <ndd_checkpointing_semi_automatic>`
+   :class:`~checkpoint.Checkpoint` aggregator that collects, serializes, and
+   restores the state of a registered set of objects.
+
+.. note::
+
+   A :class:`Reader`'s state can be applied only to a freshly constructed
+   reader, *before* its first iteration. The underlying prefetch thread starts
+   on the first call into the reader, after which the snapshot queue is locked.
+   Calls to :meth:`set_state` after iteration has begun raise a
+   :class:`RuntimeError`.
+
+.. _ndd_checkpointing_manual:
+
+Manual checkpointing
+--------------------
+
+Both :class:`~nvidia.dali.experimental.dynamic.random.RNG` and the readers
+exposed via ``ndd.readers.*`` provide ``get_state`` and ``set_state`` methods.
+The state object returned by ``get_state`` can be converted to a string with
+:func:`str`, and ``set_state`` accepts either the state object or its string
+representation:
+
+.. code-block:: python
+
+   import nvidia.dali.experimental.dynamic as ndd
+
+   reader = ndd.readers.File(file_root="...")
+   it = reader.next_epoch(batch_size=16)
+
+   # Iterate for a while...
+   first = next(it)
+   second = next(it)
+
+   # Capture a checkpoint after the second batch.
+   reader_state = reader.get_state()
+   serialized = str(reader_state)  # safe to write to disk, send over the wire, etc.
+
+   # Later, on a fresh reader:
+   resumed = ndd.readers.File(file_root="...")
+   resumed.set_state(serialized)
+   for batch in resumed.next_epoch(batch_size=16):
+       ...  # produces the third batch first
+
+The :class:`~nvidia.dali.experimental.dynamic.random.RNG` interface is symmetric:
+
+.. code-block:: python
+
+   rng = ndd.random.RNG(seed=42)
+   rng_state = rng.get_state()
+   ...
+   rng.set_state(rng_state)
+
+.. _ndd_checkpointing_semi_automatic:
+
+Semi-automatic checkpointing with ``Checkpoint``
+------------------------------------------------
+
+The :class:`~checkpoint.Checkpoint` class collects the state of a registered
+set of stateful objects, serializes it to a single string, and restores the
+state of new objects from that string.
+
+A typical save/restore cycle looks like this:
+
+.. code-block:: python
+
+   import nvidia.dali.experimental.dynamic as ndd
+
+   reader = ndd.readers.File(file_root="...")
+   rng = ndd.random.RNG(seed=42)
+
+   ckpt = ndd.checkpoint.Checkpoint()
+   ckpt.register(reader, "reader")
+   ckpt.register(rng, "rng")
+
+   # ... iterate for some time ...
+
+   ckpt.collect()                          # capture the current state
+   ckpt.save("ckpt_{seq:04d}.json")        # writes ckpt_0000.json, ckpt_0001.json, ...
+
+Restoring from disk is the symmetric operation:
+
+.. code-block:: python
+
+   reader = ndd.readers.File(file_root="...")
+   rng = ndd.random.RNG()
+
+   ckpt = ndd.checkpoint.Checkpoint()
+   ckpt.load("ckpt_{seq:04d}.json")        # picks up the most recent file
+   ckpt.register(reader, "reader")          # state applied implicitly here
+   ckpt.register(rng, "rng")                # ditto
+
+   for batch in reader.next_epoch(batch_size=16):
+       ...
+
+The convenience function :func:`checkpoint.current` returns the
+:class:`~checkpoint.Checkpoint` bound to the current
+:class:`EvalContext`. It is created lazily on first access, so the same instance
+is reused across the lifetime of the context:
+
+.. code-block:: python
+
+   ckpt = ndd.checkpoint.current()
+   ckpt.register(reader, "reader")
+
+Registration semantics
+^^^^^^^^^^^^^^^^^^^^^^
+
+:meth:`~checkpoint.Checkpoint.register` accepts an optional ``name`` argument:
+
+* If ``name`` is provided, the entry is stored under that key. Any previous op
+  registered under the same key is replaced.
+* If ``name`` is omitted, the checkpoint first looks up the op by identity. If
+  it is already registered, the existing key is returned. Otherwise, a sequential
+  numeric key (``"0"``, ``"1"``, ...) is generated.
+
+When the checkpoint is in *loaded* state and the registered key is present in
+the loaded dictionary, the saved state is applied to the op immediately. This
+makes the load/restore flow above a single line per op.
+
+Lifecycle flags
+^^^^^^^^^^^^^^^
+
+The :attr:`~checkpoint.Checkpoint.is_complete` and
+:attr:`~checkpoint.Checkpoint.is_loaded` properties reflect the most recent
+operation that populated the state dictionary:
+
+* :meth:`~checkpoint.Checkpoint.collect` sets ``is_complete`` and clears
+  ``is_loaded``. New ops cannot be registered (call
+  :meth:`~checkpoint.Checkpoint.clear` to reset).
+* :meth:`~checkpoint.Checkpoint.deserialize` (and :meth:`~checkpoint.Checkpoint.load`)
+  set ``is_loaded`` and clear ``is_complete``. Subsequent
+  :meth:`~checkpoint.Checkpoint.register` calls must use keys that exist in the
+  loaded state.
+
+Filename patterns
+^^^^^^^^^^^^^^^^^
+
+:meth:`~checkpoint.Checkpoint.save` and :meth:`~checkpoint.Checkpoint.load`
+take a Python format string with a single ``{seq}`` placeholder. ``save``
+substitutes the next free sequence number, ``load`` picks the highest one
+matching the pattern on disk. Format specifiers (e.g. ``{seq:04d}``) are
+honored.
+
+API reference
+-------------
+
+.. currentmodule:: nvidia.dali.experimental.dynamic
+
+ReaderState
+^^^^^^^^^^^
+.. autoclass:: nvidia.dali.experimental.dynamic._ops.ReaderState
+   :members:
+
+Reader checkpoint methods
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: nvidia.dali.experimental.dynamic._ops.Reader.get_state
+.. automethod:: nvidia.dali.experimental.dynamic._ops.Reader.set_state
+
+RNG checkpoint methods
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: nvidia.dali.experimental.dynamic.random.RNG.get_state
+.. automethod:: nvidia.dali.experimental.dynamic.random.RNG.set_state
+
+.. currentmodule:: nvidia.dali.experimental.dynamic.checkpoint
+
+Checkpoint
+^^^^^^^^^^
+.. autoclass:: Checkpoint
+   :members:
+
+current
+^^^^^^^
+.. autofunction:: current

--- a/docs/dali_dynamic/checkpointing.rst
+++ b/docs/dali_dynamic/checkpointing.rst
@@ -159,6 +159,57 @@ substitutes the next free sequence number, ``load`` picks the highest one
 matching the pattern on disk. Format specifiers (e.g. ``{seq:04d}``) are
 honored.
 
+Manual restore
+^^^^^^^^^^^^^^
+
+The state of every registered op is applied implicitly when the op is added to
+a loaded checkpoint via :meth:`~checkpoint.Checkpoint.register`. The
+:meth:`~checkpoint.Checkpoint.restore` method is the explicit counterpart -
+it applies all currently dirty states in one call, and is mostly useful when
+the ops were registered *before* the state was supplied (e.g. via
+:meth:`~checkpoint.Checkpoint.set_state` or
+:meth:`~checkpoint.Checkpoint.deserialize`).
+
+Limitations
+^^^^^^^^^^^
+
+A few constraints to keep in mind when using ``Checkpoint``:
+
+* **Readers must opt in.** A :class:`Reader` only supports checkpointing when
+  constructed with ``enable_checkpointing=True``; the backend then maintains a
+  ``prefetch_queue_depth + 1`` deep snapshot queue, which has a small runtime
+  cost. Registering a reader that was not opted in is allowed only if its
+  backend has not yet been initialized - the call to
+  :meth:`~checkpoint.Checkpoint.register` will then enable checkpointing
+  retroactively; otherwise it raises a :class:`RuntimeError`.
+* **Compiled mode is not supported.** Calling
+  :meth:`Reader.next_epoch <nvidia.dali.experimental.dynamic._ops.Reader.next_epoch>`
+  with ``compile=True`` on a reader that has checkpointing enabled (or vice
+  versa) raises :class:`NotImplementedError`.
+* **Reader state must be applied early.** ``Reader.set_state`` (and any
+  buffered state propagated through :meth:`~checkpoint.Checkpoint.register`)
+  must run before the reader's first iteration; the prefetch thread cannot
+  be restored once it has started.
+* **The order of anonymous registrations matters.** When a checkpoint is
+  loaded and ops are re-added without explicit names, the same number of ops
+  must be registered in the same order as at save time. The count is
+  validated, and a stored type tag is checked at apply time - so cross-type
+  swaps fail loudly - but registering ops of compatible types in a different
+  order is not detected. Prefer named registration when in doubt.
+* **Format version is strict.** :meth:`~checkpoint.Checkpoint.deserialize`
+  rejects payloads whose ``version`` does not match the current format with a
+  :class:`ValueError`; there is no automatic upgrade path.
+* **Not thread-safe.** A single :class:`Checkpoint` instance must not be
+  accessed concurrently from multiple threads. The
+  :class:`EvalContext`-bound checkpoint shared by
+  :func:`checkpoint.current` follows the same rule.
+* **The default ``EvalContext`` is reused.** ``ndd.checkpoint.current()``
+  returns the checkpoint bound to the thread-local default
+  :class:`EvalContext`, which lives for the lifetime of the process (or the
+  enclosing ``with EvalContext(...):`` block). Registrations accumulate
+  across unrelated runs unless you call
+  :meth:`~checkpoint.Checkpoint.clear` between them.
+
 API reference
 -------------
 

--- a/docs/dali_dynamic/checkpointing.rst
+++ b/docs/dali_dynamic/checkpointing.rst
@@ -110,8 +110,7 @@ Restoring from disk is the symmetric operation:
 
 The convenience function :func:`checkpoint.current` returns the
 :class:`~checkpoint.Checkpoint` bound to the current
-:class:`EvalContext`. It is created lazily on first access, so the same instance
-is reused across the lifetime of the context.
+:class:`EvalContext`.
 
 Using :func:`checkpoint.current`:
 

--- a/docs/dali_dynamic/checkpointing.rst
+++ b/docs/dali_dynamic/checkpointing.rst
@@ -112,6 +112,7 @@ The convenience function :func:`checkpoint.current` returns the
 :class:`~checkpoint.Checkpoint` bound to the current
 :class:`EvalContext`. It is created lazily on first access, so the same instance
 is reused across the lifetime of the context:
+Using :func:`checkpoint.current`
 
 .. code-block:: python
 
@@ -126,8 +127,8 @@ Registration semantics
 * If ``name`` is provided, the entry is stored under that key. Any previous op
   registered under the same key is replaced.
 * If ``name`` is omitted, the checkpoint first looks up the op by identity. If
-  it is already registered, the existing key is returned. Otherwise, a sequential
-  numeric key (``"0"``, ``"1"``, ...) is generated.
+  it is already registered, the existing key is returned. Otherwise, internally
+  generated sequential names are used.
 
 When the checkpoint is in *loaded* state and the registered key is present in
 the loaded dictionary, the saved state is applied to the op immediately. This

--- a/docs/dali_dynamic/checkpointing.rst
+++ b/docs/dali_dynamic/checkpointing.rst
@@ -30,6 +30,16 @@ This page describes the two checkpointing layers that DALI Dynamic exposes:
 Manual checkpointing
 --------------------
 
+.. note::
+  Manual checkpointing is a an advanced feature. It is a set building blocks
+  for higher level systems, including the built-in
+  :ref:`semi-automatic <ndd_checkpointing_semi_automatic>` checkpointing.
+  It allows fine-grained control over individual reader or RNG
+  states, enabling integration with pre-existing checkpoint systems or
+  transferring state of compatible objects across process boundary. In typical
+  usage scenario, it's more convenent to use the
+  :ref:`semi-automatic <ndd_checkpointing_semi_automatic>` checkpointing.
+
 Both :class:`~nvidia.dali.experimental.dynamic.random.RNG` and the readers
 exposed via ``ndd.readers.*`` provide ``get_state`` and ``set_state`` methods.
 The state object returned by ``get_state`` can be converted to a string with

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ NVIDIA DALI Documentation
    dali_dynamic/api_reference
    dali_dynamic/threading
    dali_dynamic/control_features
+   dali_dynamic/checkpointing
    dali_dynamic/readers_reference
    dali_dynamic/ops_reference
    ndd_framework_plugins


### PR DESCRIPTION
# Add checkpointing support to DALI Dynamic Mode

## Summary

Adds checkpointing support to `nvidia.dali.experimental.dynamic` (`ndd`). A checkpoint captures the state of all stateful operators - readers and random number generators - so that processing can be resumed at the captured point. All other operators are conceptually stateless and are not part of a checkpoint.

Two layers of API are exposed:

1. **Manual** - `get_state` / `set_state` on individual `Reader` and `RNG` instances.
2. **Semi-automatic** - a new `Checkpoint` aggregator that registers a chosen subset of stateful objects and saves/loads their state as a single artifact.

## Category

New feature (will not break existing API).

## What's new

### Manual checkpointing

* `Reader.get_state()` returns a `ReaderState` whose `__str__` is a serialized representation of the underlying loader's snapshot. The reader's `checkpointing` arg is enabled automatically in dynamic mode, so the snapshot queue is always available.
* `Reader.set_state(state)` accepts a `ReaderState`, a `str`, or `bytes`. The state is buffered if the reader hasn't been initialized yet and applied automatically when the backend is created. A clear `RuntimeError` is raised if `set_state` is called after iteration has begun (the underlying C++ reader cannot restore after the prefetch thread starts).
* `RNG.get_state()` / `RNG.set_state()` are added as method aliases of the existing `state` property, so readers and RNGs share a uniform duck-typed contract.

### Semi-automatic checkpointing

A new `nvidia.dali.experimental.dynamic.checkpoint` submodule introduces:

* `Checkpoint` class with:
  * `register(op, name=None)` - registers a stateful op; named registration replaces an existing entry, anonymous registration is idempotent (reverse lookup) and otherwise allocates an `__op_<N>` key.
  * `get_state(name)` / `set_state(name, value)` - read / overwrite individual entries; setting marks the entry dirty.
  * `collect()` - capture the state of every registered op (sets `is_complete`, clears `is_loaded`).
  * `restore()` - apply all dirty states to their ops at once; validates completeness.
  * `serialize()` / `deserialize(data)` - JSON round-trip; loaded entries are marked dirty so subsequent `register` calls auto-apply them.
  * `save(filename)` / `load(filename)` - the filename is a Python format string with an optional `{seq}` placeholder; `save` picks the next free sequence number (avoids overwriting), `load` picks the highest matching one.
  * `clear()`, `is_complete`, `is_loaded`, `names`, `__len__`, `__contains__`.
* `checkpoint.current()` returns the `Checkpoint` bound to the active `EvalContext`.
* `EvalContext.checkpoint` lazily creates / returns that bound `Checkpoint`.

### C++ binding

Adds `_Operator.SaveCheckpoint()` / `RestoreCheckpoint(data)` to `nvidia.dali.backend_impl` so the Python wrappers can drive `OperatorBase::SaveState` / `SerializeCheckpoint` / `DeserializeCheckpoint` / `RestoreState` directly. `SaveCheckpoint` returns `py::bytes` because reader checkpoints are arbitrary protobuf bytes; the dynamic-mode `Reader` wraps that in a base64-ASCII `ReaderState` so it round-trips through `str(...)` and JSON.

## Example

```python
import nvidia.dali.experimental.dynamic as ndd

reader = ndd.readers.File(file_root="...")
rng = ndd.random.RNG(seed=42)

ckpt = ndd.checkpoint.Checkpoint()
ckpt.register(reader, "reader")
ckpt.register(rng, "rng")

# ... iterate for a while ...

ckpt.collect()
ckpt.save("ckpt_{seq:04d}.json")          # ckpt_0000.json, ckpt_0001.json, ...

# Later, resume:
reader = ndd.readers.File(file_root="...")
rng = ndd.random.RNG()

ckpt = ndd.checkpoint.Checkpoint()
ckpt.load("ckpt_{seq:04d}.json")          # picks up the most recent file
ckpt.register(reader, "reader")            # state applied implicitly
ckpt.register(rng, "rng")

for batch in reader.next_epoch(batch_size=16):
    ...
```

## Files

| File | What changed |
| --- | --- |
| `dali/python/backend_impl.cc` | Expose `SaveCheckpoint` / `RestoreCheckpoint` on the `_Operator` Python class. |
| `dali/python/nvidia/dali/experimental/dynamic/_ops.py` | New `ReaderState`; `Reader.get_state`, `Reader.set_state`; `_init_spec_no_lock` / `_init_backend` overrides that enable backend checkpointing and apply pending state. |
| `dali/python/nvidia/dali/experimental/dynamic/random.py` | Add `RNG.get_state` / `RNG.set_state` mirroring the `state` property. |
| `dali/python/nvidia/dali/experimental/dynamic/checkpoint.py` | New module: `Checkpoint`, `current()`, file-pattern helpers. |
| `dali/python/nvidia/dali/experimental/dynamic/_eval_context.py` | Lazy `EvalContext.checkpoint` property. |
| `dali/python/nvidia/dali/experimental/dynamic/__init__.py` | Re-export the `checkpoint` submodule. |
| `dali/test/python/experimental_mode/test_checkpoint.py` | New test file with end-to-end coverage. |
| `docs/dali_dynamic/checkpointing.rst` + `docs/index.rst` | New documentation page added to the Dynamic API section. |

## Notes / caveats

* A reader's saved state can only be restored on a reader that hasn't iterated yet; calling `set_state` on a reader whose prefetch thread has already started raises `RuntimeError` with an explanatory message rather than silently misbehaving.
* The on-disk format is JSON with a version tag (`_CHECKPOINT_FORMAT_VERSION`); the version field guards future format changes.
* Reader state contains binary protobuf data; `ReaderState` base64-encodes it so the serialized form is a plain ASCII string (safe for JSON, logs, and IPC).

### Tests:
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [X] Docstring
  - [ ] Doxygen
  - [X] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4617, DALI-4618
<!--- DALI-XXXX or NA --->
