### PR TITLE
Hide WorkerThread implementation details

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -23,6 +23,7 @@
 #include "dali/core/format.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/core/mm/default_resources.h"
+#include "dali/core/nvtx.h"
 #include "dali/pipeline/init.h"
 
 #include "dali/pipeline/pipeline.h"
@@ -905,4 +906,3 @@ void daliDestroyExternalContextCheckpoint(daliExternalContextCheckpoint *externa
   if (external_context->pipeline_data.data) daliFree(external_context->pipeline_data.data);
   if (external_context->iterator_data.data) daliFree(external_context->iterator_data.data);
 }
-

--- a/dali/operators/video/legacy/reader/video_loader.cc
+++ b/dali/operators/video/legacy/reader/video_loader.cc
@@ -728,12 +728,12 @@ void VideoLoader::ReadSample(SequenceWrapper& tensor) {
     tensor.read_sample_f = [this,
                             file_name = file_info_[seq_meta.filename_idx].filename,
                             index = seq_meta.frame_idx, count = seq_meta.length, &tensor] () {
-      thread_file_reader_.DoWork([this]() {
+      thread_file_reader_->DoWork([this]() {
         read_file();
       });
       push_sequence_to_read(file_name, index, count);
       receive_frames(tensor);
-      thread_file_reader_.WaitForWork();
+      thread_file_reader_->WaitForWork();
     };
     ++current_frame_idx_;
 

--- a/dali/operators/video/legacy/reader/video_loader.h
+++ b/dali/operators/video/legacy/reader/video_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -152,7 +152,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper, true> {
         spec.GetArgument<bool>("file_list_include_preceding_frame")),
       pad_sequences_(spec.GetArgument<bool>("pad_sequences")),
       stats_({0, 0, 0, 0, 0}),
-      thread_file_reader_(device_id_, false, "Video read_file thread"),
+      thread_file_reader_(CreateWorkerThread(device_id_, false, "Video read_file thread")),
       current_frame_idx_(-1),
       stop_(false) {
     DALI_ENFORCE(stride_ > 0, "Stride should be > 0");
@@ -175,7 +175,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper, true> {
       "to https://github.com/NVIDIA/nvidia-docker/wiki/Usage");
 
       av_log_set_level(AV_LOG_ERROR);
-      thread_file_reader_.WaitForInit();
+      thread_file_reader_->WaitForInit();
   }
 
   ~VideoLoader() noexcept override {
@@ -184,8 +184,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper, true> {
     if (vid_decoder_) {
       vid_decoder_->finish();
     }
-    thread_file_reader_.ForceStop();
-    thread_file_reader_.Shutdown();
+    thread_file_reader_->ForceStop();
+    thread_file_reader_->Shutdown();
   }
 
   void PrepareEmpty(SequenceWrapper &tensor) override;
@@ -358,7 +358,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper, true> {
 
   ThreadSafeQueue<FrameReq> send_queue_;
 
-  WorkerThread thread_file_reader_;
+  std::unique_ptr<WorkerThread> thread_file_reader_;
 
   std::vector<struct sequence_meta> frame_starts_;
   Index current_frame_idx_;

--- a/dali/operators/video/legacy/reader/video_reader_op_test.cc
+++ b/dali/operators/video/legacy/reader/video_reader_op_test.cc
@@ -18,7 +18,7 @@
 #include <fstream>
 #include "dali/pipeline/pipeline.h"
 #include "dali/test/dali_test_config.h"
-#include "dali/util/nvml_wrap.h"
+#include "dali/util/nvml.h"
 #include "opencv2/opencv.hpp"
 
 #ifndef VIDEO_READER_OP

--- a/dali/operators/video/reader/video_reader_decoder_op.cc
+++ b/dali/operators/video/reader/video_reader_decoder_op.cc
@@ -26,6 +26,9 @@
 #include "dali/operators/video/frames_decoder_cpu.h"
 #include "dali/operators/video/frames_decoder_gpu.h"
 #include "dali/operators/video/video_utils.h"
+#if NVML_ENABLED
+#include "dali/util/nvml.h"
+#endif
 
 #include "libavutil/rational.h"
 

--- a/dali/pipeline/executor/async_pipelined_executor.cc
+++ b/dali/pipeline/executor/async_pipelined_executor.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ void AsyncPipelinedExecutor::RunCPU() {
   std::unique_lock<std::mutex> lock(GetReadyMutex());
   ++cpu_work_counter_;
   lock.unlock();
-  cpu_thread_.DoWork([this]() {
+  cpu_thread_->DoWork([this]() {
         // Run the cpu work. We know there is cpu
         // work so we do not have to wait to take
         // the work
@@ -48,7 +48,7 @@ void AsyncPipelinedExecutor::RunCPU() {
 
 void AsyncPipelinedExecutor::RunMixed() {
   CheckForErrors();
-  mixed_thread_.DoWork([this]() {
+  mixed_thread_->DoWork([this]() {
         // Block until there is mixed work to do
         std::unique_lock<std::mutex> lock(GetReadyMutex());
         while (mixed_work_counter_ == 0 && !exec_error_ && !IsStopSignaled()) {
@@ -74,7 +74,7 @@ void AsyncPipelinedExecutor::RunMixed() {
 
 void AsyncPipelinedExecutor::RunGPU() {
   CheckForErrors();
-  gpu_thread_.DoWork([this]() {
+  gpu_thread_->DoWork([this]() {
         // Block until there is gpu work to do
         std::unique_lock<std::mutex> lock(GetReadyMutex());
         while (gpu_work_counter_ == 0 && !exec_error_ && !IsStopSignaled()) {

--- a/dali/pipeline/executor/async_pipelined_executor.cc
+++ b/dali/pipeline/executor/async_pipelined_executor.cc
@@ -21,7 +21,7 @@ void AsyncPipelinedExecutor::RunCPU() {
   std::unique_lock<std::mutex> lock(GetReadyMutex());
   ++cpu_work_counter_;
   lock.unlock();
-  cpu_thread_->DoWork([this]() {
+  cpu_thread_.DoWork([this]() {
         // Run the cpu work. We know there is cpu
         // work so we do not have to wait to take
         // the work
@@ -48,7 +48,7 @@ void AsyncPipelinedExecutor::RunCPU() {
 
 void AsyncPipelinedExecutor::RunMixed() {
   CheckForErrors();
-  mixed_thread_->DoWork([this]() {
+  mixed_thread_.DoWork([this]() {
         // Block until there is mixed work to do
         std::unique_lock<std::mutex> lock(GetReadyMutex());
         while (mixed_work_counter_ == 0 && !exec_error_ && !IsStopSignaled()) {
@@ -74,7 +74,7 @@ void AsyncPipelinedExecutor::RunMixed() {
 
 void AsyncPipelinedExecutor::RunGPU() {
   CheckForErrors();
-  gpu_thread_->DoWork([this]() {
+  gpu_thread_.DoWork([this]() {
         // Block until there is gpu work to do
         std::unique_lock<std::mutex> lock(GetReadyMutex());
         while (gpu_work_counter_ == 0 && !exec_error_ && !IsStopSignaled()) {

--- a/dali/pipeline/executor/async_pipelined_executor.h
+++ b/dali/pipeline/executor/async_pipelined_executor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #ifndef DALI_PIPELINE_EXECUTOR_ASYNC_PIPELINED_EXECUTOR_H_
 #define DALI_PIPELINE_EXECUTOR_ASYNC_PIPELINED_EXECUTOR_H_
 
+#include <memory>
 #include <string>
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
@@ -37,9 +38,12 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
                                            QueueSizes prefetch_queue_depth = QueueSizes{2, 2})
       : PipelinedExecutor(batch_size, num_thread, device_id, bytes_per_sample_hint, flags,
                           prefetch_queue_depth),
-        cpu_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "CPU executor"),
-        mixed_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "Mixed executor"),
-        gpu_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "GPU executor") {}
+        cpu_thread_(CreateWorkerThread(
+            device_id, Test(flags, ExecutorFlags::SetAffinity), "CPU executor")),
+        mixed_thread_(CreateWorkerThread(
+            device_id, Test(flags, ExecutorFlags::SetAffinity), "Mixed executor")),
+        gpu_thread_(CreateWorkerThread(
+            device_id, Test(flags, ExecutorFlags::SetAffinity), "GPU executor")) {}
 
   DLL_PUBLIC ~AsyncPipelinedExecutor() override {
     Shutdown();
@@ -47,9 +51,9 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
 
   DLL_PUBLIC void Shutdown() override {
     ShutdownQueue();
-    cpu_thread_.ForceStop();
-    mixed_thread_.ForceStop();
-    gpu_thread_.ForceStop();
+    cpu_thread_->ForceStop();
+    mixed_thread_->ForceStop();
+    gpu_thread_->ForceStop();
     PipelinedExecutor::Shutdown();
 
     /*
@@ -66,16 +70,17 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
      * from this class may no longer exist while work inside WorkerThread is still
      * using it what can cause a hang
      */
-    cpu_thread_.Shutdown();
-    mixed_thread_.Shutdown();
-    gpu_thread_.Shutdown();
+    cpu_thread_->Shutdown();
+    mixed_thread_->Shutdown();
+    gpu_thread_->Shutdown();
   }
 
   DLL_PUBLIC void Init() override {
-    if (!cpu_thread_.WaitForInit() || !mixed_thread_.WaitForInit() || !gpu_thread_.WaitForInit()) {
-      cpu_thread_.ForceStop();
-      mixed_thread_.ForceStop();
-      gpu_thread_.ForceStop();
+    if (!cpu_thread_->WaitForInit() || !mixed_thread_->WaitForInit() ||
+        !gpu_thread_->WaitForInit()) {
+      cpu_thread_->ForceStop();
+      mixed_thread_->ForceStop();
+      gpu_thread_->ForceStop();
       std::string error = "Failed to init pipeline on device " + std::to_string(device_id_);
       throw std::runtime_error(error);
     }
@@ -108,12 +113,20 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
   DLL_PUBLIC void RunGPU() override;
 
   void CheckForErrors() {
-    cpu_thread_.CheckForErrors();
-    mixed_thread_.CheckForErrors();
-    gpu_thread_.CheckForErrors();
+    try {
+      cpu_thread_->CheckForErrors();
+      mixed_thread_->CheckForErrors();
+      gpu_thread_->CheckForErrors();
+    } catch (...) {
+      exec_error_ = true;
+      SignalStop();
+      mixed_work_cv_.notify_all();
+      gpu_work_cv_.notify_all();
+      throw;
+    }
   }
 
-  WorkerThread cpu_thread_, mixed_thread_, gpu_thread_;
+  std::unique_ptr<WorkerThread> cpu_thread_, mixed_thread_, gpu_thread_;
   int cpu_work_counter_ = 0, mixed_work_counter_ = 0, gpu_work_counter_ = 0;
   std::condition_variable mixed_work_cv_, gpu_work_cv_;
 };

--- a/dali/pipeline/executor/async_pipelined_executor.h
+++ b/dali/pipeline/executor/async_pipelined_executor.h
@@ -15,12 +15,11 @@
 #ifndef DALI_PIPELINE_EXECUTOR_ASYNC_PIPELINED_EXECUTOR_H_
 #define DALI_PIPELINE_EXECUTOR_ASYNC_PIPELINED_EXECUTOR_H_
 
-#include <memory>
 #include <string>
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
 #include "dali/pipeline/executor/pipelined_executor.h"
-#include "dali/pipeline/util/worker_thread.h"
+#include "dali/pipeline/util/worker_thread_internal.h"
 
 namespace dali {
 
@@ -38,12 +37,9 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
                                            QueueSizes prefetch_queue_depth = QueueSizes{2, 2})
       : PipelinedExecutor(batch_size, num_thread, device_id, bytes_per_sample_hint, flags,
                           prefetch_queue_depth),
-        cpu_thread_(CreateWorkerThread(
-            device_id, Test(flags, ExecutorFlags::SetAffinity), "CPU executor")),
-        mixed_thread_(CreateWorkerThread(
-            device_id, Test(flags, ExecutorFlags::SetAffinity), "Mixed executor")),
-        gpu_thread_(CreateWorkerThread(
-            device_id, Test(flags, ExecutorFlags::SetAffinity), "GPU executor")) {}
+        cpu_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "CPU executor"),
+        mixed_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "Mixed executor"),
+        gpu_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "GPU executor") {}
 
   DLL_PUBLIC ~AsyncPipelinedExecutor() override {
     Shutdown();
@@ -51,9 +47,9 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
 
   DLL_PUBLIC void Shutdown() override {
     ShutdownQueue();
-    cpu_thread_->ForceStop();
-    mixed_thread_->ForceStop();
-    gpu_thread_->ForceStop();
+    cpu_thread_.ForceStop();
+    mixed_thread_.ForceStop();
+    gpu_thread_.ForceStop();
     PipelinedExecutor::Shutdown();
 
     /*
@@ -70,17 +66,17 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
      * from this class may no longer exist while work inside WorkerThread is still
      * using it what can cause a hang
      */
-    cpu_thread_->Shutdown();
-    mixed_thread_->Shutdown();
-    gpu_thread_->Shutdown();
+    cpu_thread_.Shutdown();
+    mixed_thread_.Shutdown();
+    gpu_thread_.Shutdown();
   }
 
   DLL_PUBLIC void Init() override {
-    if (!cpu_thread_->WaitForInit() || !mixed_thread_->WaitForInit() ||
-        !gpu_thread_->WaitForInit()) {
-      cpu_thread_->ForceStop();
-      mixed_thread_->ForceStop();
-      gpu_thread_->ForceStop();
+    if (!cpu_thread_.WaitForInit() || !mixed_thread_.WaitForInit() ||
+        !gpu_thread_.WaitForInit()) {
+      cpu_thread_.ForceStop();
+      mixed_thread_.ForceStop();
+      gpu_thread_.ForceStop();
       std::string error = "Failed to init pipeline on device " + std::to_string(device_id_);
       throw std::runtime_error(error);
     }
@@ -114,9 +110,9 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
 
   void CheckForErrors() {
     try {
-      cpu_thread_->CheckForErrors();
-      mixed_thread_->CheckForErrors();
-      gpu_thread_->CheckForErrors();
+      cpu_thread_.CheckForErrors();
+      mixed_thread_.CheckForErrors();
+      gpu_thread_.CheckForErrors();
     } catch (...) {
       exec_error_ = true;
       SignalStop();
@@ -126,7 +122,7 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
     }
   }
 
-  std::unique_ptr<WorkerThread> cpu_thread_, mixed_thread_, gpu_thread_;
+  WorkerThreadImpl cpu_thread_, mixed_thread_, gpu_thread_;
   int cpu_work_counter_ = 0, mixed_work_counter_ = 0, gpu_work_counter_ = 0;
   std::condition_variable mixed_work_cv_, gpu_work_cv_;
 };

--- a/dali/pipeline/executor/async_separated_pipelined_executor.cc
+++ b/dali/pipeline/executor/async_separated_pipelined_executor.cc
@@ -19,17 +19,17 @@ namespace dali {
 void AsyncSeparatedPipelinedExecutor::RunCPU() {
   CheckForErrors();
   // Run the cpu work. We schedule it in queue and wait for free buffers
-  cpu_thread_->DoWork([this]() { SeparatedPipelinedExecutor::RunCPU(); });
+  cpu_thread_.DoWork([this]() { SeparatedPipelinedExecutor::RunCPU(); });
 }
 
 void AsyncSeparatedPipelinedExecutor::RunMixed() {
   CheckForErrors();
-  mixed_thread_->DoWork([this]() { SeparatedPipelinedExecutor::RunMixed(); });
+  mixed_thread_.DoWork([this]() { SeparatedPipelinedExecutor::RunMixed(); });
 }
 
 void AsyncSeparatedPipelinedExecutor::RunGPU() {
   CheckForErrors();
-  gpu_thread_->DoWork([this]() { SeparatedPipelinedExecutor::RunGPU(); });
+  gpu_thread_.DoWork([this]() { SeparatedPipelinedExecutor::RunGPU(); });
 }
 
 void AsyncSeparatedPipelinedExecutor::Prefetch() {

--- a/dali/pipeline/executor/async_separated_pipelined_executor.cc
+++ b/dali/pipeline/executor/async_separated_pipelined_executor.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,17 +19,17 @@ namespace dali {
 void AsyncSeparatedPipelinedExecutor::RunCPU() {
   CheckForErrors();
   // Run the cpu work. We schedule it in queue and wait for free buffers
-  cpu_thread_.DoWork([this]() { SeparatedPipelinedExecutor::RunCPU(); });
+  cpu_thread_->DoWork([this]() { SeparatedPipelinedExecutor::RunCPU(); });
 }
 
 void AsyncSeparatedPipelinedExecutor::RunMixed() {
   CheckForErrors();
-  mixed_thread_.DoWork([this]() { SeparatedPipelinedExecutor::RunMixed(); });
+  mixed_thread_->DoWork([this]() { SeparatedPipelinedExecutor::RunMixed(); });
 }
 
 void AsyncSeparatedPipelinedExecutor::RunGPU() {
   CheckForErrors();
-  gpu_thread_.DoWork([this]() { SeparatedPipelinedExecutor::RunGPU(); });
+  gpu_thread_->DoWork([this]() { SeparatedPipelinedExecutor::RunGPU(); });
 }
 
 void AsyncSeparatedPipelinedExecutor::Prefetch() {

--- a/dali/pipeline/executor/async_separated_pipelined_executor.h
+++ b/dali/pipeline/executor/async_separated_pipelined_executor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #ifndef DALI_PIPELINE_EXECUTOR_ASYNC_SEPARATED_PIPELINED_EXECUTOR_H_
 #define DALI_PIPELINE_EXECUTOR_ASYNC_SEPARATED_PIPELINED_EXECUTOR_H_
 
+#include <memory>
 #include <string>
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
@@ -37,9 +38,12 @@ class DLL_PUBLIC AsyncSeparatedPipelinedExecutor : public SeparatedPipelinedExec
       ExecutorFlags flags = {}, QueueSizes prefetch_queue_depth = QueueSizes{2, 2})
       : SeparatedPipelinedExecutor(batch_size, num_thread, device_id, bytes_per_sample_hint,
                                    flags, prefetch_queue_depth),
-        cpu_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "CPU executor"),
-        mixed_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "Mixed executor"),
-        gpu_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "GPU executor") {}
+        cpu_thread_(CreateWorkerThread(
+            device_id, Test(flags, ExecutorFlags::SetAffinity), "CPU executor")),
+        mixed_thread_(CreateWorkerThread(
+            device_id, Test(flags, ExecutorFlags::SetAffinity), "Mixed executor")),
+        gpu_thread_(CreateWorkerThread(
+            device_id, Test(flags, ExecutorFlags::SetAffinity), "GPU executor")) {}
 
   DLL_PUBLIC ~AsyncSeparatedPipelinedExecutor() override {
     Shutdown();
@@ -48,9 +52,9 @@ class DLL_PUBLIC AsyncSeparatedPipelinedExecutor : public SeparatedPipelinedExec
   DLL_PUBLIC void Shutdown() override {
     ShutdownQueue();
 
-    cpu_thread_.ForceStop();
-    mixed_thread_.ForceStop();
-    gpu_thread_.ForceStop();
+    cpu_thread_->ForceStop();
+    mixed_thread_->ForceStop();
+    gpu_thread_->ForceStop();
     SyncDevice();
 
     /*
@@ -59,16 +63,17 @@ class DLL_PUBLIC AsyncSeparatedPipelinedExecutor : public SeparatedPipelinedExec
      * from this class may no longer exist while work inside WorkerThread is still
      * using it what can cause a hang
      */
-    cpu_thread_.Shutdown();
-    mixed_thread_.Shutdown();
-    gpu_thread_.Shutdown();
+    cpu_thread_->Shutdown();
+    mixed_thread_->Shutdown();
+    gpu_thread_->Shutdown();
   }
 
   DLL_PUBLIC void Init() override {
-    if (!cpu_thread_.WaitForInit() || !mixed_thread_.WaitForInit() || !gpu_thread_.WaitForInit()) {
-      cpu_thread_.ForceStop();
-      mixed_thread_.ForceStop();
-      gpu_thread_.ForceStop();
+    if (!cpu_thread_->WaitForInit() || !mixed_thread_->WaitForInit() ||
+        !gpu_thread_->WaitForInit()) {
+      cpu_thread_->ForceStop();
+      mixed_thread_->ForceStop();
+      gpu_thread_->ForceStop();
       std::string error = "Failed to init pipeline on device " + std::to_string(device_id_);
       throw std::runtime_error(error);
     }
@@ -101,12 +106,18 @@ class DLL_PUBLIC AsyncSeparatedPipelinedExecutor : public SeparatedPipelinedExec
   DLL_PUBLIC void RunGPU() override;
 
   void CheckForErrors() {
-    cpu_thread_.CheckForErrors();
-    mixed_thread_.CheckForErrors();
-    gpu_thread_.CheckForErrors();
+    try {
+      cpu_thread_->CheckForErrors();
+      mixed_thread_->CheckForErrors();
+      gpu_thread_->CheckForErrors();
+    } catch (...) {
+      exec_error_ = true;
+      SignalStop();
+      throw;
+    }
   }
 
-  WorkerThread cpu_thread_, mixed_thread_, gpu_thread_;
+  std::unique_ptr<WorkerThread> cpu_thread_, mixed_thread_, gpu_thread_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/executor/async_separated_pipelined_executor.h
+++ b/dali/pipeline/executor/async_separated_pipelined_executor.h
@@ -15,12 +15,11 @@
 #ifndef DALI_PIPELINE_EXECUTOR_ASYNC_SEPARATED_PIPELINED_EXECUTOR_H_
 #define DALI_PIPELINE_EXECUTOR_ASYNC_SEPARATED_PIPELINED_EXECUTOR_H_
 
-#include <memory>
 #include <string>
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
 #include "dali/pipeline/executor/pipelined_executor.h"
-#include "dali/pipeline/util/worker_thread.h"
+#include "dali/pipeline/util/worker_thread_internal.h"
 
 namespace dali {
 
@@ -38,12 +37,9 @@ class DLL_PUBLIC AsyncSeparatedPipelinedExecutor : public SeparatedPipelinedExec
       ExecutorFlags flags = {}, QueueSizes prefetch_queue_depth = QueueSizes{2, 2})
       : SeparatedPipelinedExecutor(batch_size, num_thread, device_id, bytes_per_sample_hint,
                                    flags, prefetch_queue_depth),
-        cpu_thread_(CreateWorkerThread(
-            device_id, Test(flags, ExecutorFlags::SetAffinity), "CPU executor")),
-        mixed_thread_(CreateWorkerThread(
-            device_id, Test(flags, ExecutorFlags::SetAffinity), "Mixed executor")),
-        gpu_thread_(CreateWorkerThread(
-            device_id, Test(flags, ExecutorFlags::SetAffinity), "GPU executor")) {}
+        cpu_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "CPU executor"),
+        mixed_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "Mixed executor"),
+        gpu_thread_(device_id, Test(flags, ExecutorFlags::SetAffinity), "GPU executor") {}
 
   DLL_PUBLIC ~AsyncSeparatedPipelinedExecutor() override {
     Shutdown();
@@ -52,9 +48,9 @@ class DLL_PUBLIC AsyncSeparatedPipelinedExecutor : public SeparatedPipelinedExec
   DLL_PUBLIC void Shutdown() override {
     ShutdownQueue();
 
-    cpu_thread_->ForceStop();
-    mixed_thread_->ForceStop();
-    gpu_thread_->ForceStop();
+    cpu_thread_.ForceStop();
+    mixed_thread_.ForceStop();
+    gpu_thread_.ForceStop();
     SyncDevice();
 
     /*
@@ -63,17 +59,17 @@ class DLL_PUBLIC AsyncSeparatedPipelinedExecutor : public SeparatedPipelinedExec
      * from this class may no longer exist while work inside WorkerThread is still
      * using it what can cause a hang
      */
-    cpu_thread_->Shutdown();
-    mixed_thread_->Shutdown();
-    gpu_thread_->Shutdown();
+    cpu_thread_.Shutdown();
+    mixed_thread_.Shutdown();
+    gpu_thread_.Shutdown();
   }
 
   DLL_PUBLIC void Init() override {
-    if (!cpu_thread_->WaitForInit() || !mixed_thread_->WaitForInit() ||
-        !gpu_thread_->WaitForInit()) {
-      cpu_thread_->ForceStop();
-      mixed_thread_->ForceStop();
-      gpu_thread_->ForceStop();
+    if (!cpu_thread_.WaitForInit() || !mixed_thread_.WaitForInit() ||
+        !gpu_thread_.WaitForInit()) {
+      cpu_thread_.ForceStop();
+      mixed_thread_.ForceStop();
+      gpu_thread_.ForceStop();
       std::string error = "Failed to init pipeline on device " + std::to_string(device_id_);
       throw std::runtime_error(error);
     }
@@ -107,9 +103,9 @@ class DLL_PUBLIC AsyncSeparatedPipelinedExecutor : public SeparatedPipelinedExec
 
   void CheckForErrors() {
     try {
-      cpu_thread_->CheckForErrors();
-      mixed_thread_->CheckForErrors();
-      gpu_thread_->CheckForErrors();
+      cpu_thread_.CheckForErrors();
+      mixed_thread_.CheckForErrors();
+      gpu_thread_.CheckForErrors();
     } catch (...) {
       exec_error_ = true;
       SignalStop();
@@ -117,7 +113,7 @@ class DLL_PUBLIC AsyncSeparatedPipelinedExecutor : public SeparatedPipelinedExec
     }
   }
 
-  std::unique_ptr<WorkerThread> cpu_thread_, mixed_thread_, gpu_thread_;
+  WorkerThreadImpl cpu_thread_, mixed_thread_, gpu_thread_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operator/builtin/input_operator.h
+++ b/dali/pipeline/operator/builtin/input_operator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #ifndef DALI_PIPELINE_OPERATOR_BUILTIN_INPUT_OPERATOR_H_
 #define DALI_PIPELINE_OPERATOR_BUILTIN_INPUT_OPERATOR_H_
 
+#include <condition_variable>
 #include <list>
 #include <memory>
 #include <optional>
@@ -28,6 +29,7 @@
 #include "dali/pipeline/operator/builtin/caching_list.h"
 #include "dali/pipeline/operator/operator.h"
 #include "dali/pipeline/util/worker_thread.h"
+#include "dali/core/nvtx.h"
 
 namespace dali {
 
@@ -147,18 +149,18 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
           device_id_(spec.GetArgument<int>("device_id")),
           blocking_(spec.GetArgument<bool>("blocking")),
           no_copy_(spec.GetArgument<bool>("no_copy")),
-          sync_worker_(device_id_, false, "InputOperator sync_worker_") {
+          sync_worker_(CreateWorkerThread(device_id_, false, "InputOperator sync_worker_")) {
     if (std::is_same<Backend, GPUBackend>::value) {
       internal_copy_stream_ = CUDAStreamPool::instance().Get(device_id_);
       internal_copy_order_ = internal_copy_stream_;
     }
-    sync_worker_.WaitForInit();
+    sync_worker_->WaitForInit();
   }
 
 
   virtual ~InputOperator() {
-    sync_worker_.ForceStop();
-    sync_worker_.Shutdown();
+    sync_worker_->ForceStop();
+    sync_worker_->Shutdown();
   }
 
   DISABLE_COPY_MOVE_ASSIGN(InputOperator);
@@ -560,7 +562,7 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
    */
   bool zero_copy_noncontiguous_gpu_input_ = false;
 
-  WorkerThread sync_worker_;
+  std::unique_ptr<WorkerThread> sync_worker_;
   CUDAStreamLease internal_copy_stream_ = {};
   AccessOrder internal_copy_order_ = AccessOrder::host();
 };

--- a/dali/pipeline/util/worker_thread.cc
+++ b/dali/pipeline/util/worker_thread.cc
@@ -1,0 +1,259 @@
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/util/worker_thread.h"
+
+#include <condition_variable>
+#include <cstddef>
+#include <exception>
+#include <iostream>
+#include <mutex>
+#include <queue>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
+#include "dali/core/device_guard.h"
+#include "dali/core/error_handling.h"
+#include "dali/core/nvtx.h"
+#if NVML_ENABLED
+#include "dali/util/nvml.h"
+#endif
+
+namespace dali {
+
+class Barrier {
+ public:
+  explicit Barrier(std::size_t count) : count_(count), current_(count) {}
+
+  void Wait(bool reset = false);
+  void Break();
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  size_t count_;
+  size_t current_;
+};
+
+class WorkerThreadImpl final : public WorkerThread {
+ public:
+  explicit WorkerThreadImpl(int device_id, bool set_affinity, const std::string &name);
+  ~WorkerThreadImpl() override;
+
+  void Shutdown() override;
+  void DoWork(Work work) override;
+  void WaitForWork(bool rethrow_worker_errors = true) override;
+  void ForceStop() override;
+  void CheckForErrors() override;
+  bool WaitForInit() override;
+
+ private:
+  void ThreadMain(int device_id, bool set_affinity, const std::string &name);
+
+  bool running_ = true;
+  bool work_complete_ = true;
+  std::queue<Work> work_queue_;
+  std::thread thread_;
+  std::mutex mutex_;
+  std::condition_variable cv_, completed_;
+
+  std::queue<string> errors_;
+
+  Barrier barrier_{2};
+#if NVML_ENABLED
+  nvml::NvmlInstance nvml_handle_;
+#endif
+};
+
+void Barrier::Wait(bool reset) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  current_--;
+  if (current_ == 0 || count_ == 0) {
+    if (reset) {
+      current_ = count_;
+    }
+    cv_.notify_all();
+  } else {
+    cv_.wait(lock, [this] { return current_ == 0; });
+  }
+}
+
+void Barrier::Break() {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    count_ = 0;
+    current_ = count_;
+  }
+  cv_.notify_all();
+}
+
+WorkerThreadImpl::WorkerThreadImpl(int device_id, bool set_affinity, const std::string &name) {
+#if NVML_ENABLED
+  if (set_affinity && device_id != CPU_ONLY_DEVICE_ID) {
+    nvml_handle_ = nvml::NvmlInstance::CreateNvmlInstance();
+  }
+#endif
+  thread_ = std::thread(&WorkerThreadImpl::ThreadMain,
+                        this, device_id, set_affinity, make_string("[DALI][WT]", name));
+}
+
+WorkerThreadImpl::~WorkerThreadImpl() {
+  Shutdown();
+}
+
+void WorkerThreadImpl::Shutdown() {
+  // Wait for work to find errors
+  if (running_) {
+    WaitForWork(false);
+
+    // Mark the thread as not running
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      running_ = false;
+    }
+    cv_.notify_one();
+  } else {
+    ForceStop();
+  }
+  // Join the thread
+  if (thread_.joinable()) {
+    ForceStop();
+    thread_.join();
+  }
+}
+
+void WorkerThreadImpl::DoWork(Work work) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    work_queue_.push(std::move(work));
+    work_complete_ = false;
+  }
+  cv_.notify_one();
+}
+
+void WorkerThreadImpl::WaitForWork(bool rethrow_worker_errors) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  while (!work_complete_ && running_) {
+    completed_.wait(lock);
+  }
+
+  // Check for errors
+  if (rethrow_worker_errors && !errors_.empty()) {
+    string error = "Error in worker thread: " + errors_.front();
+    errors_.pop();
+    running_ = false;
+    lock.unlock();
+    cv_.notify_all();
+    throw std::runtime_error(error);
+  }
+}
+
+void WorkerThreadImpl::ForceStop() {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    running_ = false;
+  }
+  barrier_.Break();
+  cv_.notify_all();
+}
+
+void WorkerThreadImpl::CheckForErrors() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (!errors_.empty()) {
+    string error = "Error in worker thread: " + errors_.front();
+    errors_.pop();
+    running_ = false;
+    lock.unlock();
+    cv_.notify_all();
+    throw std::runtime_error(error);
+  }
+}
+
+bool WorkerThreadImpl::WaitForInit() {
+  barrier_.Wait();
+  return running_;
+}
+
+void WorkerThreadImpl::ThreadMain(int device_id, bool set_affinity, const std::string &name) {
+  SetThreadName(name.c_str());
+  DeviceGuard g(device_id);
+  try {
+    if (set_affinity) {
+#if NVML_ENABLED
+      nvml::SetCPUAffinity();
+#endif
+    }
+  } catch (std::exception &e) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    errors_.push(e.what());
+    running_ = false;
+  } catch (...) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    errors_.push("Unknown exception");
+    running_ = false;
+  }
+
+  barrier_.Wait();
+
+  while (running_) {
+    // Check the queue for work
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (work_queue_.empty() && running_) {
+      cv_.wait(lock);
+    }
+
+    if (!running_) {
+      break;
+    }
+
+    Work work = std::move(work_queue_.front());
+    work_queue_.pop();
+    lock.unlock();
+
+    try {
+      work();
+    } catch (std::exception &e) {
+      std::cerr << std::this_thread::get_id() << " Exception in thread: " << e.what() << endl;
+      lock.lock();
+      errors_.push(e.what());
+      running_ = false;
+      completed_.notify_one();
+      lock.unlock();
+      break;
+    } catch (...) {
+      std::cerr << std::this_thread::get_id() << " Exception in thread" << endl;
+      lock.lock();
+      errors_.push("Caught unknown exception in thread.");
+      running_ = false;
+      completed_.notify_one();
+      lock.unlock();
+      break;
+    }
+
+    lock.lock();
+
+    if (work_queue_.empty()) {
+      work_complete_ = true;
+      completed_.notify_one();
+    }
+  }
+}
+
+std::unique_ptr<WorkerThread> CreateWorkerThread(
+    int device_id, bool set_affinity, const std::string &name) {
+  return std::make_unique<WorkerThreadImpl>(device_id, set_affinity, name);
+}
+
+}  // namespace dali

--- a/dali/pipeline/util/worker_thread.cc
+++ b/dali/pipeline/util/worker_thread.cc
@@ -201,7 +201,7 @@ void WorkerThreadImpl::ThreadMain(int device_id, bool set_affinity, const std::s
 }
 
 std::unique_ptr<WorkerThread> CreateWorkerThread(
-    int device_id, bool set_affinity, std::string_view &name) {
+    int device_id, bool set_affinity, const std::string &name) {
   return std::make_unique<WorkerThreadImpl>(device_id, set_affinity, name);
 }
 

--- a/dali/pipeline/util/worker_thread.cc
+++ b/dali/pipeline/util/worker_thread.cc
@@ -201,7 +201,7 @@ void WorkerThreadImpl::ThreadMain(int device_id, bool set_affinity, const std::s
 }
 
 std::unique_ptr<WorkerThread> CreateWorkerThread(
-    int device_id, bool set_affinity, const std::string &name) {
+    int device_id, bool set_affinity, std::string_view &name) {
   return std::make_unique<WorkerThreadImpl>(device_id, set_affinity, name);
 }
 

--- a/dali/pipeline/util/worker_thread.cc
+++ b/dali/pipeline/util/worker_thread.cc
@@ -48,7 +48,7 @@ void detail::Barrier::Break() {
   cv_.notify_all();
 }
 
-WorkerThreadImpl::WorkerThreadImpl(int device_id, bool set_affinity, const std::string &name) {
+WorkerThreadImpl::WorkerThreadImpl(int device_id, bool set_affinity, std::string_view name) {
 #if NVML_ENABLED
   if (set_affinity && device_id != CPU_ONLY_DEVICE_ID) {
     nvml_handle_ = nvml::NvmlInstance::CreateNvmlInstance();
@@ -201,7 +201,7 @@ void WorkerThreadImpl::ThreadMain(int device_id, bool set_affinity, const std::s
 }
 
 std::unique_ptr<WorkerThread> CreateWorkerThread(
-    int device_id, bool set_affinity, const std::string &name) {
+    int device_id, bool set_affinity, std::string_view name) {
   return std::make_unique<WorkerThreadImpl>(device_id, set_affinity, name);
 }
 

--- a/dali/pipeline/util/worker_thread.cc
+++ b/dali/pipeline/util/worker_thread.cc
@@ -13,71 +13,20 @@
 // limitations under the License.
 
 #include "dali/pipeline/util/worker_thread.h"
+#include "dali/pipeline/util/worker_thread_internal.h"
 
-#include <condition_variable>
-#include <cstddef>
 #include <exception>
 #include <iostream>
-#include <mutex>
-#include <queue>
 #include <stdexcept>
-#include <thread>
 #include <utility>
 
 #include "dali/core/device_guard.h"
 #include "dali/core/error_handling.h"
 #include "dali/core/nvtx.h"
-#if NVML_ENABLED
-#include "dali/util/nvml.h"
-#endif
 
 namespace dali {
 
-class Barrier {
- public:
-  explicit Barrier(std::size_t count) : count_(count), current_(count) {}
-
-  void Wait(bool reset = false);
-  void Break();
-
- private:
-  std::mutex mutex_;
-  std::condition_variable cv_;
-  size_t count_;
-  size_t current_;
-};
-
-class WorkerThreadImpl final : public WorkerThread {
- public:
-  explicit WorkerThreadImpl(int device_id, bool set_affinity, const std::string &name);
-  ~WorkerThreadImpl() override;
-
-  void Shutdown() override;
-  void DoWork(Work work) override;
-  void WaitForWork(bool rethrow_worker_errors = true) override;
-  void ForceStop() override;
-  void CheckForErrors() override;
-  bool WaitForInit() override;
-
- private:
-  void ThreadMain(int device_id, bool set_affinity, const std::string &name);
-
-  bool running_ = true;
-  bool work_complete_ = true;
-  std::queue<Work> work_queue_;
-  std::thread thread_;
-  std::mutex mutex_;
-  std::condition_variable cv_, completed_;
-
-  std::queue<string> errors_;
-
-  Barrier barrier_{2};
-#if NVML_ENABLED
-  nvml::NvmlInstance nvml_handle_;
-#endif
-};
-
-void Barrier::Wait(bool reset) {
+void detail::Barrier::Wait(bool reset) {
   std::unique_lock<std::mutex> lock(mutex_);
   current_--;
   if (current_ == 0 || count_ == 0) {
@@ -90,7 +39,7 @@ void Barrier::Wait(bool reset) {
   }
 }
 
-void Barrier::Break() {
+void detail::Barrier::Break() {
   {
     std::lock_guard<std::mutex> lock(mutex_);
     count_ = 0;

--- a/dali/pipeline/util/worker_thread.h
+++ b/dali/pipeline/util/worker_thread.h
@@ -44,7 +44,7 @@ class DLL_PUBLIC WorkerThread {
 };
 
 DLL_PUBLIC std::unique_ptr<WorkerThread> CreateWorkerThread(
-    int device_id, bool set_affinity, const std::string &name);
+    int device_id, bool set_affinity, std::string_view &name);
 
 }  // namespace dali
 

--- a/dali/pipeline/util/worker_thread.h
+++ b/dali/pipeline/util/worker_thread.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,228 +15,36 @@
 #ifndef DALI_PIPELINE_UTIL_WORKER_THREAD_H_
 #define DALI_PIPELINE_UTIL_WORKER_THREAD_H_
 
-#include <condition_variable>
 #include <functional>
-#include <mutex>
-#include <queue>
+#include <memory>
 #include <string>
-#include <thread>
-#include <utility>
 
 #include "dali/core/common.h"
-#include "dali/core/error_handling.h"
-#if NVML_ENABLED
-#include "dali/util/nvml.h"
-#endif
-#include "dali/core/device_guard.h"
-#include "dali/core/nvtx.h"
 
 namespace dali {
 
-class Barrier {
- public:
-    explicit Barrier(std::size_t count) : count_(count), current_(count) {}
-    void Wait(bool reset = false) {
-        std::unique_lock<std::mutex> lock(mutex_);
-        current_--;
-        if (current_ == 0 || count_ == 0) {
-            if (reset)
-              current_ = count_;
-            cv_.notify_all();
-        } else {
-            cv_.wait(lock, [this] { return current_ == 0; });
-        }
-    }
-    void Break() {
-      {
-        std::lock_guard<std::mutex> lock(mutex_);
-        count_ = 0;
-        current_ = count_;
-      }
-      cv_.notify_all();
-    }
-
- private:
-    std::mutex mutex_;
-    std::condition_variable cv_;
-    size_t count_;
-    size_t current_;
-};
-
-class WorkerThread {
+class DLL_PUBLIC WorkerThread {
  public:
   typedef std::function<void(void)> Work;
 
-  inline WorkerThread(int device_id, bool set_affinity, const std::string &name) :
-    running_(true), work_complete_(true), barrier_(2) {
-#if NVML_ENABLED
-    if (device_id != CPU_ONLY_DEVICE_ID) {
-      nvml_handle_ = nvml::NvmlInstance::CreateNvmlInstance();
-    }
-#endif
-    thread_ = std::thread(&WorkerThread::ThreadMain,
-        this, device_id, set_affinity, make_string("[DALI][WT]", name));
-  }
-
-  inline ~WorkerThread() {
-    Shutdown();
-  }
+  virtual ~WorkerThread() = default;
 
   /*
    * Separate Shutdown function is needed as we cannot rely on destructor to stop the thread.
    * When the destructor is called other things that work() is using may have been gone long
-   * before causing a hang. Now when Shutdown is called we are sure that all things around still exist.
+   * before causing a hang. Now when Shutdown is called we are sure that all things around
+   * still exist.
    */
-  inline void Shutdown() {
-    // Wait for work to find errors
-    if (running_) {
-      WaitForWork(false);
-
-      // Mark the thread as not running
-      {
-        std::lock_guard<std::mutex> lock(mutex_);
-        running_ = false;
-      }
-      cv_.notify_one();
-    } else {
-      ForceStop();
-    }
-    // Join the thread
-    if (thread_.joinable()) {
-      ForceStop();
-      thread_.join();
-    }
-  }
-
-  inline void DoWork(Work work) {
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      work_queue_.push(std::move(work));
-      work_complete_ = false;
-    }
-    cv_.notify_one();
-  }
-
-  inline void WaitForWork(bool rethrow_worker_errors = true) {
-    std::unique_lock<std::mutex> lock(mutex_);
-    while (!work_complete_ && running_) {
-      completed_.wait(lock);
-    }
-
-    // Check for errors
-    if (rethrow_worker_errors && !errors_.empty()) {
-      string error = "Error in worker thread: " +
-        errors_.front();
-      errors_.pop();
-      running_ = false;
-      lock.unlock();
-      cv_.notify_all();
-      throw std::runtime_error(error);
-    }
-  }
-
-  inline void ForceStop() {
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      running_ = false;
-    }
-    barrier_.Break();
-    cv_.notify_all();
-  }
-
-  inline void CheckForErrors() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (!errors_.empty()) {
-      string error = "Error in worker thread: " +
-        errors_.front();
-      errors_.pop();
-    }
-  }
-
-  inline bool WaitForInit() {
-    barrier_.Wait();
-    return running_;
-  }
-
- private:
-  void ThreadMain(int device_id, bool set_affinity, const std::string &name) {
-    SetThreadName(name.c_str());
-    DeviceGuard g(device_id);
-    try {
-      if (set_affinity) {
-#if NVML_ENABLED
-        nvml::SetCPUAffinity();
-#endif
-      }
-    } catch (std::exception &e) {
-      std::lock_guard<std::mutex> lock(mutex_);
-      errors_.push(e.what());
-      running_ = false;
-    } catch (...) {
-      std::lock_guard<std::mutex> lock(mutex_);
-      errors_.push("Unknown exception");
-      running_ = false;
-    }
-
-    barrier_.Wait();
-
-    while (running_) {
-      // Check the queue for work
-      std::unique_lock<std::mutex> lock(mutex_);
-      while (work_queue_.empty() && running_) {
-        cv_.wait(lock);
-      }
-
-      if (!running_) {
-        break;
-      }
-
-      Work work = std::move(work_queue_.front());
-      work_queue_.pop();
-      lock.unlock();
-
-      try {
-        work();
-      } catch (std::exception &e) {
-        std::cerr << std::this_thread::get_id() << " Exception in thread: " << e.what() << endl;
-        lock.lock();
-        errors_.push(e.what());
-        running_ = false;
-        completed_.notify_one();
-        lock.unlock();
-        break;
-      } catch (...) {
-        std::cerr << std::this_thread::get_id() << " Exception in thread" << endl;
-        lock.lock();
-        errors_.push("Caught unknown exception in thread.");
-        running_ = false;
-        completed_.notify_one();
-        lock.unlock();
-        break;
-      }
-
-      lock.lock();
-
-      if (work_queue_.empty()) {
-        work_complete_ = true;
-        completed_.notify_one();
-      }
-    }
-  }
-
-  bool running_, work_complete_;
-  std::queue<Work> work_queue_;
-  std::thread thread_;
-  std::mutex mutex_;
-  std::condition_variable cv_, completed_;
-
-  std::queue<string> errors_;
-
-  Barrier barrier_;
-#if NVML_ENABLED
-  nvml::NvmlInstance nvml_handle_;
-#endif
+  virtual void Shutdown() = 0;
+  virtual void DoWork(Work work) = 0;
+  virtual void WaitForWork(bool rethrow_worker_errors = true) = 0;
+  virtual void ForceStop() = 0;
+  virtual void CheckForErrors() = 0;
+  virtual bool WaitForInit() = 0;
 };
+
+DLL_PUBLIC std::unique_ptr<WorkerThread> CreateWorkerThread(
+    int device_id, bool set_affinity, const std::string &name);
 
 }  // namespace dali
 

--- a/dali/pipeline/util/worker_thread.h
+++ b/dali/pipeline/util/worker_thread.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "dali/core/common.h"
 
@@ -44,7 +45,7 @@ class DLL_PUBLIC WorkerThread {
 };
 
 DLL_PUBLIC std::unique_ptr<WorkerThread> CreateWorkerThread(
-    int device_id, bool set_affinity, const std::string &name);
+    int device_id, bool set_affinity, std::string_view name);
 
 }  // namespace dali
 

--- a/dali/pipeline/util/worker_thread.h
+++ b/dali/pipeline/util/worker_thread.h
@@ -44,7 +44,7 @@ class DLL_PUBLIC WorkerThread {
 };
 
 DLL_PUBLIC std::unique_ptr<WorkerThread> CreateWorkerThread(
-    int device_id, bool set_affinity, std::string_view &name);
+    int device_id, bool set_affinity, const std::string &name);
 
 }  // namespace dali
 

--- a/dali/pipeline/util/worker_thread_internal.h
+++ b/dali/pipeline/util/worker_thread_internal.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_UTIL_WORKER_THREAD_INTERNAL_H_
+#define DALI_PIPELINE_UTIL_WORKER_THREAD_INTERNAL_H_
+
+#include "dali/pipeline/util/worker_thread.h"
+
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+
+#if NVML_ENABLED
+#include "dali/util/nvml.h"
+#endif
+
+namespace dali {
+
+namespace detail {
+
+class Barrier {
+ public:
+  explicit Barrier(std::size_t count) : count_(count), current_(count) {}
+
+  void Wait(bool reset = false);
+  void Break();
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  std::size_t count_;
+  std::size_t current_;
+};
+
+}  // namespace detail
+
+class DLL_PUBLIC WorkerThreadImpl final : public WorkerThread {
+ public:
+  explicit WorkerThreadImpl(int device_id, bool set_affinity, const std::string &name);
+  ~WorkerThreadImpl() override;
+
+  void Shutdown() override;
+  void DoWork(Work work) override;
+  void WaitForWork(bool rethrow_worker_errors = true) override;
+  void ForceStop() override;
+  void CheckForErrors() override;
+  bool WaitForInit() override;
+
+ private:
+  void ThreadMain(int device_id, bool set_affinity, const std::string &name);
+
+  bool running_ = true;
+  bool work_complete_ = true;
+  std::queue<Work> work_queue_;
+  std::thread thread_;
+  std::mutex mutex_;
+  std::condition_variable cv_, completed_;
+
+  std::queue<std::string> errors_;
+
+  detail::Barrier barrier_{2};
+#if NVML_ENABLED
+  nvml::NvmlInstance nvml_handle_;
+#endif
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_UTIL_WORKER_THREAD_INTERNAL_H_

--- a/dali/pipeline/util/worker_thread_internal.h
+++ b/dali/pipeline/util/worker_thread_internal.h
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <queue>
 #include <string>
+#include <string_view>
 #include <thread>
 
 #if NVML_ENABLED
@@ -50,7 +51,7 @@ class Barrier {
 
 class DLL_PUBLIC WorkerThreadImpl final : public WorkerThread {
  public:
-  explicit WorkerThreadImpl(int device_id, bool set_affinity, const std::string &name);
+  explicit WorkerThreadImpl(int device_id, bool set_affinity, std::string_view name);
   ~WorkerThreadImpl() override;
 
   void Shutdown() override;

--- a/dali/pipeline/util/worker_thread_test.cc
+++ b/dali/pipeline/util/worker_thread_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,19 +24,19 @@ namespace dali {
 namespace test {
 
 TEST(WorkerThread, Destructing) {
-  WorkerThread wt(0, false, "WorkerThread test");
+  auto wt = CreateWorkerThread(CPU_ONLY_DEVICE_ID, false, "WorkerThread test");
   // check destruction of a running worker thread
 }
 
 TEST(WorkerThread, WaitForWorkErrorHandling) {
-  WorkerThread wt(0, false, "WorkerThread test");
-  ASSERT_TRUE(wt.WaitForInit());
-  wt.DoWork([]() {
+  auto wt = CreateWorkerThread(CPU_ONLY_DEVICE_ID, false, "WorkerThread test");
+  ASSERT_TRUE(wt->WaitForInit());
+  wt->DoWork([]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     throw std::runtime_error("Asdf");
   });
   try {
-    wt.WaitForWork();
+    wt->WaitForWork();
   } catch (const std::runtime_error &e) {
     EXPECT_EQ(e.what(), std::string("Error in worker thread: Asdf"));
     return;
@@ -45,13 +45,32 @@ TEST(WorkerThread, WaitForWorkErrorHandling) {
 }
 
 TEST(WorkerThread, ShutdownErrorHandling) {
-  WorkerThread wt(0, false, "WorkerThread test");
-  ASSERT_TRUE(wt.WaitForInit());
-  wt.DoWork([]() {
+  auto wt = CreateWorkerThread(CPU_ONLY_DEVICE_ID, false, "WorkerThread test");
+  ASSERT_TRUE(wt->WaitForInit());
+  wt->DoWork([]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     throw std::runtime_error("Worker thread exception message 2");
   });
-  wt.Shutdown();  // assure it does not deadlock
+  wt->Shutdown();  // assure it does not deadlock
+}
+
+TEST(WorkerThread, CheckForErrorsErrorHandling) {
+  auto wt = CreateWorkerThread(CPU_ONLY_DEVICE_ID, false, "WorkerThread test");
+  ASSERT_TRUE(wt->WaitForInit());
+  wt->DoWork([]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    throw std::runtime_error("Worker thread exception message 3");
+  });
+  wt->WaitForWork(false);
+  EXPECT_THROW(
+    try {
+      wt->CheckForErrors();
+    } catch (const std::runtime_error &e) {
+      EXPECT_EQ(e.what(),
+                std::string("Error in worker thread: Worker thread exception message 3"));
+      throw;
+    },
+    std::runtime_error);
 }
 
 TEST(WorkerThread, CheckName) {
@@ -59,12 +78,12 @@ TEST(WorkerThread, CheckName) {
   const char full_thread_name[] = "[DALI][WT]WorkerThread test";
   // max len supported by pthread_getname_np is 16
   char read_thread_name[16] = {0, };
-  WorkerThread wt(0, false, given_thread_name);
-  ASSERT_TRUE(wt.WaitForInit());
-  wt.DoWork([&read_thread_name]() {
+  auto wt = CreateWorkerThread(CPU_ONLY_DEVICE_ID, false, given_thread_name);
+  ASSERT_TRUE(wt->WaitForInit());
+  wt->DoWork([&read_thread_name]() {
     pthread_getname_np(pthread_self(), read_thread_name, sizeof(read_thread_name));
   });
-  wt.Shutdown();  // assure it does not deadlock
+  wt->Shutdown();  // assure it does not deadlock
   // skip terminating \0 character
   ASSERT_EQ(0, memcmp(read_thread_name, full_thread_name,
                       std::min(sizeof(full_thread_name), sizeof(read_thread_name)) - 1));


### PR DESCRIPTION
Hide WorkerThread implementation details

- Makes WorkerThread a virtual interface with a factory that returns the private
  implementation.

- Moves WorkerThreadImpl and its helper state into an internal header so async
  pipelined executors can include it and store WorkerThreadImpl directly,
  without exposing the implementation through the public WorkerThread API.

- Updates public/template-visible users such as InputOperator and the legacy
  video loader to store WorkerThread through the interface and factory, keeping
  private WorkerThread layout out of external operator plugin headers.

- Keeps OldThreadPool and NewThreadPool as direct concrete implementations.
  ThreadPool and ThreadPoolBase already provide the virtual interface used by
  operators, so the concrete pools do not add internal pImpl storage.

- Makes WorkerThread::CheckForErrors surface queued worker failures and routes
  async executor worker errors through their stop-signaling paths.

## Category:

**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:

This PR moves WorkerThread's private state out of the public WorkerThread header
behind a stable interface and factory.

WorkerThread is used by public/template-visible DALI types. Keeping its private
state in public headers makes external operator plugins depend on DALI-private
build flags, including NVML_ENABLED, because those flags can change class
layout.

CreateWorkerThread() now returns the private WorkerThread implementation, and
the public WorkerThread header exposes only the interface. Public-header users
such as InputOperator and the legacy video loader store std::unique_ptr<WorkerThread>.
Async pipelined executors are built inside DALI and need direct concrete storage,
so they include worker_thread_internal.h and store WorkerThreadImpl members
directly.

OldThreadPool and NewThreadPool intentionally remain direct concrete
implementations. Operators already use the ThreadPool/ThreadPoolBase virtual
interfaces, so adding pImpl inside the concrete thread pools would add an extra
pointer chase without improving that boundary.

WorkerThread::CheckForErrors() now throws queued worker failures instead of
discarding them. The async pipelined executors catch those failures, mark the
executor as failed, signal stop, notify dependent stage condition variables
where needed, and then rethrow.

WorkerThread also avoids initializing NVML unless CPU affinity setup is
requested, and its GTests use the CPU-only device sentinel so they validate
thread/error handling without requiring a loaded CUDA driver.

## Additional information:

### Affected modules and functionalities:

- dali/pipeline/util/worker_thread.*
- dali/pipeline/util/worker_thread_internal.h
- dali/pipeline/util/thread_pool.*
- dali/pipeline/util/new_thread_pool.*
- Async pipelined executor worker storage and worker-error propagation
- InputOperator and legacy video-loader worker storage
- Direct include cleanup in input operator, C API, and video reader code

### Key points relevant for the review:

- WorkerThread public headers no longer include NVML headers or expose
  NVML-dependent members.
- WorkerThreadImpl is final and declared in an internal DALI header.
- Public-header users depend on the WorkerThread interface and factory.
- Async pipelined executors store WorkerThreadImpl directly rather than through
  std::unique_ptr<WorkerThread>.
- OldThreadPool and NewThreadPool keep direct implementation storage and do not
  use internal pImpl.
- Call sites that previously relied on transitive includes now include nvtx.h,
  nvml.h, or <condition_variable> directly.
- Worker-thread failures surfaced by CheckForErrors() now trigger the async
  executor stop path before being rethrown.

### Tests:

- [x] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

Focused validation:

```bash
cmake --build compile/dali --target dali_test -j$(nproc)
compile/dali/dali/python/nvidia/dali/test/dali_test.bin --gtest_filter=ThreadPool.*:WorkerThread.*

cmake --build compile/dali --target pipeline/executor/async_pipelined_executor.o
cmake --build compile/dali --target pipeline/executor/async_separated_pipelined_executor.o
cmake --build compile/dali --target dali
cmake --build compile/dali --target install_headers
cmake --build compile --target dali_python_3.12
compile/dali/python/nvidia/dali/test/dali_test.bin --gtest_filter=WorkerThread.*
compile/dali/python/nvidia/dali/test/dali_test.bin --gtest_filter=ExecutorTest/3.TestRunBasicGraph:ExecutorTest/4.TestRunBasicGraph
```

Issue #6361 repro validation:

- Rebuilt the external feed-bug plugin against the refreshed staged DALI headers.
- The original AccessOrder::wait segfault / invalid stream path is no longer
  observed after refreshing headers and rebuilding backend_impl.
- The original repro still needs to account for executor2 lookahead: with its
  custom fixed NextBatchSize()/no-op Advance() and default prefetching, it can
  report input depletion after consuming the queued batch. A queue-aware variant
  using InputOperator's base NextBatchSize()/Advance() and prefetch_queue_depth=1
  passed two feed_input + run iterations.

## Checklist

### Documentation

- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements

- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
