### PR TITLE
Fix docs version selector paths for DALI 2.x

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -294,7 +294,7 @@ correction = -1 if "dev" in version_long else 0
 v_major = int(version_short.split(".")[0])
 v_minor = int(version_short.split(".")[1])
 for i in range(0, v_minor + correction):
-    versions.append((f"{v_major}.{i}", f"dali_{v_major}_{i}_0"))
+    versions.append((f"{v_major}.{i}", f"dali_{v_major}_{i}_0", "short_user"))
 
 # ToDo add logic to handle other major releases after 1 and before the current
 


### PR DESCRIPTION
## Category:
**Other** (*Documentation*)

## Description:
It fixes the docs version selector for DALI 2.x generated entries. Those
entries were not marked as short user-guide links, which made the selector add
an unnecessary `docs/` path component.

The generated DALI 2.x entries now use the existing `short_user` path mode so
the selector builds links that match the published layout.

## Additional information:

### Affected modules and functionalities:
Docs configuration for the version selector in `docs/conf.py`.

### Key points relevant for the review:
The generated version entries for the current major release now include the
path mode expected by the selector link-generation logic.

### Tests:
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A