### PR TITLE
Require batch size for dynamic batch permutation

### DIFF
--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -259,7 +259,10 @@ def _get_inputs(schema):
 
 def _check_batch_size_available(op_class, batch_size):
     if op_class._schema_name == "BatchPermutation" and batch_size is None:
-        raise ValueError("`batch_size` must be specified for dynamic `batch_permutation`.")
+        raise ValueError(
+            "`batch_size` must be specified for dynamic `batch_permutation` "
+            "because it has no data inputs to infer the batch size from."
+        )
 
 
 def build_call_function(schema, op_class):

--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -325,7 +325,6 @@ def build_call_function(schema, op_class):
 
         if batch_size is None:
             batch_size = _ops._infer_batch_size(*raw_args, **raw_kwargs)
-        _check_batch_size_available(op_class, batch_size)
         is_batch = batch_size is not None
 
         if _process_params:

--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -257,6 +257,11 @@ def _get_inputs(schema):
     return inputs
 
 
+def _check_batch_size_available(op_class, batch_size):
+    if op_class._schema_name == "BatchPermutation" and batch_size is None:
+        raise ValueError("`batch_size` must be specified for dynamic `batch_permutation`.")
+
+
 def build_call_function(schema, op_class):
     """
     Generates __call__ method for an operator subclass.
@@ -317,6 +322,7 @@ def build_call_function(schema, op_class):
 
         if batch_size is None:
             batch_size = _ops._infer_batch_size(*raw_args, **raw_kwargs)
+        _check_batch_size_available(op_class, batch_size)
         is_batch = batch_size is not None
 
         if _process_params:
@@ -484,6 +490,7 @@ def build_fn_wrapper(op, fn_name=None, add_to_module=True):
     def fn_call(*inputs, batch_size=None, device=None, _backend=None, **raw_kwargs):
         if batch_size is None:
             batch_size = _ops._infer_batch_size(*inputs, **raw_kwargs)
+        _check_batch_size_available(op, batch_size)
         max_batch_size = _next_pow2(batch_size or 1)
         init_args = {
             arg: _scalar_decay(value)

--- a/dali/test/python/experimental_mode/test_random.py
+++ b/dali/test/python/experimental_mode/test_random.py
@@ -156,17 +156,8 @@ def test_batch_permutation_requires_batch_size():
     with assert_raises(ValueError, glob="*batch_size*batch_permutation*"):
         ndd.batch_permutation(rng=ndd.random.RNG(seed=1234))
 
-    op = ndd._ops.BatchPermutation()
-    with assert_raises(ValueError, glob="*batch_size*batch_permutation*"):
-        op(rng=ndd.random.RNG(seed=1234))
-
     batch_size = 4
     result = ndd.batch_permutation(batch_size=batch_size, rng=ndd.random.RNG(seed=1234))
-    result_np = asnumpy(result)
-    assert result_np.shape == (batch_size,)
-    assert sorted(result_np.tolist()) == list(range(batch_size))
-
-    result = op(batch_size=batch_size, rng=ndd.random.RNG(seed=1234))
     result_np = asnumpy(result)
     assert result_np.shape == (batch_size,)
     assert sorted(result_np.tolist()) == list(range(batch_size))

--- a/dali/test/python/experimental_mode/test_random.py
+++ b/dali/test/python/experimental_mode/test_random.py
@@ -160,6 +160,17 @@ def test_batch_permutation_requires_batch_size():
     with assert_raises(ValueError, glob="*batch_size*batch_permutation*"):
         op(rng=ndd.random.RNG(seed=1234))
 
+    batch_size = 4
+    result = ndd.batch_permutation(batch_size=batch_size, rng=ndd.random.RNG(seed=1234))
+    result_np = asnumpy(result)
+    assert result_np.shape == (batch_size,)
+    assert sorted(result_np.tolist()) == list(range(batch_size))
+
+    result = op(batch_size=batch_size, rng=ndd.random.RNG(seed=1234))
+    result_np = asnumpy(result)
+    assert result_np.shape == (batch_size,)
+    assert sorted(result_np.tolist()) == list(range(batch_size))
+
 
 def test_rng_set_seed():
     # Explicit RNG instance

--- a/dali/test/python/experimental_mode/test_random.py
+++ b/dali/test/python/experimental_mode/test_random.py
@@ -15,7 +15,7 @@
 import nvidia.dali.experimental.dynamic as ndd
 import numpy as np
 from nose2.tools import cartesian_params, params
-from nose_utils import raises
+from nose_utils import assert_raises, raises
 
 
 def asnumpy(tensor_or_batch):
@@ -150,6 +150,15 @@ def test_rng_clone():
 @raises(ValueError, glob="both")
 def test_rng_init_seed_and_state_error():
     ndd.random.RNG(seed=0, state="")
+
+
+def test_batch_permutation_requires_batch_size():
+    with assert_raises(ValueError, glob="*batch_size*batch_permutation*"):
+        ndd.batch_permutation(rng=ndd.random.RNG(seed=1234))
+
+    op = ndd._ops.BatchPermutation()
+    with assert_raises(ValueError, glob="*batch_size*batch_permutation*"):
+        op(rng=ndd.random.RNG(seed=1234))
 
 
 def test_rng_set_seed():


### PR DESCRIPTION
Require dynamic `batch_permutation` calls to provide an explicit `batch_size` when it cannot be inferred.

Dynamic mode has no pipeline-level batch size to inherit. `BatchPermutation` has no data inputs, so calling it without `batch_size` previously continued into operator setup as a sample-mode call and failed later with less actionable errors. This PR adds an early validation for the generated functional and class APIs.

## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
This fixes dynamic-mode `batch_permutation` argument validation by requiring `batch_size` when no input can provide one.

The check is applied in both generated dynamic entry points:
- `ndd.batch_permutation(...)`
- `ndd._ops.BatchPermutation().__call__(...)`

## Additional information:

### Affected modules and functionalities:
Dynamic mode generated operator wrappers for `BatchPermutation`.

### Key points relevant for the review:
The validation is intentionally targeted to `BatchPermutation`, since other random operators can validly produce a single sample when `batch_size` is omitted.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_batch_permutation_requires_batch_size
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: DALI-4601
