### PR TITLE
Validate COCO annotation bbox size

### DIFF
--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -14,6 +14,7 @@
 
 #include <list>
 #include <map>
+#include <stdexcept>
 #include <unordered_map>
 #include <iomanip>
 #include <iostream>
@@ -296,10 +297,19 @@ void ParseAnnotations(LookaheadParser &parser, std::vector<Annotation> &annotati
       } else if (0 == std::strcmp(internal_key, "bbox")) {
         RAPIDJSON_ASSERT(parser.PeekType() == kArrayType);
         parser.EnterArray();
-        int i = 0;
+        size_t i = 0;
         while (parser.NextArrayValue()) {
+          if (i >= annotation.box_.size()) {
+            throw std::invalid_argument(make_string(
+                "Invalid COCO annotation: `bbox` must contain exactly 4 values, got at least ",
+                i + 1, "."));
+          }
           annotation.box_[i] = parser.GetDouble();
           ++i;
+        }
+        if (i != annotation.box_.size()) {
+          throw std::invalid_argument(make_string(
+              "Invalid COCO annotation: `bbox` must contain exactly 4 values, got ", i, "."));
         }
       } else if (parse_segmentation && 0 == std::strcmp(internal_key, "segmentation")) {
         // That means that the mask encoding is not polygons but RLE

--- a/dali/test/python/reader/test_coco.py
+++ b/dali/test/python/reader/test_coco.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dali/test/python/reader/test_coco.py
+++ b/dali/test/python/reader/test_coco.py
@@ -19,7 +19,7 @@ import tempfile
 import json
 from nvidia.dali import Pipeline, pipeline_def
 
-from nose_utils import raises
+from nose_utils import assert_raises, raises
 from nose2.tools import params
 from test_utils import compare_pipelines, get_dali_extra_path
 
@@ -127,6 +127,51 @@ def test_operator_coco_reader_label_remap(avoid_remap):
                 out[1].at(s).item()
             ), f"{i}, {ids_map[int(out[0].at(s).item())]} vs {out[1].at(s).item()}"
             i = i + 1
+
+
+@pipeline_def(batch_size=1, num_threads=1, device_id=None)
+def coco_invalid_bbox_pipe(annotations_file):
+    inputs, boxes, labels = fn.readers.coco(
+        file_root=file_root,
+        annotations_file=annotations_file,
+    )
+    return inputs, boxes, labels
+
+
+@params([], [1, 2, 3], [1, 2, 3, 4, 5])
+def test_operator_coco_reader_rejects_invalid_bbox_size(bbox):
+    annotations = {
+        "images": [
+            {
+                "id": 1,
+                "width": 640,
+                "height": 480,
+                "file_name": "car-race-438467_1280.jpg",
+            }
+        ],
+        "categories": [{"id": 1}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": bbox,
+                "iscrowd": 0,
+            }
+        ],
+    }
+
+    with tempfile.TemporaryDirectory() as annotations_dir:
+        annotations_file = os.path.join(annotations_dir, "instances.json")
+        with open(annotations_file, "w") as f:
+            json.dump(annotations, f)
+
+        pipe = coco_invalid_bbox_pipe(annotations_file)
+        assert_raises(
+            ValueError,
+            pipe.run,
+            glob="*Invalid COCO annotation: `bbox` must contain exactly 4 values*",
+        )
 
 
 def test_operator_coco_reader_same_images():


### PR DESCRIPTION
- Validates the number of values in each COCO annotation bbox
  before copying parsed JSON values into the fixed-size box array.
  Reject overlong arrays before they can write past the array
  and reject short arrays to avoid partially initialized boxes.
- Adds a COCO reader regression test that exercises the real
  reader path with short and overlong bbox arrays.

## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Validate COCO annotation `bbox` arrays while parsing JSON annotations. The reader now rejects malformed boxes that do not contain exactly four values, preventing writes past the fixed-size box storage and avoiding partially initialized boxes.

## Additional information:

### Affected modules and functionalities:
COCO reader annotation parsing and COCO reader Python tests.

### Key points relevant for the review:
The bounds check is performed before writing each parsed bbox value. A final size check rejects short arrays after parsing the bbox.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A