### PR TITLE
Fix separated external source prefetch drain

### DIFF
--- a/dali/pipeline/executor/async_separated_pipelined_executor.cc
+++ b/dali/pipeline/executor/async_separated_pipelined_executor.cc
@@ -14,6 +14,8 @@
 
 #include "dali/pipeline/executor/async_separated_pipelined_executor.h"
 
+#include <algorithm>
+
 namespace dali {
 
 void AsyncSeparatedPipelinedExecutor::RunCPU() {
@@ -39,14 +41,16 @@ void AsyncSeparatedPipelinedExecutor::Prefetch() {
     RunGPU();
   }
 
-  for (int i = 0; i < queue_sizes_.cpu_size; i++) {
+  int cpu_only_prefetch_count =
+      std::max(0, queue_sizes_.cpu_size - queue_sizes_.gpu_size);
+  for (int i = 0; i < cpu_only_prefetch_count; i++) {
     RunCPU();
   }
 }
 
 int AsyncSeparatedPipelinedExecutor::InputFeedCount(std::string_view op_name) {
   (void)graph_->Node(op_name);
-  return queue_sizes_.cpu_size + queue_sizes_.gpu_size;
+  return std::max(queue_sizes_.cpu_size, queue_sizes_.gpu_size);
 }
 
 }  // namespace dali

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1933,53 +1933,36 @@ class Pipeline(object):
         if iters == 0:
             self.iter_setup()
 
-    def _run_input_callbacks(self, is_prefetch=False):
+    def _run_input_callbacks(self):
         if self._input_callbacks is None:
             return 0, True
 
-        done = False
-        stop_iter = False
-        iter = 0
-        while not done and not stop_iter:
-            done = True
-            batches = []  # data from external source callbacks is gathered here
-            for i, group in enumerate(self._parallel_input_callbacks):
-                try:
-                    count = group.feed_count(self) if is_prefetch else 1
-                    if iter < count:
-                        batches.append(
-                            group.schedule_and_receive(
-                                self, self._py_pool, i, self._max_batch_size, self._epoch_idx
-                            )
-                        )
-                        if iter + 1 < count:
-                            done = False
-                except StopIteration:
-                    stop_iter = True
-            for group in self._seq_input_callbacks:
-                try:
-                    count = group.feed_count(self) if is_prefetch else 1
-                    if iter < count:
-                        batches.append(group.get_batch(self, self._max_batch_size, self._epoch_idx))
-                        if iter + 1 < count:
-                            done = False
-                except StopIteration:
-                    stop_iter = True
-
-            if stop_iter:
-                return iter, False
-
+        batches = []  # data from external source callbacks is gathered here
+        for i, group in enumerate(self._parallel_input_callbacks):
             try:
-                self.iter_setup()
+                batches.append(
+                    group.schedule_and_receive(
+                        self, self._py_pool, i, self._max_batch_size, self._epoch_idx
+                    )
+                )
             except StopIteration:
-                return iter, False
+                return 0, False
+        for group in self._seq_input_callbacks:
+            try:
+                batches.append(group.get_batch(self, self._max_batch_size, self._epoch_idx))
+            except StopIteration:
+                return 0, False
 
-            # we only fill external source queues when we know that all callbacks succeeded
-            for batch in batches:
-                batch.feed()
+        try:
+            self.iter_setup()
+        except StopIteration:
+            return 0, False
 
-            iter += 1
-        return iter, True
+        # we only fill external source queues when we know that all callbacks succeeded
+        for batch in batches:
+            batch.feed()
+
+        return 1, True
 
     def iter_setup(self):
         """A deprecated method of providing the pipeline with external inputs.

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1591,27 +1591,10 @@ class Pipeline(object):
             raise RuntimeError("The pipeline was destroyed.")
         self._schedule_py_workers()
 
-        # A larger separated CPU queue leaves CPU-only iterations after backend
-        # Prefetch. If a Python source reaches end of epoch, those iterations
-        # cannot be advanced through Mixed/GPU without feeding more CPU work.
-        cpu_queue_is_longer = self._cpu_queue_size > self._gpu_queue_size
-        if not self._exec_separated or cpu_queue_is_longer:
-            self._legacy_interleaved_prefetch()
-            return
-
-        # The new way: try to run the inputs and then feed them, finally call
-        # _pipe.Prefetch(). If this fails, we just run `_pipe.Run()` a bunch of
-        # times. This will likely blow up for separated queues, which are not
-        # properly supported anyway.
-        iters_fed = 0
-        self._first_iter = False
-        iters_fed, success = self._prefetch_inputs()
-        if success:
-            self._pipe.Prefetch()
-        else:
-            self._last_iter = True
-            for _ in range(iters_fed):
-                self._pipe.Run()
+        # Keep input feeding interleaved with backend runs. Feeding all inputs
+        # first can leave separated execution with prefetched batches that have
+        # no scheduled Mixed/GPU work when a Python source reaches end of epoch.
+        self._legacy_interleaved_prefetch()
 
     # This is the old way of prefetching - the feeding and running steps are interleaved.
     # Running all callbacks at once, then feeding, then running - may affect the performance
@@ -1633,27 +1616,6 @@ class Pipeline(object):
             except StopIteration:
                 self._last_iter = True
                 break
-
-    def _prefetch_inputs(self):
-        prefetched, success = self._run_input_callbacks(True)
-        self._batches_to_consume += prefetched
-
-        if success:
-            if self._exec_separated:
-                prefetch_count = max(self._cpu_queue_size, self._gpu_queue_size)
-            else:
-                prefetch_count = self._cpu_queue_size
-
-            for i in range(prefetched, prefetch_count):
-                try:
-                    self.iter_setup()
-                    prefetched = i + 1
-                    self._batches_to_consume += 1
-                except StopIteration:
-                    success = False
-                    break
-
-        return prefetched, success
 
     def _run_once(self):
         """Start running the whole pipeline once without waiting for its results.

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1591,29 +1591,25 @@ class Pipeline(object):
             raise RuntimeError("The pipeline was destroyed.")
         self._schedule_py_workers()
 
-        # We probably need some benchmarking before we remove this code path
-        if not self._exec_separated:
-            self._legacy_interleaved_prefetch()
-            return
-
-        # The new way: try to run the inputs and then feed them, finally call _pipe.Prefetch()
-        # If this fails, we just run `_pipe.Run()` a bunch of times. This will likely blow up for
-        # separated queues, which are not properly supported anyway.
-        iters_fed = 0
-        self._first_iter = False
-        iters_fed, success = self._prefetch_inputs()
-        if success:
-            self._pipe.Prefetch()
-        else:
-            self._last_iter = True
-            for _ in range(iters_fed):
-                self._pipe.Run()
+        # Keep input feeding interleaved with backend runs. Feeding all inputs
+        # first can leave separated execution with CPU-prefetched batches that
+        # have no scheduled Mixed/GPU work when an external source reaches end
+        # of epoch.
+        self._legacy_interleaved_prefetch()
 
     # This is the old way of prefetching - the feeding and running steps are interleaved.
     # Running all callbacks at once, then feeding, then running - may affect the performance
     # of the 1st iteration.
     def _legacy_interleaved_prefetch(self):
-        for _ in range(self._cpu_queue_size):
+        # Separated execution has independent CPU and GPU queue depths. Each
+        # interleaved Run schedules one batch through every stage, so the
+        # larger queue depth is enough to prime both queues.
+        prefetch_count = (
+            max(self._cpu_queue_size, self._gpu_queue_size)
+            if self._exec_separated
+            else self._cpu_queue_size
+        )
+        for _ in range(prefetch_count):
             try:
                 self._first_iter = False
                 self._iter_setup()
@@ -1624,27 +1620,6 @@ class Pipeline(object):
             except StopIteration:
                 self._last_iter = True
                 break
-
-    def _prefetch_inputs(self):
-        prefetched, success = self._run_input_callbacks(True)
-        self._batches_to_consume += prefetched
-
-        if success:
-            if self._exec_separated:
-                prefetch_count = self._cpu_queue_size + self._gpu_queue_size
-            else:
-                prefetch_count = self._cpu_queue_size
-
-            for i in range(prefetched, prefetch_count):
-                try:
-                    self.iter_setup()
-                    prefetched = i + 1
-                    self._batches_to_consume += 1
-                except StopIteration:
-                    success = False
-                    break
-
-        return prefetched, success
 
     def _run_once(self):
         """Start running the whole pipeline once without waiting for its results.

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1601,9 +1601,12 @@ class Pipeline(object):
     # Running all callbacks at once, then feeding, then running - may affect the performance
     # of the 1st iteration.
     def _legacy_interleaved_prefetch(self):
-        # Separated execution has independent CPU and GPU queue depths. Each
-        # interleaved Run schedules one batch through every stage, so the
-        # larger queue depth is enough to prime both queues.
+        # Separated execution has independent CPU and GPU queue depths, but an
+        # interleaved Run schedules one whole pipeline iteration through all
+        # stages. After max(cpu, gpu) runs each stage has seen enough iterations
+        # to fill its own queue. Using cpu + gpu would schedule extra full
+        # iterations, not just fill the GPU queue, and could over-read external
+        # inputs at an epoch boundary.
         prefetch_count = (
             max(self._cpu_queue_size, self._gpu_queue_size)
             if self._exec_separated

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1931,6 +1931,7 @@ class Pipeline(object):
             return 0, True
 
         batches = []  # data from external source callbacks is gathered here
+        stop_iter = False
         for i, group in enumerate(self._parallel_input_callbacks):
             try:
                 batches.append(
@@ -1939,12 +1940,15 @@ class Pipeline(object):
                     )
                 )
             except StopIteration:
-                return 0, False
+                stop_iter = True
         for group in self._seq_input_callbacks:
             try:
                 batches.append(group.get_batch(self, self._max_batch_size, self._epoch_idx))
             except StopIteration:
-                return 0, False
+                stop_iter = True
+
+        if stop_iter:
+            return 0, False
 
         try:
             self.iter_setup()

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1591,22 +1591,32 @@ class Pipeline(object):
             raise RuntimeError("The pipeline was destroyed.")
         self._schedule_py_workers()
 
-        # Keep input feeding interleaved with backend runs. Feeding all inputs
-        # first can leave separated execution with CPU-prefetched batches that
-        # have no scheduled Mixed/GPU work when an external source reaches end
-        # of epoch.
-        self._legacy_interleaved_prefetch()
+        # A larger separated CPU queue leaves CPU-only iterations after backend
+        # Prefetch. If a Python source reaches end of epoch, those iterations
+        # cannot be advanced through Mixed/GPU without feeding more CPU work.
+        cpu_queue_is_longer = self._cpu_queue_size > self._gpu_queue_size
+        if not self._exec_separated or cpu_queue_is_longer:
+            self._legacy_interleaved_prefetch()
+            return
+
+        # The new way: try to run the inputs and then feed them, finally call
+        # _pipe.Prefetch(). If this fails, we just run `_pipe.Run()` a bunch of
+        # times. This will likely blow up for separated queues, which are not
+        # properly supported anyway.
+        iters_fed = 0
+        self._first_iter = False
+        iters_fed, success = self._prefetch_inputs()
+        if success:
+            self._pipe.Prefetch()
+        else:
+            self._last_iter = True
+            for _ in range(iters_fed):
+                self._pipe.Run()
 
     # This is the old way of prefetching - the feeding and running steps are interleaved.
     # Running all callbacks at once, then feeding, then running - may affect the performance
     # of the 1st iteration.
     def _legacy_interleaved_prefetch(self):
-        # Separated execution has independent CPU and GPU queue depths, but an
-        # interleaved Run schedules one whole pipeline iteration through all
-        # stages. After max(cpu, gpu) runs each stage has seen enough iterations
-        # to fill its own queue. Using cpu + gpu would schedule extra full
-        # iterations, not just fill the GPU queue, and could over-read external
-        # inputs at an epoch boundary.
         prefetch_count = (
             max(self._cpu_queue_size, self._gpu_queue_size)
             if self._exec_separated
@@ -1623,6 +1633,27 @@ class Pipeline(object):
             except StopIteration:
                 self._last_iter = True
                 break
+
+    def _prefetch_inputs(self):
+        prefetched, success = self._run_input_callbacks(True)
+        self._batches_to_consume += prefetched
+
+        if success:
+            if self._exec_separated:
+                prefetch_count = max(self._cpu_queue_size, self._gpu_queue_size)
+            else:
+                prefetch_count = self._cpu_queue_size
+
+            for i in range(prefetched, prefetch_count):
+                try:
+                    self.iter_setup()
+                    prefetched = i + 1
+                    self._batches_to_consume += 1
+                except StopIteration:
+                    success = False
+                    break
+
+        return prefetched, success
 
     def _run_once(self):
         """Start running the whole pipeline once without waiting for its results.

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -28,6 +28,7 @@ import warnings
 import weakref
 import gc
 from webdataset_base import generate_temp_index_file as generate_temp_wds_index
+from nose2.tools import params
 
 from test_utils import (
     check_batch,
@@ -1893,7 +1894,8 @@ def test_properties():
     my_pipe(device_id=0, seed=1234, num_threads=3, set_affinity=True, py_num_workers=3)
 
 
-def test_separated_queue_external_source_drains_prefetched_batches():
+@params((2, 2), (3, 2), (2, 3))
+def test_separated_queue_external_source_drains_prefetched_batches(cpu_size, gpu_size):
     batch_size = 4
     num_batches = 10
     image_pattern = os.path.join(jpeg_folder, "*", "*.jpg")
@@ -1905,40 +1907,38 @@ def test_separated_queue_external_source_drains_prefetched_batches():
             batch_paths = paths[i * batch_size : (i + 1) * batch_size]
             yield [np.fromfile(path, dtype=np.uint8) for path in batch_paths]
 
-    for cpu_size, gpu_size in [(2, 2), (3, 2), (2, 3)]:
-
-        @dali.pipeline_def(
-            batch_size=batch_size,
-            num_threads=4,
-            device_id=0,
-            prefetch_queue_depth={"cpu_size": cpu_size, "gpu_size": gpu_size},
+    @dali.pipeline_def(
+        batch_size=batch_size,
+        num_threads=4,
+        device_id=0,
+        prefetch_queue_depth={"cpu_size": cpu_size, "gpu_size": gpu_size},
+    )
+    def pipe():
+        encoded = fn.external_source(
+            source=batches,
+            batch=True,
+            cycle="raise",
         )
-        def pipe():
-            encoded = fn.external_source(
-                source=batches,
-                batch=True,
-                cycle="raise",
-            )
-            decoded = fn.decoders.image(
-                encoded,
-                device="mixed",
-                output_type=types.RGB,
-            )
-            return decoded
+        decoded = fn.decoders.image(
+            encoded,
+            device="mixed",
+            output_type=types.RGB,
+        )
+        return decoded
 
-        p = pipe()
-        p.build()
-        for _ in range(num_batches):
-            out = p.run()[0]
-            assert len(out) == batch_size
-            decoded = out.as_cpu()
-            for sample_idx in range(batch_size):
-                sample = decoded.at(sample_idx)
-                assert sample.ndim == 3
-                assert sample.shape[-1] == 3
-                assert np.any(sample)
-        with assert_raises(StopIteration):
-            p.run()
+    p = pipe()
+    p.build()
+    for _ in range(num_batches):
+        out = p.run()[0]
+        assert len(out) == batch_size
+        decoded = out.as_cpu()
+        for sample_idx in range(batch_size):
+            sample = decoded.at(sample_idx)
+            assert sample.ndim == 3
+            assert sample.shape[-1] == 3
+            assert np.any(sample)
+    with assert_raises(StopIteration):
+        p.run()
 
 
 def test_not_iterable():

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1891,6 +1891,54 @@ def test_properties():
         return np.float32([1, 2, 3])
 
     my_pipe(device_id=0, seed=1234, num_threads=3, set_affinity=True, py_num_workers=3)
+
+
+def test_separated_queue_external_source_drains_prefetched_batches():
+    batch_size = 4
+    num_batches = 10
+    image_pattern = os.path.join(jpeg_folder, "*", "*.jpg")
+    paths = sorted(glob.glob(image_pattern))[: batch_size * num_batches]
+    assert len(paths) == batch_size * num_batches
+
+    def batches():
+        for i in range(num_batches):
+            batch_paths = paths[i * batch_size : (i + 1) * batch_size]
+            yield [np.fromfile(path, dtype=np.uint8) for path in batch_paths]
+
+    for cpu_size, gpu_size in [(2, 2), (3, 2), (2, 3)]:
+
+        @dali.pipeline_def(
+            batch_size=batch_size,
+            num_threads=4,
+            device_id=0,
+            prefetch_queue_depth={"cpu_size": cpu_size, "gpu_size": gpu_size},
+        )
+        def pipe():
+            encoded = fn.external_source(
+                source=batches,
+                batch=True,
+                cycle="raise",
+            )
+            decoded = fn.decoders.image(
+                encoded,
+                device="mixed",
+                output_type=types.RGB,
+            )
+            return decoded
+
+        p = pipe()
+        p.build()
+        for _ in range(num_batches):
+            out = p.run()[0]
+            assert len(out) == batch_size
+            decoded = out.as_cpu()
+            for sample_idx in range(batch_size):
+                sample = decoded.at(sample_idx)
+                assert sample.ndim == 3
+                assert sample.shape[-1] == 3
+                assert np.any(sample)
+        with assert_raises(StopIteration):
+            p.run()
 
 
 def test_not_iterable():


### PR DESCRIPTION
## Category:
**Bug fix**

## Description:
This PR fixes a hang at the end of an epoch when a Python-managed
`external_source` is used with separated CPU/GPU prefetch queues.

The newer prefetch path fed all inputs before running the backend. For
separated execution this could leave CPU-prefetched external source batches
without scheduled Mixed/GPU work once the source reached end of epoch. The
consumer then waited indefinitely for output indexes in the separated queue
policy.

The fix keeps prefetching interleaved with backend runs, so input feeding and
backend scheduling stay aligned at epoch boundaries.

Related to https://github.com/NVIDIA/DALI/issues/5199

## Additional information:

### Affected modules and functionalities:
- `nvidia.dali.Pipeline` prefetch scheduling in the legacy executor path.
- Python regression coverage for `external_source(batch=True, cycle="raise")`
  with mixed image decoding and separated prefetch queues.

### Key points relevant for the review:
Review whether routing prefetch through the interleaved path is acceptable for
legacy separated execution. This restores the behavior that avoids a CPU-only
tail when input callbacks reach end of epoch.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_pipeline.py:test_separated_queue_external_source_drains_prefetched_batches
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A