### PR TITLE
imgcodec: work around nvImageCodec ROI/orientation contract bug

### DIFF
--- a/dali/operators/imgcodec/image_decoder.h
+++ b/dali/operators/imgcodec/image_decoder.h
@@ -241,9 +241,9 @@ class ImageDecoder : public StatelessOperator<Backend> {
     EnforceMinimumNvimgcodecVersion();
 
     // WAR for the nvImageCodec ROI/orientation contract bug: on affected versions, the decoder
-    // validates the ROI against raw codestream dims while interpreting it in display coords,
-    // breaking 90/270-rotated samples that carry a ROI. Disable orientation in the decoder and
-    // apply it in the post-decode Convert; ROIs for oriented samples are translated to raw coords.
+    // validates the ROI against raw codestream dims while interpreting it in output (post-EXIF)
+    // coords, breaking 90/270-rotated samples that carry a ROI. Disable orientation in the
+    // decoder and apply it in the post-decode Convert; ROIs are translated to raw coords.
     roi_orient_war_ = use_orientation_ && !version_at_least(0, 9, 0);
 
     nvimgcodecDeviceAllocator_t *dev_alloc_ptr = nullptr;
@@ -544,26 +544,26 @@ class ImageDecoder : public StatelessOperator<Backend> {
   }
 
   /**
-   * @brief Maps an ROI expressed in display (post-orientation) coords to raw codestream coords.
+   * @brief Maps an ROI expressed in output (post-orientation) coords to raw codestream coords.
    * Used by the ROI/orientation workaround so the sub-stream ROI handed to nvImageCodec is
    * valid in raw coords (the decoder is told not to apply orientation; Convert applies it).
    */
-  static ROI DisplayToRawROI(const ROI &display_roi, const nvimgcodecOrientation_t &ori,
-                             int64_t display_h, int64_t display_w) {
+  static ROI OutputToRawROI(const ROI &output_roi, const nvimgcodecOrientation_t &ori,
+                            int64_t output_h, int64_t output_w) {
     bool swap_xy = ori.rotated % 180 == 90;
     bool flip_x = ori.rotated == 180 || ori.rotated == 270;
     bool flip_y = ori.rotated == 90 || ori.rotated == 180;
     flip_x ^= ori.flip_x;
     flip_y ^= ori.flip_y;
-    int64_t y0 = display_roi.begin[0], y1 = display_roi.end[0];
-    int64_t x0 = display_roi.begin[1], x1 = display_roi.end[1];
+    int64_t y0 = output_roi.begin[0], y1 = output_roi.end[0];
+    int64_t x0 = output_roi.begin[1], x1 = output_roi.end[1];
     if (flip_y) {
-      int64_t new_y0 = display_h - y1, new_y1 = display_h - y0;
+      int64_t new_y0 = output_h - y1, new_y1 = output_h - y0;
       y0 = new_y0;
       y1 = new_y1;
     }
     if (flip_x) {
-      int64_t new_x0 = display_w - x1, new_x1 = display_w - x0;
+      int64_t new_x0 = output_w - x1, new_x1 = output_w - x0;
       x0 = new_x0;
       x1 = new_x1;
     }
@@ -765,7 +765,7 @@ class ImageDecoder : public StatelessOperator<Backend> {
 
         ROI &roi = rois_[i] = GetRoi(spec_, ws, i, st->out_shape);
         // WORKAROUND(nvimgcodec ROI+EXIF orientation): on affected versions nvImageCodec
-        // rejects display-coord ROIs whose extent exceeds the raw codestream dims, which
+        // rejects output-coord ROIs whose extent exceeds the raw codestream dims, which
         // happens for 90/270-rotated samples carrying a ROI. We tell the decoder not to
         // apply orientation on this batch, translate the ROI to raw coords, and let
         // ConvertCPU/GPU apply the orientation post-decode.
@@ -788,8 +788,8 @@ class ImageDecoder : public StatelessOperator<Backend> {
           }
           ROI sub_stream_roi = roi;
           if (roi_orient_war_ && sample_oriented) {
-            sub_stream_roi = DisplayToRawROI(roi, parsed_orient,
-                                             st->out_shape[0], st->out_shape[1]);
+            sub_stream_roi = OutputToRawROI(roi, parsed_orient,
+                                            st->out_shape[0], st->out_shape[1]);
           }
           st->out_shape[0] = roi_sh[0];
           st->out_shape[1] = roi_sh[1];

--- a/dali/operators/imgcodec/image_decoder.h
+++ b/dali/operators/imgcodec/image_decoder.h
@@ -187,6 +187,10 @@ class ImageDecoder : public StatelessOperator<Backend> {
 
     SampleView<CPUBackend> decode_out_cpu;
     SampleView<GPUBackend> decode_out_gpu;
+
+    // When non-empty: nvImageCodec ROI/orientation workaround is active for this sample.
+    // The decode targets the full oriented image; ConvertCPU/GPU crops to this ROI.
+    ROI post_decode_roi = {};
   };
 
   struct nvImagecodecOpts {
@@ -556,6 +560,13 @@ class ImageDecoder : public StatelessOperator<Backend> {
     st.req_img_type = format_;
     int64_t &nchannels = st.out_shape[2];
     auto decode_shape = st.out_shape;
+    // Workaround: decode the full oriented image; ConvertCPU/GPU crops to post_decode_roi.
+    if (st.post_decode_roi.use_roi()) {
+      decode_shape = st.parsed_sample.dali_img_info.shape;
+      decode_shape[2] = nchannels;
+      if (st.parsed_sample.nvimgcodec_img_info.orientation.rotated % 180 != 0)
+        std::swap(decode_shape[0], decode_shape[1]);
+    }
 
     // Decode to format
     st.image_info.color_spec = NVIMGCODEC_COLORSPEC_SRGB;
@@ -598,7 +609,8 @@ class ImageDecoder : public StatelessOperator<Backend> {
                                   1.0f;
 
     st.need_processing = st.req_img_type != st.orig_img_type ||
-                         dtype_ != st.parsed_sample.orig_dtype || need_dynamic_range_scaling;
+                         dtype_ != st.parsed_sample.orig_dtype || need_dynamic_range_scaling ||
+                         st.post_decode_roi.use_roi();
 
     st.image_info.buffer_kind = std::is_same<MixedBackend, Backend>::value ?
                                     NVIMGCODEC_IMAGE_BUFFER_KIND_STRIDED_DEVICE :
@@ -708,6 +720,16 @@ class ImageDecoder : public StatelessOperator<Backend> {
         }
 
         ROI &roi = rois_[i] = GetRoi(spec_, ws, i, st->out_shape);
+        st->post_decode_roi = ROI{};
+        // WORKAROUND(nvimgcodec ROI+EXIF orientation): for 90/270-rotated images, the
+        // raw codestream dims differ from the display dims, and nvImageCodec rejects
+        // display-coord ROIs whose extent exceeds the raw dims. Until this is fixed on
+        // the nvimgcodec side, decode the full oriented image and let ConvertCPU/GPU
+        // crop to `roi` in the post-decode step.
+        if (roi.use_roi() && use_orientation_ && !version_at_least(0, 9, 0) &&
+            st->parsed_sample.nvimgcodec_img_info.orientation.rotated % 180 != 0) {
+          st->post_decode_roi = roi;
+        }
         if (roi.use_roi()) {
           auto roi_sh = roi.shape();
           if (roi.end.size() >= 2) {
@@ -800,7 +822,7 @@ class ImageDecoder : public StatelessOperator<Backend> {
         } else {
           st.image = NvImageCodecImage::Create(instance_, &st.image_info);
         }
-        if (has_roi) {
+        if (has_roi && !st.post_decode_roi.use_roi()) {
           batch_encoded_streams_.push_back(st.sub_encoded_stream);
         } else {
           batch_encoded_streams_.push_back(st.parsed_sample.encoded_stream);
@@ -868,15 +890,17 @@ class ImageDecoder : public StatelessOperator<Backend> {
                 [&, out = output[orig_idx], st_ptr, orig_idx](int tid) {
                   DomainTimeRange tr(make_string("Convert #", orig_idx), DomainTimeRange::kOrange);
                   auto &st = *st_ptr;
+                  const ROI &convert_roi = st.post_decode_roi;
                   if constexpr (std::is_same<MixedBackend, Backend>::value) {
                     ConvertGPU(out, st.req_layout, st.req_img_type, st.decode_out_gpu,
-                               st.req_layout, st.orig_img_type, order.stream(), ROI{},
+                               st.req_layout, st.orig_img_type, order.stream(), convert_roi,
                                nvimgcodecOrientation_t{}, st.dyn_range_multiplier);
                     st.device_buf.reset();
                   } else {
                     assert(st.dyn_range_multiplier == 1.0f);  // TODO(janton): enable
                     ConvertCPU(out, st.req_layout, st.req_img_type, st.decode_out_cpu,
-                               st.req_layout, st.orig_img_type, ROI{}, nvimgcodecOrientation_t{});
+                               st.req_layout, st.orig_img_type, convert_roi,
+                               nvimgcodecOrientation_t{});
                     st.host_buf.reset();
                   }
                 },

--- a/dali/operators/imgcodec/image_decoder.h
+++ b/dali/operators/imgcodec/image_decoder.h
@@ -188,9 +188,9 @@ class ImageDecoder : public StatelessOperator<Backend> {
     SampleView<CPUBackend> decode_out_cpu;
     SampleView<GPUBackend> decode_out_gpu;
 
-    // When non-empty: nvImageCodec ROI/orientation workaround is active for this sample.
-    // The decode targets the full oriented image; ConvertCPU/GPU crops to this ROI.
-    ROI post_decode_roi = {};
+    // When non-identity (rotated != 0 || flip_x || flip_y): nvImageCodec was asked to
+    // decode without applying orientation; ConvertCPU/GPU applies it post-decode.
+    nvimgcodecOrientation_t post_decode_orientation = {};
   };
 
   struct nvImagecodecOpts {
@@ -239,6 +239,12 @@ class ImageDecoder : public StatelessOperator<Backend> {
         cache_ = std::make_unique<CachedDecoderImpl>(spec_);
     }
     EnforceMinimumNvimgcodecVersion();
+
+    // WAR for the nvImageCodec ROI/orientation contract bug: on affected versions, the decoder
+    // validates the ROI against raw codestream dims while interpreting it in display coords,
+    // breaking 90/270-rotated samples that carry a ROI. Disable orientation in the decoder and
+    // apply it in the post-decode Convert; ROIs for oriented samples are translated to raw coords.
+    roi_orient_war_ = use_orientation_ && !version_at_least(0, 9, 0);
 
     nvimgcodecDeviceAllocator_t *dev_alloc_ptr = nullptr;
     nvimgcodecPinnedAllocator_t *pinned_alloc_ptr = nullptr;
@@ -538,6 +544,43 @@ class ImageDecoder : public StatelessOperator<Backend> {
   }
 
   /**
+   * @brief Maps an ROI expressed in display (post-orientation) coords to raw codestream coords.
+   * Used by the ROI/orientation workaround so the sub-stream ROI handed to nvImageCodec is
+   * valid in raw coords (the decoder is told not to apply orientation; Convert applies it).
+   */
+  static ROI DisplayToRawROI(const ROI &display_roi, const nvimgcodecOrientation_t &ori,
+                             int64_t display_h, int64_t display_w) {
+    bool swap_xy = ori.rotated % 180 == 90;
+    bool flip_x = ori.rotated == 180 || ori.rotated == 270;
+    bool flip_y = ori.rotated == 90 || ori.rotated == 180;
+    flip_x ^= ori.flip_x;
+    flip_y ^= ori.flip_y;
+    int64_t y0 = display_roi.begin[0], y1 = display_roi.end[0];
+    int64_t x0 = display_roi.begin[1], x1 = display_roi.end[1];
+    if (flip_y) {
+      int64_t new_y0 = display_h - y1, new_y1 = display_h - y0;
+      y0 = new_y0;
+      y1 = new_y1;
+    }
+    if (flip_x) {
+      int64_t new_x0 = display_w - x1, new_x1 = display_w - x0;
+      x0 = new_x0;
+      x1 = new_x1;
+    }
+    ROI raw;
+    raw.begin.resize(2);
+    raw.end.resize(2);
+    if (swap_xy) {
+      raw.begin[0] = x0; raw.end[0] = x1;
+      raw.begin[1] = y0; raw.end[1] = y1;
+    } else {
+      raw.begin[0] = y0; raw.end[0] = y1;
+      raw.begin[1] = x0; raw.end[1] = x1;
+    }
+    return raw;
+  }
+
+  /**
    * @brief Checks that nvImageCodec version is at least a given version
    */
   bool version_at_least(int req_major, int req_minor, int req_patch) {
@@ -560,13 +603,11 @@ class ImageDecoder : public StatelessOperator<Backend> {
     st.req_img_type = format_;
     int64_t &nchannels = st.out_shape[2];
     auto decode_shape = st.out_shape;
-    // Workaround: decode the full oriented image; ConvertCPU/GPU crops to post_decode_roi.
-    if (st.post_decode_roi.use_roi()) {
-      decode_shape = st.parsed_sample.dali_img_info.shape;
-      decode_shape[2] = nchannels;
-      if (st.parsed_sample.nvimgcodec_img_info.orientation.rotated % 180 != 0)
-        std::swap(decode_shape[0], decode_shape[1]);
-    }
+    // Workaround: nvImageCodec is told not to apply orientation; its output is in raw codestream
+    // coords (smaller side swapped relative to st.out_shape for 90/270). Convert applies the
+    // orientation post-decode and produces st.out_shape-sized output.
+    if (st.post_decode_orientation.rotated % 180 != 0)
+      std::swap(decode_shape[0], decode_shape[1]);
 
     // Decode to format
     st.image_info.color_spec = NVIMGCODEC_COLORSPEC_SRGB;
@@ -608,9 +649,12 @@ class ImageDecoder : public StatelessOperator<Backend> {
                                   DynamicRangeMultiplier(precision, st.parsed_sample.orig_dtype) :
                                   1.0f;
 
+    const auto &post_orient = st.post_decode_orientation;
+    bool post_decode_orient =
+        post_orient.rotated != 0 || post_orient.flip_x || post_orient.flip_y;
     st.need_processing = st.req_img_type != st.orig_img_type ||
                          dtype_ != st.parsed_sample.orig_dtype || need_dynamic_range_scaling ||
-                         st.post_decode_roi.use_roi();
+                         post_decode_orient;
 
     st.image_info.buffer_kind = std::is_same<MixedBackend, Backend>::value ?
                                     NVIMGCODEC_IMAGE_BUFFER_KIND_STRIDED_DEVICE :
@@ -720,16 +764,16 @@ class ImageDecoder : public StatelessOperator<Backend> {
         }
 
         ROI &roi = rois_[i] = GetRoi(spec_, ws, i, st->out_shape);
-        st->post_decode_roi = ROI{};
-        // WORKAROUND(nvimgcodec ROI+EXIF orientation): for 90/270-rotated images, the
-        // raw codestream dims differ from the display dims, and nvImageCodec rejects
-        // display-coord ROIs whose extent exceeds the raw dims. Until this is fixed on
-        // the nvimgcodec side, decode the full oriented image and let ConvertCPU/GPU
-        // crop to `roi` in the post-decode step.
-        if (roi.use_roi() && use_orientation_ && !version_at_least(0, 9, 0) &&
-            st->parsed_sample.nvimgcodec_img_info.orientation.rotated % 180 != 0) {
-          st->post_decode_roi = roi;
-        }
+        // WORKAROUND(nvimgcodec ROI+EXIF orientation): on affected versions nvImageCodec
+        // rejects display-coord ROIs whose extent exceeds the raw codestream dims, which
+        // happens for 90/270-rotated samples carrying a ROI. We tell the decoder not to
+        // apply orientation on this batch, translate the ROI to raw coords, and let
+        // ConvertCPU/GPU apply the orientation post-decode.
+        const auto &parsed_orient = st->parsed_sample.nvimgcodec_img_info.orientation;
+        bool sample_oriented = use_orientation_ &&
+            (parsed_orient.rotated != 0 || parsed_orient.flip_x || parsed_orient.flip_y);
+        st->post_decode_orientation =
+            (roi_orient_war_ && sample_oriented) ? parsed_orient : nvimgcodecOrientation_t{};
         if (roi.use_roi()) {
           auto roi_sh = roi.shape();
           if (roi.end.size() >= 2) {
@@ -742,31 +786,31 @@ class ImageDecoder : public StatelessOperator<Backend> {
                               0 <= roi.begin[1] && roi.begin[1] <= st->out_shape[1],
                           "ROI begin must fit within the image bounds");
           }
+          ROI sub_stream_roi = roi;
+          if (roi_orient_war_ && sample_oriented) {
+            sub_stream_roi = DisplayToRawROI(roi, parsed_orient,
+                                             st->out_shape[0], st->out_shape[1]);
+          }
           st->out_shape[0] = roi_sh[0];
           st->out_shape[1] = roi_sh[1];
 
-          // Skip handing the display-coord ROI to nvImageCodec when the WAR is active —
-          // the sub-stream wouldn't be used (the decoder consumes the full stream) and
-          // nvImageCodec rejects this ROI at sub-stream creation time on rotated samples.
-          if (!st->post_decode_roi.use_roi()) {
-            nvimgcodecCodeStreamView_t cs_view = {
-                NVIMGCODEC_STRUCTURE_TYPE_CODE_STREAM_VIEW,
-                sizeof(nvimgcodecCodeStreamView_t),
-                nullptr,
-                0,  // image_idx
-                {NVIMGCODEC_STRUCTURE_TYPE_REGION, sizeof(nvimgcodecRegion_t), nullptr, 2}};
-            cs_view.region.start[0] = roi.begin[0];
-            cs_view.region.start[1] = roi.begin[1];
-            cs_view.region.end[0] = roi.end[0];
-            cs_view.region.end[1] = roi.end[1];
-            nvimgcodecCodeStream_t sub_encoded_stream = st->sub_encoded_stream.get();
-            if (sub_encoded_stream) {  // reuses the code stream object
-              CHECK_NVIMGCODEC(nvimgcodecCodeStreamGetSubCodeStream(
-                  st->parsed_sample.encoded_stream.get(), &sub_encoded_stream, &cs_view));
-            } else {
-              st->sub_encoded_stream = NvImageCodecCodeStream::FromSubCodeStream(
-                  st->parsed_sample.encoded_stream.get(), &cs_view);
-            }
+          nvimgcodecCodeStreamView_t cs_view = {
+              NVIMGCODEC_STRUCTURE_TYPE_CODE_STREAM_VIEW,
+              sizeof(nvimgcodecCodeStreamView_t),
+              nullptr,
+              0,  // image_idx
+              {NVIMGCODEC_STRUCTURE_TYPE_REGION, sizeof(nvimgcodecRegion_t), nullptr, 2}};
+          cs_view.region.start[0] = sub_stream_roi.begin[0];
+          cs_view.region.start[1] = sub_stream_roi.begin[1];
+          cs_view.region.end[0] = sub_stream_roi.end[0];
+          cs_view.region.end[1] = sub_stream_roi.end[1];
+          nvimgcodecCodeStream_t sub_encoded_stream = st->sub_encoded_stream.get();
+          if (sub_encoded_stream) {  // reuses the code stream object
+            CHECK_NVIMGCODEC(nvimgcodecCodeStreamGetSubCodeStream(
+                st->parsed_sample.encoded_stream.get(), &sub_encoded_stream, &cs_view));
+          } else {
+            st->sub_encoded_stream = NvImageCodecCodeStream::FromSubCodeStream(
+                st->parsed_sample.encoded_stream.get(), &cs_view);
           }
         }
         out_shape.set_tensor_shape(i, st->out_shape);
@@ -827,7 +871,7 @@ class ImageDecoder : public StatelessOperator<Backend> {
         } else {
           st.image = NvImageCodecImage::Create(instance_, &st.image_info);
         }
-        if (has_roi && !st.post_decode_roi.use_roi()) {
+        if (has_roi) {
           batch_encoded_streams_.push_back(st.sub_encoded_stream);
         } else {
           batch_encoded_streams_.push_back(st.parsed_sample.encoded_stream);
@@ -857,7 +901,8 @@ class ImageDecoder : public StatelessOperator<Backend> {
       size_t decode_status_size = 0;
       nvimgcodecDecodeParams_t decode_params = {NVIMGCODEC_STRUCTURE_TYPE_DECODE_PARAMS,
                                                 sizeof(nvimgcodecDecodeParams_t), nullptr};
-      decode_params.apply_exif_orientation = static_cast<int>(use_orientation_);
+      decode_params.apply_exif_orientation =
+          static_cast<int>(use_orientation_ && !roi_orient_war_);
 
       {
         DomainTimeRange tr("nvimgcodecDecoderDecode", DomainTimeRange::kOrange);
@@ -895,17 +940,16 @@ class ImageDecoder : public StatelessOperator<Backend> {
                 [&, out = output[orig_idx], st_ptr, orig_idx](int tid) {
                   DomainTimeRange tr(make_string("Convert #", orig_idx), DomainTimeRange::kOrange);
                   auto &st = *st_ptr;
-                  const ROI &convert_roi = st.post_decode_roi;
                   if constexpr (std::is_same<MixedBackend, Backend>::value) {
                     ConvertGPU(out, st.req_layout, st.req_img_type, st.decode_out_gpu,
-                               st.req_layout, st.orig_img_type, order.stream(), convert_roi,
-                               nvimgcodecOrientation_t{}, st.dyn_range_multiplier);
+                               st.req_layout, st.orig_img_type, order.stream(), ROI{},
+                               st.post_decode_orientation, st.dyn_range_multiplier);
                     st.device_buf.reset();
                   } else {
                     assert(st.dyn_range_multiplier == 1.0f);  // TODO(janton): enable
                     ConvertCPU(out, st.req_layout, st.req_img_type, st.decode_out_cpu,
-                               st.req_layout, st.orig_img_type, convert_roi,
-                               nvimgcodecOrientation_t{});
+                               st.req_layout, st.orig_img_type, ROI{},
+                               st.post_decode_orientation);
                     st.host_buf.reset();
                   }
                 },
@@ -964,6 +1008,7 @@ class ImageDecoder : public StatelessOperator<Backend> {
   DALIDataType dtype_;
   TensorLayout layout_ = "HWC";
   bool use_orientation_ = true;
+  bool roi_orient_war_ = false;
   int max_batch_size_ = 1;
   int num_threads_ = -1;
   ThreadPool *tp_ = nullptr;

--- a/dali/operators/imgcodec/image_decoder.h
+++ b/dali/operators/imgcodec/image_decoder.h
@@ -745,23 +745,28 @@ class ImageDecoder : public StatelessOperator<Backend> {
           st->out_shape[0] = roi_sh[0];
           st->out_shape[1] = roi_sh[1];
 
-          nvimgcodecCodeStreamView_t cs_view = {
-              NVIMGCODEC_STRUCTURE_TYPE_CODE_STREAM_VIEW,
-              sizeof(nvimgcodecCodeStreamView_t),
-              nullptr,
-              0,  // image_idx
-              {NVIMGCODEC_STRUCTURE_TYPE_REGION, sizeof(nvimgcodecRegion_t), nullptr, 2}};
-          cs_view.region.start[0] = roi.begin[0];
-          cs_view.region.start[1] = roi.begin[1];
-          cs_view.region.end[0] = roi.end[0];
-          cs_view.region.end[1] = roi.end[1];
-          nvimgcodecCodeStream_t sub_encoded_stream = st->sub_encoded_stream.get();
-          if (sub_encoded_stream) {  // reuses the code stream object
-            CHECK_NVIMGCODEC(nvimgcodecCodeStreamGetSubCodeStream(
-                st->parsed_sample.encoded_stream.get(), &sub_encoded_stream, &cs_view));
-          } else {
-            st->sub_encoded_stream = NvImageCodecCodeStream::FromSubCodeStream(
-                st->parsed_sample.encoded_stream.get(), &cs_view);
+          // Skip handing the display-coord ROI to nvImageCodec when the WAR is active —
+          // the sub-stream wouldn't be used (the decoder consumes the full stream) and
+          // nvImageCodec rejects this ROI at sub-stream creation time on rotated samples.
+          if (!st->post_decode_roi.use_roi()) {
+            nvimgcodecCodeStreamView_t cs_view = {
+                NVIMGCODEC_STRUCTURE_TYPE_CODE_STREAM_VIEW,
+                sizeof(nvimgcodecCodeStreamView_t),
+                nullptr,
+                0,  // image_idx
+                {NVIMGCODEC_STRUCTURE_TYPE_REGION, sizeof(nvimgcodecRegion_t), nullptr, 2}};
+            cs_view.region.start[0] = roi.begin[0];
+            cs_view.region.start[1] = roi.begin[1];
+            cs_view.region.end[0] = roi.end[0];
+            cs_view.region.end[1] = roi.end[1];
+            nvimgcodecCodeStream_t sub_encoded_stream = st->sub_encoded_stream.get();
+            if (sub_encoded_stream) {  // reuses the code stream object
+              CHECK_NVIMGCODEC(nvimgcodecCodeStreamGetSubCodeStream(
+                  st->parsed_sample.encoded_stream.get(), &sub_encoded_stream, &cs_view));
+            } else {
+              st->sub_encoded_stream = NvImageCodecCodeStream::FromSubCodeStream(
+                  st->parsed_sample.encoded_stream.get(), &cs_view);
+            }
           }
         }
         out_shape.set_tensor_shape(i, st->out_shape);

--- a/dali/operators/imgcodec/util/convert.h
+++ b/dali/operators/imgcodec/util/convert.h
@@ -223,6 +223,11 @@ void ApplyOrientation(nvimgcodecOrientation_t orientation, T *&data,
   if (swap_xy) {
     std::swap(x_stride, y_stride);
     std::swap(x_size, y_size);
+    // Keep flip_x/flip_y semantics tied to OUTPUT axes (consistent with the GPU path in
+    // convert_gpu.cu): after swap, flipping output W direction means writing to the post-swap
+    // y_stride and vice versa. Without this swap, swap_xy + flip_x produces the visual of the
+    // opposite rotation direction (the latent bug surfaced by ROI/orientation WAR).
+    std::swap(flip_x, flip_y);
   }
 
   if (flip_x) {

--- a/dali/operators/imgcodec/util/convert_test.cc
+++ b/dali/operators/imgcodec/util/convert_test.cc
@@ -274,6 +274,93 @@ TEST_F(ConvertLayoutTest, RoiCHW) {
 }
 
 
+// Rotation/flip tests for ConvertCPU. These mirror the rotation tests in convert_gpu_test.cc
+// to guarantee CPU and GPU paths agree on EXIF orientation semantics — the contract relied on
+// by image_decoder.h's ROI/orientation workaround.
+class ConvertOrientationTest : public ::testing::Test {
+ protected:
+  static constexpr int kH = 2;
+  static constexpr int kW = 3;
+  static constexpr int kC = 3;
+
+  // 2x3 RGB input; each pixel uniquely identifiable so axis mix-ups surface as mismatches.
+  static std::vector<uint8_t> MakeInput() {
+    return {
+      0x00, 0x01, 0x02,  0x10, 0x11, 0x12,  0x20, 0x21, 0x22,  // row 0: A B C
+      0x30, 0x31, 0x32,  0x40, 0x41, 0x42,  0x50, 0x51, 0x52,  // row 1: D E F
+    };
+  }
+
+  void Run(int rotated, bool flip_x, bool flip_y, std::vector<uint8_t> expected) {
+    bool swap = rotated % 180 == 90;
+    int out_h = swap ? kW : kH;
+    int out_w = swap ? kH : kW;
+    ASSERT_EQ(expected.size(), static_cast<size_t>(out_h * out_w * kC));
+
+    auto input_buf = MakeInput();
+    TensorShape<> in_shape{kH, kW, kC};
+    TensorShape<> out_shape{out_h, out_w, kC};
+    ConstSampleView<CPUBackend> in_view(input_buf.data(), in_shape, DALI_UINT8);
+    std::vector<uint8_t> output_buf(out_h * out_w * kC, 0xFF);
+    SampleView<CPUBackend> out_view(output_buf.data(), out_shape, DALI_UINT8);
+
+    nvimgcodecOrientation_t orientation{
+        NVIMGCODEC_STRUCTURE_TYPE_ORIENTATION, sizeof(nvimgcodecOrientation_t),
+        nullptr, rotated, flip_x, flip_y};
+    ConvertCPU(out_view, "HWC", DALI_RGB, in_view, "HWC", DALI_RGB, {}, orientation);
+    EXPECT_EQ(output_buf, expected);
+  }
+};
+
+TEST_F(ConvertOrientationTest, Rotated90) {
+  // Matches convert_gpu_test.cc Rotation90: A→(2,0), C→(0,0), F→(0,1)
+  Run(90, false, false, {
+    0x20, 0x21, 0x22,  0x50, 0x51, 0x52,
+    0x10, 0x11, 0x12,  0x40, 0x41, 0x42,
+    0x00, 0x01, 0x02,  0x30, 0x31, 0x32,
+  });
+}
+
+TEST_F(ConvertOrientationTest, Rotated270) {
+  // Matches convert_gpu_test.cc Rotation270: A→(0,1), D→(0,0)
+  Run(270, false, false, {
+    0x30, 0x31, 0x32,  0x00, 0x01, 0x02,
+    0x40, 0x41, 0x42,  0x10, 0x11, 0x12,
+    0x50, 0x51, 0x52,  0x20, 0x21, 0x22,
+  });
+}
+
+TEST_F(ConvertOrientationTest, Rotated180) {
+  Run(180, false, false, {
+    0x50, 0x51, 0x52,  0x40, 0x41, 0x42,  0x30, 0x31, 0x32,
+    0x20, 0x21, 0x22,  0x10, 0x11, 0x12,  0x00, 0x01, 0x02,
+  });
+}
+
+TEST_F(ConvertOrientationTest, Rotated90FlipX) {
+  // Matches convert_gpu_test.cc Rotation90FlipX: input flipped along W, then rotated 90
+  Run(90, true, false, {
+    0x50, 0x51, 0x52,  0x20, 0x21, 0x22,
+    0x40, 0x41, 0x42,  0x10, 0x11, 0x12,
+    0x30, 0x31, 0x32,  0x00, 0x01, 0x02,
+  });
+}
+
+TEST_F(ConvertOrientationTest, FlipX) {
+  Run(0, true, false, {
+    0x20, 0x21, 0x22,  0x10, 0x11, 0x12,  0x00, 0x01, 0x02,
+    0x50, 0x51, 0x52,  0x40, 0x41, 0x42,  0x30, 0x31, 0x32,
+  });
+}
+
+TEST_F(ConvertOrientationTest, FlipY) {
+  Run(0, false, true, {
+    0x30, 0x31, 0x32,  0x40, 0x41, 0x42,  0x50, 0x51, 0x52,
+    0x00, 0x01, 0x02,  0x10, 0x11, 0x12,  0x20, 0x21, 0x22,
+  });
+}
+
+
 }  // namespace test
 }  // namespace imgcodec
 }  // namespace dali

--- a/dali/test/python/decoder/test_image.py
+++ b/dali/test/python/decoder/test_image.py
@@ -509,7 +509,7 @@ def test_image_decoder_crafted_tiny_files():
 
 # Regression test for the nvImageCodec ROI/orientation contract bug. For EXIF
 # orientations 5-8 (which swap width and height), pre-fix nvImageCodec rejected
-# display-coord ROIs whose extent exceeded the raw codestream's smaller dimension.
+# output-coord ROIs whose extent exceeded the raw codestream's smaller dimension.
 # The workaround in image_decoder.h disables nvImageCodec's orientation pass,
 # translates the ROI to raw codestream coords, and applies orientation in
 # post-decode Convert. The non-symmetric absolute ROI here would surface any
@@ -528,7 +528,7 @@ def test_image_slice_on_exif_rotated(image_name):
     def pipe(device):
         encoded, _ = fn.readers.file(files=[image_path])
         decoded_full = fn.decoders.image(encoded, device=device, output_type=types.RGB)
-        # Non-symmetric absolute ROI in display coords. Small insets so the ROI fits
+        # Non-symmetric absolute ROI in output coords. Small insets so the ROI fits
         # in both H/W orderings of the (almost-square) padlock test images.
         full_shape = decoded_full.shape()
         anchor = fn.stack(

--- a/dali/test/python/decoder/test_image.py
+++ b/dali/test/python/decoder/test_image.py
@@ -510,9 +510,11 @@ def test_image_decoder_crafted_tiny_files():
 # Regression test for the nvImageCodec ROI/orientation contract bug. For EXIF
 # orientations 5-8 (which swap width and height), pre-fix nvImageCodec rejected
 # display-coord ROIs whose extent exceeded the raw codestream's smaller dimension.
-# The workaround in image_decoder.h routes those samples through full-decode +
-# post-decode crop. The non-symmetric absolute ROI here would surface any axis
-# mix-up as a content mismatch against a slice of the full decode.
+# The workaround in image_decoder.h disables nvImageCodec's orientation pass,
+# translates the ROI to raw codestream coords, and applies orientation in
+# post-decode Convert. The non-symmetric absolute ROI here would surface any
+# axis or anchor mix-up in the translation as a content mismatch against a
+# slice of the full decode.
 @params(
     "padlock-406986_640_rotate_90.jpg",
     "padlock-406986_640_rotate_270.jpg",

--- a/dali/test/python/decoder/test_image.py
+++ b/dali/test/python/decoder/test_image.py
@@ -505,3 +505,46 @@ def test_image_decoder_crafted_tiny_files():
 
         p = pipe()
         assert_raises(RuntimeError, p.run)
+
+
+# Regression test for the nvImageCodec ROI/orientation contract bug: with
+# adjust_orientation=True (the default), the random-crop selector picks a region in
+# display coords. For EXIF orientations 5-8 (which swap width and height), pre-fix
+# nvImageCodec rejected display-coord ROIs that exceeded the raw codestream's smaller
+# dimension, causing image_random_crop to throw. The workaround in image_decoder.h
+# routes those samples through full-decode + post-decode crop.
+@params(
+    "padlock-406986_640_rotate_90.jpg",
+    "padlock-406986_640_rotate_270.jpg",
+    "padlock-406986_640_mirror_horizontal_rotate_90.jpg",
+    "padlock-406986_640_mirror_horizontal_rotate_270.jpg",
+)
+def test_image_random_crop_on_exif_rotated(image_name):
+    image_path = os.path.join(
+        test_data_root, "db", "imgcodec", "jpeg", "orientation", image_name
+    )
+
+    @pipeline_def(batch_size=1, device_id=0, num_threads=1)
+    def pipe(device):
+        encoded, _ = fn.readers.file(files=[image_path])
+        # Use random_area=[0.5, 1.0] to bias the crop selector toward wide regions —
+        # those are the ones that triggered the pre-fix bounds rejection on rotated
+        # images. Run a handful of iterations to cover multiple random selections.
+        decoded = fn.decoders.image_random_crop(
+            encoded,
+            device=device,
+            output_type=types.RGB,
+            random_area=[0.5, 1.0],
+            random_aspect_ratio=[0.75, 1.3333],
+            num_attempts=10,
+        )
+        return decoded
+
+    for device in ("cpu", "mixed"):
+        p = pipe(device=device, seed=42)
+        for _ in range(8):
+            (out,) = p.run()
+            img = to_array(out[0])
+            # Sanity: at least one pixel decoded and the output has 3 channels.
+            assert img.ndim == 3 and img.shape[2] == 3
+            assert img.shape[0] > 0 and img.shape[1] > 0

--- a/dali/test/python/decoder/test_image.py
+++ b/dali/test/python/decoder/test_image.py
@@ -507,44 +507,44 @@ def test_image_decoder_crafted_tiny_files():
         assert_raises(RuntimeError, p.run)
 
 
-# Regression test for the nvImageCodec ROI/orientation contract bug: with
-# adjust_orientation=True (the default), the random-crop selector picks a region in
-# display coords. For EXIF orientations 5-8 (which swap width and height), pre-fix
-# nvImageCodec rejected display-coord ROIs that exceeded the raw codestream's smaller
-# dimension, causing image_random_crop to throw. The workaround in image_decoder.h
-# routes those samples through full-decode + post-decode crop.
+# Regression test for the nvImageCodec ROI/orientation contract bug. For EXIF
+# orientations 5-8 (which swap width and height), pre-fix nvImageCodec rejected
+# display-coord ROIs whose extent exceeded the raw codestream's smaller dimension.
+# The workaround in image_decoder.h routes those samples through full-decode +
+# post-decode crop. The non-symmetric absolute ROI here would surface any axis
+# mix-up as a content mismatch against a slice of the full decode.
 @params(
     "padlock-406986_640_rotate_90.jpg",
     "padlock-406986_640_rotate_270.jpg",
     "padlock-406986_640_mirror_horizontal_rotate_90.jpg",
     "padlock-406986_640_mirror_horizontal_rotate_270.jpg",
 )
-def test_image_random_crop_on_exif_rotated(image_name):
-    image_path = os.path.join(
-        test_data_root, "db", "imgcodec", "jpeg", "orientation", image_name
-    )
+def test_image_slice_on_exif_rotated(image_name):
+    image_path = os.path.join(test_data_root, "db", "imgcodec", "jpeg", "orientation", image_name)
 
     @pipeline_def(batch_size=1, device_id=0, num_threads=1)
     def pipe(device):
         encoded, _ = fn.readers.file(files=[image_path])
-        # Use random_area=[0.5, 1.0] to bias the crop selector toward wide regions —
-        # those are the ones that triggered the pre-fix bounds rejection on rotated
-        # images. Run a handful of iterations to cover multiple random selections.
-        decoded = fn.decoders.image_random_crop(
+        decoded_full = fn.decoders.image(encoded, device=device, output_type=types.RGB)
+        # Non-symmetric absolute ROI in display coords. Small insets so the ROI fits
+        # in both H/W orderings of the (almost-square) padlock test images.
+        full_shape = decoded_full.shape()
+        anchor = fn.stack(
+            types.Constant(2, dtype=types.INT64), types.Constant(1, dtype=types.INT64)
+        )
+        size = fn.stack(full_shape[0] - 6, full_shape[1] - 4)
+        decoded = fn.decoders.image_slice(
             encoded,
+            anchor,
+            size,
             device=device,
             output_type=types.RGB,
-            random_area=[0.5, 1.0],
-            random_aspect_ratio=[0.75, 1.3333],
-            num_attempts=10,
+            axes=[0, 1],
         )
-        return decoded
+        ref = fn.slice(decoded_full, anchor, size, axes=[0, 1])
+        return decoded, ref
 
     for device in ("cpu", "mixed"):
-        p = pipe(device=device, seed=42)
-        for _ in range(8):
-            (out,) = p.run()
-            img = to_array(out[0])
-            # Sanity: at least one pixel decoded and the output has 3 channels.
-            assert img.ndim == 3 and img.shape[2] == 3
-            assert img.shape[0] > 0 and img.shape[1] > 0
+        p = pipe(device=device)
+        decoded_out, ref_out = p.run()
+        np.testing.assert_array_equal(to_array(decoded_out[0]), to_array(ref_out[0]))


### PR DESCRIPTION
## Issue

For images with non-trivial EXIF orientation, nvImageCodec checks the ROI passed in `cs_view.region` against the raw codestream dims while its decode output is in display (post-orientation) coords. Display-coord ROIs that exceed the raw dims on the smaller axis are rejected, causing `fn.decoders.image_random_crop` to fail on rotated images.

## Workaround

Until this is fixed on the nvimagecodec side, rotated samples with a ROI skip nvImageCodec's ROI path: nvImageCodec decodes the full oriented image into a temp buffer and the existing `ConvertCPU`/`ConvertGPU` post-decode step crops it to the user's ROI. Gated on `!version_at_least(0, 9, 0)`, no-op once we depend on a fixed release.