### PR TITLE
Fix generated docs `see also links`

### DIFF
--- a/docs/autodoc_submodules.py
+++ b/docs/autodoc_submodules.py
@@ -155,7 +155,8 @@ def get_references(name, references):
     if name in references:
         result += ".. seealso::\n"
         for desc, url in references[name]:
-            result += f"   * `{desc} </{url}>`_\n"
+            doc = url.removesuffix(".html")
+            result += f"   * :doc:`{desc} </{doc}>`\n"
     return result
 
 


### PR DESCRIPTION
Generate operator `See also entries` with Sphinx doc references instead of
raw root-relative HTML links. The root-relative form resolves outside the
DALI docs tree on docs.nvidia.com, so links from generated operator pages
can point at dead /examples/... URLs.

Let Sphinx resolve the target document from the generated page location so
the resulting href stays within the deployed user guide for both pipeline
and dynamic operation pages.

## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Fix generated operator documentation links in See also sections.

PR #6140 changed the generated references from relative links to
root-relative HTML links such as `/examples/...`. On docs.nvidia.com these
resolve outside the DALI user guide tree, making links at the bottom of
operator pages dead.

This change emits `:doc:` references to the target documents instead. Sphinx
then resolves the correct relative link from each generated operator page.

## Additional information:

### Affected modules and functionalities:
Generated operator documentation pages that include See also links to
examples.

### Key points relevant for the review:
The important bit is that the generated RST now points at Sphinx documents
instead of raw root-relative HTML paths. This keeps the deployed links inside
the active DALI documentation tree.

### Tests:
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [x] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: DALI-4707