### PR TITLE
Fix build issues exposed by newer Clang 21 toolchains

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,4 +28,4 @@
 	url = https://github.com/cocodataset/cocoapi
 [submodule "third_party/cvcuda"]
 	path = third_party/cvcuda
-        url = https://github.com/CVCUDA/CV-CUDA.git
+	url = https://github.com/JanuszL/CV-CUDA.git

--- a/dali/operators/image/remap/jitter.cuh
+++ b/dali/operators/image/remap/jitter.cuh
@@ -16,7 +16,7 @@
 #ifndef DALI_OPERATORS_IMAGE_REMAP_JITTER_CUH_
 #define DALI_OPERATORS_IMAGE_REMAP_JITTER_CUH_
 
-#include <ctgmath>
+#include <cmath>
 #include <vector>
 #include <random>
 #include <string>

--- a/dali/operators/image/remap/sphere.h
+++ b/dali/operators/image/remap/sphere.h
@@ -16,7 +16,7 @@
 #ifndef DALI_OPERATORS_IMAGE_REMAP_SPHERE_H_
 #define DALI_OPERATORS_IMAGE_REMAP_SPHERE_H_
 
-#include <ctgmath>
+#include <cmath>
 #include <vector>
 #include "dali/pipeline/operator/operator.h"
 #include "dali/core/geom/vec.h"

--- a/dali/operators/image/remap/water.h
+++ b/dali/operators/image/remap/water.h
@@ -16,7 +16,7 @@
 #ifndef DALI_OPERATORS_IMAGE_REMAP_WATER_H_
 #define DALI_OPERATORS_IMAGE_REMAP_WATER_H_
 
-#include <ctgmath>
+#include <cmath>
 #include <vector>
 #include <string>
 #include "dali/core/host_dev.h"


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Fix build issues exposed by newer Clang 21 toolchains.

The DALI remap headers included obsolete `<ctgmath>`. This PR replaces
those includes with `<cmath>` in the sphere and water remap operators.

The CVCUDA legacy OSD header uses `uint8_t` directly but did not include
a header that defines it. Some toolchains no longer provide `uint8_t`
transitively through the current include graph, which makes the CVCUDA
build fail with `unknown type name 'uint8_t'`. This PR updates the
CVCUDA submodule to a fork commit that adds the missing `<stdint.h>`
include.

The CVCUDA submodule URL is changed to
`https://github.com/JanuszL/CV-CUDA.git` so CI can fetch the fix commit.

## Additional information:

### Affected modules and functionalities:
- `dali/operators/image/remap/sphere.h`
- `dali/operators/image/remap/water.h`
- `third_party/cvcuda` submodule advanced to `3f8cc441`
  (`Include stdint in OSD legacy header`).
- `.gitmodules` updated for `third_party/cvcuda` to use
  `https://github.com/JanuszL/CV-CUDA.git`.

### Key points relevant for the review:
- The DALI source changes only replace `<ctgmath>` with `<cmath>`.
- The CVCUDA change is intentionally minimal: it adds the missing
  fixed-width integer include in the header that uses `uint8_t`.
- The submodule URL points to a fork because the fix commit is not in
  upstream CVCUDA.

### Tests:
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A