### PR TITLE
Bind FileReader samples by reference

### DIFF
--- a/dali/operators/reader/file_reader_op.h
+++ b/dali/operators/reader/file_reader_op.h
@@ -42,7 +42,7 @@ class FileReader : public DataReader<CPUBackend, ImageLabelWrapper, ImageLabelWr
   bool SetupImpl(std::vector<OutputDesc>& output_desc, const Workspace& ws) override {
     // If necessary start prefetching thread and wait for a consumable batch
     DataReader<CPUBackend, ImageLabelWrapper, ImageLabelWrapper, true>::SetupImpl(output_desc, ws);
-    auto samples = GetCurrBatch();
+    const auto &samples = GetCurrBatch();
     int batch_size = samples.size();
 
     output_desc.resize(2);
@@ -65,7 +65,7 @@ class FileReader : public DataReader<CPUBackend, ImageLabelWrapper, ImageLabelWr
   void RunImpl(Workspace &ws) override {
     auto &file_output = ws.Output<CPUBackend>(0);
     auto &label_output = ws.Output<CPUBackend>(1);
-    auto samples = GetCurrBatch();
+    const auto &samples = GetCurrBatch();
     int batch_size = samples.size();
 
     auto &thread_pool = ws.GetThreadPool();


### PR DESCRIPTION
## Category:
**Bug fix**

## Description:
This removes two unnecessary copies from the `FileReader` hot path.

`GetCurrBatch()` already returns a reference, but `FileReader` was binding it by value in both `SetupImpl` and `RunImpl`. That means copying the `std::vector<std::shared_ptr<...>>` twice per batch and doing the extra refcount churn for no benefit.

Those two lines came in with the S3/file reader refactor in #5415 and stayed as-is through the repeated-sample follow-up in #5493. This change keeps behavior the same and just binds both sites by `const` reference.

## Additional information:

### Affected modules and functionalities:
FileReader

### Key points relevant for the review:
The change is intentionally small: two `auto` to `const auto &` fixes in `file_reader_op.h`.

### Tests:
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

I didn't add a dedicated test for this since it's a non-functional cleanup, but I'm happy to add coverage if reviewers want it.

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
