### PR TITLE
Promote 0d reader tensor args to scalars

### DIFF
--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -483,7 +483,6 @@ def _prepare_reader_arg(value: Any) -> Any:
     if isinstance(value, (Tensor, Batch)):
         if value.device.device_type != "cpu":
             raise ValueError("GPU arguments inputs are not supported")
-        # TODO(rtabet, DALI-4708): Classify scalar CPU Tensor args earlier to allow ScalarConstant.
         return dali_types.Constant(np.asarray(as_tensor(value)), layout=value.layout, device="cpu")
     return dali_types.Constant(value, device="cpu")
 

--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -83,6 +83,14 @@ def _argument_type_conversion(dtype_id):
         return None
 
 
+def _promote_0d_cpu_tensor(value):
+    if not isinstance(value, Tensor):
+        return value
+    if value.device.device_type != "cpu" or value.ndim != 0:
+        return value
+    return value.item()
+
+
 def _get_module_name(module, legacy_op_class):
     """
     Replicates behaviour of _names._process_op_name() + _adjust_operator_module()
@@ -214,12 +222,17 @@ def build_constructor(schema, op_class):
                 arg = kwargs.get(arg_name)
                 if arg is None or isinstance(arg, (int, float, bool, str, tuple, list)):
                     continue
-                del kwargs[arg_name]
                 if isinstance(arg, Batch):
                     raise ValueError("Readers cannot be constructed with batch keyword arguments")
-                original_tensor_args[arg_name] = arg
+                original_arg = arg
                 dtype = op_class._argument_conversion_map[arg_name]
-                tensor_args[arg_name] = to_tensor(arg, dtype=dtype)
+                arg = _promote_0d_cpu_tensor(to_tensor(arg, dtype=dtype))
+                if isinstance(arg, (int, float, bool, str)):
+                    kwargs[arg_name] = arg
+                    continue
+                del kwargs[arg_name]
+                original_tensor_args[arg_name] = original_arg
+                tensor_args[arg_name] = arg
         kwargs = {k: _scalar_decay(v) for k, v in kwargs.items()}
         op_class.__base__.__init__(self, max_batch_size, name, **kwargs)
         if is_reader:  # Need to be done here not to be overridden by the constructor

--- a/dali/test/python/experimental_mode/test_compile.py
+++ b/dali/test/python/experimental_mode/test_compile.py
@@ -389,6 +389,22 @@ def test_compile_scalar_args():
     _test_video_resize(resize_x=ndd.tensor(108), resize_y=192)
 
 
+def test_reader_constructor_promotes_0d_tensor_args_to_scalars():
+    reader = ndd.readers.Numpy(
+        files=["unused.npy"],
+        roi_start=ndd.tensor(0),
+        roi_shape=ndd.tensor([10]),
+    )
+
+    assert reader._init_args["roi_start"] == 0
+    assert "roi_start" in reader._tensor_arg_names
+    assert "roi_start" not in reader._raw_tensor_args
+    assert "roi_start" not in reader._original_tensor_args
+    assert "roi_shape" in reader._tensor_arg_names
+    assert "roi_shape" in reader._raw_tensor_args
+    assert "roi_shape" in reader._original_tensor_args
+
+
 def test_compile_incompatible_kwarg_dtype():
     reader_dyn = ndd.readers.File(file_root=images_root)
     reader_comp = ndd.readers.File(file_root=images_root)


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Promotes 0d CPU tensor arguments passed to dynamic reader constructors to scalar values before reader initialization. This lets scalar tensor arguments follow the same path as plain scalar arguments instead of being stored as tensor argument inputs.

Fixes DALI-4708.

## Additional information:

### Affected modules and functionalities:
- Dynamic mode reader constructor argument handling.
- Compile-mode reader tensor/scalar argument classification.

### Key points relevant for the review:
- Only 0d CPU `ndd.Tensor` reader arguments are promoted.
- Non-scalar tensor arguments keep the existing tensor argument path.
- Batch reader constructor arguments are still rejected.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

Tested locally:
- `test_compile.test_reader_constructor_promotes_0d_tensor_args_to_scalars`
- `test_compile.test_compile_scalar_args`

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: DALI-4708
