### PR TITLE
Handle non-ASCII names in wds2idx

### DIFF
--- a/dali/test/python/reader/test_wds2idx.py
+++ b/dali/test/python/reader/test_wds2idx.py
@@ -30,7 +30,7 @@ def _load_wds2idx():
     return wds2idx
 
 
-def test_wds2idx_accepts_utf8_tar_member_name():
+def test_wds2idx_gnu_tar_path_accepts_utf8_tar_member_name():
     if which("tar") is None:
         raise unittest.SkipTest("GNU tar not installed")
 
@@ -49,15 +49,8 @@ def test_wds2idx_accepts_utf8_tar_member_name():
 
         with wds2idx.IndexCreator(tar_path, idx_path, verbose=False) as creator:
             entries = list(creator._get_data_tar())
-            assert len(entries) == 1
-            _, name, size = entries[0]
-            assert name == member_name
-            assert size == len(payload)
 
-            creator.create_index()
-
-        with open(idx_path, encoding="utf-8") as index:
-            contents = index.read()
-
-        assert member_name in contents
-        assert str(len(payload)) in contents
+        assert len(entries) == 1
+        _, name, size = entries[0]
+        assert name == member_name
+        assert size == len(payload)

--- a/dali/test/python/reader/test_wds2idx.py
+++ b/dali/test/python/reader/test_wds2idx.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import io
+import os
+from pathlib import Path
+import tarfile
+import tempfile
+
+
+def _load_wds2idx():
+    script_path = Path(__file__).parents[4] / "tools" / "wds2idx.py"
+    spec = importlib.util.spec_from_file_location("wds2idx", script_path)
+    wds2idx = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(wds2idx)
+    return wds2idx
+
+
+def test_wds2idx_accepts_utf8_tar_member_name():
+    wds2idx = _load_wds2idx()
+
+    with tempfile.TemporaryDirectory() as test_dir:
+        tar_path = os.path.join(test_dir, "data.tar")
+        idx_path = os.path.join(test_dir, "data.idx")
+        member_name = "imgé.jpg"
+        payload = b"\xff\xd8\xff\xe0payload"
+
+        with tarfile.open(tar_path, "w") as archive:
+            info = tarfile.TarInfo(name=member_name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+
+        with wds2idx.IndexCreator(tar_path, idx_path, verbose=False) as creator:
+            creator.create_index()
+
+        with open(idx_path, encoding="utf-8") as index:
+            contents = index.read()
+
+        assert member_name in contents
+        assert str(len(payload)) in contents

--- a/dali/test/python/reader/test_wds2idx.py
+++ b/dali/test/python/reader/test_wds2idx.py
@@ -16,8 +16,10 @@ import importlib.util
 import io
 import os
 from pathlib import Path
+from shutil import which
 import tarfile
 import tempfile
+import unittest
 
 
 def _load_wds2idx():
@@ -29,6 +31,9 @@ def _load_wds2idx():
 
 
 def test_wds2idx_accepts_utf8_tar_member_name():
+    if which("tar") is None:
+        raise unittest.SkipTest("GNU tar not installed")
+
     wds2idx = _load_wds2idx()
 
     with tempfile.TemporaryDirectory() as test_dir:
@@ -43,6 +48,12 @@ def test_wds2idx_accepts_utf8_tar_member_name():
             archive.addfile(info, io.BytesIO(payload))
 
         with wds2idx.IndexCreator(tar_path, idx_path, verbose=False) as creator:
+            entries = list(creator._get_data_tar())
+            assert len(entries) == 1
+            _, name, size = entries[0]
+            assert name == member_name
+            assert size == len(payload)
+
             creator.create_index()
 
         with open(idx_path, encoding="utf-8") as index:

--- a/tools/wds2idx.py
+++ b/tools/wds2idx.py
@@ -104,7 +104,7 @@ class IndexCreator:
             if not blocks_line or not types_sizes_line:
                 continue
 
-            name = str(blocks_line[blocks_line.find(b":") + 2 :], "ascii")
+            name = os.fsdecode(blocks_line[blocks_line.find(b":") + 2 :])
             entry_type = types_sizes_line[0:1]
 
             if entry_type != b"-":
@@ -117,9 +117,7 @@ class IndexCreator:
             # So the size of the header needs to be added to get the data offset
             offset = (offset + 1) * 512
 
-            size = types_sizes_line[: -len(name)]
-            size = size[: size.rfind(b"-") - 8]  # "... <size> 20yy-mm-...."
-            size = int(size[size.rfind(b" ") :])
+            size = int(types_sizes_line.split(maxsplit=5)[2])
 
             yield offset, name, size
 

--- a/tools/wds2idx.py
+++ b/tools/wds2idx.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Fixes `tools/wds2idx.py` so the GNU tar fast path accepts UTF-8/non-ASCII tar member names instead of decoding names as ASCII. The old decode raised `UnicodeDecodeError` for valid tar member names containing non-ASCII bytes.

The size parser is also changed to read the verbose tar size field directly, avoiding byte/character length mismatches when decoded names contain multi-byte characters.

## Additional information:

### Affected modules and functionalities:
- `tools/wds2idx.py`: WebDataset index generation through the GNU tar fast path.
- `dali/test/python/reader/test_wds2idx.py`: regression coverage for UTF-8 member names in the GNU tar path.

### Key points relevant for the review:
Please check the GNU tar parsing path. The fallback `tarfile` implementation already handled Python string member names; this change aligns the faster GNU tar path with that behavior and makes the regression test call `_get_data_tar()` directly so it cannot pass through the fallback path.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: DALI-4800