### PR TITLE
Validate RecordIO record lengths before parsing

### DIFF
--- a/dali/operators/reader/parser/recordio_parser.h
+++ b/dali/operators/reader/parser/recordio_parser.h
@@ -18,6 +18,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "dali/operators/reader/parser/parser.h"
@@ -58,7 +59,7 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
   }
 
   inline void CheckAvailable(const uint8_t* in, const uint8_t* end, size_t size,
-                             const string& source_info, const string& context) {
+                             std::string_view source_info, std::string_view context) {
     size_t available = RemainingBytes(in, end);
     if (size > available) {
       throw std::runtime_error(
@@ -78,8 +79,8 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
   }
 
   template <typename T>
-  void ReadSingle(const uint8_t** in, const uint8_t* end, T* out, const string& source_info,
-                  const string& context) {
+  void ReadSingle(const uint8_t** in, const uint8_t* end, T* out,
+                  std::string_view source_info, std::string_view context) {
     CheckAvailable(*in, end, sizeof(T), source_info, context);
     std::memcpy(out, *in, sizeof(T));
     *in += sizeof(T);
@@ -89,7 +90,7 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
                 Tensor<CPUBackend>& o_label,
                 const uint8_t* input,
                 size_t record_size,
-                const string& source_info) {
+                std::string_view source_info) {
     const uint8_t* end = input + record_size;
     uint32_t magic;
     const uint32_t kMagic = 0xced7230a;

--- a/dali/operators/reader/parser/recordio_parser.h
+++ b/dali/operators/reader/parser/recordio_parser.h
@@ -15,12 +15,14 @@
 #ifndef DALI_OPERATORS_READER_PARSER_RECORDIO_PARSER_H_
 #define DALI_OPERATORS_READER_PARSER_RECORDIO_PARSER_H_
 
+#include <cstddef>
 #include <cstring>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "dali/core/int_literals.h"
 #include "dali/operators/reader/parser/parser.h"
 
 namespace dali {
@@ -54,14 +56,13 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
     return rec & ((1U << 29U) - 1U);
   }
 
-  inline size_t RemainingBytes(const uint8_t* in, const uint8_t* end) {
-    return static_cast<size_t>(end - in);
-  }
-
   inline void CheckAvailable(const uint8_t* in, const uint8_t* end, size_t size,
                              std::string_view source_info, std::string_view context) {
-    size_t available = RemainingBytes(in, end);
-    if (size > available) {
+    std::ptrdiff_t available = end - in;
+    if (available < 0) {
+      throw std::out_of_range("Internal error: the input pointer is past the end of buffer.");
+    }
+    if (size > static_cast<size_t>(available)) {
       throw std::runtime_error(
         make_string("Invalid RecordIO file: ", source_info, " (", context, " requires ", size,
                     " bytes, but only ", available, " bytes are available)."));
@@ -69,7 +70,7 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
   }
 
   inline size_t PaddedLength(uint32_t length) {
-    return (static_cast<size_t>(length) + 3U) & ~static_cast<size_t>(3U);
+    return (length + 3) & ~3_uz;
   }
 
   inline void CopyBytes(void* out, const void* in, size_t size) {

--- a/dali/operators/reader/parser/recordio_parser.h
+++ b/dali/operators/reader/parser/recordio_parser.h
@@ -109,13 +109,6 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
     ImageRecordIOHeader hdr;
     ReadSingle(&input, end, &hdr, source_info, "record header");
 
-    if (hdr.flag == 0) {
-      o_label.Resize({1}, DALI_FLOAT);
-      o_label.mutable_data<float>()[0] = hdr.label;
-    } else {
-      o_label.Resize({hdr.flag}, DALI_FLOAT);
-    }
-
     size_t data_size = clength - sizeof(ImageRecordIOHeader);
     size_t label_size = static_cast<size_t>(hdr.flag) * sizeof(float);
     if (label_size > data_size) {
@@ -125,6 +118,14 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
     }
     size_t image_size = data_size - label_size;
     CheckAvailable(input, end, data_size, source_info, "record data");
+
+    if (hdr.flag == 0) {
+      o_label.Resize({1}, DALI_FLOAT);
+      o_label.mutable_data<float>()[0] = hdr.label;
+    } else {
+      o_label.Resize({hdr.flag}, DALI_FLOAT);
+    }
+
     if (cflag == 0) {
       o_image.Resize({static_cast<Index>(image_size)}, DALI_UINT8);
       uint8_t* data = o_image.mutable_data<uint8_t>();

--- a/dali/operators/reader/parser/recordio_parser.h
+++ b/dali/operators/reader/parser/recordio_parser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 #ifndef DALI_OPERATORS_READER_PARSER_RECORDIO_PARSER_H_
 #define DALI_OPERATORS_READER_PARSER_RECORDIO_PARSER_H_
 
+#include <cstring>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -37,7 +39,8 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
   void Parse(const Tensor<CPUBackend>& tensor, SampleWorkspace* ws) override {
     auto& image = ws->Output<CPUBackend>(0);
     auto& label = ws->Output<CPUBackend>(1);
-    ReadSingleImageRecordIO(image, label, tensor.data<uint8_t>());
+    ReadSingleImageRecordIO(image, label, tensor.data<uint8_t>(), tensor.nbytes(),
+                            tensor.GetSourceInfo());
     image.SetSourceInfo(tensor.GetSourceInfo());
   }
 
@@ -50,26 +53,62 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
     return rec & ((1U << 29U) - 1U);
   }
 
+  inline size_t RemainingBytes(const uint8_t* in, const uint8_t* end) {
+    return static_cast<size_t>(end - in);
+  }
+
+  inline void CheckAvailable(const uint8_t* in, const uint8_t* end, size_t size,
+                             const string& source_info, const string& context) {
+    size_t available = RemainingBytes(in, end);
+    if (size > available) {
+      throw std::runtime_error(
+        make_string("Invalid RecordIO file: ", source_info, " (", context, " requires ", size,
+                    " bytes, but only ", available, " bytes are available)."));
+    }
+  }
+
+  inline size_t PaddedLength(uint32_t length) {
+    return (static_cast<size_t>(length) + 3U) & ~static_cast<size_t>(3U);
+  }
+
+  inline void CopyBytes(void* out, const void* in, size_t size) {
+    if (size > 0) {
+      std::memcpy(out, in, size);
+    }
+  }
+
   template <typename T>
-  void ReadSingle(const uint8_t** in, T* out) {
-    memcpy(out, *in, sizeof(T));
+  void ReadSingle(const uint8_t** in, const uint8_t* end, T* out, const string& source_info,
+                  const string& context) {
+    CheckAvailable(*in, end, sizeof(T), source_info, context);
+    std::memcpy(out, *in, sizeof(T));
     *in += sizeof(T);
   }
 
   inline void ReadSingleImageRecordIO(Tensor<CPUBackend>& o_image,
                 Tensor<CPUBackend>& o_label,
-                const uint8_t* input) {
+                const uint8_t* input,
+                size_t record_size,
+                const string& source_info) {
+    const uint8_t* end = input + record_size;
     uint32_t magic;
     const uint32_t kMagic = 0xced7230a;
-    ReadSingle<uint32_t>(&input, &magic);
+    ReadSingle<uint32_t>(&input, end, &magic, source_info, "magic number");
     DALI_ENFORCE(magic == kMagic, "Invalid RecordIO: wrong magic number");
 
     uint32_t length_flag;
-    ReadSingle(&input, &length_flag);
+    ReadSingle(&input, end, &length_flag, source_info, "length flag");
     uint32_t cflag = DecodeFlag(length_flag);
     uint32_t clength = DecodeLength(length_flag);
+    CheckAvailable(input, end, clength, source_info, "record payload");
     ImageRecordIOHeader hdr;
-    ReadSingle(&input, &hdr);
+    ReadSingle(&input, end, &hdr, source_info, "record header");
+
+    if (clength < sizeof(ImageRecordIOHeader)) {
+      throw std::runtime_error(
+        make_string("Invalid RecordIO file: ", source_info, " (record payload length: ", clength,
+                    " bytes, minimum is ", sizeof(ImageRecordIOHeader), " bytes)."));
+    }
 
     if (hdr.flag == 0) {
       o_label.Resize({1}, DALI_FLOAT);
@@ -78,48 +117,67 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
       o_label.Resize({hdr.flag}, DALI_FLOAT);
     }
 
-    int64_t data_size = clength - sizeof(ImageRecordIOHeader);
-    int64_t label_size = hdr.flag * sizeof(float);
-    int64_t image_size = data_size - label_size;
+    size_t data_size = clength - sizeof(ImageRecordIOHeader);
+    size_t label_size = static_cast<size_t>(hdr.flag) * sizeof(float);
+    if (label_size > data_size) {
+      throw std::runtime_error(
+        make_string("Invalid RecordIO file: ", source_info, " (label size: ", label_size,
+                    " bytes, available data: ", data_size, " bytes)."));
+    }
+    size_t image_size = data_size - label_size;
+    CheckAvailable(input, end, data_size, source_info, "record data");
     if (cflag == 0) {
-      o_image.Resize({image_size}, DALI_UINT8);
+      o_image.Resize({static_cast<Index>(image_size)}, DALI_UINT8);
       uint8_t* data = o_image.mutable_data<uint8_t>();
-      memcpy(data, input + label_size, image_size);
+      CopyBytes(data, input + label_size, image_size);
       if (hdr.flag > 0) {
         float * label = o_label.mutable_data<float>();
-        memcpy(label, input, label_size);
+        CopyBytes(label, input, label_size);
       }
     } else {
       std::vector<uint8_t> temp_vec(data_size);
-      memcpy(&temp_vec[0], input, data_size);
+      CopyBytes(temp_vec.data(), input, data_size);
       input += data_size;
 
       while (true) {
-        size_t pad = clength - (((clength + 3U) >> 2U) << 2U);
+        size_t pad = PaddedLength(clength) - clength;
+        CheckAvailable(input, end, pad, source_info, "record padding");
         input += pad;
 
         if (cflag != 3) {
           size_t s = temp_vec.size();
-          temp_vec.resize(static_cast<int64_t>(s + sizeof(kMagic)));
-          memcpy(&temp_vec[s], &kMagic, sizeof(kMagic));
+          temp_vec.resize(s + sizeof(kMagic));
+          std::memcpy(&temp_vec[s], &kMagic, sizeof(kMagic));
         } else {
           break;
         }
-        ReadSingle(&input, &magic);
-        ReadSingle(&input, &length_flag);
+        ReadSingle(&input, end, &magic, source_info, "segment magic number");
+        DALI_ENFORCE(magic == kMagic, "Invalid RecordIO: wrong magic number");
+        ReadSingle(&input, end, &length_flag, source_info, "segment length flag");
         cflag = DecodeFlag(length_flag);
         clength = DecodeLength(length_flag);
+        CheckAvailable(input, end, clength, source_info, "segment payload");
         size_t s = temp_vec.size();
-        temp_vec.resize(static_cast<int64_t>(s + clength));
-        memcpy(&temp_vec[s], input, clength);
+        temp_vec.resize(s + clength);
+        if (clength > 0) {
+          std::memcpy(temp_vec.data() + s, input, clength);
+        }
         input += clength;
       }
-      o_image.Resize({static_cast<Index>(temp_vec.size() - label_size)}, DALI_UINT8);
+      if (label_size > temp_vec.size()) {
+        throw std::runtime_error(
+          make_string("Invalid RecordIO file: ", source_info, " (label size: ", label_size,
+                      " bytes, decoded data: ", temp_vec.size(), " bytes)."));
+      }
+      size_t decoded_image_size = temp_vec.size() - label_size;
+      o_image.Resize({static_cast<Index>(decoded_image_size)}, DALI_UINT8);
       uint8_t* data = o_image.mutable_data<uint8_t>();
-      memcpy(data, (&temp_vec[0]) + label_size, temp_vec.size() - label_size);
+      if (decoded_image_size > 0) {
+        std::memcpy(data, temp_vec.data() + label_size, decoded_image_size);
+      }
       if (hdr.flag > 0) {
         float * label = o_label.mutable_data<float>();
-        memcpy(label, &temp_vec[0], label_size);
+        CopyBytes(label, temp_vec.data(), label_size);
       }
     }
   }

--- a/dali/operators/reader/parser/recordio_parser.h
+++ b/dali/operators/reader/parser/recordio_parser.h
@@ -101,14 +101,13 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
     uint32_t cflag = DecodeFlag(length_flag);
     uint32_t clength = DecodeLength(length_flag);
     CheckAvailable(input, end, clength, source_info, "record payload");
-    ImageRecordIOHeader hdr;
-    ReadSingle(&input, end, &hdr, source_info, "record header");
-
     if (clength < sizeof(ImageRecordIOHeader)) {
       throw std::runtime_error(
         make_string("Invalid RecordIO file: ", source_info, " (record payload length: ", clength,
                     " bytes, minimum is ", sizeof(ImageRecordIOHeader), " bytes)."));
     }
+    ImageRecordIOHeader hdr;
+    ReadSingle(&input, end, &hdr, source_info, "record header");
 
     if (hdr.flag == 0) {
       o_label.Resize({1}, DALI_FLOAT);
@@ -152,7 +151,11 @@ class RecordIOParser : public Parser<Tensor<CPUBackend>> {
           break;
         }
         ReadSingle(&input, end, &magic, source_info, "segment magic number");
-        DALI_ENFORCE(magic == kMagic, "Invalid RecordIO: wrong magic number");
+        if (magic != kMagic) {
+          throw std::runtime_error(
+            make_string("Invalid RecordIO file: ", source_info,
+                        " (wrong segment magic number)."));
+        }
         ReadSingle(&input, end, &length_flag, source_info, "segment length flag");
         cflag = DecodeFlag(length_flag);
         clength = DecodeLength(length_flag);

--- a/dali/test/python/reader/test_index.py
+++ b/dali/test/python/reader/test_index.py
@@ -238,6 +238,12 @@ def test_recordio_reader_rejects_oversized_label_data():
     _assert_malformed_recordio_fails(record, "label size: 4 bytes, available data: 0 bytes")
 
 
+def test_recordio_reader_rejects_wrong_segment_magic():
+    payload = _recordio_header()
+    record = _recordio_record(len(payload), payload, cflag=1) + struct.pack("<I", 0)
+    _assert_malformed_recordio_fails(record, "wrong segment magic number")
+
+
 def test_wrong_feature_shape():
     features = {
         "image/encoded": tfrec.FixedLenFeature((), tfrec.string, ""),

--- a/dali/test/python/reader/test_index.py
+++ b/dali/test/python/reader/test_index.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 import nvidia.dali.tfrecord as tfrec
 import os.path
+import struct
 import tempfile
 import numpy as np
 from test_utils import compare_pipelines, get_dali_extra_path
@@ -177,6 +178,64 @@ def test_recordio():
         for a, b in zip(out, out_ref):
             assert np.array_equal(a.as_array(), b.as_array())
         _ = pipe_org.run()
+
+
+def _recordio_header(num_labels=0):
+    return struct.pack("<IfQQ", num_labels, 0.0, 0, 0)
+
+
+def _recordio_record(payload_length, payload, cflag=0):
+    magic = 0xCED7230A
+    length_flag = (cflag << 29) | payload_length
+    return struct.pack("<II", magic, length_flag) + payload
+
+
+def _write_recordio_with_index(record):
+    data_dir = tempfile.TemporaryDirectory()
+    path = os.path.join(data_dir.name, "malformed.rec")
+    index_path = os.path.join(data_dir.name, "malformed.idx")
+    with open(path, "wb") as f:
+        f.write(record)
+    with open(index_path, "w") as f:
+        f.write("0 0\n")
+    return data_dir, path, index_path
+
+
+def _assert_malformed_recordio_fails(record, message):
+    data_dir, path, index_path = _write_recordio_with_index(record)
+
+    @pipeline_def(batch_size=1, device_id=None, num_threads=1)
+    def malformed_recordio_pipe():
+        image, _ = fn.readers.mxnet(path=path, index_path=index_path)
+        return image
+
+    pipe = malformed_recordio_pipe()
+    try:
+        assert_raises(
+            RuntimeError,
+            pipe.run,
+            glob="Error in CPU operator `nvidia.dali.fn.readers.mxnet`*" + message,
+        )
+    finally:
+        data_dir.cleanup()
+
+
+def test_recordio_reader_rejects_oversized_payload_length():
+    record = _recordio_record(1024, _recordio_header())
+    _assert_malformed_recordio_fails(
+        record, "record payload requires 1024 bytes, but only 24 bytes are available"
+    )
+
+
+def test_recordio_reader_rejects_too_short_payload_length():
+    record = _recordio_record(4, _recordio_header())
+    _assert_malformed_recordio_fails(record, "record payload length: 4 bytes, minimum is 24 bytes")
+
+
+def test_recordio_reader_rejects_oversized_label_data():
+    payload = _recordio_header(num_labels=1)
+    record = _recordio_record(len(payload), payload)
+    _assert_malformed_recordio_fails(record, "label size: 4 bytes, available data: 0 bytes")
 
 
 def test_wrong_feature_shape():

--- a/dali/test/python/reader/test_index.py
+++ b/dali/test/python/reader/test_index.py
@@ -209,8 +209,8 @@ def _assert_malformed_recordio_fails(record, message):
         image, _ = fn.readers.mxnet(path=path, index_path=index_path)
         return image
 
-    pipe = malformed_recordio_pipe()
     try:
+        pipe = malformed_recordio_pipe()
         assert_raises(
             RuntimeError,
             pipe.run,


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
This PR fixes malformed RecordIO / MXNet reader handling in DALI. The parser now validates that attacker-controlled RecordIO length fields fit inside the sample bytes loaded from the index before using those values for size arithmetic, allocation, and memory copies.

Without these checks, a malformed .rec/.idx pair could make the parser underflow payload sizes or copy past the loaded record buffer.

## Additional information:

### Affected modules and functionalities:
- RecordIO parser validation in dali/operators/reader/parser/recordio_parser.h.
- MXNet / RecordIO reader regression tests in dali/test/python/reader/test_index.py.

### Key points relevant for the review:
- Fixed-size RecordIO fields are bounds-checked before reading.
- The declared payload length is checked against the actual indexed sample size.
- Payload, label, image, segment, and padding sizes are validated before copies.
- Existing valid MXNet / RecordIO reader behavior is covered by the CPU reader smoke test.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_index.py: test_recordio_reader_rejects_oversized_payload_length, test_recordio_reader_rejects_too_short_payload_length, test_recordio_reader_rejects_oversized_label_data
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: DALI-4799