### PR TITLE
Accept constant local variables as arguments with compile=True

### DIFF
--- a/conda/dali_python_bindings/recipe/meta.yaml
+++ b/conda/dali_python_bindings/recipe/meta.yaml
@@ -105,6 +105,7 @@ requirements:
     - nvtx
     - makefun
     - numpy
+    - libcst ~=1.8
     - nvidia-dali-core{% if environ.get('NVIDIA_DALI_BUILD_FLAVOR', '')|length %}{{"-" + environ.get('NVIDIA_DALI_BUILD_FLAVOR', '')}}{% endif %}-cuda{{ environ.get('CUDA_VERSION', '') | replace(".","") }} ={{ environ.get('DALI_CONDA_BUILD_VERSION', '') }}
     - libnvimgcodec-dev >=0.8.0,<0.9.0
   run:
@@ -127,6 +128,7 @@ requirements:
     - nvtx
     - makefun
     - numpy
+    - libcst ~=1.8
     - nvidia-dali-core{% if environ.get('NVIDIA_DALI_BUILD_FLAVOR', '')|length %}{{"-" + environ.get('NVIDIA_DALI_BUILD_FLAVOR', '')}}{% endif %}-cuda{{ environ.get('CUDA_VERSION', '') | replace(".","") }} ={{ environ.get('DALI_CONDA_BUILD_VERSION', '') }}
     - libnvimgcodec >=0.8.0,<0.9.0
     - libnvimgcodec-libjpeg-turbo-ext >=0.8.0,<0.9.0

--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -152,8 +152,6 @@ class CompileContext:
     _tls = threading.local()
 
     def __init__(self, reader: "Reader", batch_size: int):
-        from ._source_analysis import CallSiteAnalyzer
-
         self.state = State.TRACING
         self.reader = reader
         self.batch_size = batch_size
@@ -164,7 +162,6 @@ class CompileContext:
         self._pipeline_results: dict[CompileNode, Any] = {}
         self._iteration = 0
         self._epoch_size_padded: int | None = None
-        self.analyzer = CallSiteAnalyzer()
 
     @classmethod
     def current(cls) -> "CompileContext | None":
@@ -549,6 +546,7 @@ def _compile_intercept(
 ) -> types.FunctionType:
     """Wrap an fn_call to intercept operator calls for transparent pipelining."""
     from ._op_builder import _resolve_backend
+    from ._source_analysis import classify
 
     @mark_transparent
     def wrapper(*inputs, batch_size=None, device=None, **raw_kwargs):
@@ -588,7 +586,7 @@ def _compile_intercept(
         if op_class._is_stateful:
             return result
 
-        classification = compile_ctx.analyzer.classify(frame, inputs, raw_kwargs)
+        classification = classify(frame, inputs, raw_kwargs)
         if classification is None:
             return result
 

--- a/dali/python/nvidia/dali/experimental/dynamic/_source_analysis.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_source_analysis.py
@@ -13,173 +13,394 @@
 # limitations under the License.
 
 import ast
+import inspect
 import itertools
 import linecache
 import sys
 import types
-from collections.abc import Mapping
-from dataclasses import dataclass
-from typing import Any, TypeAlias, cast
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, cast
 
+import libcst as cst
+from libcst import matchers
+from libcst.metadata import (
+    Assignment,
+    CodeRange,
+    FunctionScope,
+    MetadataWrapper,
+    ParentNodeProvider,
+    PositionProvider,
+    Scope,
+    ScopeProvider,
+)
 from nvidia.dali.types import DALIDataType, DALIImageType, DALIInterpType
 
 from ._call_site import CodeLoc
-from ._compile import CompileRef
+from ._compile import CompiledBatch, CompileRef
 from ._device import Device
 from ._type import DType
 
-CodePosition: TypeAlias = tuple[int, int, int, int]
-
-
-@dataclass(frozen=True, slots=True)
-class SourceCalls:
-    by_span: Mapping[CodePosition, ast.Call | None]
-    by_line: Mapping[int, tuple[ast.Call, ...]]
-
-    @classmethod
-    def from_ast(cls, tree: ast.Module) -> "SourceCalls":
-        by_span: dict[CodePosition, ast.Call | None] = {}
-        by_line: dict[int, list[ast.Call]] = {}
-        collect_spans = sys.version_info >= (3, 11)
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-
-            by_line.setdefault(node.lineno, []).append(node)
-            if not collect_spans:
-                continue
-
-            pos = (node.lineno, node.end_lineno, node.col_offset, node.end_col_offset)
-            if any(x is None for x in pos):
-                continue
-            pos = cast(CodePosition, pos)
-            by_span[pos] = None if pos in by_span else node
-
-        return cls(
-            by_span=types.MappingProxyType(by_span),
-            by_line=types.MappingProxyType(
-                {lineno: tuple(calls) for lineno, calls in by_line.items()}
-            ),
-        )
-
-
-_file_cache: dict[str, tuple[object, SourceCalls | None]] = {}
-
-
-def is_constant_node(node: ast.AST) -> bool:
-    """Check if an AST node represents a constant expression."""
-    match node:
-        case ast.Constant():
-            return True
-        case ast.UnaryOp(op=ast.USub() | ast.UAdd()):
-            return is_constant_node(node.operand)
-        case ast.BinOp():
-            return is_constant_node(node.left) and is_constant_node(node.right)
-        case ast.List() | ast.Tuple():
-            return all(is_constant_node(elt) for elt in node.elts)
-        case _:
-            return False
+_DALI_CONST_TYPES = (Device, DType, DALIDataType, DALIInterpType, DALIImageType)
 
 
 def is_dali_constant(value: Any) -> bool:
-    """Check if a value is a constant defined by DALI (e.g., ndd.int32)"""
-    return isinstance(value, (Device, DType, DALIDataType, DALIInterpType, DALIImageType))
+    return isinstance(value, _DALI_CONST_TYPES)
 
 
-def _get_source_calls(filename: str) -> SourceCalls | None:
-    """Parse and cache source calls. Returns None for empty/invalid source."""
+def _is_dali_anchor(value: Any) -> bool:
+    if inspect.ismodule(value):
+        return value.__name__ == "nvidia.dali" or value.__name__.startswith("nvidia.dali.")
+    return isinstance(value, type) and issubclass(value, _DALI_CONST_TYPES)
+
+
+class _Unresolved(Exception):
+    """Raised to abandon capture of an expression (unresolvable statically, or not capturable)."""
+
+
+def _is_immutable_value(value: Any) -> bool:
+    if isinstance(value, (int, float, complex, bool, str, bytes)) or value is None:
+        return True
+    if isinstance(value, (tuple, frozenset)):
+        return all(_is_immutable_value(item) for item in value)
+    return is_dali_constant(value)
+
+
+def _bind_attribute(base: Any, attr: str) -> Any:
+    """base.attr via getattr_static, so no user code (property / __getattr__) runs."""
+    try:
+        descriptor = inspect.getattr_static(base, attr)
+    except AttributeError:
+        raise _Unresolved
+    match descriptor:
+        case staticmethod():
+            return descriptor.__func__
+        case classmethod():
+            owner = base if isinstance(base, type) else type(base)
+            return descriptor.__func__.__get__(owner, type(owner))
+        case types.FunctionType() if isinstance(base, type) or inspect.ismodule(base):
+            return descriptor
+        case types.FunctionType():
+            return descriptor.__get__(base, type(base))
+        case type():
+            return descriptor
+        case _ if inspect.ismodule(descriptor):
+            return descriptor  # submodule (e.g. nvidia.dali.types)
+        case _ if is_dali_constant(descriptor):
+            return descriptor  # DALI sentinel / enum member
+    raise _Unresolved
+
+
+def _safe_resolve(expr: cst.BaseExpression, frame: types.FrameType) -> Any:
+    """Resolve a Name / Attribute / literal without running user code."""
+    match expr:
+        case cst.BaseNumber(value=v) | cst.SimpleString(value=v):
+            return ast.literal_eval(v)
+        case cst.Name(value="True"):
+            return True
+        case cst.Name(value="False"):
+            return False
+        case cst.Name(value="None"):
+            return None
+        case cst.Name(value=name):
+            for ns in (frame.f_locals, frame.f_globals, frame.f_builtins):
+                if name in ns:
+                    return ns[name]
+            raise _Unresolved
+        case cst.Attribute(value=base, attr=cst.Name(value=attr)):
+            return _bind_attribute(_safe_resolve(base, frame), attr)
+    raise _Unresolved
+
+
+def _byte_to_char_col(lines: list[str], lineno: int, byte_col: int) -> int | None:
+    """Map a UTF-8 byte column to a character column."""
+    if not 1 <= lineno <= len(lines):
+        return None
+    try:
+        return len(lines[lineno - 1].encode("utf-8")[:byte_col].decode("utf-8"))
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return None
+
+
+def _unpack_alignment(
+    lhs: Sequence[cst.BaseElement],
+    rhs: Sequence[cst.BaseElement],
+) -> list[cst.BaseExpression | None] | None:
+    """RHS literal bound to each LHS element (None for the *star slot);
+    None overall if the RHS itself unpacks"""
+    if any(isinstance(e, cst.StarredElement) for e in rhs):
+        return None
+    rhs_values: list[cst.BaseExpression | None] = [e.value for e in rhs]
+    stars = [i for i, e in enumerate(lhs) if isinstance(e, cst.StarredElement)]
+    if not stars:
+        return rhs_values
+    star = stars[0]
+    n_tail = len(lhs) - star - 1
+    bound: list[cst.BaseExpression | None] = [None] * len(lhs)
+    bound[:star] = rhs_values[:star]  # prefix binds left-to-right
+    bound[star + 1 :] = rhs_values[len(rhs_values) - n_tail :]  # suffix binds right-to-left
+    return bound
+
+
+def _unpack_bindings(
+    lhs: Sequence[cst.BaseElement],
+    rhs: Sequence[cst.BaseElement],
+) -> dict[cst.CSTNode, cst.BaseExpression]:
+    """Record target Name -> bound RHS, recursing into nested tuple/list targets."""
+
+    def _unpack_bindings_impl(lhs: Sequence[cst.BaseElement], rhs: Sequence[cst.BaseElement]):
+        bound = _unpack_alignment(lhs, rhs)
+        if bound is None:
+            return
+        for element, expr in zip(lhs, bound):
+            if expr is None:  # *star slot: binds a runtime list
+                continue
+            target = element.value
+            if isinstance(target, cst.Name):
+                bindings[target] = expr
+            elif isinstance(target, (cst.Tuple, cst.List)) and isinstance(
+                expr, (cst.Tuple, cst.List)
+            ):
+                _unpack_bindings_impl(target.elements, expr.elements)
+
+    bindings: dict[cst.CSTNode, cst.BaseExpression] = {}
+    _unpack_bindings_impl(lhs, rhs)
+    return bindings
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleInfo:
+    """Per-file parsed libcst data plus the queries classification needs over it."""
+
+    scope_of_node: Mapping[cst.CSTNode, Scope]  # LibCST ScopeProvider
+    parent_of: Mapping[cst.CSTNode, cst.CSTNode]  # LibCST ParentNodeProvider
+
+    calls_by_position: Mapping[tuple[int, int, int, int], cst.Call | None]  # None if ambiguous
+    calls_by_line: Mapping[int, tuple[cst.Call, ...]]  # 3.10 fallback for call-site identification
+
+    call_cache: dict[CodeLoc, cst.Call | None] = field(default_factory=dict, repr=False)
+
+    def call_at(self, frame: types.FrameType) -> cst.Call | None:
+        """The ``cst.Call`` executing at `frame`'s current instruction, memoized per call site."""
+        key = CodeLoc(frame.f_code, frame.f_lasti)
+        if key not in self.call_cache:
+            self.call_cache[key] = self._resolve_call(frame)
+        return self.call_cache[key]
+
+    def _resolve_call(self, frame: types.FrameType) -> cst.Call | None:
+        code = frame.f_code
+        if sys.version_info >= (3, 11):
+            # One co_positions tuple per 2-byte code unit.
+            pos = next(itertools.islice(code.co_positions(), frame.f_lasti // 2, None), None)
+            if pos is not None and all(x is not None for x in pos):
+                sl, el, sc, ec = cast(tuple[int, int, int, int], pos)
+                lines = linecache.getlines(code.co_filename)
+                sc, ec = _byte_to_char_col(lines, sl, sc), _byte_to_char_col(lines, el, ec)
+                if sc is None or ec is None:
+                    return None
+                return self.calls_by_position.get((sl, el, sc, ec))
+        candidates = self.calls_by_line.get(frame.f_lineno, ())
+        return candidates[0] if len(candidates) == 1 else None
+
+    def local_rhs(self, name_node: cst.Name) -> cst.BaseExpression | None:
+        """The RHS of `name_node`'s single capturable function-local binding, else None."""
+        scope = self.scope_of_node.get(name_node)
+        if scope is None:
+            return None
+        resolved = scope[name_node.value]  # LEGB-resolved; empty set if undefined
+        if len(resolved) != 1:
+            return None  # rebound / nonlocal-rebind / undefined
+
+        assignment = next(iter(resolved))
+        if type(assignment) is not Assignment:
+            return None  # excludes ImportAssignment and BuiltinAssignment
+
+        if not isinstance(assignment.scope, FunctionScope):
+            return None  # function locals only (excludes global / class / comprehension)
+        if isinstance(assignment.node, cst.Param):
+            return None  # parameters, not handled for now
+        if assignment.scope is not scope:
+            return None  # closure, not handled for now
+        return self._rhs_for_target(assignment.node)
+
+    def _rhs_for_target(self, target: cst.CSTNode) -> cst.BaseExpression | None:
+        match self.parent_of.get(target):
+            case cst.AssignTarget(target=cst.Name()) as target:  # `x = v`
+                return cast(cst.Assign, self.parent_of.get(target)).value
+            case cst.AnnAssign(value=value):  # `x: T = v`
+                return value
+            case cst.NamedExpr(value=value):  # walrus `(x := v)`
+                return value
+            case cst.Element():  # `x, y = a, b`
+                # Climb tuple/list nesting to the AssignTarget. StarredElement is omitted: a target
+                # under a *star binds a runtime list, so stopping there rejects it.
+                owner = self.parent_of.get(target)
+                while isinstance(owner, (cst.Element, cst.Tuple, cst.List)):
+                    owner = self.parent_of.get(owner)
+                if not isinstance(owner, cst.AssignTarget):  # for/with target, or under a *star
+                    return None
+
+                assign = cast(cst.Assign, self.parent_of.get(owner))
+                lhs = cast(cst.Tuple | cst.List, owner.target)
+                if not isinstance(assign.value, (cst.Tuple, cst.List)):
+                    return None
+
+                bindings = _unpack_bindings(lhs.elements, assign.value.elements)
+                return bindings.get(target)  # nested-aware, None for a *star slot
+        return None
+
+
+# Keyed by filename, holding the linecache entry for invalidation.
+# A file edit rebuilds the ModuleInfo and with it a fresh cache.
+_file_cache: dict[str, tuple[object, ModuleInfo | None]] = {}
+
+
+def _get_module_info(filename: str) -> ModuleInfo | None:
+    """Parse and cache the ModuleInfo for `filename`.
+
+    Resolving metadata for the whole file is the dominant trace-time cost
+    but is paid once per file and amortizes over a multi-epoch run.
+    """
     lines = linecache.getlines(filename)
     if not lines:
         return None
-
-    # We rely on the linecache entry to make sure that our cache didn't get invalidated
-    entry = linecache.cache[filename]
-    cached = _file_cache.get(filename)
-    # The cache entry is not hashable so we can't use it as a key
-    if cached is not None and cached[0] is entry:
+    # The linecache entry detects edits; it is not hashable so it can't be the key itself.
+    entry = linecache.cache.get(filename)
+    if (cached := _file_cache.get(filename)) is not None and cached[0] is entry:
         return cached[1]
-
     try:
-        tree = ast.parse("".join(lines), filename=filename)
-    except SyntaxError:
-        calls = None
-    else:
-        calls = SourceCalls.from_ast(tree)
+        wrapper = MetadataWrapper(cst.parse_module("".join(lines)), unsafe_skip_copy=True)
+        md = wrapper.resolve_many([PositionProvider, ScopeProvider, ParentNodeProvider])
 
-    _file_cache[filename] = (entry, calls)
-    return calls
+        pos = cast(Mapping[cst.CSTNode, CodeRange], md[PositionProvider])
+        by_position: dict[tuple[int, int, int, int], cst.Call | None] = {}
+        by_line: dict[int, list[cst.Call]] = {}
+        for node in matchers.findall(wrapper.module, matchers.Call()):
+            call = cast(cst.Call, node)
+            r = pos[call]
+            span = (r.start.line, r.end.line, r.start.column, r.end.column)
+            by_position[span] = None if span in by_position else call  # seen twice -> ambiguous
+            by_line.setdefault(r.start.line, []).append(call)
 
-
-def _get_positions(code: types.CodeType, lasti: int) -> CodePosition | None:
-    """Return the (start_line, end_line, start_col, end_col) for the bytecode index `lasti`."""
-    if sys.version_info < (3, 11) or lasti < 0:
-        return None
-    pos = next(itertools.islice(code.co_positions(), lasti // 2, None), None)
-    if pos is None or any(x is None for x in pos):
-        # Some items can be None, e.g. when PYTHONNODEBUGRANGES=1
-        return None
-
-    return cast(CodePosition, pos)
-
-
-def get_call_from_frame(frame: types.FrameType) -> ast.Call | None:
-    """Resolve the ``ast.Call`` executing at `frame`'s current instruction, or None"""
-    calls = _get_source_calls(frame.f_code.co_filename)
-    if calls is None:
-        return None
-    if pos := _get_positions(frame.f_code, frame.f_lasti):
-        return calls.by_span.get(pos)
-    candidates = calls.by_line.get(frame.f_lineno, ())
-    return candidates[0] if len(candidates) == 1 else None
+        info = ModuleInfo(
+            scope_of_node=cast(Mapping[cst.CSTNode, Scope], md[ScopeProvider]),
+            parent_of=cast(Mapping[cst.CSTNode, cst.CSTNode], md[ParentNodeProvider]),
+            calls_by_position=by_position,
+            calls_by_line={ln: tuple(calls) for ln, calls in by_line.items()},
+        )
+    except Exception:
+        info = None
+    _file_cache[filename] = (entry, info)
+    return info
 
 
-class CallSiteAnalyzer:
-    """Caches AST analysis per CodeLoc and classifies operator arguments."""
+@dataclass(frozen=True, slots=True)
+class _Classifier:
+    """Per call frame argument classifier.
 
-    def __init__(self) -> None:
-        self._cache: dict[CodeLoc, ast.Call | None] = {}
+    Each argument is either an already captured batch, invariant or not capturable.
+    """
+
+    module_info: ModuleInfo
+    frame: types.FrameType
 
     def classify(
-        self,
-        frame: types.FrameType,
-        inputs: tuple[Any, ...],
-        raw_kwargs: dict[str, Any],
+        self, inputs: tuple[Any, ...], raw_kwargs: dict[str, Any]
     ) -> tuple[list[CompileRef | Any], dict[str, CompileRef | Any]] | None:
-        """Classify all arguments as CompileRef or constant. Returns None if any fails."""
-        from ._compile import CompiledBatch
+        call = self.module_info.call_at(self.frame)
+        if call is None or any(a.star for a in call.args):
+            return None  # no call node, or caller-side *args/**kwargs
+        pos_nodes = [a.value for a in call.args if a.keyword is None]
+        kw_nodes = {a.keyword.value: a.value for a in call.args if a.keyword is not None}
 
-        call = self._get_call_node(frame)
-        if call is None:
-            return None
-
-        classified_inputs: list[CompileRef | Any] = []
-        for i, inp in enumerate(inputs):
-            if inp is None:
-                classified_inputs.append(None)
-                continue
-            if isinstance(inp, CompiledBatch):
-                classified_inputs.append(inp._compile_ref)
-            elif i < len(call.args) and is_constant_node(call.args[i]) or is_dali_constant(inp):
-                classified_inputs.append(inp)
-            else:
-                return None
-
-        kw_nodes = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
-        classified_kwargs: dict[str, CompileRef | Any] = {}
-        for name, value in raw_kwargs.items():
-            if value is None:
-                continue
-            if isinstance(value, CompiledBatch):
-                classified_kwargs[name] = value._compile_ref
-            elif name in kw_nodes and is_constant_node(kw_nodes[name]) or is_dali_constant(value):
-                classified_kwargs[name] = value
-            else:
-                return None
-
+        try:
+            classified_inputs: list[CompileRef | Any] = []
+            for i, inp in enumerate(inputs):
+                if inp is None:
+                    classified_inputs.append(None)
+                else:
+                    node = pos_nodes[i] if i < len(pos_nodes) else None
+                    classified_inputs.append(self._capture_arg(node, inp))
+            classified_kwargs = {
+                name: self._capture_arg(kw_nodes.get(name), raw)
+                for name, raw in raw_kwargs.items()
+                if raw is not None
+            }
+        except _Unresolved:
+            return None  # an argument is neither a CompiledBatch nor a capturable constant
         return classified_inputs, classified_kwargs
 
-    def _get_call_node(self, frame: types.FrameType) -> ast.Call | None:
-        code_loc = CodeLoc(frame.f_code, frame.f_lasti)
-        if code_loc not in self._cache:
-            self._cache[code_loc] = get_call_from_frame(frame)
-        return self._cache[code_loc]
+    def _capture_arg(self, node: cst.BaseExpression | None, value: Any) -> CompileRef | Any:
+        if isinstance(value, CompiledBatch):
+            return value._compile_ref
+        if node is not None and self.is_invariant(node):
+            return value
+        raise _Unresolved
+
+    def is_invariant(self, node: cst.BaseExpression) -> bool:
+        match node:
+            case cst.BaseNumber() | cst.SimpleString():
+                return True
+            case cst.Name(value="True" | "False" | "None"):
+                return True
+            case cst.UnaryOperation(operator=cst.Minus() | cst.Plus(), expression=x):
+                return self.is_invariant(x)
+            case cst.BinaryOperation(left=left, right=right):
+                return self.is_invariant(left) and self.is_invariant(right)
+            case cst.NamedExpr(value=value):
+                return self.is_invariant(value)  # walrus `(c := v)` evaluates to v
+            case cst.List() | cst.Tuple():
+                return all(self.is_invariant(e.value) for e in node.elements)
+            case cst.Name():
+                return self._is_name_invariant(node)
+            case cst.Attribute():
+                # We can't accept any attributes, even if the base is a local name.
+                # Mutability and aliasing makes them hard to reliably track.
+                return self._is_dali_chain(node)
+        return False
+
+    def _is_name_invariant(self, name_node: cst.Name) -> bool:
+        rhs = self.module_info.local_rhs(name_node)
+        if rhs is None or not self.is_invariant(rhs):
+            return False
+        # A named mutable is a live handle the user can alias and mutate.
+        # It's hard to prove that they are invariant.
+        try:
+            return _is_immutable_value(_safe_resolve(name_node, self.frame))
+        except _Unresolved:
+            return False
+
+    def _is_dali_chain(self, node: cst.Attribute) -> bool:
+        """The only supported exceptions for attributes are those
+        anchored in nvidia.dali or a DALI enum.
+        """
+        attrs: list[str] = []
+        base: cst.BaseExpression = node
+        while isinstance(base, cst.Attribute):
+            attrs.append(base.attr.value)
+            base = base.value
+        if not isinstance(base, cst.Name):
+            return False
+        try:
+            value = _safe_resolve(base, self.frame)  # resolve once, bind attrs incrementally
+            anchored = _is_dali_anchor(value)
+            if not (anchored or inspect.ismodule(value)):
+                return False  # root must be a module or a DALI type, not a user object
+            for attr in reversed(attrs):
+                value = _bind_attribute(value, attr)
+                anchored = anchored or _is_dali_anchor(value)
+        except _Unresolved:
+            return False
+        return anchored and is_dali_constant(value)
+
+
+def classify(
+    frame: types.FrameType, inputs: tuple[Any, ...], raw_kwargs: dict[str, Any]
+) -> tuple[list[CompileRef | Any], dict[str, CompileRef | Any]] | None:
+    """Classify operator args as captured constants / CompileRefs, or None to run eager."""
+    mi = _get_module_info(frame.f_code.co_filename)
+    if mi is None:
+        return None
+
+    classifier = _Classifier(mi, frame)
+    return classifier.classify(inputs, raw_kwargs)

--- a/dali/python/nvidia/dali/experimental/dynamic/_source_analysis.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_source_analysis.py
@@ -266,6 +266,7 @@ def _get_module_info(filename: str) -> ModuleInfo | None:
         return None
     # The linecache entry detects edits; it is not hashable so it can't be the key itself.
     entry = linecache.cache.get(filename)
+    # Note: We don't guard for concurrent calls because the function is idempotent anyway.
     if (cached := _file_cache.get(filename)) is not None and cached[0] is entry:
         return cached[1]
     try:

--- a/dali/python/setup.py.in
+++ b/dali/python/setup.py.in
@@ -94,6 +94,7 @@ For more details please check the
           'numpy',
           'nvtx',
           'makefun',
+          'libcst ~= 1.8',
           @DALI_INSTALL_REQUIRES_NVIMGCODEC@
           @DALI_INSTALL_REQUIRES_NVCOMP@
           ],

--- a/dali/test/python/experimental_mode/ndd_utils.py
+++ b/dali/test/python/experimental_mode/ndd_utils.py
@@ -20,6 +20,11 @@ from typing import Any
 
 import nvidia.dali.experimental.dynamic as ndd
 from nose_utils import SkipTest
+from nvidia.dali.experimental.dynamic._compile import CompiledBatch
+
+
+def _is_compiled(batch):
+    return isinstance(batch, CompiledBatch)
 
 
 def eval_modes(*modes: ndd.EvalMode):

--- a/dali/test/python/experimental_mode/test_compile.py
+++ b/dali/test/python/experimental_mode/test_compile.py
@@ -18,17 +18,12 @@ import sys
 import numpy as np
 import nvidia.dali.backend_impl as _backend
 import nvidia.dali.experimental.dynamic as ndd
-from ndd_utils import eval_modes
+from ndd_utils import _is_compiled, eval_modes
 from nose_utils import SkipTest, assert_raises, assert_warns
-from nvidia.dali.experimental.dynamic._compile import CompiledBatch
 from test_utils import get_dali_extra_path
 
 dali_extra_path = get_dali_extra_path()
 images_root = os.path.join(dali_extra_path, "db", "single", "jpeg")
-
-
-def _is_compiled(batch):
-    return isinstance(batch, CompiledBatch)
 
 
 def test_compile_mode_stickiness():

--- a/dali/test/python/experimental_mode/test_compile_invariants.py
+++ b/dali/test/python/experimental_mode/test_compile_invariants.py
@@ -1,0 +1,315 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import os
+from collections.abc import Callable
+
+import numpy as np
+import nvidia.dali.experimental.dynamic as ndd
+import nvidia.dali.types
+from ndd_utils import _is_compiled
+from nvidia.dali.types import DALIDataType
+from test_utils import get_dali_extra_path
+
+dali_extra_path = get_dali_extra_path()
+images_root = os.path.join(dali_extra_path, "db", "single", "jpeg")
+
+
+def assert_compiled_matches_eager(
+    transform: Callable[[ndd.Batch], ndd.Batch],
+    expect_captured: bool,
+) -> None:
+    """Apply `transform` to an eager and compiled epoch. Assert that the results are identical."""
+    reader_dyn = ndd.readers.File(file_root=images_root)
+    reader_comp = ndd.readers.File(file_root=images_root)
+
+    dyn = []
+    for jpegs, _ in reader_dyn.next_epoch(batch_size=2):
+        images = ndd.decoders.image(jpegs, device="gpu")
+        dyn.append(ndd.as_tensor(transform(images), pad=True).cpu())
+
+    comp = []
+    for jpegs, _ in reader_comp.next_epoch(batch_size=2, compile=True):
+        images = ndd.decoders.image(jpegs, device="gpu")
+        assert _is_compiled(images)
+        out = transform(images)
+        assert _is_compiled(out) is expect_captured
+        comp.append(ndd.as_tensor(out, pad=True).cpu())
+
+    for d, c in zip(dyn, comp, strict=True):
+        np.testing.assert_array_equal(d, c)
+
+
+def compiled_test(*, expect_captured: bool):
+    def decorator(transform: Callable[[ndd.Batch], ndd.Batch]):
+        @functools.wraps(transform)
+        def test():
+            assert_compiled_matches_eager(transform, expect_captured=expect_captured)
+
+        return test
+
+    return decorator
+
+
+# Module-level fixtures for the rejection tests
+#
+_MODULE_DTYPE = ndd.float32
+_GLOBAL_ANGLE = 60
+
+
+class _Cfg:
+    DTYPE = ndd.float32
+
+
+class _DaliHolder:
+    pkg = nvidia.dali
+
+
+# Tests for captured cases
+
+
+@compiled_test(expect_captured=True)
+def test_literal_scalar(images):
+    return ndd.rotate(images, angle=60)
+
+
+@compiled_test(expect_captured=True)
+def test_literal_list(images):
+    return ndd.resize(images, size=[224, 224])
+
+
+@compiled_test(expect_captured=True)
+def test_local_scalar(images):
+    c = 60
+    return ndd.rotate(images, angle=c)
+
+
+@compiled_test(expect_captured=True)
+def test_invariant_names(images):
+    c = 224
+    return ndd.resize(images, size=[c, c])
+
+
+@compiled_test(expect_captured=True)
+def test_computed_local(images):
+    c = 60 + 16
+    return ndd.rotate(images, angle=c)
+
+
+@compiled_test(expect_captured=True)
+def test_chained_locals(images):
+    a = 60
+    c = a + 16
+    return ndd.rotate(images, angle=c)
+
+
+@compiled_test(expect_captured=True)
+def test_annotated_local(images):
+    a: int = 60
+    return ndd.rotate(images, angle=a)
+
+
+@compiled_test(expect_captured=True)
+def test_chained_plain(images):
+    _ = a = 60
+    return ndd.rotate(images, angle=a)
+
+
+@compiled_test(expect_captured=True)
+def test_tuple_unpack(images):
+    a, _ = 60, 90
+    return ndd.rotate(images, angle=a)
+
+
+@compiled_test(expect_captured=True)
+def test_starred_sibling(images):
+    a, *_ = 60, 1, 2
+    return ndd.rotate(images, angle=a)
+
+
+@compiled_test(expect_captured=True)
+def test_starred_immutable_name(images):
+    x = (64, 64)
+    return ndd.resize(images, size=(*x,))
+
+
+@compiled_test(expect_captured=True)
+def test_chained_unpack(images):
+    _ = (a, _) = (60, 90)
+    return ndd.rotate(images, angle=a)
+
+
+@compiled_test(expect_captured=True)
+def test_nested_unpack_inner(images):
+    _, (x, _), _ = 1, (60, 2), 90
+    return ndd.rotate(images, angle=x)
+
+
+@compiled_test(expect_captured=True)
+def test_nested_unpack_outer(images):
+    _, (_, _), c = 1, (60, 2), 90
+    return ndd.rotate(images, angle=c)
+
+
+@compiled_test(expect_captured=True)
+def test_walrus_direct(images):
+    return ndd.rotate(images, angle=(c := 60))  # noqa: F841
+
+
+@compiled_test(expect_captured=True)
+def test_walrus_named(images):
+    if (c := 60) > 0:
+        return ndd.rotate(images, angle=c)
+
+
+@compiled_test(expect_captured=True)
+def test_local_in_block(images):
+    if images is not None:
+        c = 60
+        return ndd.rotate(images, angle=c)
+    assert False
+
+
+@compiled_test(expect_captured=True)
+def test_dali_attribute(images):
+    return ndd.cast(images, dtype=ndd.int32)
+
+
+@compiled_test(expect_captured=True)
+def test_dali_attribute_local(images):
+    dtype = ndd.int32
+    return ndd.cast(images, dtype=dtype)
+
+
+@compiled_test(expect_captured=True)
+def test_dali_fully_qualified(images):
+    return ndd.cast(images, dtype=nvidia.dali.types.DALIDataType.FLOAT)
+
+
+@compiled_test(expect_captured=True)
+def test_dali_imported_class(images):
+    return ndd.cast(images, dtype=DALIDataType.FLOAT)
+
+
+@compiled_test(expect_captured=True)
+def test_list_comprehension(images):
+    items = [images]
+    return [ndd.resize(x, size=[64, 64]) for x in items][0]
+
+
+@compiled_test(expect_captured=True)
+def test_non_ascii_line(images):
+    carré = (64, 64)  # noqa: E501
+    return ndd.resize(images, size=carré)
+
+
+def test_not_decorated_callsite():
+    def transform(images):
+        c = 64
+        return ndd.resize(images, size=[c, c])
+
+    compiled_test(expect_captured=True)(transform)()
+
+
+# Tests for rejected cases
+
+
+@compiled_test(expect_captured=False)
+def test_branch_rebind(images):
+    if images is not None:
+        c = 60
+    else:
+        c = 90
+    return ndd.rotate(images, angle=c)
+
+
+@compiled_test(expect_captured=False)
+def test_nonlocal_rebind(images):
+    def rebind():
+        nonlocal c
+        c = 60
+
+    c = 42
+    rebind()
+    return ndd.rotate(images, angle=c)
+
+
+@compiled_test(expect_captured=False)
+def test_global_name(images):
+    return ndd.rotate(images, angle=_GLOBAL_ANGLE)
+
+
+@compiled_test(expect_captured=False)
+def test_mutable_name(images):
+    c = [224, 224]  # named mutables are not captured
+    return ndd.resize(images, size=c)
+
+
+@compiled_test(expect_captured=False)
+def test_rhs_unpack(images):
+    x = [60]
+    a, _ = *x, 1  # RHS itself unpacks, so the bound length is not statically known
+    return ndd.rotate(images, angle=a)
+
+
+@compiled_test(expect_captured=False)
+def test_starred_target(images):
+    _, *b = 0, 64, 64  # b is the *star target, a runtime list
+    return ndd.resize(images, size=b)
+
+
+@compiled_test(expect_captured=False)
+def test_for_target(images):
+    for c in (0, 60, 90):
+        return ndd.rotate(images, angle=c)
+    assert False
+
+
+@compiled_test(expect_captured=False)
+def test_augassign(images):
+    c = 60
+    image = ndd.rotate(images, angle=c)
+    # In this specific case, c is not accessed again so it could theoretically be captured,
+    # this needs to be proven statically. This requires data-flow analysis.
+    c += 5
+    return image
+
+
+@compiled_test(expect_captured=False)
+def test_call_result(images):
+    c = abs(-60)  # We don't resolve calls yet
+    return ndd.rotate(images, angle=c)
+
+
+@compiled_test(expect_captured=False)
+def test_global_dali_attribute(images):
+    return ndd.cast(images, dtype=_MODULE_DTYPE)
+
+
+@compiled_test(expect_captured=False)
+def test_non_dali_class_chain(images):
+    return ndd.cast(images, dtype=_Cfg.DTYPE)
+
+
+@compiled_test(expect_captured=False)
+def test_user_rooted_dali_chain(images):
+    return ndd.cast(images, dtype=_DaliHolder.pkg.types.DALIDataType.FLOAT)
+
+
+@compiled_test(expect_captured=False)
+def test_import_name(images):
+    from math import pi
+
+    return ndd.rotate(images, angle=pi)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ ${LIBRARY_PATH}
 RUN ln -s /opt/python/cp${PYV}* /opt/python/v
 
 # install Python bindings and patch it to use the clang we have here
-RUN pip install future setuptools wheel clang==14.0 flake8 bandit astunparse gast optree numpy "black[jupyter]"==26.1.0 nvtx makefun && \
+RUN pip install future setuptools wheel clang==14.0 flake8 bandit astunparse gast optree numpy "black[jupyter]"==26.1.0 nvtx makefun "libcst~=1.8" && \
     PY_CLANG_PATH=$(echo $(pip show clang) | sed 's/.*Location: \(.*\) Requires.*/\1/')/clang/cindex.py && \
     LIBCLANG_PATH=/usr/lib64/libclang.so && \
     sed -i "s|library_file = None|library_file = \"${LIBCLANG_PATH}\"|" ${PY_CLANG_PATH} && \

--- a/qa/TL1_custom_src_pattern_build/test.sh
+++ b/qa/TL1_custom_src_pattern_build/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-pip_packages='astunparse gast optree black nvtx makefun numpy'
+pip_packages='astunparse gast optree black nvtx makefun numpy libcst~=1.8'
 
 build_and_check() {
   make -j


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**New feature** (*non-breaking change which adds functionality*)

## Description:

Currently, transparent pipelining (`next_epoch(compile=True)`) only captures operators three kinds of arguments:
- Literals
- Outputs of other captured operators
- DALI attributes (e.g., `ndd.float32`)

The reason for this is that for prefetching the arguments for subsequent iterations need to be known in advance. This PR adds constant propagation for local variables in a function.

Module globals are still not accepted as proving constness would require full-program analysis. Similarly, attributes, even of local variables identified as invariant, are not accepted because mutability and aliasing make proving constness harder.

A follow-up PR will cover function parameters and closures.

## Additional information:

### Affected modules and functionalities:

Dynamic mode, transparent pipelining.
Adds the LibCST dependency.

### Key points relevant for the review:

- Check if the assumptions to determine if a value is invariant are correct.
- Check that we don't  capture values that can be mutated between iterations by accident.

Note: It's still possible for some captured values to change between iterations but not under normal use. For instance, a user can reassign `ndd.int8` or poke Python internals in many ways. This is caught by `CompileContext._matches` and causes a fallback to eager mode.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4739
<!--- DALI-XXXX or NA --->
