### PR TITLE
Fix escaped string parsing in numpy headers

### DIFF
--- a/dali/util/numpy.cc
+++ b/dali/util/numpy.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -87,7 +87,9 @@ std::string ParseStringValue(const char*& input, char delim_start = '\'', char d
   std::string out;
   for (; *input != '\0'; input++) {
     if (*input == '\\') {
-      switch (*++input) {
+      input++;
+      DALI_ENFORCE(*input != '\0', "Unexpected end of string after escape character.");
+      switch (*input) {
         case '\\':
           out += '\\';
           break;

--- a/dali/util/numpy_test.cc
+++ b/dali/util/numpy_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ TEST(NumpyLoaderTest, ParseHeaderError) {
     "random_string",
     "{descr:'<f4'}",
     "{'descr':'','fortran_order':False,'shape':(4,7),}",
+    "{'descr':'<f4\\",
     "{'descr':'<f4','fortran_order':false,'shape':(4,7),}"
     "{'descr':'<f4','fortran_order':false,'shape':(a, b, c),}"
     "{'descr':'<f4','fortran_order':False,'shape':[4,7],}"
@@ -64,4 +65,3 @@ TEST(NumpyLoaderTest, ParseHeaderError) {
 
 }  // namespace numpy
 }  // namespace dali
-


### PR DESCRIPTION
## Category:

**Bug fix** (*non-breaking change which fixes an issue*)


## Description:

Fixes malformed `.npy` header parsing when a string value ends with an
unfinished backslash escape.

`ParseStringValue` advanced to the string terminator while handling the
escape and then allowed the loop increment to move past the terminator. The
parser now rejects a trailing escape before continuing, so malformed headers
fail cleanly instead of reading past the header buffer.


## Additional information:

### Affected modules and functionalities:

- `dali/util/numpy.cc`: reject an unfinished escape sequence in numpy header
  string values.
- `dali/util/numpy_test.cc`: add parser coverage for a `descr` field ending
  with a backslash escape.


### Key points relevant for the review:

Please check that the pointer advancement in `ParseStringValue` still
preserves the existing behavior for supported escape sequences while rejecting
the unterminated escape case before the loop increment runs.

### Tests:

- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

Ran:

```bash
cmake --build compile/dali --target dali_test -j"$(nproc)"
DALI_EXTRA_PATH=/home/jlisiecki/Dali/DALI_extra \
LD_LIBRARY_PATH=/home/jlisiecki/Dali/dali/compile/dali/python/nvidia/dali \
compile/dali/python/nvidia/dali/test/dali_test.bin --gtest_filter=NumpyLoaderTest.*
```


## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
