### PR TITLE
Restore default hw_decoder_load to 0.65 in imgcodec decoder

### DIFF
--- a/dali/operators/imgcodec/decoder_schema.cc
+++ b/dali/operators/imgcodec/decoder_schema.cc
@@ -90,7 +90,7 @@ Determines the percentage of the workload that will be offloaded to the hardware
 if available. The optimal workload depends on the number of threads that are provided to
 the DALI pipeline and should be found empirically. More details can be found at
 https://developer.nvidia.com/blog/loading-data-fast-with-dali-and-new-jpeg-decoder-in-a100)code",
-      0.90f)
+      0.65f)
   .AddOptionalArg("preallocate_width_hint",
       R"code(Image width hint.
 


### PR DESCRIPTION
## Summary

- Change the default value of the `hw_decoder_load` argument in the nvImageCodec-based image decoder (`dali/operators/imgcodec/decoder_schema.cc`) from `0.90f` back to `0.65f`, matching the legacy decoder's default.

## Motivation

The legacy decoder (`dali/operators/decoder/image_decoder.cc`) defaults `hw_decoder_load` to **0.65**. The new nvImageCodec-based decoder ships with **0.90**, which causes a meaningful behavior change for users who relied on the default value.

Nsys profiling of EfficientNet + AutoAugment ImageNet training (single-GPU, batch 256) on the two defaults shows:

| | legacy default (0.65) | new default (0.90) |
| --- | --- | --- |
| Measured HW path share | 64.8 % | 90.2 % |
| Hybrid (CPU+GPU) share | 34.6 % | 9.8 % |
| Decoder p50 | 15.6 ms | 17.7 ms |
| Decoder p99 | 24.5 ms | 34.3 ms |
| Decoder max | **30.8 ms** | **72.7 ms** |
| End-to-end iters/s | 18.2 | 18.6 (+1.8 %) |


Users who want the higher HW-routing fraction can still opt in explicitly via the operator argument.

## Test plan

- [ ] Existing decoder tests pass
- [ ] `internal_tools/hw_decoder_bench.py` shows no regression at default settings