### PR TITLE
Exclude CodeQL cyclic import diagnostics

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,3 +4,5 @@ queries:
 query-filters:
   - exclude:
       id: py/unsafe-cyclic-import
+  - exclude:
+      id: py/cyclic-import


### PR DESCRIPTION
## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)


## Description:
Exclude the `py/cyclic-import` CodeQL query from the Python CodeQL scan configuration.

## Additional information:

### Affected modules and functionalities:
CodeQL configuration for Python analysis.


### Key points relevant for the review:
The existing exclusion is kept, and this adds the exact query ID used by CodeQL for the non-unsafe cyclic import diagnostic.

### Tests:
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
