### PR TITLE
Include reader in pipelines in transparent pipelining

### DIFF
--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -44,7 +44,7 @@ class OpGraph;
 class DLL_PUBLIC ExecutorBase {
  public:
   DLL_PUBLIC virtual ~ExecutorBase() {}
-  DLL_PUBLIC virtual void Build(const graph::OpGraph &graph, OperatorsMap &&operators) = 0;
+  DLL_PUBLIC virtual void Build(const graph::OpGraph &graph, OperatorsMap &&transferred_ops) = 0;
   // TODO(michalz): Remove
   DLL_PUBLIC virtual void Build(OpGraph *graph, std::vector<std::string> output_names) = 0;
   DLL_PUBLIC virtual void Init() = 0;

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -15,6 +15,7 @@
 #ifndef DALI_PIPELINE_EXECUTOR_EXECUTOR_H_
 #define DALI_PIPELINE_EXECUTOR_EXECUTOR_H_
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -27,6 +28,7 @@
 namespace dali {
 
 class OperatorBase;
+using OperatorsMap = std::unordered_map<std::string, std::unique_ptr<OperatorBase>>;
 
 struct DLL_PUBLIC ExecutorMeta {
   size_t real_size;
@@ -42,7 +44,7 @@ class OpGraph;
 class DLL_PUBLIC ExecutorBase {
  public:
   DLL_PUBLIC virtual ~ExecutorBase() {}
-  DLL_PUBLIC virtual void Build(const graph::OpGraph &graph) = 0;
+  DLL_PUBLIC virtual void Build(const graph::OpGraph &graph, OperatorsMap &&operators) = 0;
   // TODO(michalz): Remove
   DLL_PUBLIC virtual void Build(OpGraph *graph, std::vector<std::string> output_names) = 0;
   DLL_PUBLIC virtual void Init() = 0;

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -44,7 +44,8 @@ class OpGraph;
 class DLL_PUBLIC ExecutorBase {
  public:
   DLL_PUBLIC virtual ~ExecutorBase() {}
-  DLL_PUBLIC virtual void Build(const graph::OpGraph &graph, OperatorMap &&transferred_ops) = 0;
+  DLL_PUBLIC virtual void Build(const graph::OpGraph &graph,
+                                OperatorMap &&transferred_ops = {}) = 0;
   // TODO(michalz): Remove
   DLL_PUBLIC virtual void Build(OpGraph *graph, std::vector<std::string> output_names) = 0;
   DLL_PUBLIC virtual void Init() = 0;
@@ -57,7 +58,7 @@ class DLL_PUBLIC ExecutorBase {
   DLL_PUBLIC virtual void EnableCheckpointing(bool checkpointing = false) = 0;
   DLL_PUBLIC virtual ExecutorMetaMap GetExecutorMeta() = 0;
   DLL_PUBLIC virtual void Shutdown() = 0;
-  DLL_PUBLIC virtual Checkpoint& GetCurrentCheckpoint() = 0;
+  DLL_PUBLIC virtual Checkpoint &GetCurrentCheckpoint() = 0;
   DLL_PUBLIC virtual void RestoreStateFromCheckpoint(const Checkpoint &cpt) = 0;
   DLL_PUBLIC virtual int InputFeedCount(std::string_view input_name) = 0;
   DLL_PUBLIC virtual OperatorBase *GetOperator(std::string_view name) = 0;

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -28,7 +28,7 @@
 namespace dali {
 
 class OperatorBase;
-using OperatorsMap = std::unordered_map<std::string, std::unique_ptr<OperatorBase>>;
+using OperatorMap = std::unordered_map<std::string, std::unique_ptr<OperatorBase>>;
 
 struct DLL_PUBLIC ExecutorMeta {
   size_t real_size;
@@ -44,7 +44,7 @@ class OpGraph;
 class DLL_PUBLIC ExecutorBase {
  public:
   DLL_PUBLIC virtual ~ExecutorBase() {}
-  DLL_PUBLIC virtual void Build(const graph::OpGraph &graph, OperatorsMap &&transferred_ops) = 0;
+  DLL_PUBLIC virtual void Build(const graph::OpGraph &graph, OperatorMap &&transferred_ops) = 0;
   // TODO(michalz): Remove
   DLL_PUBLIC virtual void Build(OpGraph *graph, std::vector<std::string> output_names) = 0;
   DLL_PUBLIC virtual void Init() = 0;

--- a/dali/pipeline/executor/executor2/exec2.cc
+++ b/dali/pipeline/executor/executor2/exec2.cc
@@ -94,7 +94,7 @@ class Executor2::Impl {
     ShutDown,
   };
 
-  void Build(const graph::OpGraph &graph, OperatorsMap &&operators) {
+  void Build(const graph::OpGraph &graph, OperatorsMap &&transferred_ops) {
     DomainTimeRange tr("[DALI][Executor] Build");
     if (state_ != State::New)
       throw std::logic_error("Already built.");
@@ -109,7 +109,7 @@ class Executor2::Impl {
 
     state_ = State::Building;
     DeviceGuard dg(config_.device.value_or(CPU_ONLY_DEVICE_ID));
-    graph_.Lower(graph, std::move(operators));
+    graph_.Lower(graph, std::move(transferred_ops));
     BuildNodeDict();
     AnalyzeGraph();
     CheckNodeTypes();
@@ -470,8 +470,8 @@ Executor2::~Executor2() {
   impl_.reset();
 }
 
-void Executor2::Build(const graph::OpGraph &graph, OperatorsMap &&operators) {
-  impl_->Build(graph, std::move(operators));
+void Executor2::Build(const graph::OpGraph &graph, OperatorsMap &&transferred_ops) {
+  impl_->Build(graph, std::move(transferred_ops));
 }
 
 void Executor2::Init() {

--- a/dali/pipeline/executor/executor2/exec2.cc
+++ b/dali/pipeline/executor/executor2/exec2.cc
@@ -94,7 +94,7 @@ class Executor2::Impl {
     ShutDown,
   };
 
-  void Build(const graph::OpGraph &graph, OperatorsMap &&transferred_ops) {
+  void Build(const graph::OpGraph &graph, OperatorMap &&transferred_ops) {
     DomainTimeRange tr("[DALI][Executor] Build");
     if (state_ != State::New)
       throw std::logic_error("Already built.");
@@ -470,7 +470,7 @@ Executor2::~Executor2() {
   impl_.reset();
 }
 
-void Executor2::Build(const graph::OpGraph &graph, OperatorsMap &&transferred_ops) {
+void Executor2::Build(const graph::OpGraph &graph, OperatorMap &&transferred_ops) {
   impl_->Build(graph, std::move(transferred_ops));
 }
 

--- a/dali/pipeline/executor/executor2/exec2.cc
+++ b/dali/pipeline/executor/executor2/exec2.cc
@@ -94,7 +94,7 @@ class Executor2::Impl {
     ShutDown,
   };
 
-  void Build(const graph::OpGraph &graph) {
+  void Build(const graph::OpGraph &graph, OperatorsMap &&operators) {
     DomainTimeRange tr("[DALI][Executor] Build");
     if (state_ != State::New)
       throw std::logic_error("Already built.");
@@ -109,7 +109,7 @@ class Executor2::Impl {
 
     state_ = State::Building;
     DeviceGuard dg(config_.device.value_or(CPU_ONLY_DEVICE_ID));
-    graph_.Lower(graph);
+    graph_.Lower(graph, std::move(operators));
     BuildNodeDict();
     AnalyzeGraph();
     CheckNodeTypes();
@@ -470,8 +470,8 @@ Executor2::~Executor2() {
   impl_.reset();
 }
 
-void Executor2::Build(const graph::OpGraph &graph) {
-  impl_->Build(graph);
+void Executor2::Build(const graph::OpGraph &graph, OperatorsMap &&operators) {
+  impl_->Build(graph, std::move(operators));
 }
 
 void Executor2::Init() {

--- a/dali/pipeline/executor/executor2/exec2.h
+++ b/dali/pipeline/executor/executor2/exec2.h
@@ -97,7 +97,7 @@ class DLL_PUBLIC Executor2 : public ExecutorBase {
   explicit Executor2(const Config &config);
   ~Executor2() override;
 
-  void Build(const graph::OpGraph &graph, OperatorsMap &&transferred_ops) override;
+  void Build(const graph::OpGraph &graph, OperatorMap &&transferred_ops) override;
 
   void Build(OpGraph *graph, std::vector<std::string> output_names) override {
     throw std::logic_error("This function is maintained in the interface for legacy tests only.");

--- a/dali/pipeline/executor/executor2/exec2.h
+++ b/dali/pipeline/executor/executor2/exec2.h
@@ -97,7 +97,7 @@ class DLL_PUBLIC Executor2 : public ExecutorBase {
   explicit Executor2(const Config &config);
   ~Executor2() override;
 
-  void Build(const graph::OpGraph &graph) override;
+  void Build(const graph::OpGraph &graph, OperatorsMap &&operators) override;
 
   void Build(OpGraph *graph, std::vector<std::string> output_names) override {
     throw std::logic_error("This function is maintained in the interface for legacy tests only.");

--- a/dali/pipeline/executor/executor2/exec2.h
+++ b/dali/pipeline/executor/executor2/exec2.h
@@ -97,7 +97,7 @@ class DLL_PUBLIC Executor2 : public ExecutorBase {
   explicit Executor2(const Config &config);
   ~Executor2() override;
 
-  void Build(const graph::OpGraph &graph, OperatorMap &&transferred_ops) override;
+  void Build(const graph::OpGraph &graph, OperatorMap &&transferred_ops = {}) override;
 
   void Build(OpGraph *graph, std::vector<std::string> output_names) override {
     throw std::logic_error("This function is maintained in the interface for legacy tests only.");

--- a/dali/pipeline/executor/executor2/exec2.h
+++ b/dali/pipeline/executor/executor2/exec2.h
@@ -97,7 +97,7 @@ class DLL_PUBLIC Executor2 : public ExecutorBase {
   explicit Executor2(const Config &config);
   ~Executor2() override;
 
-  void Build(const graph::OpGraph &graph, OperatorsMap &&operators) override;
+  void Build(const graph::OpGraph &graph, OperatorsMap &&transferred_ops) override;
 
   void Build(OpGraph *graph, std::vector<std::string> output_names) override {
     throw std::logic_error("This function is maintained in the interface for legacy tests only.");

--- a/dali/pipeline/executor/executor2/exec2_test.cc
+++ b/dali/pipeline/executor/executor2/exec2_test.cc
@@ -98,7 +98,7 @@ class Exec2Test : public::testing::TestWithParam<Executor2::Config> {
 TEST_P(Exec2Test, Graph1_CPUOnly) {
   Executor2 exec(config_);
   graph::OpGraph graph = GetTestGraph1();
-  exec.Build(graph, {});
+  exec.Build(graph);
   for (int i = 0; i < 10; i++) {
     exec.Run();
   }
@@ -113,7 +113,7 @@ TEST_P(Exec2Test, Graph1_CPUOnly) {
 TEST_P(Exec2Test, Graph2_CPU2GPU) {
   Executor2 exec(config_);
   graph::OpGraph graph = GetTestGraph2();
-  exec.Build(graph, {});
+  exec.Build(graph);
   for (int i = 0; i < 10; i++) {
     exec.Run();
   }
@@ -128,7 +128,7 @@ TEST_P(Exec2Test, Graph2_CPU2GPU) {
 TEST_P(Exec2Test, Graph3_SinkOnly) {
   Executor2 exec(config_);
   graph::OpGraph graph = GetTestGraph3();
-  exec.Build(graph, {});
+  exec.Build(graph);
   for (int i = 0; i < 10; i++) {
     exec.Run();
   }

--- a/dali/pipeline/executor/executor2/exec2_test.cc
+++ b/dali/pipeline/executor/executor2/exec2_test.cc
@@ -98,7 +98,7 @@ class Exec2Test : public::testing::TestWithParam<Executor2::Config> {
 TEST_P(Exec2Test, Graph1_CPUOnly) {
   Executor2 exec(config_);
   graph::OpGraph graph = GetTestGraph1();
-  exec.Build(graph);
+  exec.Build(graph, {});
   for (int i = 0; i < 10; i++) {
     exec.Run();
   }
@@ -113,7 +113,7 @@ TEST_P(Exec2Test, Graph1_CPUOnly) {
 TEST_P(Exec2Test, Graph2_CPU2GPU) {
   Executor2 exec(config_);
   graph::OpGraph graph = GetTestGraph2();
-  exec.Build(graph);
+  exec.Build(graph, {});
   for (int i = 0; i < 10; i++) {
     exec.Run();
   }
@@ -128,7 +128,7 @@ TEST_P(Exec2Test, Graph2_CPU2GPU) {
 TEST_P(Exec2Test, Graph3_SinkOnly) {
   Executor2 exec(config_);
   graph::OpGraph graph = GetTestGraph3();
-  exec.Build(graph);
+  exec.Build(graph, {});
   for (int i = 0; i < 10; i++) {
     exec.Run();
   }

--- a/dali/pipeline/executor/executor2/exec_graph.h
+++ b/dali/pipeline/executor/executor2/exec_graph.h
@@ -380,7 +380,7 @@ class DLL_PUBLIC ExecGraph {
   tasking::TaskFuture Launch(tasking::Scheduler &sched);
 
   /** Populates the graph based on a pipeline definiton graph. */
-  void Lower(const graph::OpGraph &def, OperatorsMap &&transferred_ops = {});
+  void Lower(const graph::OpGraph &def, OperatorMap &&transferred_ops = {});
 
  private:
   /** Sorts the graph topologically. */

--- a/dali/pipeline/executor/executor2/exec_graph.h
+++ b/dali/pipeline/executor/executor2/exec_graph.h
@@ -380,7 +380,7 @@ class DLL_PUBLIC ExecGraph {
   tasking::TaskFuture Launch(tasking::Scheduler &sched);
 
   /** Populates the graph based on a pipeline definiton graph. */
-  void Lower(const graph::OpGraph &def, OperatorsMap &&operators = {});
+  void Lower(const graph::OpGraph &def, OperatorsMap &&transferred_ops = {});
 
  private:
   /** Sorts the graph topologically. */

--- a/dali/pipeline/executor/executor2/exec_graph.h
+++ b/dali/pipeline/executor/executor2/exec_graph.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "dali/core/cuda_shared_event.h"
+#include "dali/pipeline/executor/executor.h"
 #include "dali/pipeline/operator/operator.h"
 #include "dali/pipeline/workspace/workspace.h"
 
@@ -379,7 +380,7 @@ class DLL_PUBLIC ExecGraph {
   tasking::TaskFuture Launch(tasking::Scheduler &sched);
 
   /** Populates the graph based on a pipeline definiton graph. */
-  void Lower(const graph::OpGraph &def);
+  void Lower(const graph::OpGraph &def, OperatorsMap &&operators = {});
 
  private:
   /** Sorts the graph topologically. */
@@ -412,4 +413,3 @@ class DLL_PUBLIC ExecGraph {
 }  // namespace dali
 
 #endif  // DALI_PIPELINE_EXECUTOR_EXECUTOR2_EXEC_GRAPH_H_
-

--- a/dali/pipeline/executor/executor2/exec_graph_lowering.cc
+++ b/dali/pipeline/executor/executor2/exec_graph_lowering.cc
@@ -22,22 +22,31 @@
 namespace dali {
 namespace exec2 {
 
-void ExecGraph::Lower(const graph::OpGraph &def) {
+void ExecGraph::Lower(const graph::OpGraph &def, OperatorsMap &&operators) {
   Invalidate();
   std::unordered_map<const graph::OpNode *, ExecNode *> def2exec(def.OpNodes().size());
   for (const graph::OpNode &op_node : def.OpNodes()) {
     std::unique_ptr<OperatorBase> op;
-    try {
-      op = InstantiateOperator(op_node.spec);
-    } catch (...) {
-      PropagateError({std::current_exception(),
-                      "Critical error when building pipeline:\n" +
-                          GetErrorContextMessage(op_node.spec),
-                      "\nCurrent pipeline object is no longer valid."});
+    auto op_it = operators.find(op_node.instance_name);
+    if (op_it != operators.end()) {
+      op = std::move(op_it->second);
+      operators.erase(op_it);
+    } else {
+      try {
+        op = InstantiateOperator(op_node.spec);
+      } catch (...) {
+        PropagateError({std::current_exception(),
+                        "Critical error when building pipeline:\n" +
+                            GetErrorContextMessage(op_node.spec),
+                        "\nCurrent pipeline object is no longer valid."});
+      }
     }
     ExecNode *exec_node = AddNode(std::move(op), &op_node);
     def2exec.emplace(&op_node, exec_node);
   }
+  DALI_ENFORCE(operators.empty(),
+               make_string("Transferred operator instance \"", operators.begin()->first,
+                           "\" was not found in the pipeline graph."));
 
   auto it_def = def.OpNodes().begin();
   for (ExecNode &exec_node : nodes_) {

--- a/dali/pipeline/executor/executor2/exec_graph_lowering.cc
+++ b/dali/pipeline/executor/executor2/exec_graph_lowering.cc
@@ -22,7 +22,7 @@
 namespace dali {
 namespace exec2 {
 
-void ExecGraph::Lower(const graph::OpGraph &def, OperatorsMap &&transferred_ops) {
+void ExecGraph::Lower(const graph::OpGraph &def, OperatorMap &&transferred_ops) {
   Invalidate();
   std::unordered_map<const graph::OpNode *, ExecNode *> def2exec(def.OpNodes().size());
   for (const graph::OpNode &op_node : def.OpNodes()) {

--- a/dali/pipeline/executor/executor2/exec_graph_lowering.cc
+++ b/dali/pipeline/executor/executor2/exec_graph_lowering.cc
@@ -22,15 +22,15 @@
 namespace dali {
 namespace exec2 {
 
-void ExecGraph::Lower(const graph::OpGraph &def, OperatorsMap &&operators) {
+void ExecGraph::Lower(const graph::OpGraph &def, OperatorsMap &&transferred_ops) {
   Invalidate();
   std::unordered_map<const graph::OpNode *, ExecNode *> def2exec(def.OpNodes().size());
   for (const graph::OpNode &op_node : def.OpNodes()) {
     std::unique_ptr<OperatorBase> op;
-    auto op_it = operators.find(op_node.instance_name);
-    if (op_it != operators.end()) {
+    auto op_it = transferred_ops.find(op_node.instance_name);
+    if (op_it != transferred_ops.end()) {
       op = std::move(op_it->second);
-      operators.erase(op_it);
+      transferred_ops.erase(op_it);
     } else {
       try {
         op = InstantiateOperator(op_node.spec);
@@ -44,8 +44,8 @@ void ExecGraph::Lower(const graph::OpGraph &def, OperatorsMap &&operators) {
     ExecNode *exec_node = AddNode(std::move(op), &op_node);
     def2exec.emplace(&op_node, exec_node);
   }
-  DALI_ENFORCE(operators.empty(),
-               make_string("Transferred operator instance \"", operators.begin()->first,
+  DALI_ENFORCE(transferred_ops.empty(),
+               make_string("Transferred operator instance \"", transferred_ops.begin()->first,
                            "\" was not found in the pipeline graph."));
 
   auto it_def = def.OpNodes().begin();

--- a/dali/pipeline/executor/executor_impl.h
+++ b/dali/pipeline/executor/executor_impl.h
@@ -129,8 +129,8 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
 
   DLL_PUBLIC int InputFeedCount(std::string_view op_name) override;
 
-  DLL_PUBLIC void Build(const graph::OpGraph &graph, OperatorsMap &&operators) override {
-    DALI_ENFORCE(operators.empty(), "Pre-instantiated operator instances are not supported.");
+  DLL_PUBLIC void Build(const graph::OpGraph &graph, OperatorsMap &&transferred_ops) override {
+    DALI_ENFORCE(transferred_ops.empty(), "Pre-instantiated operator instances are not supported.");
     lowered_graph_.Lower(graph);
     std::vector<std::string> output_names;
     for (std::string_view out : graph.Outputs())

--- a/dali/pipeline/executor/executor_impl.h
+++ b/dali/pipeline/executor/executor_impl.h
@@ -129,7 +129,7 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
 
   DLL_PUBLIC int InputFeedCount(std::string_view op_name) override;
 
-  DLL_PUBLIC void Build(const graph::OpGraph &graph, OperatorsMap &&transferred_ops) override {
+  DLL_PUBLIC void Build(const graph::OpGraph &graph, OperatorMap &&transferred_ops) override {
     DALI_ENFORCE(transferred_ops.empty(), "Pre-instantiated operator instances are not supported.");
     lowered_graph_.Lower(graph);
     std::vector<std::string> output_names;

--- a/dali/pipeline/executor/executor_impl.h
+++ b/dali/pipeline/executor/executor_impl.h
@@ -129,7 +129,8 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
 
   DLL_PUBLIC int InputFeedCount(std::string_view op_name) override;
 
-  DLL_PUBLIC void Build(const graph::OpGraph &graph) override {
+  DLL_PUBLIC void Build(const graph::OpGraph &graph, OperatorsMap &&operators) override {
+    DALI_ENFORCE(operators.empty(), "Pre-instantiated operator instances are not supported.");
     lowered_graph_.Lower(graph);
     std::vector<std::string> output_names;
     for (std::string_view out : graph.Outputs())

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -364,7 +364,7 @@ int Pipeline::AddOperatorInstance(const OpSpec &spec,
   DALI_ENFORCE(op);
   DALI_ENFORCE(op->GetSpec().SchemaName() == spec.SchemaName());
   int result = AddOperator(spec, inst_name, logical_id);
-  transfer_ops_.emplace(std::string(inst_name), std::move(op));
+  transferred_ops_.emplace(std::string(inst_name), std::move(op));
   return result;
 }
 
@@ -653,7 +653,7 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
     const string &inst_name = name_op_spec.instance_name;
     OpSpec op_spec = name_op_spec.spec;
     try {
-      if (!transfer_ops_.count(inst_name))
+      if (!transferred_ops_.count(inst_name))
         PrepareOpSpec(&op_spec, name_op_spec.logical_id);
       graph_builder_.Add(inst_name, op_spec);
     } catch (...) {
@@ -681,7 +681,7 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
   graph::ComputeDataNodeMetadata(graph_);
 
   // Load the final graph into the executor
-  executor_->Build(graph_, std::move(transfer_ops_));
+  executor_->Build(graph_, std::move(transferred_ops_));
   // CAUTION: Do not insert anything that can throw between `executor_->Build()` and
   //          `DiscoverInputOperators`.
   DiscoverInputOperators();

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -357,6 +357,23 @@ int Pipeline::AddOperator(const OpSpec &const_spec, std::string_view inst_name, 
   return result;
 }
 
+int Pipeline::AddOperatorInstance(const OpSpec &spec,
+                                  std::string_view inst_name,
+                                  std::unique_ptr<OperatorBase> op,
+                                  int logical_id) {
+  DALI_ENFORCE(op);
+  DALI_ENFORCE(op->GetSpec().SchemaName() == spec.SchemaName());
+  int result = AddOperator(spec, inst_name, logical_id);
+  transfer_ops_.emplace(std::string(inst_name), std::move(op));
+  return result;
+}
+
+int Pipeline::AddOperatorInstance(const OpSpec &spec,
+                                  std::string_view inst_name,
+                                  std::unique_ptr<OperatorBase> op) {
+  return AddOperatorInstance(spec, inst_name, std::move(op), GetNextLogicalId());
+}
+
 int Pipeline::AddOperatorImpl(const OpSpec &const_spec,
                               std::string_view inst_name,
                               int logical_id) {
@@ -636,7 +653,8 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
     const string &inst_name = name_op_spec.instance_name;
     OpSpec op_spec = name_op_spec.spec;
     try {
-      PrepareOpSpec(&op_spec, name_op_spec.logical_id);
+      if (!transfer_ops_.count(inst_name))
+        PrepareOpSpec(&op_spec, name_op_spec.logical_id);
       graph_builder_.Add(inst_name, op_spec);
     } catch (...) {
       PropagateError({std::current_exception(),
@@ -663,7 +681,7 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
   graph::ComputeDataNodeMetadata(graph_);
 
   // Load the final graph into the executor
-  executor_->Build(graph_);
+  executor_->Build(graph_, std::move(transfer_ops_));
   // CAUTION: Do not insert anything that can throw between `executor_->Build()` and
   //          `DiscoverInputOperators`.
   DiscoverInputOperators();

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -756,7 +756,7 @@ class DLL_PUBLIC Pipeline {
 
   std::vector<OpDefinition> op_specs_;
   std::vector<OpDefinition> op_specs_for_serialization_;
-  OperatorsMap transferred_ops_;
+  OperatorMap transferred_ops_;
   std::set<std::string, std::less<>> instance_names_;
 
   std::vector<PipelineOutputDesc> output_descs_;

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -756,7 +756,7 @@ class DLL_PUBLIC Pipeline {
 
   std::vector<OpDefinition> op_specs_;
   std::vector<OpDefinition> op_specs_for_serialization_;
-  OperatorsMap transfer_ops_;
+  OperatorsMap transferred_ops_;
   std::set<std::string, std::less<>> instance_names_;
 
   std::vector<PipelineOutputDesc> output_descs_;

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -225,6 +225,21 @@ class DLL_PUBLIC Pipeline {
   DLL_PUBLIC int AddOperator(const OpSpec &spec, std::string_view inst_name, int logical_id);
 
   /**
+   * @brief Adds an operator to the pipeline and transfers a live operator instance to the executor.
+   */
+  DLL_PUBLIC int AddOperatorInstance(const OpSpec &spec,
+                                     std::string_view inst_name,
+                                     std::unique_ptr<OperatorBase> op,
+                                     int logical_id);
+
+  /**
+   * @brief Adds an operator instance with a separate logical_id.
+   */
+  DLL_PUBLIC int AddOperatorInstance(const OpSpec &spec,
+                                     std::string_view inst_name,
+                                     std::unique_ptr<OperatorBase> op);
+
+  /**
    * @brief Adds an Operator with the input specification to the pipeline. It will be assigned
    * a separate logical_id based on internal state of the pipeline.
    */
@@ -741,6 +756,7 @@ class DLL_PUBLIC Pipeline {
 
   std::vector<OpDefinition> op_specs_;
   std::vector<OpDefinition> op_specs_for_serialization_;
+  OperatorsMap transfer_ops_;
   std::set<std::string, std::less<>> instance_names_;
 
   std::vector<PipelineOutputDesc> output_descs_;

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -2208,6 +2208,16 @@ void ExposePipeline(py::module &m) {
     .def("AddOperator",
          static_cast<int (Pipeline::*)(const OpSpec &, std::string_view, int)>
                                       (&Pipeline::AddOperator))
+    .def("AddOperatorInstance",
+         [](Pipeline *p, const OpSpec &spec, std::string_view name,
+            std::unique_ptr<OperatorBase> op) {
+           return p->AddOperatorInstance(spec, name, std::move(op));
+         })
+    .def("AddOperatorInstance",
+         [](Pipeline *p, const OpSpec &spec, std::string_view name,
+            std::unique_ptr<OperatorBase> op, int logical_id) {
+           return p->AddOperatorInstance(spec, name, std::move(op), logical_id);
+         })
     .def("GetOperatorNode", &Pipeline::GetOperatorNode)
     .def("Build",
          [](Pipeline *p, const std::vector<OutputDesc> &outputs) {
@@ -2733,7 +2743,7 @@ void SetupAndRun(OperatorBase &self, Workspace &ws, std::optional<int> batch_siz
 }
 
 void ExposeOperator(py::module &m) {
-  py::class_<OperatorBase, std::unique_ptr<OperatorBase>>(m, "_Operator")
+  py::class_<OperatorBase, py::smart_holder>(m, "_Operator")
     .def(py::init([](const OpSpec &spec) {
       DomainTimeRange tr("Instantiate " + GetOpDisplayName(spec, true), kDynamicDefaultColor);
       return dali::InstantiateOperator(spec);

--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -269,6 +269,7 @@ class CompileContext:
         source = self.source
         assert source is not None
 
+        transferred = False
         try:
             pipe = Pipeline(
                 batch_size=self.batch_size,
@@ -279,9 +280,10 @@ class CompileContext:
             with pipe:
                 _wire_compile_graph(self.reader, source, self.nodes)
             assert self.reader._op_backend is not None
-            pipe._transfer_operator_instance(self.reader._name, self.reader._op_backend)
+            pipe._transfer_operator(self.reader._name, self.reader._op_backend)
+            transferred = True
             pipe.build()
-        except Exception:
+        except Exception as exception:
             self.nodes.clear()
             self._call_trie = _CallTrie()
             self._pipeline_results.clear()
@@ -290,6 +292,15 @@ class CompileContext:
             # Reset Reader fields here, the exception propagates past the iterator
             self.reader._compile_mode = None
             self.reader._compiled_iter = None
+            # If there's a failure after _op_backend was transferred, we can't safely recover.
+            # Disable the reader. In practice, this case should be rare.
+            if transferred:
+                self.reader._disabled = True
+                raise RuntimeError(
+                    "Failed to build pipeline after transferring operator. "
+                    "Reader is now in invalid state."
+                ) from exception
+
             raise
 
         self.pipeline = pipe

--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -17,14 +17,14 @@ import enum
 import threading
 import types
 import warnings
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+import numpy as np
 import nvidia.dali.backend_impl as _b
 import nvidia.dali.types as dali_types
 from nvidia.dali import fn
-from nvidia.dali.external_source import ExternalSource
 from nvidia.dali.pipeline import Pipeline
 
 from ._batch import Batch
@@ -37,6 +37,7 @@ from ._call_site import (
 )
 from ._device import Device
 from ._nvtx import NVTXRange
+from ._tensor import Tensor, as_tensor
 
 if TYPE_CHECKING:
     from ._eval_context import EvalContext
@@ -162,6 +163,7 @@ class CompileContext:
         self.pipeline: Pipeline | None = None
         self._pipeline_results: dict[CompileNode, Any] = {}
         self._iteration = 0
+        self._epoch_size_padded: int | None = None
         self.analyzer = CallSiteAnalyzer()
 
     @classmethod
@@ -267,14 +269,6 @@ class CompileContext:
         source = self.source
         assert source is not None
 
-        def reader_callback():
-            assert self.reader._op_backend is not None
-            workspace = _b._Workspace(ctx.thread_pool._create_facade(), ctx.cuda_stream)
-            for name, arg in self.reader._process_tensor_args(self.batch_size).items():
-                workspace.AddArgumentInput(name, arg.evaluate()._storage)
-            self.reader._op_backend.SetupAndRun(workspace, self.batch_size)
-            return workspace.GetOutputs()
-
         try:
             pipe = Pipeline(
                 batch_size=self.batch_size,
@@ -283,7 +277,9 @@ class CompileContext:
                 prefetch_queue_depth=2,
             )
             with pipe:
-                _wire_compile_graph(source, self.nodes, reader_callback)
+                _wire_compile_graph(self.reader, source, self.nodes)
+            assert self.reader._op_backend is not None
+            pipe._transfer_operator_instance(self.reader._name, self.reader._op_backend)
             pipe.build()
         except Exception:
             self.nodes.clear()
@@ -298,6 +294,15 @@ class CompileContext:
 
         self.pipeline = pipe
         self.state = State.COMPILED
+
+    def reader_epoch_size(self) -> int:
+        from ._ops import _shard_size
+
+        assert self.pipeline is not None
+        if self._epoch_size_padded is None:
+            metadata = self.pipeline.reader_meta(self.reader._name)
+            self._epoch_size_padded = metadata["epoch_size_padded"]
+        return _shard_size(self._epoch_size_padded, self.reader._shard_id, self.reader._num_shards)
 
     @_nvtx_range("Running compiled pipeline")
     def run_pipeline(self) -> tuple | dict:
@@ -448,7 +453,7 @@ class CompiledEpochIterator:
         """Subsequent epochs: yield from compiled pipeline."""
         compile_ctx = self._compile_ctx
 
-        epoch_size = self._reader._shard_epoch_size()
+        epoch_size = compile_ctx.reader_epoch_size()
         idx = start_idx
         while idx < epoch_size:
             batches = compile_ctx.run_pipeline()
@@ -457,24 +462,39 @@ class CompiledEpochIterator:
                 yield batches
 
 
+def _prepare_reader_arg(value: Any) -> Any:
+    if isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (Tensor, Batch)):
+        if value.device.device_type != "cpu":
+            raise ValueError("GPU arguments inputs are not supported")
+        # TODO(rtabet): Classify scalar CPU Tensor args earlier to allow ScalarConstant.
+        return dali_types.Constant(np.asarray(as_tensor(value)), layout=value.layout, device="cpu")
+    return dali_types.Constant(value, device="cpu")
+
+
 @_nvtx_range("Graph Wiring")
 def _wire_compile_graph(
+    reader: "Reader",
     source: CompileSource,
     nodes: Sequence[CompileNode],
-    reader_callback: Callable[[], Iterable],
 ) -> None:
     """Wire the compile graph into a Pipeline. Must be called inside ``with pipe:``."""
     from ._op_builder import _scalar_decay
 
-    es = ExternalSource(
-        source=reader_callback,
-        num_outputs=source.num_outputs,
-        batch=True,
-        device=source.device,
-        no_copy=True,
-    )
-    reader_outs = es()
-    assert isinstance(reader_outs, Iterable)
+    reader_op = reader._legacy_op(name=reader._name, device=reader._backend, **reader._init_args)
+    reader_args = {
+        name: _prepare_reader_arg(value) for name, value in reader._original_tensor_args.items()
+    }
+    reader_out = reader_op(**reader_args)
+    if isinstance(reader_out, dict):
+        assert source.output_keys is not None
+        reader_outs = tuple(reader_out[k] for k in source.output_keys)
+    elif isinstance(reader_out, (tuple, list)):
+        reader_outs = tuple(reader_out)
+    else:
+        reader_outs = (reader_out,)
+    assert len(reader_outs) == source.num_outputs
 
     datanode_map: dict[CompileRef, Any] = {}
     for i, out in enumerate(reader_outs):

--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -468,7 +468,7 @@ def _prepare_reader_arg(value: Any) -> Any:
     if isinstance(value, (Tensor, Batch)):
         if value.device.device_type != "cpu":
             raise ValueError("GPU arguments inputs are not supported")
-        # TODO(rtabet): Classify scalar CPU Tensor args earlier to allow ScalarConstant.
+        # TODO(rtabet, DALI-4708): Classify scalar CPU Tensor args earlier to allow ScalarConstant.
         return dali_types.Constant(np.asarray(as_tensor(value)), layout=value.layout, device="cpu")
     return dali_types.Constant(value, device="cpu")
 

--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -208,6 +208,7 @@ def build_constructor(schema, op_class):
             actual_tensor_arg_names = {
                 arg_name for arg_name in tensor_arg_names if kwargs.get(arg_name) is not None
             }
+            original_tensor_args = {}
             tensor_args = {}
             for arg_name in tensor_arg_names:
                 arg = kwargs.get(arg_name)
@@ -216,6 +217,7 @@ def build_constructor(schema, op_class):
                 del kwargs[arg_name]
                 if isinstance(arg, Batch):
                     raise ValueError("Readers cannot be constructed with batch keyword arguments")
+                original_tensor_args[arg_name] = arg
                 dtype = op_class._argument_conversion_map[arg_name]
                 tensor_args[arg_name] = to_tensor(arg, dtype=dtype)
         kwargs = {k: _scalar_decay(v) for k, v in kwargs.items()}
@@ -223,6 +225,7 @@ def build_constructor(schema, op_class):
         if is_reader:  # Need to be done here not to be overridden by the constructor
             self._tensor_arg_names = actual_tensor_arg_names
             self._raw_tensor_args = tensor_args
+            self._original_tensor_args = original_tensor_args
         if stateful:
             self._call_id = 0
 

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -30,6 +30,12 @@ from threading import Lock
 _nvtx_to_tensor = NVTXRange("to_tensor", category="op_builder")
 
 
+def _shard_size(padded_size: int, shard_id: int, num_shards: int) -> int:
+    beg = math.floor(shard_id * padded_size / num_shards)
+    end = math.floor((shard_id + 1) * padded_size / num_shards)
+    return end - beg
+
+
 def _to_tensor(x, device=None, dtype=None):
     with _nvtx_to_tensor:
         if x is None:
@@ -709,6 +715,7 @@ class Reader(Operator):
         )
 
         self._raw_tensor_args = {}
+        self._original_tensor_args = {}  # Used when compile=True
         self._tensor_args = {}
         # Used to know when to recompute _tensor_args for _raw_tensor_args
         self._previous_batch_size: int | None = None
@@ -865,11 +872,8 @@ class Reader(Operator):
             self._pending_state = raw
 
     def _shard_epoch_size(self):
-        meta = self._op_backend.GetReaderMeta()
-        padded_size = meta["epoch_size_padded"]
-        shards_beg = math.floor(self._shard_id * padded_size / self._num_shards)
-        shards_end = math.floor((self._shard_id + 1) * padded_size / self._num_shards)
-        return shards_end - shards_beg
+        epoch_size = self._op_backend.GetReaderMeta()["epoch_size_padded"]
+        return _shard_size(epoch_size, self._shard_id, self._num_shards)
 
     def _advance_shard(self):
         if not self._stick_to_shard:
@@ -995,7 +999,10 @@ class Reader(Operator):
 
         batch_size = self._get_batch_size(batch_size)
         self._init_backend(None, (), self._process_tensor_args(batch_size))
-        return self._op_backend.GetReaderMeta()
+        try:
+            return self._op_backend.GetReaderMeta()
+        except ValueError as e:
+            raise RuntimeError("Reader was transferred to a compiled pipeline.") from e
 
     def _samples(self, ctx: _eval_context.EvalContext | None = None):
         self._require_api_type("samples")

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -723,6 +723,8 @@ class Reader(Operator):
         self._tensor_arg_names: set[str] = set()
         # If set, the checkpoint state to apply once the backend is constructed.
         self._pending_state = None
+        # If set, the reader is in an invalid state and cannot be used
+        self._disabled = False
 
         if self._num_shards < 1:
             raise ValueError(
@@ -890,6 +892,10 @@ class Reader(Operator):
 
     def _run_unchecked(self, ctx=None, **kwargs):
         """Run the reader backend without API-type checking."""
+        if self._disabled:
+            raise RuntimeError(
+                "This reader is in an invalidate state due to a previous error and cannot be used."
+            )
         return super()._run(ctx, **kwargs)
 
     @staticmethod
@@ -938,6 +944,11 @@ class Reader(Operator):
             If True, transparently compile operator sequences into a pipeline for prefetching.
             Once used in compiled mode, the reader cannot switch back.
         """
+        if self._disabled:
+            raise RuntimeError(
+                "This reader is in an invalidate state due to a previous error and cannot be used."
+            )
+
         batch_size = self._get_batch_size(batch_size)
         if batch_size is None:
             batch_size = self._batch_size

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1061,7 +1061,7 @@ class Pipeline(object):
         self._backend_prepared = True
         self._names_and_devices = [(e.name, e.device) for e in self._graph_outputs]
 
-    def _transfer_operator_instance(self, name, op_backend):
+    def _transfer_operator(self, name, op_backend):
         assert op_backend is not None
         assert name not in self._transfer_ops
         self._transfer_ops[name] = op_backend

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -346,6 +346,7 @@ class Pipeline(object):
         self._skip_api_check = False
         self._graph_out = None
         self._ops = None
+        self._transfer_ops = {}
         self._graph_outputs = None
         self._py_pool = None
         self._input_callbacks = None
@@ -1046,12 +1047,24 @@ class Pipeline(object):
         related_logical_id = {}
 
         for op in self._ops:
-            if op.relation_id not in related_logical_id:
-                related_logical_id[op.relation_id] = self._pipe.AddOperator(op.spec, op.name)
+            transfer_op = self._transfer_ops.pop(op.name, None)
+            if transfer_op is not None:
+                add_fn = self._pipe.AddOperatorInstance
+                extra = (transfer_op,)
             else:
-                self._pipe.AddOperator(op.spec, op.name, related_logical_id[op.relation_id])
+                add_fn = self._pipe.AddOperator
+                extra = ()
+            if op.relation_id in related_logical_id:
+                add_fn(op.spec, op.name, *extra, related_logical_id[op.relation_id])
+            else:
+                related_logical_id[op.relation_id] = add_fn(op.spec, op.name, *extra)
         self._backend_prepared = True
         self._names_and_devices = [(e.name, e.device) for e in self._graph_outputs]
+
+    def _transfer_operator_instance(self, name, op_backend):
+        assert op_backend is not None
+        assert name not in self._transfer_ops
+        self._transfer_ops[name] = op_backend
 
     def _disable_pruned_external_source_instances(self):
         def truncate_str(obj, max_len=103):

--- a/dali/test/python/experimental_mode/test_compile.py
+++ b/dali/test/python/experimental_mode/test_compile.py
@@ -161,6 +161,30 @@ def test_compile_multi_epoch():
             np.testing.assert_array_equal(dyn, comp)
 
 
+def test_compile_shard_rotation():
+    reader_dyn = ndd.readers.File(file_root=images_root, shard_id=0, num_shards=2)
+    reader_comp = ndd.readers.File(file_root=images_root, shard_id=0, num_shards=2)
+    num_epochs = 4
+
+    dynamic_epochs = []
+    for _ in range(num_epochs):
+        epoch = []
+        for jpegs, _ in reader_dyn.next_epoch(batch_size=2):
+            epoch.extend(np.asarray(sample).tobytes() for sample in jpegs)
+        dynamic_epochs.append(epoch)
+
+    compiled_epochs = []
+    for _ in range(num_epochs):
+        epoch = []
+        for jpegs, _ in reader_comp.next_epoch(batch_size=2, compile=True):
+            images = ndd.decoders.image(jpegs)
+            assert _is_compiled(images)
+            epoch.extend(np.asarray(sample).tobytes() for sample in jpegs)
+        compiled_epochs.append(epoch)
+
+    assert dynamic_epochs == compiled_epochs
+
+
 @eval_modes()
 def test_compile_loop_identical():
     reader_dyn = ndd.readers.File(file_root=images_root)
@@ -306,22 +330,20 @@ def test_compile_stale_batch():
         prev = images
 
 
-def test_compile_tensor_args():
-    def make_reader():
-        video_root = os.path.join(dali_extra_path, "db", "video", "sintel", "video_files")
-        sequence_length = 60
-        width, height = 108, 192
-        return ndd.readers.VideoResize(
-            filenames=[os.path.join(video_root, "sintel_trailer-720p_3.mp4")],
-            sequence_length=sequence_length,
-            device="gpu",
-            resize_x=ndd.tensor(width),
-            resize_y=height,
-            file_list_include_preceding_frame=True,
-        )
+def _make_video_reader(**resize_args):
+    video_root = os.path.join(dali_extra_path, "db", "video", "sintel", "video_files")
+    return ndd.readers.VideoResize(
+        filenames=[os.path.join(video_root, "sintel_trailer-720p_3.mp4")],
+        sequence_length=60,
+        device="gpu",
+        file_list_include_preceding_frame=True,
+        **resize_args,
+    )
 
-    reader_dyn = make_reader()
-    reader_comp = make_reader()
+
+def _test_video_resize(**resize_args):
+    reader_dyn = _make_video_reader(**resize_args)
+    reader_comp = _make_video_reader(**resize_args)
 
     dynamic_results = []
     for (videos,) in reader_dyn.next_epoch(batch_size=4):
@@ -337,6 +359,18 @@ def test_compile_tensor_args():
     assert len(dynamic_results) == len(compiled_results)
     for dyn, comp in zip(dynamic_results, compiled_results):
         np.testing.assert_array_equal(dyn, comp)
+
+
+def test_compile_tensor_arg():
+    _test_video_resize(size=ndd.tensor([192, 108]))
+
+
+def test_compile_tensor_arg_external():
+    _test_video_resize(size=np.array([192, 108]))
+
+
+def test_compile_scalar_args():
+    _test_video_resize(resize_x=ndd.tensor(108), resize_y=192)
 
 
 def test_compile_incompatible_kwarg_dtype():


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**New feature** (*non-breaking change which adds functionality*)

## Description:

Transparent pipelining initially used `ExternalSource` for readers. As a result, indexing needs to happen twice and performance is suboptimal.

This PR allows transferring the live operator instance to the pipeline in order to include the reader in the pipeline without having to explicitly synchronize the state.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply: `test_compile.py`
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

Transparent pipelining is not documented yet

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4672
<!--- DALI-XXXX or NA --->
