### PR TITLE
test: disable HW JPEG decoder in free-threading multithreading test

### DIFF
--- a/dali/test/python/free-threading/test_multithreading.py
+++ b/dali/test/python/free-threading/test_multithreading.py
@@ -58,7 +58,7 @@ class Result:
 )
 def dali_pipeline():
     enc = fn.external_source(name="INPUT")
-    img = fn.decoders.image(enc, device="mixed")
+    img = fn.decoders.image(enc, device="mixed", hw_decoder_load=0)
     img = fn.resize(img, size=(224, 224))
     img = fn.crop_mirror_normalize(
         img,


### PR DESCRIPTION
## Summary
- The free-threading parallel-pipeline stress test in `dali/test/python/free-threading/test_multithreading.py` spins up 100 worker threads, each running a pipeline that decodes JPEGs on `device="mixed"`. The shared HW JPEG decoder path contends under that level of parallelism and caused OOM on 16 GB GPUs.
- Lowering the worker count to 32 was shown to work, but that defeats the purpose — the test exists to exercise parallelism, not HW decoder resource pressure. Following the team discussion, this PR disables the HW decoder (`hw_decoder_load=0`) while keeping the mixed-device path and the full 100-worker fan-out intact.

## Test plan
- [ ] CI runs the free-threading multithreading test successfully on a 16 GB GPU.
- [ ] Test still exercises 100 parallel pipelines (no reduction in `num_workers`).

Refs DALI-4705