### PR TITLE
Add ExternalSource support to transparent pipelining

### DIFF
--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -14,15 +14,17 @@
 
 import dataclasses
 import enum
+import itertools
 import threading
 import types
 import warnings
-from collections.abc import Mapping, Sequence
+from abc import ABC, abstractmethod
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, Generic, NamedTuple, Protocol, TypeVar
 
 import numpy as np
-import nvidia.dali.backend_impl as _b
+
 import nvidia.dali.types as dali_types
 from nvidia.dali import fn
 from nvidia.dali.pipeline import Pipeline
@@ -37,10 +39,10 @@ from ._call_site import (
 )
 from ._device import Device
 from ._nvtx import NVTXRange
-from ._tensor import Tensor, as_tensor
 
 if TYPE_CHECKING:
     from ._eval_context import EvalContext
+    from ._external_source import ExternalSource  # noqa: F401
     from ._ops import Operator, Reader
 
 
@@ -54,19 +56,27 @@ class State(enum.Enum):
     DISABLED = enum.auto()
 
 
-class CompileSource(NamedTuple):
-    """The reader root of the compile graph."""
+class SupportsCompile(Protocol):
+    """A class supporting being used as a source of a compile graph."""
+
+    _compiled_iter: "CompiledEpochIterator | None"
+
+    def _wire_pipeline(self, source: "CompileSource") -> tuple: ...
+    def _shape_result(self, source: "CompileSource", batches: tuple) -> Any: ...
+    def _transfer_into(self, pipe: Pipeline) -> bool: ...
+    def _make_epoch_iterator(self, batch_size: int) -> "CompiledEpochIterator": ...
+    def _teardown_compile(self) -> None: ...
+
+
+@dataclasses.dataclass(eq=False, slots=True)
+class CompileSource:
+    """A compile graph source: a transferred reader op or an external_source callback."""
 
     num_outputs: int
+    ctx: "CompileContext"
+    compilable: "SupportsCompile"  # the Reader or ExternalSource behind this source
     output_keys: tuple[str, ...] | None = None
-    device: str = "cpu"
-
-
-class CompileRef(NamedTuple):
-    """Reference to one output of a compile graph node."""
-
-    source: "CompileSource | CompileNode"
-    output_index: int
+    pipeline_output_offset: int | None = None
 
 
 @dataclasses.dataclass(eq=False)
@@ -75,12 +85,19 @@ class CompileNode:
 
     op_class: type["Operator"]
     backend: str
-    inputs: Sequence[CompileRef | Any]
-    kwargs: Mapping[str, CompileRef | Any]
+    inputs: Sequence["CompileRef | Any"]
+    kwargs: Mapping[str, "CompileRef | Any"]
     kwarg_casts: dict[str, dali_types.DALIDataType]
     num_outputs: int
     device: Device | None = None
     pipeline_output_offset: int | None = dataclasses.field(default=None, repr=False)
+
+
+class CompileRef(NamedTuple):
+    """Reference to one output of a compile graph node."""
+
+    owner: "CompileSource | CompileNode"
+    output_index: int
 
 
 class _CallTrie:
@@ -145,21 +162,22 @@ class CompiledBatch(Batch):
 
 
 class CompileContext:
-    """Manages compile state for one reader (TRACING → COMPILED or DISABLED)."""
+    """Manages the compile state (TRACING -> COMPILED or DISABLED)."""
 
     _tls = threading.local()
 
-    def __init__(self, reader: "Reader", batch_size: int):
+    def __init__(self, batch_size: int):
         self.state = State.TRACING
-        self.reader = reader
         self.batch_size = batch_size
-        self.source: CompileSource | None = None
+        self.sources: list[CompileSource] = []  # only sources[0] is iterated on
         self.nodes: list[CompileNode] = []
         self._call_trie = _CallTrie()
         self.pipeline: Pipeline | None = None
-        self._pipeline_results: dict[CompileNode, Any] = {}
+        self._results: dict[CompileSource | CompileNode, tuple[CompiledBatch, ...]] = {}
         self._iteration = 0
-        self._epoch_size_padded: int | None = None
+        self._read_this_step: set[CompileSource] = set()  # extra sources pulled this step
+        # Sources that raised StopIteration this step. The root's presence marks a clean epoch end.
+        self._stopped_sources: set[CompileSource] = set()
 
     @classmethod
     def current(cls) -> "CompileContext | None":
@@ -172,34 +190,64 @@ class CompileContext:
             return
         prev = getattr(CompileContext._tls, "current", None)
         if prev is not None and prev is not self:
-            raise RuntimeError(
-                "Multiple compiled readers active simultaneously is not supported. "
-                "Only one reader can use compile=True at a time."
-            )
+            raise RuntimeError("Only one compiled loop can be active at a time")
         CompileContext._tls.current = self
         try:
             yield
         finally:
             CompileContext._tls.current = prev
 
-    def init_source(
+    def check_batch_size(self, batch_size: int | None) -> None:
+        if batch_size is not None and batch_size != self.batch_size:
+            raise RuntimeError(
+                f"Cannot change batch size to {batch_size}, "
+                f"the compiled loop uses {self.batch_size}."
+            )
+
+    def add_source(
         self,
         num_outputs: int,
+        compilable: "SupportsCompile",
+        *,
         output_keys: tuple[str, ...] | None = None,
-        device: str = "cpu",
-    ) -> None:
-        if self.source is not None:
-            assert self.source.num_outputs == num_outputs
-            assert self.source.output_keys == output_keys
-            return
-        self.source = CompileSource(num_outputs, output_keys, device)
+    ) -> CompileSource:
+        """Register a graph source (sources[0] is registered first and iterated by the loop)"""
+        source = CompileSource(num_outputs, self, compilable, output_keys=output_keys)
+        self.sources.append(source)
+        return source
 
-    def make_source_batches(self, tensor_lists: Sequence[Any]) -> tuple[CompiledBatch, ...]:
-        assert self.source is not None
+    def _wrap_tensor_lists(
+        self,
+        source: CompileSource,
+        tensor_lists: Sequence,
+    ) -> tuple[CompiledBatch, ...]:
         return tuple(
-            CompiledBatch(tl, CompileRef(self.source, i), self._iteration)
+            CompiledBatch(tl, CompileRef(source, i), self._iteration)
             for i, tl in enumerate(tensor_lists)
         )
+
+    def _mark_read(self, source: CompileSource) -> None:
+        if source in self._read_this_step:
+            raise RuntimeError("An ExternalSource may be read only once per compiled step")
+        self._read_this_step.add(source)
+
+    def _mark_stopped(self, source: CompileSource) -> None:
+        self._stopped_sources.add(source)
+
+    def _reset_stop(self) -> None:
+        self._stopped_sources.clear()
+
+    def _require_consumed(self) -> None:
+        # the executor pulls every source each step, so a skipped one silently drops data
+        for source in self.sources[1:]:
+            if source not in self._read_this_step:
+                self._teardown()
+                raise RuntimeError("An ExternalSource was not consumed this step")
+
+    def _teardown(self) -> None:
+        self.state = State.DISABLED
+        for source in self.sources:
+            source.compilable._teardown_compile()
 
     @staticmethod
     def _compute_kwarg_casts(op: type["Operator"], raw_kwargs: Mapping[str, CompiledBatch | Any]):
@@ -260,13 +308,10 @@ class CompileContext:
                 "compile=True was specified but no operators were captured during tracing. "
                 "Falling back to dynamic mode.",
             )
-            self.state = State.DISABLED
+            self._teardown()
             return
 
         self._assign_output_offsets()
-
-        source = self.source
-        assert source is not None
 
         transferred = False
         try:
@@ -277,65 +322,60 @@ class CompileContext:
                 prefetch_queue_depth=2,
             )
             with pipe:
-                _wire_compile_graph(self.reader, source, self.nodes)
-            assert self.reader._op_backend is not None
-            pipe._transfer_operator(self.reader._name, self.reader._op_backend)
-            transferred = True
+                _wire_compile_graph(self.sources, self.nodes)
+            for source in self.sources:
+                transferred |= source.compilable._transfer_into(pipe)
             pipe.build()
         except Exception as exception:
-            self.nodes.clear()
-            self._call_trie = _CallTrie()
-            self._pipeline_results.clear()
-            self.source = None
-            self.state = State.DISABLED
-            # Reset Reader fields here, the exception propagates past the iterator
-            self.reader._compile_mode = None
-            self.reader._compiled_iter = None
-            # If there's a failure after _op_backend was transferred, we can't safely recover.
-            # Disable the reader. In practice, this case should be rare.
+            self._teardown()
+            # Only a transferred reader sets `transferred`; its op now belongs to the failed
+            # pipeline and cannot be recovered, so the reader is left disabled.
             if transferred:
-                self.reader._disabled = True
                 raise RuntimeError(
-                    "Failed to build pipeline after transferring operator. "
-                    "Reader is now in invalid state."
+                    "Failed to build pipeline. Reader is now in invalid state."
                 ) from exception
-
             raise
 
         self.pipeline = pipe
         self.state = State.COMPILED
 
-    def reader_epoch_size(self) -> int:
-        from ._ops import _shard_size
-
-        assert self.pipeline is not None
-        if self._epoch_size_padded is None:
-            metadata = self.pipeline.reader_meta(self.reader._name)
-            self._epoch_size_padded = metadata["epoch_size_padded"]
-        return _shard_size(self._epoch_size_padded, self.reader._shard_id, self.reader._num_shards)
-
     @_nvtx_range("Running compiled pipeline")
     def run_pipeline(self) -> tuple | dict:
-        """Run the compiled pipeline and cache all node results for this iteration."""
-        assert self.pipeline is not None and self.source is not None
+        """Run the pipeline, cache results, and return sources[0]'s output.
+
+        ``StopIteration`` propagates for the caller to classify (epoch end or underrun).
+        Any other failure invalidates the context.
+        """
+        assert self.pipeline is not None
         self._iteration += 1
-        pipeline_outputs = self.pipeline.run()
-        source_batches = tuple(
-            CompiledBatch(pipeline_outputs[i], CompileRef(self.source, i), self._iteration)
-            for i in range(self.source.num_outputs)
+        self._read_this_step.clear()
+        try:
+            pipeline_outputs = self.pipeline.run()
+        except StopIteration:
+            raise  # Propagate and let the caller classify
+        except Exception:
+            self._teardown()
+            raise
+        self._results.clear()
+        for owner in itertools.chain(self.sources, self.nodes):
+            self._results[owner] = self._wrap_outputs(owner, pipeline_outputs)
+        return self.result_for(self.sources[0])
+
+    def _wrap_outputs(
+        self, owner: "CompileSource | CompileNode", pipeline_outputs: Sequence
+    ) -> tuple[CompiledBatch, ...]:
+        offset = owner.pipeline_output_offset
+        assert offset is not None
+        return tuple(
+            CompiledBatch(pipeline_outputs[offset + i], CompileRef(owner, i), self._iteration)
+            for i in range(owner.num_outputs)
         )
-        self._pipeline_results.clear()
-        for node in self.nodes:
-            assert node.pipeline_output_offset is not None
-            offset = node.pipeline_output_offset
-            batches = tuple(
-                CompiledBatch(pipeline_outputs[offset + i], CompileRef(node, i), self._iteration)
-                for i in range(node.num_outputs)
-            )
-            self._pipeline_results[node] = batches[0] if node.num_outputs == 1 else batches
-        if self.source.output_keys is not None:
-            return dict(zip(self.source.output_keys, source_batches))
-        return source_batches
+
+    def result_for(self, owner: "CompileSource | CompileNode") -> Any:
+        batches = self._results[owner]
+        if isinstance(owner, CompileNode):
+            return batches[0] if owner.num_outputs == 1 else batches
+        return owner.compilable._shape_result(owner, batches)
 
     def _matches(self, actual: Any, expected: Any) -> bool:
         """Check if an actual value matches the expected traced value."""
@@ -380,51 +420,126 @@ class CompileContext:
             return None
         if not all(self._matches(kwargs[name], expected) for name, expected in node.kwargs.items()):
             return None
-        return self._pipeline_results.get(node)
+        if node not in self._results:
+            return None
+        return self.result_for(node)
 
     def _assign_output_offsets(self) -> None:
-        assert self.source is not None
-        offset = self.source.num_outputs
-        for node in self.nodes:
+        offset = 0
+        for node in itertools.chain(self.sources, self.nodes):
             node.pipeline_output_offset = offset
             offset += node.num_outputs
 
 
-class CompiledEpochIterator:
-    """Owns the compile lifecycle for one reader."""
+_Compilable = TypeVar("_Compilable", bound=SupportsCompile)
 
-    def __init__(self, reader: "Reader", batch_size: int):
-        self._reader = reader
-        self._compile_ctx = CompileContext(reader, batch_size)
-        self._ctx: "EvalContext | None" = None
+
+class CompiledEpochIterator(ABC, Generic[_Compilable]):
+    """Owns the compile lifecycle for one compilable source."""
+
+    def __init__(self, compilable: _Compilable, batch_size: int):
+        self._compilable = compilable
+        self._compile_ctx = CompileContext(batch_size)
+        self._eval_ctx: "EvalContext | None" = None
 
     @property
     def compile_context(self) -> CompileContext:
         return self._compile_ctx
 
-    def batches(self, ctx: "EvalContext | None"):
-        """Yield batches, tracing on first epoch, compiled thereafter."""
-        from . import _eval_context
-
-        reader = self._reader
-        reader._require_api_type("batches")
+    def batches(self, ctx: "EvalContext | None") -> Iterator[CompiledBatch]:
+        """Yield one epoch: tracing on the first, compiled thereafter."""
+        from ._eval_context import EvalContext
 
         if ctx is None:
-            ctx = _eval_context.EvalContext.current()
-        if self._ctx is not None and ctx is not self._ctx:
-            raise RuntimeError("Cannot change EvalContext for a compiled reader.")
-        self._ctx = ctx
-        with ctx:
-            if self._compile_ctx.state is State.COMPILED:
-                yield from self._batches_compiled()
-            else:
-                yield from self._batches_tracing(ctx)
-        reader._advance_shard()
+            ctx = EvalContext.current()
+        if self._eval_ctx is not None and ctx is not self._eval_ctx:
+            raise RuntimeError("Cannot change EvalContext for a compiled loop.")
+        self._eval_ctx = ctx
 
-    def _batches_tracing(self, ctx: "EvalContext"):
-        """First epoch: run dynamically, record graph, build pipeline."""
+        compiled = self._compile_ctx.state is State.COMPILED
+        with ctx:
+            yield from (self._compiled() if compiled else self._tracing(ctx))
+
+    def _next_batches(self) -> tuple | dict | None:
+        """Run one compiled step. Return the batches, or None at a clean epoch end."""
+        try:
+            return self._compile_ctx.run_pipeline()
+        except StopIteration:
+            if self._stop_is_epoch_end():
+                return None
+            self._compile_ctx._teardown()
+            raise RuntimeError("A source was exhausted before the iteration ended")
+
+    def _emit_step(self, batches):
+        ctx = self._compile_ctx
+        try:
+            with ctx.active():
+                yield batches
+        except GeneratorExit:
+            self._on_break()
+            raise
+        ctx._require_consumed()
+
+    @abstractmethod
+    def _tracing(self, ctx: "EvalContext") -> Iterator: ...
+
+    @abstractmethod
+    def _compiled(self) -> Iterator: ...
+
+    @abstractmethod
+    def _stop_is_epoch_end(self) -> bool: ...
+
+    @abstractmethod
+    def _on_break(self) -> None: ...
+
+
+class _ReaderEpochIterator(CompiledEpochIterator["Reader"]):
+    def __init__(self, compilable: "Reader", batch_size: int):
+        super().__init__(compilable, batch_size)
+        self._epoch_size_padded: int | None = None
+        self._resume_idx = 0  # batches already emitted during tracing, resumed by _compiled
+
+    def batches(self, ctx: "EvalContext | None"):
+        self._compilable._require_api_type("batches")
+        yield from super().batches(ctx)
+        self._compilable._advance_shard()
+
+    def _epoch_size(self) -> int:
+        from ._ops import _shard_size
+
+        reader = self._compilable
+        pipeline = self._compile_ctx.pipeline
+        assert pipeline is not None
+
+        if self._epoch_size_padded is None:
+            meta = pipeline.reader_meta(reader._name)
+            self._epoch_size_padded = meta["epoch_size_padded"]
+
+        return _shard_size(self._epoch_size_padded, reader._shard_id, reader._num_shards)
+
+    def _trace_step(self, ctx: "EvalContext", tensor_args: dict) -> tuple[Any, int]:
+        """Run one eager reader step, registering the source on first use.
+        Return (batches, batch_size).
+        """
+        reader = self._compilable
         compile_ctx = self._compile_ctx
-        reader = self._reader
+        outputs = reader._run_unchecked(ctx, batch_size=compile_ctx.batch_size, **tensor_args)
+
+        if isinstance(outputs, tuple):
+            output_keys, raw = None, outputs
+        else:
+            output_keys, raw = zip(*outputs.items())
+
+        if not compile_ctx.sources:
+            compile_ctx.add_source(len(raw), reader, output_keys=output_keys)
+
+        batches = compile_ctx._wrap_tensor_lists(compile_ctx.sources[0], raw)
+        result = batches if output_keys is None else dict(zip(output_keys, batches))
+        return result, reader._output_batch_size(outputs)
+
+    def _tracing(self, ctx: "EvalContext"):
+        compile_ctx = self._compile_ctx
+        reader = self._compilable
         batch_size = compile_ctx.batch_size
         tensor_args = reader._process_tensor_args(batch_size)
 
@@ -433,86 +548,107 @@ class CompiledEpochIterator:
             reader._init_backend(ctx, (), tensor_args)
 
         epoch_size = reader._shard_epoch_size()
-        idx = 0
-        first_iteration = True
-        while idx < epoch_size:
-            outputs = reader._run_unchecked(ctx, batch_size=batch_size, **tensor_args)
-            batch_size_returned = reader._output_batch_size(outputs)
-            idx += batch_size_returned
-            if isinstance(outputs, tuple):
-                raw = outputs
-                output_keys = None
-            else:
-                raw = tuple(outputs.values())
-                output_keys = tuple(outputs.keys())
-            # No reader returns multiple outputs on different devices
-            device = "gpu" if isinstance(raw[0], _b.TensorListGPU) else "cpu"
-            compile_ctx.init_source(len(raw), output_keys=output_keys, device=device)
-            batches = compile_ctx.make_source_batches(raw)
+        if epoch_size == 0:
+            return
+
+        value, idx = self._trace_step(ctx, tensor_args)  # step 0 records the graph
+        with compile_ctx.active():
+            yield value
+
+        compile_ctx.build_pipeline(ctx)
+        if compile_ctx.state is State.COMPILED:
+            self._resume_idx = idx
+            yield from self._compiled()
+            return
+
+        while idx < epoch_size:  # build disabled: finish the epoch eagerly
+            value, count = self._trace_step(ctx, tensor_args)
+            idx += count
             with compile_ctx.active():
-                if isinstance(outputs, tuple):
-                    yield batches
-                else:
-                    yield dict(zip(outputs.keys(), batches))
-            if first_iteration:
-                first_iteration = False
-                compile_ctx.build_pipeline(ctx)
-                if compile_ctx.state is State.COMPILED:
-                    yield from self._batches_compiled(start_idx=idx)
-                    return
-                if compile_ctx.state is State.DISABLED:
-                    reader._compile_mode = None
-                    reader._compiled_iter = None
+                yield value
 
-    def _batches_compiled(self, start_idx: int = 0):
-        """Subsequent epochs: yield from compiled pipeline."""
-        compile_ctx = self._compile_ctx
+    def _compiled(self):
+        self._compile_ctx._reset_stop()
+        epoch_size = self._epoch_size()
+        idx = self._resume_idx
+        self._resume_idx = 0
 
-        epoch_size = compile_ctx.reader_epoch_size()
-        idx = start_idx
         while idx < epoch_size:
-            batches = compile_ctx.run_pipeline()
-            idx += self._reader._output_batch_size(batches)
-            with compile_ctx.active():
-                yield batches
+            batches = self._next_batches()
+            assert batches is not None
+            idx += self._compilable._output_batch_size(batches)
+            yield from self._emit_step(batches)
+
+    def _stop_is_epoch_end(self) -> bool:
+        return False  # reader is count-bounded, a StopIteration means a feeder died
+
+    def _on_break(self):
+        # consumer aborted mid-step, extra sources already advanced, fail safe
+        if len(self._compile_ctx.sources) > 1:
+            self._compile_ctx._teardown()
 
 
-def _prepare_reader_arg(value: Any) -> Any:
-    if isinstance(value, (bool, int, float, str)):
-        return value
-    if isinstance(value, (Tensor, Batch)):
-        if value.device.device_type != "cpu":
-            raise ValueError("GPU arguments inputs are not supported")
-        return dali_types.Constant(np.asarray(as_tensor(value)), layout=value.layout, device="cpu")
-    return dali_types.Constant(value, device="cpu")
+class _ExternalSourceEpochIterator(CompiledEpochIterator["ExternalSource"]):
+    def _tracing(self, ctx: "EvalContext"):
+        es = self._compilable
+        try:
+            first = es._trace_pull(self._compile_ctx, self._compile_ctx.batch_size)
+        except StopIteration:
+            es._teardown_compile()  # empty source: leave the instance unbound and reusable
+            return
+
+        yield from self._emit_step(first)
+
+        self._compile_ctx.build_pipeline(ctx)
+        if self._compile_ctx.state is State.COMPILED:
+            yield from self._compiled()
+            return
+
+        assert self._compile_ctx.state is State.DISABLED
+        # first batch already yielded above; finish the epoch eagerly
+        while True:
+            try:
+                yield es._eager_call(batch_size=self._compile_ctx.batch_size)
+            except StopIteration:
+                return
+
+    def _compiled(self):
+        ctx = self._compile_ctx
+        ctx._reset_stop()
+        while (batches := self._next_batches()) is not None:
+            yield from self._emit_step(batches)
+        assert ctx.pipeline is not None
+        ctx.pipeline.reset()
+
+    def _stop_is_epoch_end(self) -> bool:
+        ctx = self._compile_ctx
+        return ctx.sources[0] in ctx._stopped_sources
+
+    def _on_break(self) -> None:
+        self._compile_ctx._teardown()
+
+
+def make_iterator(compilable: SupportsCompile, batch_size: int) -> CompiledEpochIterator:
+    """Return ``compilable._compiled_iter``, creating it or rejecting a batch_size change"""
+    if compilable._compiled_iter is None:
+        compilable._compiled_iter = compilable._make_epoch_iterator(batch_size)
+    elif compilable._compiled_iter.compile_context.batch_size != batch_size:
+        raise ValueError(
+            f"Cannot change batch_size from "
+            f"{compilable._compiled_iter.compile_context.batch_size} to {batch_size}"
+        )
+    return compilable._compiled_iter
 
 
 @_nvtx_range("Graph Wiring")
-def _wire_compile_graph(
-    reader: "Reader",
-    source: CompileSource,
-    nodes: Sequence[CompileNode],
-) -> None:
+def _wire_compile_graph(sources: Sequence[CompileSource], nodes: Sequence[CompileNode]) -> None:
     """Wire the compile graph into a Pipeline. Must be called inside ``with pipe:``."""
     from ._op_builder import _scalar_decay
 
-    reader_op = reader._legacy_op(name=reader._name, device=reader._backend, **reader._init_args)
-    reader_args = {
-        name: _prepare_reader_arg(value) for name, value in reader._original_tensor_args.items()
-    }
-    reader_out = reader_op(**reader_args)
-    if isinstance(reader_out, dict):
-        assert source.output_keys is not None
-        reader_outs = tuple(reader_out[k] for k in source.output_keys)
-    elif isinstance(reader_out, (tuple, list)):
-        reader_outs = tuple(reader_out)
-    else:
-        reader_outs = (reader_out,)
-    assert len(reader_outs) == source.num_outputs
-
     datanode_map: dict[CompileRef, Any] = {}
-    for i, out in enumerate(reader_outs):
-        datanode_map[CompileRef(source, i)] = out
+    for source in sources:
+        for i, out in enumerate(source.compilable._wire_pipeline(source)):
+            datanode_map[CompileRef(source, i)] = out
 
     for node in nodes:
         positional = [
@@ -541,8 +677,8 @@ def _wire_compile_graph(
             for i, o in enumerate(out):
                 datanode_map[CompileRef(node, i)] = o
 
-    outputs = [datanode_map[CompileRef(source, i)] for i in range(source.num_outputs)]
-    for node in nodes:
+    outputs = []
+    for node in itertools.chain(sources, nodes):
         outputs.extend(datanode_map[CompileRef(node, i)] for i in range(node.num_outputs))
     Pipeline.current().set_outputs(*outputs)
 

--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -176,8 +176,7 @@ class CompileContext:
         self._results: dict[CompileSource | CompileNode, tuple[CompiledBatch, ...]] = {}
         self._iteration = 0
         self._read_this_step: set[CompileSource] = set()  # extra sources pulled this step
-        # Sources that raised StopIteration this step. The root's presence marks a clean epoch end.
-        self._stopped_sources: set[CompileSource] = set()
+        self._root_stopped = False  # sources[0] raised StopIteration: a clean epoch end
 
     @classmethod
     def current(cls) -> "CompileContext | None":
@@ -218,7 +217,7 @@ class CompileContext:
 
     def _wrap_tensor_lists(
         self,
-        source: CompileSource,
+        source: "CompileSource | CompileNode",
         tensor_lists: Sequence,
     ) -> tuple[CompiledBatch, ...]:
         return tuple(
@@ -232,28 +231,32 @@ class CompileContext:
         self._read_this_step.add(source)
 
     def _mark_stopped(self, source: CompileSource) -> None:
-        self._stopped_sources.add(source)
+        if source is self.sources[0]:
+            self._root_stopped = True
 
     def _reset_stop(self) -> None:
-        self._stopped_sources.clear()
+        # Once per epoch, not per step: prefetch can raise the source's StopIteration
+        # one or more run() calls before the step that surfaces it.
+        self._root_stopped = False
 
     def _require_consumed(self) -> None:
         # the executor pulls every source each step, so a skipped one silently drops data
         for source in self.sources[1:]:
             if source not in self._read_this_step:
-                self._teardown()
-                raise RuntimeError("An ExternalSource was not consumed this step")
+                self._fail("An ExternalSource was not consumed this step")
 
     def _teardown(self) -> None:
         self.state = State.DISABLED
         for source in self.sources:
             source.compilable._teardown_compile()
 
+    def _fail(self, message: str):
+        self._teardown()
+        raise RuntimeError(message)
+
     @staticmethod
     def _compute_kwarg_casts(op: type["Operator"], raw_kwargs: Mapping[str, CompiledBatch | Any]):
         casts: dict[str, dali_types.DALIDataType] = {}
-        schema = op._schema
-        assert schema is not None
 
         for name, data in raw_kwargs.items():
             if not isinstance(data, CompiledBatch):
@@ -366,10 +369,8 @@ class CompileContext:
     ) -> tuple[CompiledBatch, ...]:
         offset = owner.pipeline_output_offset
         assert offset is not None
-        return tuple(
-            CompiledBatch(pipeline_outputs[offset + i], CompileRef(owner, i), self._iteration)
-            for i in range(owner.num_outputs)
-        )
+        outputs = pipeline_outputs[offset : offset + owner.num_outputs]
+        return self._wrap_tensor_lists(owner, outputs)
 
     def result_for(self, owner: "CompileSource | CompileNode") -> Any:
         batches = self._results[owner]
@@ -442,10 +443,6 @@ class CompiledEpochIterator(ABC, Generic[_Compilable]):
         self._compile_ctx = CompileContext(batch_size)
         self._eval_ctx: "EvalContext | None" = None
 
-    @property
-    def compile_context(self) -> CompileContext:
-        return self._compile_ctx
-
     def batches(self, ctx: "EvalContext | None") -> Iterator[CompiledBatch]:
         """Yield one epoch: tracing on the first, compiled thereafter."""
         from ._eval_context import EvalContext
@@ -465,10 +462,9 @@ class CompiledEpochIterator(ABC, Generic[_Compilable]):
         try:
             return self._compile_ctx.run_pipeline()
         except StopIteration:
-            if self._stop_is_epoch_end():
+            if self._compile_ctx._root_stopped:
                 return None
-            self._compile_ctx._teardown()
-            raise RuntimeError("A source was exhausted before the iteration ended")
+            self._compile_ctx._fail("A source was exhausted before the iteration ended")
 
     def _emit_step(self, batches):
         ctx = self._compile_ctx
@@ -485,9 +481,6 @@ class CompiledEpochIterator(ABC, Generic[_Compilable]):
 
     @abstractmethod
     def _compiled(self) -> Iterator: ...
-
-    @abstractmethod
-    def _stop_is_epoch_end(self) -> bool: ...
 
     @abstractmethod
     def _on_break(self) -> None: ...
@@ -534,7 +527,7 @@ class _ReaderEpochIterator(CompiledEpochIterator["Reader"]):
             compile_ctx.add_source(len(raw), reader, output_keys=output_keys)
 
         batches = compile_ctx._wrap_tensor_lists(compile_ctx.sources[0], raw)
-        result = batches if output_keys is None else dict(zip(output_keys, batches))
+        result = reader._shape_result(compile_ctx.sources[0], batches)
         return result, reader._output_batch_size(outputs)
 
     def _tracing(self, ctx: "EvalContext"):
@@ -552,8 +545,7 @@ class _ReaderEpochIterator(CompiledEpochIterator["Reader"]):
             return
 
         value, idx = self._trace_step(ctx, tensor_args)  # step 0 records the graph
-        with compile_ctx.active():
-            yield value
+        yield from self._emit_step(value)
 
         compile_ctx.build_pipeline(ctx)
         if compile_ctx.state is State.COMPILED:
@@ -568,7 +560,6 @@ class _ReaderEpochIterator(CompiledEpochIterator["Reader"]):
                 yield value
 
     def _compiled(self):
-        self._compile_ctx._reset_stop()
         epoch_size = self._epoch_size()
         idx = self._resume_idx
         self._resume_idx = 0
@@ -578,9 +569,6 @@ class _ReaderEpochIterator(CompiledEpochIterator["Reader"]):
             assert batches is not None
             idx += self._compilable._output_batch_size(batches)
             yield from self._emit_step(batches)
-
-    def _stop_is_epoch_end(self) -> bool:
-        return False  # reader is count-bounded, a StopIteration means a feeder died
 
     def _on_break(self):
         # consumer aborted mid-step, extra sources already advanced, fail safe
@@ -620,10 +608,6 @@ class _ExternalSourceEpochIterator(CompiledEpochIterator["ExternalSource"]):
         assert ctx.pipeline is not None
         ctx.pipeline.reset()
 
-    def _stop_is_epoch_end(self) -> bool:
-        ctx = self._compile_ctx
-        return ctx.sources[0] in ctx._stopped_sources
-
     def _on_break(self) -> None:
         self._compile_ctx._teardown()
 
@@ -632,10 +616,10 @@ def make_iterator(compilable: SupportsCompile, batch_size: int) -> CompiledEpoch
     """Return ``compilable._compiled_iter``, creating it or rejecting a batch_size change"""
     if compilable._compiled_iter is None:
         compilable._compiled_iter = compilable._make_epoch_iterator(batch_size)
-    elif compilable._compiled_iter.compile_context.batch_size != batch_size:
+    elif compilable._compiled_iter._compile_ctx.batch_size != batch_size:
         raise ValueError(
             f"Cannot change batch_size from "
-            f"{compilable._compiled_iter.compile_context.batch_size} to {batch_size}"
+            f"{compilable._compiled_iter._compile_ctx.batch_size} to {batch_size}"
         )
     return compilable._compiled_iter
 
@@ -708,12 +692,7 @@ def _compile_intercept(
             )
 
         if compile_ctx.state is State.COMPILED:
-            if batch_size is not None and batch_size != compile_ctx.batch_size:
-                raise RuntimeError(
-                    f"Compiled reader uses batch_size={compile_ctx.batch_size} but operator "
-                    f"called with batch_size={batch_size}. Cannot change batch_size in "
-                    f"compiled mode."
-                )
+            compile_ctx.check_batch_size(batch_size)
             result = compile_ctx.get_compiled_result(
                 frame, op_class, inputs, raw_kwargs, device=device
             )

--- a/dali/python/nvidia/dali/experimental/dynamic/_external_source.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_external_source.py
@@ -12,20 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import enum
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Literal, TypeAlias, cast, TypeGuard
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeGuard, cast
+
+from nvidia.dali import fn
 
 from ..._typing import BatchLike
 from ..._utils.external_source_impl import get_callback_from_source
+from . import _compile
 from ._batch import Batch, _get_batch_size, as_batch
 from ._device import DeviceLike
+from ._device import device as _as_device
 from ._nvtx import NVTXRange
 from ._tensor import Tensor, as_tensor
 from ._type import DTypeLike
 
-# Note: TensorLike <: BatchLike
+if TYPE_CHECKING:
+    from ._eval_context import EvalContext
+
 _SourceOutput: TypeAlias = BatchLike | Sequence[BatchLike]
 SourceType: TypeAlias = Callable[[], _SourceOutput] | Iterable[_SourceOutput]
+
+_CallResult: TypeAlias = Tensor | Batch | tuple[Tensor, ...] | tuple[Batch, ...]
+
+
+class _Role(enum.Enum):
+    UNUSED = enum.auto()
+    EAGER = enum.auto()
+    FEEDER = enum.auto()  # pulled inside another source's compiled loop
+    ROOT = enum.auto()  # iterated through its own .compiled()
+
+    @property
+    def is_compiled(self) -> bool:
+        return self in (_Role.FEEDER, _Role.ROOT)
 
 
 # We don't inherit from _ops.Operator because there's nothing to reuse from there
@@ -127,14 +147,16 @@ class ExternalSource:
         if num_outputs <= 0:
             raise ValueError("num_outputs must be strictly positive")
         self._num_outputs = num_outputs
-        self._device = device
+        self._device = _as_device(device)
         self._layouts = self._broadcast_arg(layout)
         self._dtypes = self._broadcast_arg(dtype)
 
+        self._role = _Role.UNUSED
+        self._compile_source: _compile.CompileSource | None = None
+        self._compiled_iter: _compile.CompiledEpochIterator | None = None
+
     @NVTXRange("__call__: ExternalSource", category="op_builder")
-    def __call__(
-        self, *, batch_size: int | None = None
-    ) -> Tensor | Batch | tuple[Tensor, ...] | tuple[Batch, ...]:
+    def __call__(self, *, batch_size: int | None = None) -> _CallResult:
         """Consume one item from the source.
 
         Parameters
@@ -153,17 +175,132 @@ class ExternalSource:
         StopIteration
             When the source is exhausted, depending on the ``cycle`` argument.
         """
-        outputs = self._get_outputs(self._callback())
+        ctx = _compile.CompileContext.current()
+        if ctx is None:
+            if self._role.is_compiled:
+                raise RuntimeError("This ExternalSource is already used in a compiled loop")
+            self._role = _Role.EAGER
+            return self._eager_call(batch_size=batch_size)
+
+        if self._role is _Role.EAGER:
+            raise RuntimeError("This ExternalSource was already used eagerly")
+        if self._role is _Role.ROOT:
+            raise RuntimeError("Instance already used through .compiled() method")
+
+        if ctx.state is _compile.State.TRACING:
+            result = self._trace_pull(ctx, batch_size)
+            self._role = _Role.FEEDER
+            return result
+        return self._compiled_call(ctx, batch_size)
+
+    def compiled(self, batch_size: int, ctx: "EvalContext | None" = None):
+        """Iterate one epoch with this source as the compiled graph's root.
+
+        ``ExternalSource`` equivalent of :meth:`Reader.next_epoch` with ``compile=True``.
+
+        Any other ``ExternalSource`` called inside the loop must be consumed exactly once per step.
+        They are prefetched, so they are polled ahead of the loop body and breaking out may discard
+        already-pulled items.
+        """
+        if self._role is _Role.EAGER:
+            raise RuntimeError("This ExternalSource was already used eagerly")
+        if self._role is _Role.FEEDER:
+            raise RuntimeError("Instance already used through __call__")
+
+        iterator = _compile.make_iterator(self, batch_size)
+        self._role = _Role.ROOT
+        return iterator.batches(ctx)
+
+    def _unwrap(self, outputs: tuple[Tensor, ...] | tuple[Batch, ...]) -> _CallResult:
+        return outputs[0] if self._num_outputs == 1 else outputs
+
+    def _eager_call(self, *, batch_size: int | None = None) -> _CallResult:
+        data = self._callback()
+        outputs = self._convert_outputs(data, batch_size)
+        return self._unwrap(outputs)
+
+    def _trace_pull(self, ctx: _compile.CompileContext, batch_size: int | None) -> _CallResult:
+        """Pull, convert and wrap one item during tracing, registering the root on first use."""
+        src = self._compile_source
+        if src is not None and src.ctx is not ctx:
+            raise RuntimeError("Already bound to a different compile context.")
+
+        ctx.check_batch_size(batch_size)
+        # pull before registering: an empty source raises here, leaving nothing half-bound
+        try:
+            data = self._callback()
+            tensor_lists = self._to_tensor_lists(data, ctx.batch_size)
+        except Exception:
+            self._teardown_compile()
+            raise
+
+        if src is None:
+            src = self._compile_source = ctx.add_source(self._num_outputs, self)
+        ctx._mark_read(src)
+        return self._unwrap(ctx._wrap_tensor_lists(src, tensor_lists))
+
+    def _compiled_call(self, ctx: _compile.CompileContext, batch_size: int | None) -> _CallResult:
+        src = self._compile_source
+        if src is None or src.ctx is not ctx:
+            ctx._teardown()
+            raise RuntimeError("ExternalSource wasn't seen during tracing")
+
+        ctx.check_batch_size(batch_size)
+        ctx._mark_read(src)
+        return ctx.result_for(src)
+
+    def _source_callback(self):
+        """``fn.external_source``'s ``source`` callback: pull, convert, return TensorList(s)"""
+        src = self._compile_source
+        assert src is not None
+        try:
+            data = self._callback()
+        except StopIteration:
+            src.ctx._mark_stopped(src)  # lets the loop tell a clean epoch end from underrun
+            raise
+        tensor_lists = self._to_tensor_lists(data, src.ctx.batch_size)
+        return tensor_lists[0] if self._num_outputs == 1 else list(tensor_lists)
+
+    def _to_tensor_lists(self, data: _SourceOutput, batch_size: int) -> tuple:
+        outputs = self._convert_outputs(data, batch_size)
+        return tuple(output.evaluate()._storage for output in outputs)
+
+    def _teardown_compile(self):
+        self._role = _Role.UNUSED
+        self._compile_source = None
+        self._compiled_iter = None
+
+    def _wire_pipeline(self, source: "_compile.CompileSource") -> tuple:
+        device = self._device.device_type
+        if source.num_outputs == 1:
+            return (fn.external_source(self._source_callback, device=device),)
+        out = fn.external_source(self._source_callback, source.num_outputs, device=device)
+        return tuple(out)
+
+    def _shape_result(self, source, batches: tuple):
+        return self._unwrap(batches)
+
+    def _transfer_into(self, pipe) -> bool:
+        return False  # an ExternalSource holds no native op to move into a pipeline
+
+    def _make_epoch_iterator(self, batch_size: int) -> "_compile.CompiledEpochIterator":
+        return _compile._ExternalSourceEpochIterator(self, batch_size)
+
+    def _convert_outputs(
+        self, data: _SourceOutput, batch_size: int | None
+    ) -> tuple[Tensor, ...] | tuple[Batch, ...]:
+        """Convert the source's outputs, requiring them uniformly Tensors or uniformly Batches."""
+        outputs = self._get_outputs(data)
         results = tuple(
             self._convert_output(output, batch_size, idx) for idx, output in enumerate(outputs)
         )
         if not _are_types_uniform(results):
             raise TypeError("Outputs must be uniformly Tensors or uniformly Batches")
-        return results[0] if self._num_outputs == 1 else results
+        return results
 
     def _get_outputs(self, data: _SourceOutput) -> Sequence[BatchLike]:
         if self._num_outputs == 1:
-            return (cast(BatchLike, data),)
+            return (data,)  # type: ignore
         if not isinstance(data, Sequence) or len(data) != self._num_outputs:
             raise ValueError(f"Expected {self._num_outputs} outputs from the source")
         return data  # type: ignore

--- a/dali/python/nvidia/dali/experimental/dynamic/_external_source.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_external_source.py
@@ -147,7 +147,7 @@ class ExternalSource:
         if num_outputs <= 0:
             raise ValueError("num_outputs must be strictly positive")
         self._num_outputs = num_outputs
-        self._device = _as_device(device)
+        self._device = device
         self._layouts = self._broadcast_arg(layout)
         self._dtypes = self._broadcast_arg(dtype)
 
@@ -271,7 +271,7 @@ class ExternalSource:
         self._compiled_iter = None
 
     def _wire_pipeline(self, source: "_compile.CompileSource") -> tuple:
-        device = self._device.device_type
+        device = _as_device(self._device).device_type
         if source.num_outputs == 1:
             return (fn.external_source(self._source_callback, device=device),)
         out = fn.external_source(self._source_callback, source.num_outputs, device=device)
@@ -308,15 +308,16 @@ class ExternalSource:
     def _convert_output(self, data: BatchLike, batch_size: int | None, idx: int) -> Tensor | Batch:
         layout = self._layouts[idx]
         dtype = self._dtypes[idx]
+        device = _as_device(self._device)
 
         actual_batch_size = _get_batch_size(data)
         if actual_batch_size is not None:
-            batch = as_batch(data, dtype=dtype, device=self._device, layout=layout)
+            batch = as_batch(data, dtype=dtype, device=device, layout=layout)
             if batch_size is not None and actual_batch_size != batch_size:
                 raise ValueError(f"Expected batch size {batch_size}, got {actual_batch_size}")
             return batch
 
-        tensor = as_tensor(data, dtype=dtype, device=self._device, layout=layout)
+        tensor = as_tensor(data, dtype=dtype, device=device, layout=layout)
         if batch_size is not None:
             return Batch.broadcast(tensor, batch_size=batch_size)
         return tensor

--- a/dali/python/nvidia/dali/experimental/dynamic/_external_source.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_external_source.py
@@ -22,7 +22,7 @@ from ..._typing import BatchLike
 from ..._utils.external_source_impl import get_callback_from_source
 from . import _compile
 from ._batch import Batch, _get_batch_size, as_batch
-from ._device import DeviceLike
+from ._device import Device, DeviceLike
 from ._device import device as _as_device
 from ._nvtx import NVTXRange
 from ._tensor import Tensor, as_tensor
@@ -42,10 +42,6 @@ class _Role(enum.Enum):
     EAGER = enum.auto()
     FEEDER = enum.auto()  # pulled inside another source's compiled loop
     ROOT = enum.auto()  # iterated through its own .compiled()
-
-    @property
-    def is_compiled(self) -> bool:
-        return self in (_Role.FEEDER, _Role.ROOT)
 
 
 # We don't inherit from _ops.Operator because there's nothing to reuse from there
@@ -181,8 +177,8 @@ class ExternalSource:
         # - while executing a compiled context, return the traced feeder's result
 
         ctx = _compile.CompileContext.current()
-        if ctx is None:
-            if self._role.is_compiled:
+        if ctx is None or ctx.state is _compile.State.DISABLED:
+            if self._role in (_Role.FEEDER, _Role.ROOT):
                 raise RuntimeError("This ExternalSource is already used in a compiled loop")
             self._role = _Role.EAGER
             return self._eager_call(batch_size=batch_size)
@@ -216,13 +212,10 @@ class ExternalSource:
         self._role = _Role.ROOT
         return iterator.batches(ctx)
 
-    def _unwrap(self, outputs: tuple[Tensor, ...] | tuple[Batch, ...]) -> _CallResult:
-        return outputs[0] if self._num_outputs == 1 else outputs
-
     def _eager_call(self, *, batch_size: int | None = None) -> _CallResult:
         data = self._callback()
         outputs = self._convert_outputs(data, batch_size)
-        return self._unwrap(outputs)
+        return self._shape_result(..., outputs)
 
     def _trace_pull(self, ctx: _compile.CompileContext, batch_size: int | None) -> _CallResult:
         """Pull, convert and wrap one item during tracing, registering the root on first use."""
@@ -242,7 +235,7 @@ class ExternalSource:
         if src is None:
             src = self._compile_source = ctx.add_source(self._num_outputs, self)
         ctx._mark_read(src)
-        return self._unwrap(ctx._wrap_tensor_lists(src, tensor_lists))
+        return self._shape_result(src, ctx._wrap_tensor_lists(src, tensor_lists))
 
     def _compiled_call(self, ctx: _compile.CompileContext, batch_size: int | None) -> _CallResult:
         src = self._compile_source
@@ -263,8 +256,7 @@ class ExternalSource:
         except StopIteration:
             src.ctx._mark_stopped(src)  # lets the loop tell a clean epoch end from underrun
             raise
-        tensor_lists = self._to_tensor_lists(data, src.ctx.batch_size)
-        return tensor_lists[0] if self._num_outputs == 1 else list(tensor_lists)
+        return list(self._to_tensor_lists(data, src.ctx.batch_size))
 
     def _to_tensor_lists(self, data: _SourceOutput, batch_size: int) -> tuple:
         outputs = self._convert_outputs(data, batch_size)
@@ -277,13 +269,10 @@ class ExternalSource:
 
     def _wire_pipeline(self, source: "_compile.CompileSource") -> tuple:
         device = _as_device(self._device).device_type
-        if source.num_outputs == 1:
-            return (fn.external_source(self._source_callback, device=device),)
-        out = fn.external_source(self._source_callback, source.num_outputs, device=device)
-        return tuple(out)
+        return tuple(fn.external_source(self._source_callback, source.num_outputs, device=device))
 
-    def _shape_result(self, source, batches: tuple):
-        return self._unwrap(batches)
+    def _shape_result(self, source, batches: tuple) -> _CallResult:
+        return batches[0] if self._num_outputs == 1 else batches
 
     def _transfer_into(self, pipe) -> bool:
         return False  # an ExternalSource holds no native op to move into a pipeline
@@ -296,8 +285,10 @@ class ExternalSource:
     ) -> tuple[Tensor, ...] | tuple[Batch, ...]:
         """Convert the source's outputs, requiring them uniformly Tensors or uniformly Batches."""
         outputs = self._get_outputs(data)
+        device = _as_device(self._device)
         results = tuple(
-            self._convert_output(output, batch_size, idx) for idx, output in enumerate(outputs)
+            self._convert_output(output, device, batch_size, idx)
+            for idx, output in enumerate(outputs)
         )
         if not _are_types_uniform(results):
             raise TypeError("Outputs must be uniformly Tensors or uniformly Batches")
@@ -310,10 +301,11 @@ class ExternalSource:
             raise ValueError(f"Expected {self._num_outputs} outputs from the source")
         return data  # type: ignore
 
-    def _convert_output(self, data: BatchLike, batch_size: int | None, idx: int) -> Tensor | Batch:
+    def _convert_output(
+        self, data: BatchLike, device: Device, batch_size: int | None, idx: int
+    ) -> Tensor | Batch:
         layout = self._layouts[idx]
         dtype = self._dtypes[idx]
-        device = _as_device(self._device)
 
         actual_batch_size = _get_batch_size(data)
         if actual_batch_size is not None:

--- a/dali/python/nvidia/dali/experimental/dynamic/_external_source.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_external_source.py
@@ -175,6 +175,11 @@ class ExternalSource:
         StopIteration
             When the source is exhausted, depending on the ``cycle`` argument.
         """
+        # Valid dispatch paths:
+        # - without a compile context, run eagerly
+        # - while tracing, pull and register the source as a feeder
+        # - while executing a compiled context, return the traced feeder's result
+
         ctx = _compile.CompileContext.current()
         if ctx is None:
             if self._role.is_compiled:

--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -15,10 +15,10 @@
 import copy
 
 import makefun
+
 import nvidia.dali.backend as _b
 import nvidia.dali.ops as _legacy_ops
 import nvidia.dali.types
-from ._nvtx import NVTXRange
 from nvidia.dali import internal as _internal
 from nvidia.dali.fn import _to_snake_case
 from nvidia.dali.ops import _docs, _names
@@ -28,7 +28,9 @@ from ._batch import Batch
 from ._call_site import mark_transparent, resolve_callsite_frame
 from ._compile import _compile_intercept
 from ._eval_mode import EvalMode
-from ._tensor import Tensor, tensor as to_tensor
+from ._nvtx import NVTXRange
+from ._tensor import Tensor
+from ._tensor import tensor as to_tensor
 
 
 def is_external(x):
@@ -216,7 +218,6 @@ def build_constructor(schema, op_class):
             actual_tensor_arg_names = {
                 arg_name for arg_name in tensor_arg_names if kwargs.get(arg_name) is not None
             }
-            original_tensor_args = {}
             tensor_args = {}
             for arg_name in tensor_arg_names:
                 arg = kwargs.get(arg_name)
@@ -224,21 +225,18 @@ def build_constructor(schema, op_class):
                     continue
                 if isinstance(arg, Batch):
                     raise ValueError("Readers cannot be constructed with batch keyword arguments")
-                original_arg = arg
                 dtype = op_class._argument_conversion_map[arg_name]
                 arg = _promote_0d_cpu_tensor(to_tensor(arg, dtype=dtype))
                 if isinstance(arg, (int, float, bool, str)):
                     kwargs[arg_name] = arg
                     continue
                 del kwargs[arg_name]
-                original_tensor_args[arg_name] = original_arg
                 tensor_args[arg_name] = arg
         kwargs = {k: _scalar_decay(v) for k, v in kwargs.items()}
         op_class.__base__.__init__(self, max_batch_size, name, **kwargs)
         if is_reader:  # Need to be done here not to be overridden by the constructor
             self._tensor_arg_names = actual_tensor_arg_names
             self._raw_tensor_args = tensor_args
-            self._original_tensor_args = original_tensor_args
         if stateful:
             self._call_id = 0
 

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -940,12 +940,15 @@ class Reader(Operator):
                 "Cannot mix `samples`, `batches` and `_run`/`__call__` on the same reader."
             )
 
-    def _run_unchecked(self, ctx=None, **kwargs):
-        """Run the reader backend without API-type checking."""
+    def _check_not_disabled(self):
         if self._disabled:
             raise RuntimeError(
                 "This reader is in an invalid state due to a previous error and cannot be used."
             )
+
+    def _run_unchecked(self, ctx=None, **kwargs):
+        """Run the reader backend without API-type checking."""
+        self._check_not_disabled()
         return super()._run(ctx, **kwargs)
 
     @staticmethod
@@ -994,14 +997,9 @@ class Reader(Operator):
             If True, transparently compile operator sequences into a pipeline for prefetching.
             Once used in compiled mode, the reader cannot switch back.
         """
-        if self._disabled:
-            raise RuntimeError(
-                "This reader is in an invalid state due to a previous error and cannot be used."
-            )
+        self._check_not_disabled()
 
         batch_size = self._get_batch_size(batch_size)
-        if batch_size is None:
-            batch_size = self._batch_size
 
         if compile:
             if self._checkpointing_enabled:
@@ -1016,21 +1014,18 @@ class Reader(Operator):
             if batch_size is None:
                 raise ValueError("compile=True requires a non-None batch_size.")
             self._compile_mode = True
-            _compile.make_iterator(self, batch_size)
-        elif self._compile_mode is True:
+            return _compile.make_iterator(self, batch_size).batches(ctx)
+
+        if self._compile_mode is True:
             raise RuntimeError(
                 "This reader was previously used with compile=True "
                 "and cannot switch to non-compiled mode."
             )
-        else:
-            self._compile_mode = False
+        self._compile_mode = False
 
-        if self._compiled_iter is not None:
-            return self._compiled_iter.batches(ctx)
-        elif batch_size is not None:
+        if batch_size is not None:
             return self._batches(batch_size, ctx)
-        else:
-            return self._samples(ctx)
+        return self._samples(ctx)
 
     def _process_tensor_args(self, batch_size: int | None):
         """Converts stored tensor args to Batch/Tensor form for the given batch_size."""

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -12,20 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
+import math
+from threading import Lock
 from typing import TypedDict
 
-import base64
+import numpy as np
 
 import nvidia.dali as dali
 import nvidia.dali.backend_impl as _b
-import math
-from . import _eval_context, _invocation, _device, _type, _compile
-from ._batch import Batch, as_batch as _as_batch, _get_batch_size
-from ._device import Device, DeviceLike
-from ._tensor import Tensor
 
+from . import _compile, _device, _eval_context, _invocation, _type
+from ._batch import Batch, _get_batch_size
+from ._batch import as_batch as _as_batch
+from ._device import Device, DeviceLike
 from ._nvtx import NVTXRange
-from threading import Lock
+from ._tensor import Tensor, as_tensor
 
 _nvtx_to_tensor = NVTXRange("to_tensor", category="op_builder")
 
@@ -641,6 +643,17 @@ class Operator:
             return type_name
 
 
+def _wire_arg(value):
+    """Convert a stored reader argument into a pipeline-ready constant DataNode."""
+    if isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (Tensor, Batch)):
+        if value.device.device_type != "cpu":
+            raise ValueError("GPU arguments are not supported")
+        return dali.types.Constant(np.asarray(as_tensor(value)), layout=value.layout, device="cpu")
+    return dali.types.Constant(value, device="cpu")
+
+
 # Defaults used by Reader for sharding; must match Reader.__init__ normalization.
 _READER_SHARD_DEFAULTS = {"shard_id": 0, "num_shards": 1, "stick_to_shard": False}
 
@@ -699,7 +712,7 @@ class Reader(Operator):
             name = f"Reader_{id(self)}"
         self._actual_batch_size = batch_size
         self._batch_size = batch_size
-        self._compiled_iter = None
+        self._compiled_iter: "_compile.CompiledEpochIterator | None" = None
         self._compile_mode: bool | None = None
         self._checkpointing_enabled = enable_checkpointing
         device = _device.device(device)
@@ -715,7 +728,6 @@ class Reader(Operator):
         )
 
         self._raw_tensor_args = {}
-        self._original_tensor_args = {}  # Used when compile=True
         self._tensor_args = {}
         # Used to know when to recompute _tensor_args for _raw_tensor_args
         self._previous_batch_size: int | None = None
@@ -725,6 +737,8 @@ class Reader(Operator):
         self._pending_state = None
         # If set, the reader is in an invalid state and cannot be used
         self._disabled = False
+        # If set, the reader's op was transferred into a compiled pipeline
+        self._transferred = False
 
         if self._num_shards < 1:
             raise ValueError(
@@ -881,6 +895,42 @@ class Reader(Operator):
         if not self._stick_to_shard:
             self._shard_id = (self._shard_id + 1) % self._num_shards
 
+    def _teardown_compile(self) -> None:
+        """Tear down compile bindings. Reader is unrecoverable after transfer."""
+        self._compile_mode = None
+        self._compiled_iter = None
+        if self._transferred:
+            self._disabled = True
+
+    def _wire_pipeline(self, source: "_compile.CompileSource") -> tuple:
+        """Build the reader's pipeline outputs from its operator instance."""
+        op = self._legacy_op(name=self._name, device=self._backend, **self._init_args)
+        out = op(**{name: _wire_arg(value) for name, value in self._raw_tensor_args.items()})
+
+        if isinstance(out, dict):
+            assert source.output_keys is not None
+            outs = tuple(out[k] for k in source.output_keys)
+        elif isinstance(out, (tuple, list)):
+            outs = tuple(out)
+        else:
+            outs = (out,)
+        assert len(outs) == source.num_outputs
+        return outs
+
+    def _shape_result(self, source: "_compile.CompileSource", batches: tuple):
+        if source.output_keys is not None:
+            return dict(zip(source.output_keys, batches))
+        return batches
+
+    def _transfer_into(self, pipe: dali.Pipeline) -> bool:
+        assert self._op_backend is not None
+        pipe._transfer_operator(self._name, self._op_backend)
+        self._transferred = True
+        return True
+
+    def _make_epoch_iterator(self, batch_size: int) -> "_compile.CompiledEpochIterator":
+        return _compile._ReaderEpochIterator(self, batch_size)
+
     def _require_api_type(self, api_type: str) -> None:
         """Set the API type if unset, or raise if it conflicts with a previous choice."""
         if self._api_type is None:
@@ -894,7 +944,7 @@ class Reader(Operator):
         """Run the reader backend without API-type checking."""
         if self._disabled:
             raise RuntimeError(
-                "This reader is in an invalidate state due to a previous error and cannot be used."
+                "This reader is in an invalid state due to a previous error and cannot be used."
             )
         return super()._run(ctx, **kwargs)
 
@@ -946,7 +996,7 @@ class Reader(Operator):
         """
         if self._disabled:
             raise RuntimeError(
-                "This reader is in an invalidate state due to a previous error and cannot be used."
+                "This reader is in an invalid state due to a previous error and cannot be used."
             )
 
         batch_size = self._get_batch_size(batch_size)
@@ -966,14 +1016,7 @@ class Reader(Operator):
             if batch_size is None:
                 raise ValueError("compile=True requires a non-None batch_size.")
             self._compile_mode = True
-            if self._compiled_iter is None:
-                self._compiled_iter = _compile.CompiledEpochIterator(self, batch_size)
-            elif self._compiled_iter.compile_context.batch_size != batch_size:
-                raise ValueError(
-                    f"Cannot change batch_size from "
-                    f"{self._compiled_iter.compile_context.batch_size} to {batch_size} "
-                    f"in compiled mode."
-                )
+            _compile.make_iterator(self, batch_size)
         elif self._compile_mode is True:
             raise RuntimeError(
                 "This reader was previously used with compile=True "

--- a/dali/test/python/experimental_mode/ndd_utils.py
+++ b/dali/test/python/experimental_mode/ndd_utils.py
@@ -16,14 +16,15 @@ import ctypes
 import functools
 import itertools
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeGuard
+
+from nose_utils import SkipTest
 
 import nvidia.dali.experimental.dynamic as ndd
-from nose_utils import SkipTest
 from nvidia.dali.experimental.dynamic._compile import CompiledBatch
 
 
-def _is_compiled(batch):
+def _is_compiled(batch) -> TypeGuard[CompiledBatch]:
     return isinstance(batch, CompiledBatch)
 
 

--- a/dali/test/python/experimental_mode/test_compile.py
+++ b/dali/test/python/experimental_mode/test_compile.py
@@ -309,7 +309,7 @@ def test_compile_batch_size_op_mismatch():
         images = ndd.decoders.image(jpegs)
         ndd.resize(images, size=[64, 64])
 
-    with assert_raises(RuntimeError, glob="*cannot change batch_size*"):
+    with assert_raises(RuntimeError, glob="cannot change batch size"):
         for jpegs, _ in reader.next_epoch(batch_size=4, compile=True):
             ndd.resize(ndd.decoders.image(jpegs), size=[64, 64], batch_size=8)
 

--- a/dali/test/python/experimental_mode/test_compile.py
+++ b/dali/test/python/experimental_mode/test_compile.py
@@ -399,10 +399,8 @@ def test_reader_constructor_promotes_0d_tensor_args_to_scalars():
     assert reader._init_args["roi_start"] == 0
     assert "roi_start" in reader._tensor_arg_names
     assert "roi_start" not in reader._raw_tensor_args
-    assert "roi_start" not in reader._original_tensor_args
     assert "roi_shape" in reader._tensor_arg_names
     assert "roi_shape" in reader._raw_tensor_args
-    assert "roi_shape" in reader._original_tensor_args
 
 
 def test_compile_incompatible_kwarg_dtype():

--- a/dali/test/python/experimental_mode/test_compile.py
+++ b/dali/test/python/experimental_mode/test_compile.py
@@ -12,18 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import os
 import sys
 
 import numpy as np
-import nvidia.dali.backend_impl as _backend
-import nvidia.dali.experimental.dynamic as ndd
 from ndd_utils import _is_compiled, eval_modes
+from nose2.tools import params
 from nose_utils import SkipTest, assert_raises, assert_warns
 from test_utils import get_dali_extra_path
 
+import nvidia.dali.backend_impl as _backend
+import nvidia.dali.experimental.dynamic as ndd
+
 dali_extra_path = get_dali_extra_path()
 images_root = os.path.join(dali_extra_path, "db", "single", "jpeg")
+
+
+def _assert_parity(expected, actual):
+    """Assert two result lists match element-wise; lengths must be equal."""
+    for e, a in zip(expected, actual, strict=True):
+        np.testing.assert_array_equal(e, a)
 
 
 def test_compile_mode_stickiness():
@@ -82,8 +91,7 @@ def test_compile_basic_pipeline():
         compiled_results.append(ndd.as_tensor(images))
         assert _is_compiled(images)
 
-    for dyn, comp in zip(dynamic_results, compiled_results, strict=True):
-        np.testing.assert_array_equal(dyn, comp)
+    _assert_parity(dynamic_results, compiled_results)
 
 
 @eval_modes()
@@ -132,8 +140,7 @@ def test_compile_different_ops_same_call_site():
                 assert _is_compiled(out)
                 compiled_results.append(ndd.as_tensor(out, pad=True))
 
-        for dyn, comp in zip(dynamic_results, compiled_results, strict=True):
-            np.testing.assert_array_equal(dyn, comp)
+        _assert_parity(dynamic_results, compiled_results)
 
 
 @eval_modes()
@@ -157,8 +164,7 @@ def test_compile_partial():
         assert not _is_compiled(resized)
         compiled_results.append(ndd.as_tensor(resized))
 
-    for dyn, comp in zip(dynamic_results, compiled_results, strict=True):
-        np.testing.assert_array_equal(dyn, comp)
+    _assert_parity(dynamic_results, compiled_results)
 
 
 @eval_modes()
@@ -177,8 +183,7 @@ def test_compile_multi_epoch():
             images = ndd.decoders.image(jpegs)
             assert _is_compiled(images)
             compiled_results.append(ndd.as_tensor(images, pad=True))
-        for dyn, comp in zip(dynamic_results, compiled_results, strict=True):
-            np.testing.assert_array_equal(dyn, comp)
+        _assert_parity(dynamic_results, compiled_results)
 
 
 def test_compile_shard_rotation():
@@ -225,8 +230,7 @@ def test_compile_loop_identical():
             assert _is_compiled(resized)
         compiled_results.append(ndd.as_tensor(resized))
 
-    for dyn, comp in zip(dynamic_results, compiled_results, strict=True):
-        np.testing.assert_array_equal(dyn, comp)
+    _assert_parity(dynamic_results, compiled_results)
 
 
 @eval_modes()
@@ -249,8 +253,7 @@ def test_compile_loop_data_dependent():
             assert _is_compiled(images) == (i == 0)
         compiled_results.append(ndd.as_tensor(images))
 
-    for dyn, comp in zip(dynamic_results, compiled_results, strict=True):
-        np.testing.assert_array_equal(dyn, comp)
+    _assert_parity(dynamic_results, compiled_results)
 
 
 def test_compile_empty_graph():
@@ -287,8 +290,7 @@ def test_compile_diverging_inputs():
         assert _is_compiled(images) == (i % 2 == 0)
         compiled_results.append(ndd.as_tensor(images))
 
-    for dyn, comp in zip(dynamic_results, compiled_results, strict=True):
-        np.testing.assert_array_equal(dyn, comp)
+    _assert_parity(dynamic_results, compiled_results)
 
 
 def test_compile_batch_size_change_between_epochs():
@@ -363,18 +365,19 @@ def _test_video_resize(**resize_args):
     reader_comp = _make_video_reader(**resize_args)
 
     dynamic_results = []
-    for (videos,) in reader_dyn.next_epoch(batch_size=4):
-        rotated = ndd.rotate(videos, angle=60)
-        dynamic_results.append(ndd.as_tensor(rotated).cpu())
+    for _ in range(3):
+        for (videos,) in reader_dyn.next_epoch(batch_size=4):
+            rotated = ndd.rotate(videos, angle=60)
+            dynamic_results.append(ndd.as_tensor(rotated).cpu())
 
     compiled_results = []
-    for (videos,) in reader_comp.next_epoch(batch_size=4, compile=True):
-        rotated = ndd.rotate(videos, angle=60)
-        assert _is_compiled(rotated)
-        compiled_results.append(ndd.as_tensor(rotated).cpu())
+    for _ in range(3):
+        for (videos,) in reader_comp.next_epoch(batch_size=4, compile=True):
+            rotated = ndd.rotate(videos, angle=60)
+            assert _is_compiled(rotated)
+            compiled_results.append(ndd.as_tensor(rotated).cpu())
 
-    for dyn, comp in zip(dynamic_results, compiled_results, strict=True):
-        np.testing.assert_array_equal(dyn, comp)
+    _assert_parity(dynamic_results, compiled_results)
 
 
 def test_compile_tensor_arg():
@@ -423,8 +426,7 @@ def test_compile_incompatible_kwarg_dtype():
         assert _is_compiled(resized), resized
         compiled_results.append(ndd.as_tensor(resized, pad=True).cpu())
 
-    for dyn, comp in zip(dynamic_results, compiled_results, strict=True):
-        np.testing.assert_array_equal(dyn, comp)
+    _assert_parity(dynamic_results, compiled_results)
 
 
 def test_compile_nested_calls():
@@ -464,3 +466,411 @@ def test_compile_multiline_nested_calls():
             size=[64, 64],
         )
         assert _is_compiled(resized)
+
+
+def _es(n_batches: int, batch_size: int, dim=3, **kwargs):
+    """Finite (or cycling) ExternalSource of `n_batches` batches, distinct value per sample."""
+    batches = [
+        ndd.batch(
+            [np.full((dim,), b * batch_size + s, dtype=np.float32) for s in range(batch_size)]
+        )
+        for b in range(n_batches)
+    ]
+    return ndd.ExternalSource(batches, **kwargs)
+
+
+def _const_es(sample, batch_size: int):
+    """Infinite callable ExternalSource returning a batch of `sample` each call."""
+    sample = np.asarray(sample, dtype=np.float32)
+    return ndd.ExternalSource(lambda: ndd.batch([sample] * batch_size))
+
+
+@eval_modes()
+def test_compile_es_basic():
+    es_dyn = _es(3, batch_size=4)
+    es_comp = _es(3, batch_size=4)
+
+    dynamic_results = []
+    for _ in range(3):
+        out = ndd.cast(es_dyn(), dtype=ndd.int32)
+        assert not _is_compiled(out)
+        dynamic_results.append(ndd.as_tensor(out))
+
+    compiled_results = []
+    for batch in es_comp.compiled(batch_size=4):
+        assert _is_compiled(batch)
+        out = ndd.cast(batch, dtype=ndd.int32)
+        assert _is_compiled(out)
+        compiled_results.append(ndd.as_tensor(out))
+
+    assert len(compiled_results) == 3
+    _assert_parity(dynamic_results, compiled_results)
+
+
+def test_compile_es_cycle_raise():
+    es_dyn = _es(2, cycle="raise", batch_size=4)
+    es_comp = _es(2, cycle="raise", batch_size=4)
+
+    expected = []
+    try:
+        while True:
+            expected.append(ndd.as_tensor(ndd.cast(es_dyn(), dtype=ndd.int32)))
+    except StopIteration:
+        pass
+
+    for _ in range(3):
+        compiled_results = []
+        for batch in es_comp.compiled(batch_size=4):
+            assert _is_compiled(batch)
+            compiled_results.append(ndd.as_tensor(ndd.cast(batch, dtype=ndd.int32)))
+
+        assert len(compiled_results) == 2
+        _assert_parity(expected, compiled_results)
+
+
+def test_compile_es_cycle_no():
+    es = _es(3, cycle="no", batch_size=4)
+    batches = []
+    for batch in es.compiled(batch_size=4):
+        ndd.cast(batch, dtype=ndd.int32)
+        assert _is_compiled(batch)
+        batches.append(batch)
+    assert len(batches) == 3
+
+    # The source is exhausted, a subsequent epoch yields nothing.
+    second = []
+    for batch in es.compiled(batch_size=4):
+        ndd.cast(batch, dtype=ndd.int32)
+        second.append(batch)
+    assert second == []
+
+
+def test_compile_es_multi_output():
+    data = [
+        (
+            ndd.batch([np.full((2,), float(i), np.float32)] * 4),
+            ndd.batch([np.full((3,), float(i + 10), np.float32)] * 4),
+        )
+        for i in range(2)
+    ]
+    es = ndd.ExternalSource(data, num_outputs=2)
+    count = 0
+    for outputs in es.compiled(batch_size=4):
+        assert isinstance(outputs, tuple) and len(outputs) == 2
+        a, b = outputs
+        assert _is_compiled(a) and _is_compiled(b)
+        np.testing.assert_array_equal(ndd.as_tensor(a)[0], [count, count])
+        np.testing.assert_array_equal(ndd.as_tensor(b)[0], [count + 10] * 3)
+        ndd.cast(a, dtype=ndd.float32)
+        ndd.cast(b, dtype=ndd.float32)
+        count += 1
+    assert count == 2
+
+
+def test_compile_es_broadcast():
+    es = ndd.ExternalSource(lambda: np.arange(3, dtype=np.float32))
+    expected = np.broadcast_to(np.arange(3, dtype=np.float32), (4, 3))
+    count = 0
+    for batch in es.compiled(batch_size=4):
+        assert batch.batch_size == 4
+        np.testing.assert_array_equal(ndd.as_tensor(batch), expected)
+        ndd.cast(batch, dtype=ndd.float32)
+        count += 1
+        if count >= 2:  # check both the traced and a compiled batch
+            break
+    assert count == 2
+
+
+def test_compile_es_layout_dtype():
+    es = ndd.ExternalSource(
+        lambda: (np.zeros((4, 4, 3), np.float32), np.zeros((4, 4), np.float32)),
+        num_outputs=2,
+        layout=["HWC", "HW"],
+        dtype=[ndd.float32, ndd.int32],
+    )
+    count = 0
+    for a, b in es.compiled(batch_size=4):
+        assert a.layout == "HWC" and b.layout == "HW"
+        assert a.dtype == ndd.float32 and b.dtype == ndd.int32
+        ndd.cast(a, dtype=ndd.float32)
+        ndd.cast(b, dtype=ndd.int32)
+        count += 1
+        if count >= 2:  # check both the traced and a compiled batch
+            break
+    assert count == 2
+
+
+def test_compile_es_gpu():
+    if _backend.GetCUDADeviceCount() == 0:
+        raise SkipTest("At least 1 GPU device needed for the test")
+    es = ndd.ExternalSource(lambda: np.arange(3, dtype=np.float32), device="gpu")
+    count = 0
+    for batch in es.compiled(batch_size=4):
+        assert batch.device == ndd.Device("gpu")
+        ndd.cast(batch, dtype=ndd.float32)
+        count += 1
+        if count >= 2:
+            break
+    assert count == 2
+
+
+def test_compile_es_empty_graph():
+    es = _es(2, batch_size=4, cycle="raise")
+    with assert_warns(UserWarning, glob="no operators were captured"):
+        for batch in es.compiled(batch_size=4):
+            batch.evaluate()
+    # After an empty graph the source falls back to eager mode and stays reusable.
+    out = es()
+    assert not _is_compiled(out)
+
+
+def test_compile_es_break_reuse():
+    es = _const_es([3, 3], batch_size=4)
+    for i, batch in enumerate(es.compiled(batch_size=4)):
+        ndd.cast(batch, dtype=ndd.int32)
+        if i == 1:  # i=0 traced, i=1 the first compiled batch
+            break
+
+    count = 0
+    for batch in es.compiled(batch_size=4):
+        assert _is_compiled(batch)
+        ndd.cast(batch, dtype=ndd.int32)
+        count += 1
+        if count >= 3:
+            break
+    assert count == 3
+
+
+def test_compile_es_break_during_tracing():
+    es = _const_es([1, 1], batch_size=4)
+    feeder = _const_es([2, 2], batch_size=4)
+    for batch in es.compiled(batch_size=4):
+        ndd.cast(batch, dtype=ndd.float32)
+        ndd.cast(feeder(), dtype=ndd.float32)
+        break
+
+    # Both unbound and reusable, the feeder was not left locked to the abandoned context.
+    assert not _is_compiled(feeder())
+    assert not _is_compiled(es())
+
+
+def test_compile_reader_feeder():
+    reader_dyn = ndd.readers.File(file_root=images_root, pad_last_batch=True)
+    reader_comp = ndd.readers.File(file_root=images_root, pad_last_batch=True)
+    size_dyn = _const_es([64, 64], batch_size=4)
+    size_comp = _const_es([64, 64], batch_size=4)
+
+    dynamic_results = []
+    for jpegs, _ in reader_dyn.next_epoch(batch_size=4):
+        images = ndd.decoders.image(jpegs)
+        images = ndd.resize(images, size=size_dyn())
+        dynamic_results.append(ndd.as_tensor(images, pad=True))
+
+    for _ in range(3):
+        compiled_results = []
+        for jpegs, _ in reader_comp.next_epoch(batch_size=4, compile=True):
+            images = ndd.decoders.image(jpegs)
+            size = size_comp()
+            assert _is_compiled(size)
+            images = ndd.resize(images, size=size)
+            assert _is_compiled(images)
+            compiled_results.append(ndd.as_tensor(images, pad=True))
+        _assert_parity(dynamic_results, compiled_results)
+
+
+def test_compile_es_feeder():
+    es_dyn = _es(3, batch_size=4)
+    es_comp = _es(3, batch_size=4)
+    other_dyn = _const_es([7, 8], batch_size=4)
+    other_comp = _const_es([7, 8], batch_size=4)
+
+    dyn_a, dyn_b = [], []
+    for _ in range(3):
+        dyn_a.append(ndd.as_tensor(ndd.cast(es_dyn(), dtype=ndd.int32)))
+        dyn_b.append(ndd.as_tensor(ndd.cast(other_dyn(), dtype=ndd.int32)))
+
+    comp_a, comp_b = [], []
+    for batch in es_comp.compiled(batch_size=4):
+        a = ndd.cast(batch, dtype=ndd.int32)
+        b = ndd.cast(other_comp(), dtype=ndd.int32)
+        assert _is_compiled(a) and _is_compiled(b)
+        comp_a.append(ndd.as_tensor(a))
+        comp_b.append(ndd.as_tensor(b))
+
+    assert len(comp_a) == 3
+    _assert_parity(dyn_a, comp_a)
+    _assert_parity(dyn_b, comp_b)
+
+
+def test_compile_feeder_broadcast():
+    reader_dyn = ndd.readers.File(file_root=images_root, pad_last_batch=True)
+    reader_comp = ndd.readers.File(file_root=images_root, pad_last_batch=True)
+    size_dyn = ndd.ExternalSource(lambda: np.array([64, 64], dtype=np.float32))
+    size_comp = ndd.ExternalSource(lambda: np.array([64, 64], dtype=np.float32))
+
+    dynamic_results = []
+    for jpegs, _ in reader_dyn.next_epoch(batch_size=4):
+        images = ndd.decoders.image(jpegs)
+        images = ndd.resize(images, size=size_dyn())  # type: ignore
+        dynamic_results.append(ndd.as_tensor(images, pad=True))
+
+    for _ in range(3):
+        compiled_results = []
+        for jpegs, _ in reader_comp.next_epoch(batch_size=4, compile=True):
+            images = ndd.decoders.image(jpegs)
+            size = size_comp()
+            assert _is_compiled(size) and size.batch_size == 4
+            images = ndd.resize(images, size=size)
+            assert _is_compiled(images)
+            compiled_results.append(ndd.as_tensor(images, pad=True))
+        _assert_parity(dynamic_results, compiled_results)
+
+
+def test_compile_feeder_coexhaust():
+    # Root and a finite feeder of equal length end the epoch cleanly
+    es = _es(3, batch_size=4)
+    extra = _es(3, batch_size=4)
+    count = 0
+    for batch in es.compiled(batch_size=4):
+        ndd.cast(batch, dtype=ndd.float32)
+        ndd.cast(extra(), dtype=ndd.float32)
+        count += 1
+    assert count == 3
+
+
+# Tests for compiled ExternalSource misuse
+
+
+def _es_no_compiled_after_eager():
+    es = _es(3, batch_size=4)
+    es()  # eager use locks the instance to eager mode
+    for _ in es.compiled(batch_size=4):
+        pass
+
+
+def _es_no_eager_while_compiled():
+    es = _es(3, batch_size=4)
+    es.compiled(batch_size=4)  # binds the instance to a compiled loop
+    es()
+
+
+def _es_no_self_read():
+    es = _const_es([1, 1], batch_size=4)
+    for batch in es.compiled(batch_size=4):
+        ndd.cast(batch, dtype=ndd.float32)
+        ndd.cast(es(), dtype=ndd.float32)  # the iterated source must be read via the loop var
+
+
+def _es_role_lock():
+    es = _const_es([1, 1], batch_size=4)
+    es.compiled(batch_size=4)  # es now iterates its own loop
+    other = _es(3, batch_size=4)
+    for batch in other.compiled(batch_size=4):
+        ndd.cast(es(), dtype=ndd.float32)  # es already iterates its own loop
+        ndd.cast(batch, dtype=ndd.float32)
+
+
+def _feeder_context_lock():
+    co = _const_es([3, 3], batch_size=4)
+    es1 = _es(3, batch_size=4)
+    es2 = _es(3, batch_size=4)
+
+    for batch in es1.compiled(batch_size=4):
+        ndd.cast(co(), dtype=ndd.float32)
+        ndd.cast(batch, dtype=ndd.float32)
+
+    for batch in es2.compiled(batch_size=4):
+        ndd.cast(co(), dtype=ndd.float32)  # already bound to es1's context
+        ndd.cast(batch, dtype=ndd.float32)
+
+
+def _feeder_no_source_after_eager():
+    co = _const_es([1, 1], batch_size=4)
+    co()  # eager use
+    es = _es(3, batch_size=4)
+    for batch in es.compiled(batch_size=4):
+        ndd.cast(co(), dtype=ndd.float32)  # can't become a compiled feeder now
+        ndd.cast(batch, dtype=ndd.float32)
+
+
+@params(
+    (_es_no_compiled_after_eager, "used eagerly"),
+    (_es_no_eager_while_compiled, "already used in a compiled loop"),
+    (_es_no_self_read, "used through .compiled()"),
+    (_es_role_lock, "used through .compiled()"),
+    (_feeder_context_lock, "different compile context"),
+    (_feeder_no_source_after_eager, "used eagerly"),
+)
+def test_compile_es_role_errors(scenario, glob):
+    with assert_raises(RuntimeError, glob=glob):
+        scenario()
+
+
+def _feeder_underrun():
+    es = _const_es([1, 1], batch_size=4)
+    short = _es(1, batch_size=4)  # a single batch, then exhausted -> underrun
+    for batch in es.compiled(batch_size=4):
+        ndd.cast(batch, dtype=ndd.float32)
+        ndd.cast(short(), dtype=ndd.float32)
+
+
+def _feeder_read_once():
+    es = _const_es([1, 1], batch_size=4)
+    co = _const_es([2, 2], batch_size=4)
+    for batch in es.compiled(batch_size=4):
+        ndd.cast(batch, dtype=ndd.float32)
+        ndd.cast(co(), dtype=ndd.float32)
+        ndd.cast(co(), dtype=ndd.float32)  # second read in the same step
+
+
+def _feeder_must_be_consumed():
+    es = _es(3, batch_size=4)
+    co = _const_es([2, 2], batch_size=4)
+    for i, batch in enumerate(es.compiled(batch_size=4)):
+        ndd.cast(batch, dtype=ndd.float32)
+        if i == 0:  # consumed during tracing, then skipped -> not consumed next step
+            ndd.cast(co(), dtype=ndd.float32)
+
+
+def _feeder_late():
+    es = _es(3, batch_size=4)
+    late = _const_es([5, 5], batch_size=4)
+    for i, batch in enumerate(es.compiled(batch_size=4)):
+        ndd.cast(batch, dtype=ndd.float32)
+        if i > 0:  # first used only after the trace iteration
+            ndd.cast(late(), dtype=ndd.float32)
+
+
+@params(
+    (_feeder_underrun, "exhausted"),
+    (_feeder_read_once, "once per compiled step"),
+    (_feeder_must_be_consumed, "not consumed"),
+    (_feeder_late, "during tracing"),
+)
+def test_compile_feeder_errors(scenario, glob):
+    with assert_raises(RuntimeError, glob=glob):
+        scenario()
+
+
+def _es_batch_size_trace():
+    es = _es(3, batch_size=5)
+    for batch in es.compiled(batch_size=4):
+        ndd.cast(batch, dtype=ndd.float32)
+
+
+def _es_batch_size_runtime():
+    counter = itertools.count()
+    es = ndd.ExternalSource(
+        lambda: ndd.batch([np.zeros(3, np.float32)] * (4 if next(counter) == 0 else 5))
+    )
+    for batch in es.compiled(batch_size=4):
+        ndd.cast(batch, dtype=ndd.float32)
+
+
+@params(
+    (_es_batch_size_trace, ValueError, "batch size 4"),
+    (_es_batch_size_runtime, (ValueError, RuntimeError), "batch size"),
+)
+def test_compile_es_batch_size_errors(scenario, exc, glob):
+    with assert_raises(exc, glob=glob):
+        scenario()

--- a/dali/test/python/experimental_mode/test_external_source.py
+++ b/dali/test/python/experimental_mode/test_external_source.py
@@ -18,7 +18,7 @@ import numpy as np
 import nvidia.dali.backend as _backend
 import nvidia.dali.experimental.dynamic as ndd
 from nose2.tools import params
-from nose_utils import SkipTest, assert_raises
+from nose_utils import SkipTest, assert_raises, attr
 
 
 def _samples(n=3):
@@ -208,3 +208,14 @@ def test_device(device_type):
     result = es()
     assert result.device == ndd.Device(device_type)
     np.testing.assert_array_equal(result.cpu(), data)
+
+
+@attr("multi_gpu")
+def test_device_resolved_at_call():
+    if _backend.GetCUDADeviceCount() < 2:
+        raise SkipTest("At least 2 devices needed for the test")
+    with ndd.Device("gpu:0"):
+        es = ndd.ExternalSource(lambda: np.array([1, 2, 3]), device="gpu")
+    with ndd.Device("gpu:1"):
+        result = es()
+    assert result.device == ndd.Device("gpu:1")


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**New feature** (*non-breaking change which adds functionality*)

## Description:

https://github.com/NVIDIA/DALI/pull/6395 adds `ndd.ExternalSource`. This PR makes it usable with transparent pipelining.

It's usable in two ways:
1. Through `.compiled(batch_size)` to iterate on it.
2. By calling it directly in a compiled loop to add it as a co-source.

In the second case, we need to make sure that every source seen during tracing is called (exactly once) during each compiled iteration as the executor pulls data anyway, which could create misaligned states.

This PR generalizes the concept of source in `_compile.py` and decouples `CompileContext` from readers. The `SupportsCompile` protocol is implemented by both `Reader` and `ExternalSource` allowing both to be used as sources through duck typing.

## Additional information:

### Affected modules and functionalities:

Transparent pipelining.

### Key points relevant for the review:

This is a follow-up for https://github.com/NVIDIA/DALI/pull/6395.

### Tests:

- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4745
<!--- DALI-XXXX or NA --->
