### PR TITLE
Bound numpy header parsing to string views

### DIFF
--- a/dali/util/numpy.cc
+++ b/dali/util/numpy.cc
@@ -122,7 +122,8 @@ std::string ParseStringValue(const char*& input, char delim_start = '\'', char d
 
 void ParseHeaderContents(HeaderData& target, const std::string_view header) {
   target.shape = {};
-  const char* hdr = header.data();
+  std::string header_contents(header);
+  const char* hdr = header_contents.c_str();
   SkipSpaces(hdr);
   Skip(hdr, "{");
   SkipFieldName(hdr, "descr");

--- a/dali/util/numpy_test.cc
+++ b/dali/util/numpy_test.cc
@@ -63,5 +63,17 @@ TEST(NumpyLoaderTest, ParseHeaderError) {
   }
 }
 
+TEST(NumpyLoaderTest, ParseHeaderDoesNotReadPastStringView) {
+  HeaderData target;
+  std::string header = "{'descr':'<f4','fortran_order':False,'shape':(";
+  std::string valid_suffix_outside_view = "1,),}";
+  std::string backing_storage = header + valid_suffix_outside_view;
+
+  EXPECT_THROW(
+      ParseHeaderContents(
+          target, std::string_view(backing_storage.data(), header.size())),
+      std::runtime_error);
+}
+
 }  // namespace numpy
 }  // namespace dali


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Fixes malformed `.npy` header parsing for bounded in-memory inputs used by `fn.decoders.numpy`. The decoder passed a length-bounded `std::string_view` to the shared numpy header parser, while the parser helpers scan C strings until `\0`. A malformed header without a closing token could therefore make the parser read past the end of the view.

This PR materializes the parser input as a null-terminated `std::string` before the legacy pointer parser scans it, so truncated or malformed headers fail cleanly at the view boundary.

## Additional information:

### Affected modules and functionalities:
- `dali/util/numpy.cc`: normalizes `ParseHeaderContents` input to a null-terminated buffer.
- `dali/util/numpy_test.cc`: adds regression coverage for a truncated `std::string_view` backed by a larger allocation.
- `fn.decoders.numpy`: malformed in-memory `.npy` header handling.

### Key points relevant for the review:
Please check that the central parser contract is clear: callers may pass bounded `std::string_view` input, and `ParseHeaderContents` now provides the null terminator required by the existing pointer-based helpers. The regression test intentionally places valid-looking suffix bytes outside the view and verifies they are not consumed.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**:  DALI-4798