### PR TITLE
conda: pin libopencv to >=4.13,<5

### DIFF
--- a/conda/dali_native_libs/recipe/meta.yaml
+++ b/conda/dali_native_libs/recipe/meta.yaml
@@ -79,7 +79,7 @@ requirements:
     # so zlib must be in host for find_package(Protobuf) to succeed.
     - zlib
     - libjpeg-turbo
-    - libopencv
+    - libopencv >=4.13,<5
     - ffmpeg
     - lmdb
     - libtiff
@@ -94,7 +94,7 @@ requirements:
     - aws-sdk-cpp
   run:
     - libjpeg-turbo
-    - libopencv
+    - libopencv >=4.13,<5
     - ffmpeg
     - lmdb
     - libtiff

--- a/conda/dali_python_bindings/recipe/meta.yaml
+++ b/conda/dali_python_bindings/recipe/meta.yaml
@@ -89,7 +89,7 @@ requirements:
     # libprotobuf's CMake config exposes a ZLIB::ZLIB link interface dep,
     # so zlib must be in host for find_package(Protobuf) to succeed.
     - zlib
-    - libopencv
+    - libopencv >=4.13,<5
     - python
     {% if freethreading == "yes" %}
     - python-freethreading


### PR DESCRIPTION
## Description

Pin `libopencv` to `>=4.13,<5` in the conda recipes for `dali_native_libs` and `dali_python_bindings`.

The conda-forge `libopencv` recipe emits a `run_export` pinned to the patch ABI range (e.g. `>=4.13.0,<4.13.1.0a0`), and `libnvimgcodec-libopencv-ext` 0.8.0 is built against libopencv 4.13. When DALI's conda build picks up libopencv 5.0, the solver pins it to `>=5.0.0,<5.0.1.0a0`, which conflicts with the nvImageCodec OpenCV extension that is still tied to the OpenCV 4.13 ABI, breaking the conda build.

Pinning `libopencv` to the OpenCV 4.x line keeps DALI's conda build solvable until `libnvimgcodec-libopencv-ext` is rebuilt against OpenCV 5.

## Checklist

### Tests

- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

### Documentation

- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Affected modules and functionalities:
Conda packaging (recipes).

#### Key points relevant for the review:
Build-only change; pins libopencv to the 4.x line.

#### Tests:
N/A — packaging metadata change.

#### Checklist

##### Documentation

- [ ] Documentation
- [x] N/A

##### Performance

- [ ] Performance change
- [x] N/A