### PR TITLE
Document dynamic operator wrapper arguments

### DIFF
--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -450,8 +450,8 @@ def build_fn_wrapper(op, fn_name=None, add_to_module=True):
 
     fixed_args = []
     tensor_args = []
-    signature_args = ["batch_size=None, device=None"]
-    used_kwargs = set()
+    signature_args = ["batch_size=None", "device=None"]
+    used_kwargs = {"batch_size", "device"}
 
     for arg in op._schema.GetArgumentNames():
         if arg in _unsupported_args:
@@ -473,8 +473,7 @@ def build_fn_wrapper(op, fn_name=None, add_to_module=True):
         # Remove 'seed' from used_kwargs and signature_args if present
         if "seed" in used_kwargs:
             used_kwargs.remove("seed")
-        if "seed" in signature_args:
-            signature_args.remove("seed")
+        signature_args = [arg for arg in signature_args if "seed" not in arg]
 
     header = f"{fn_name}({', '.join(inputs + signature_args)})"
 

--- a/dali/python/nvidia/dali/ops/_docs.py
+++ b/dali/python/nvidia/dali/ops/_docs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -114,6 +114,26 @@ Args
     return ret
 
 
+def _get_batch_size_doc():
+    """Return documentation for the batch_size argument used in dynamic API."""
+    return _numpydoc_formatter(
+        "batch_size",
+        "int",
+        "The batch size to broadcast input tensors to. Ignored for batch inputs.",
+        optional=True,
+    )
+
+
+def _get_device_doc():
+    """Return documentation for the device argument used in dynamic API."""
+    return _numpydoc_formatter(
+        "device",
+        "device-like",
+        "The device to use for the operation. Must not conflict with the device of the inputs.",
+        optional=True,
+    )
+
+
 def _get_rng_doc():
     """Return documentation for the rng argument used in dynamic API random operators."""
     return _numpydoc_formatter(
@@ -190,10 +210,16 @@ def _get_kwargs(schema, api="ops", args=None):
         ret += "\n"
 
     # Add rng documentation for dynamic API random operators
-    if api == "dynamic" and args is not None and "rng" in args:
-        ret += _get_rng_doc()
-        ret += "\n"
-
+    if api == "dynamic" and args is not None:
+        if "batch_size" in args:
+            ret += _get_batch_size_doc()
+            ret += "\n"
+        if "device" in args:
+            ret += _get_device_doc()
+            ret += "\n"
+        if "rng" in args:
+            ret += _get_rng_doc()
+            ret += "\n"
     return ret
 
 


### PR DESCRIPTION
## Category:
Other

## Description:
This PR documents implicit dynamic operator wrapper arguments and keeps
them reserved when building dynamic operator call signatures.

Dynamic operator wrappers now expose `batch_size` and `device` as distinct
signature arguments, while tracking them as used keyword names so schema
arguments do not collide with them. The generated dynamic API docstrings
also include numpydoc entries for `batch_size`, `device`, `rng`
when those arguments are present.

Fixes hiding of `seed` argument in the dynamic mode.

## Additional information:

### Affected modules and functionalities:
Dynamic mode Python operator wrapper generation and operator docstring
generation.

### Key points relevant for the review:
Review the handling of reserved dynamic wrapper arguments in
`experimental/dynamic/_op_builder.py` and the conditional documentation
generation in `ops/_docs.py`.

Exact docs wording.

### Tests:
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

No tests were run; this is a narrow Python signature/docstring generation
change.

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
