### PR TITLE
Validate TFRecord payload length before parsing

### DIFF
--- a/dali/operators/reader/parser/tfrecord_parser.h
+++ b/dali/operators/reader/parser/tfrecord_parser.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <exception>
 #include <functional>
+#include <stdexcept>
 
 #include "dali/core/common.h"
 #include "dali/pipeline/operator/argument.h"
@@ -59,16 +60,21 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
     constexpr size_t kHeaderSize = kLengthSize + kCrcSize;
     constexpr size_t kMinRecordSize = kHeaderSize + kCrcSize;
 
-    DALI_ENFORCE(record_size >= kMinRecordSize,
-      make_string("Error while parsing TFRecord file: ", tensor.GetSourceInfo(),
-                  " (record is too short: ", record_size, " bytes)."));
+    if (record_size < kMinRecordSize) {
+      throw std::runtime_error(
+        make_string("Error while parsing TFRecord file: ", tensor.GetSourceInfo(),
+                    " (record is too short: ", record_size, " bytes, minimum is ",
+                    kMinRecordSize, " bytes)."));
+    }
 
     std::memcpy(&length, raw_data, kLengthSize);
     const size_t payload_size = record_size - kHeaderSize - kCrcSize;
-    DALI_ENFORCE(length <= static_cast<uint64_t>(payload_size),
-      make_string("Error while parsing TFRecord file: ", tensor.GetSourceInfo(),
-                  " (record payload length: ", length, " bytes, available payload: ",
-                  payload_size, " bytes)."));
+    if (length > static_cast<uint64_t>(payload_size)) {
+      throw std::runtime_error(
+        make_string("Error while parsing TFRecord file: ", tensor.GetSourceInfo(),
+                    " (record payload length: ", length, " bytes, available payload: ",
+                    payload_size, " bytes)."));
+    }
 
     // Omit length and crc
     raw_data = raw_data + kHeaderSize;

--- a/dali/operators/reader/parser/tfrecord_parser.h
+++ b/dali/operators/reader/parser/tfrecord_parser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,11 +53,25 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
     uint32_t crc;
 
     const uint8_t* raw_data = tensor.data<uint8_t>();
+    const size_t record_size = tensor.nbytes();
+    constexpr size_t kLengthSize = sizeof(length);
+    constexpr size_t kCrcSize = sizeof(crc);
+    constexpr size_t kHeaderSize = kLengthSize + kCrcSize;
+    constexpr size_t kMinRecordSize = kHeaderSize + kCrcSize;
 
-    std::memcpy(&length, raw_data, sizeof(length));
+    DALI_ENFORCE(record_size >= kMinRecordSize,
+      make_string("Error while parsing TFRecord file: ", tensor.GetSourceInfo(),
+                  " (record is too short: ", record_size, " bytes)."));
+
+    std::memcpy(&length, raw_data, kLengthSize);
+    const size_t payload_size = record_size - kHeaderSize - kCrcSize;
+    DALI_ENFORCE(length <= static_cast<uint64_t>(payload_size),
+      make_string("Error while parsing TFRecord file: ", tensor.GetSourceInfo(),
+                  " (record payload length: ", length, " bytes, available payload: ",
+                  payload_size, " bytes)."));
 
     // Omit length and crc
-    raw_data = raw_data + sizeof(length) + sizeof(crc);
+    raw_data = raw_data + kHeaderSize;
     DALI_ENFORCE(example.ParseFromArray(raw_data, length),
       make_string("Error while parsing TFRecord file: ", tensor.GetSourceInfo(),
                   " (raw data length: ", length, " bytes)."));

--- a/dali/test/python/reader/test_index.py
+++ b/dali/test/python/reader/test_index.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 import nvidia.dali.tfrecord as tfrec
 import os.path
+import struct
 import tempfile
 import numpy as np
 from test_utils import compare_pipelines, get_dali_extra_path
@@ -202,6 +203,51 @@ def test_wrong_feature_shape():
         pipe.run,
         glob="Error in CPU operator `nvidia.dali.fn.readers.tfrecord`*"
         "Output tensor shape is too small*[]*Expected at least 4 elements",
+    )
+
+
+def _write_tfrecord_with_index(record):
+    data_dir = tempfile.TemporaryDirectory()
+    path = os.path.join(data_dir.name, "malformed.tfrecord")
+    index_path = os.path.join(data_dir.name, "malformed.idx")
+    with open(path, "wb") as f:
+        f.write(record)
+    with open(index_path, "w") as f:
+        f.write(f"0 {len(record)}\n")
+    return data_dir, path, index_path
+
+
+def _assert_malformed_tfrecord_fails(record, message):
+    data_dir, path, index_path = _write_tfrecord_with_index(record)
+
+    @pipeline_def(batch_size=1, device_id=None, num_threads=1)
+    def malformed_tfrecord_pipe():
+        data = fn.readers.tfrecord(
+            path=path,
+            index_path=index_path,
+            features={"image/encoded": tfrec.FixedLenFeature((), tfrec.string, "")},
+        )
+        return data["image/encoded"]
+
+    pipe = malformed_tfrecord_pipe()
+    try:
+        assert_raises(
+            RuntimeError,
+            pipe.run,
+            glob="Error in CPU operator `nvidia.dali.fn.readers.tfrecord`*" + message,
+        )
+    finally:
+        data_dir.cleanup()
+
+
+def test_tfrecord_reader_rejects_short_record():
+    _assert_malformed_tfrecord_fails(b"\x00" * 8, "record is too short: 8 bytes")
+
+
+def test_tfrecord_reader_rejects_oversized_payload_length():
+    record = struct.pack("<QI", 1024, 0) + b"x" + struct.pack("<I", 0)
+    _assert_malformed_tfrecord_fails(
+        record, "record payload length: 1024 bytes, available payload: 1 bytes"
     )
 
 

--- a/dali/test/python/reader/test_index.py
+++ b/dali/test/python/reader/test_index.py
@@ -241,7 +241,9 @@ def _assert_malformed_tfrecord_fails(record, message):
 
 
 def test_tfrecord_reader_rejects_short_record():
-    _assert_malformed_tfrecord_fails(b"\x00" * 8, "record is too short: 8 bytes")
+    _assert_malformed_tfrecord_fails(
+        b"\x00" * 8, "record is too short: 8 bytes, minimum is 16 bytes"
+    )
 
 
 def test_tfrecord_reader_rejects_oversized_payload_length():


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
This PR fixes malformed TFRecord handling in the DALI TFRecord reader. The parser now validates that an indexed record is large enough to contain the TFRecord framing and that the declared payload length fits inside the indexed sample before passing the payload to protobuf parsing.

Without this check, a malformed TFRecord file could declare a payload length larger than the indexed record buffer and make protobuf read past the end of the sample buffer.

## Additional information:

### Affected modules and functionalities:
- readers.tfrecord parser validation in dali/operators/reader/parser/tfrecord_parser.h.
- TFRecord reader regression tests in dali/test/python/reader/test_index.py.

### Key points relevant for the review:
- The check rejects records shorter than the TFRecord header plus trailing data CRC.
- The check rejects declared payload lengths larger than the available indexed payload bytes.
- Existing valid TFRecord parsing remains unchanged after validation.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_index.py‎:test_tfrecord_reader_rejects_short_record & test_tfrecord_reader_rejects_oversized_payload_length
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A