### PR TITLE
Fix parallel external source forwarding recycled output buffers

### DIFF
--- a/dali/pipeline/executor/executor2/exec_graph.h
+++ b/dali/pipeline/executor/executor2/exec_graph.h
@@ -336,14 +336,10 @@ class DLL_PUBLIC ExecGraph {
 
   ExecNode *AddOutputNode() {
     Invalidate();
+    if (!nodes_.empty() && nodes_.back().is_pipeline_output)
+      throw std::logic_error("The graph already has an output node.");
     ExecNode *node = &nodes_.emplace_back(PipelineOutputTag());
-    if (!node->instance_name.empty()) {
-      if (!name2node_.emplace(node->instance_name, node).second) {
-        nodes_.pop_back();
-        throw std::invalid_argument(
-            make_string("Duplicate node name: \"", node->instance_name, "\""));
-      }
-    }
+
     return node;
   }
 

--- a/dali/pipeline/executor/executor2/exec_graph_analysis.cc
+++ b/dali/pipeline/executor/executor2/exec_graph_analysis.cc
@@ -49,16 +49,19 @@ class ExecGraph::Analyzer {
   }
 
   void SetMakeContiguousMode(ExecGraph &g) {
+    SmallVector<ExecNode *, 4> output_nodes;
     for (auto &node : g.Nodes()) {
       if (node.op) {
         dali::SetMakeContiguousMode(*node.op, MakeContiguousMode::Opportunistic);
-      }
-    }
-    for (auto &node : g.Nodes()) {
-      if (node.is_pipeline_output) {
-        assert(node.inputs.size() == 1);
-        auto &op = *node.inputs[0]->producer->op;
-        dali::SetMakeContiguousMode(op, MakeContiguousMode::PipelineOutput);
+      } else if (node.is_pipeline_output) {
+        // output node always comes last
+        assert(&g.Nodes().back() == &node && "Invalid graph: output node must come last");
+        for (auto *inp : node.inputs) {
+          auto &op = *inp->producer->op;
+          bool mode_set = dali::SetMakeContiguousMode(op, MakeContiguousMode::PipelineOutput);
+          (void)mode_set;  // silence an unused variable warning in release builds
+          assert(mode_set);
+        }
       }
     }
   }

--- a/dali/pipeline/executor/executor2/exec_graph_analysis.cc
+++ b/dali/pipeline/executor/executor2/exec_graph_analysis.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,8 +50,16 @@ class ExecGraph::Analyzer {
 
   void SetMakeContiguousMode(ExecGraph &g) {
     for (auto &node : g.Nodes()) {
-      if (node.op)
+      if (node.op) {
         dali::SetMakeContiguousMode(*node.op, MakeContiguousMode::Opportunistic);
+      }
+    }
+    for (auto &node : g.Nodes()) {
+      if (node.is_pipeline_output) {
+        assert(node.inputs.size() == 1);
+        auto &op = *node.inputs[0]->producer->op;
+        dali::SetMakeContiguousMode(op, MakeContiguousMode::PipelineOutput);
+      }
     }
   }
 

--- a/dali/pipeline/executor/executor2/exec_graph_analysis.cc
+++ b/dali/pipeline/executor/executor2/exec_graph_analysis.cc
@@ -58,9 +58,9 @@ class ExecGraph::Analyzer {
         assert(&g.Nodes().back() == &node && "Invalid graph: output node must come last");
         for (auto *inp : node.inputs) {
           auto &op = *inp->producer->op;
-          bool mode_set = dali::SetMakeContiguousMode(op, MakeContiguousMode::PipelineOutput);
-          (void)mode_set;  // silence an unused variable warning in release builds
-          assert(mode_set);
+          // If the output is not a MakeContiguous node (in regular pipelines it always is),
+          // there's nothing we can do.
+          dali::SetMakeContiguousMode(op, MakeContiguousMode::PipelineOutput);
         }
       }
     }

--- a/dali/pipeline/executor/executor2/exec_graph_analysis.cc
+++ b/dali/pipeline/executor/executor2/exec_graph_analysis.cc
@@ -49,7 +49,6 @@ class ExecGraph::Analyzer {
   }
 
   void SetMakeContiguousMode(ExecGraph &g) {
-    SmallVector<ExecNode *, 4> output_nodes;
     for (auto &node : g.Nodes()) {
       if (node.op) {
         dali::SetMakeContiguousMode(*node.op, MakeContiguousMode::Opportunistic);

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -22,9 +22,11 @@ template<>
 void ExternalSource<CPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
   auto &thread_pool = ws.GetThreadPool();
-  ForwardCurrentData(output, data_id_, thread_pool);
+  bool copied = ForwardCurrentData(output, data_id_, thread_pool);
   output.SetLayout(layout_);
   SetDepletedOperatorTrace(ws, !(repeats_last_ || HasDataInQueue()));
+  if (!copied)
+    MakeOutputUnshareable(ws, output);
 }
 
 
@@ -32,9 +34,11 @@ template<>
 void ExternalSource<GPUBackend>::RunImpl(Workspace &ws) {
   auto &output = ws.Output<GPUBackend>(0);
   cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
-  ForwardCurrentData(output, data_id_, stream_used);
+  bool copied = ForwardCurrentData(output, data_id_, stream_used);
   output.SetLayout(layout_);
   SetDepletedOperatorTrace(ws, !(repeats_last_ || HasDataInQueue()));
+  if (!copied)
+    MakeOutputUnshareable(ws, output);
 }
 
 

--- a/dali/pipeline/operator/builtin/input_operator.cc
+++ b/dali/pipeline/operator/builtin/input_operator.cc
@@ -50,7 +50,7 @@ and bandwidth.
 
 
 template<>
-void InputOperator<CPUBackend>::ForwardCurrentData(TensorList<CPUBackend> &target,
+bool InputOperator<CPUBackend>::ForwardCurrentData(TensorList<CPUBackend> &target,
                                                    std::optional<std::string> &target_data_id,
                                                    ThreadPool &thread_pool) {
   queue_item_t tensor_list_elm;
@@ -60,6 +60,7 @@ void InputOperator<CPUBackend>::ForwardCurrentData(TensorList<CPUBackend> &targe
   }
   target_data_id = std::move(tensor_list_elm->data_id);
   tensor_list_elm->data_id = std::nullopt;
+  bool copied = false;
   // if the output is pinned and input not it needs to be copied
   if (target.is_pinned() && !tensor_list_elm->data.is_pinned()) {
     const auto &shapes = tensor_list_elm->data.shape();
@@ -79,16 +80,19 @@ void InputOperator<CPUBackend>::ForwardCurrentData(TensorList<CPUBackend> &targe
               shapes.tensor_size(sample_id));
     }
     thread_pool.RunAll();
+    copied = true;
   } else {
     // swap output with tensor_list_elm content
     std::swap(target, tensor_list_elm->data);
+    copied = false;
   }
   RecycleBuffer(std::move(tensor_list_elm));
+  return copied;
 }
 
 
 template<>
-void InputOperator<GPUBackend>::ForwardCurrentData(TensorList<GPUBackend> &target,
+bool InputOperator<GPUBackend>::ForwardCurrentData(TensorList<GPUBackend> &target,
                                                    std::optional<std::string> &target_data_id,
                                                    cudaStream_t stream) {
   queue_item_t tensor_list_elm;
@@ -109,11 +113,13 @@ void InputOperator<GPUBackend>::ForwardCurrentData(TensorList<GPUBackend> &targe
   tensor_list_elm->data.set_order(internal_copy_order_);
 
   RecycleBuffer(std::move(tensor_list_elm));
+
+  return false;
 }
 
 
 template<>
-void InputOperator<MixedBackend>::ForwardCurrentData(TensorList<GPUBackend> &target,
+bool InputOperator<MixedBackend>::ForwardCurrentData(TensorList<GPUBackend> &target,
                                                      std::optional<std::string> &target_data_id,
                                                      cudaStream_t stream) {
   queue_item_t tensor_list_elm;
@@ -129,11 +135,13 @@ void InputOperator<MixedBackend>::ForwardCurrentData(TensorList<GPUBackend> &tar
   tensor_list_elm->data.set_order(internal_copy_order_);
 
   RecycleBuffer(std::move(tensor_list_elm));
+
+  return true;
 }
 
 
 template<>
-void InputOperator<MixedBackend>::ForwardCurrentData(TensorList<CPUBackend> &target,
+bool InputOperator<MixedBackend>::ForwardCurrentData(TensorList<CPUBackend> &target,
                                                      std::optional<std::string> &target_data_id,
                                                      ThreadPool &thread_pool) {
   queue_item_t tensor_list_elm;
@@ -143,6 +151,7 @@ void InputOperator<MixedBackend>::ForwardCurrentData(TensorList<CPUBackend> &tar
   }
   target_data_id = std::move(tensor_list_elm->data_id);
   tensor_list_elm->data_id = std::nullopt;
+  bool copied = false;
   // if the output is pinned and input not it needs to be copied
   if (target.is_pinned() && !tensor_list_elm->data.is_pinned()) {
     const auto &shapes = tensor_list_elm->data.shape();
@@ -162,11 +171,14 @@ void InputOperator<MixedBackend>::ForwardCurrentData(TensorList<CPUBackend> &tar
               shapes.tensor_size(sample_id));
     }
     thread_pool.RunAll();
+    copied = true;
   } else {
     // swap output with tensor_list_elm content
     std::swap(target, tensor_list_elm->data);
+    copied = false;
   }
   RecycleBuffer(std::move(tensor_list_elm));
+  return copied;
 }
 
 

--- a/dali/pipeline/operator/builtin/input_operator.cc
+++ b/dali/pipeline/operator/builtin/input_operator.cc
@@ -60,7 +60,7 @@ bool InputOperator<CPUBackend>::ForwardCurrentData(TensorList<CPUBackend> &targe
   }
   target_data_id = std::move(tensor_list_elm->data_id);
   tensor_list_elm->data_id = std::nullopt;
-  bool copied = false;
+  bool copied = tensor_list_elm->copy_performed;
   // if the output is pinned and input not it needs to be copied
   if (target.is_pinned() && !tensor_list_elm->data.is_pinned()) {
     const auto &shapes = tensor_list_elm->data.shape();
@@ -84,7 +84,6 @@ bool InputOperator<CPUBackend>::ForwardCurrentData(TensorList<CPUBackend> &targe
   } else {
     // swap output with tensor_list_elm content
     std::swap(target, tensor_list_elm->data);
-    copied = false;
   }
   RecycleBuffer(std::move(tensor_list_elm));
   return copied;
@@ -101,6 +100,7 @@ bool InputOperator<GPUBackend>::ForwardCurrentData(TensorList<GPUBackend> &targe
     tensor_list_elm = tl_data_.PopFront();
   }
 
+  bool copied = tensor_list_elm->copy_performed;
   if (tensor_list_elm->copy_complete) {
     CUDA_CALL(cudaStreamWaitEvent(stream, tensor_list_elm->copy_complete));
   }
@@ -114,7 +114,7 @@ bool InputOperator<GPUBackend>::ForwardCurrentData(TensorList<GPUBackend> &targe
 
   RecycleBuffer(std::move(tensor_list_elm));
 
-  return false;
+  return copied;
 }
 
 
@@ -151,7 +151,7 @@ bool InputOperator<MixedBackend>::ForwardCurrentData(TensorList<CPUBackend> &tar
   }
   target_data_id = std::move(tensor_list_elm->data_id);
   tensor_list_elm->data_id = std::nullopt;
-  bool copied = false;
+  bool copied = tensor_list_elm->copy_performed;
   // if the output is pinned and input not it needs to be copied
   if (target.is_pinned() && !tensor_list_elm->data.is_pinned()) {
     const auto &shapes = tensor_list_elm->data.shape();
@@ -175,7 +175,6 @@ bool InputOperator<MixedBackend>::ForwardCurrentData(TensorList<CPUBackend> &tar
   } else {
     // swap output with tensor_list_elm content
     std::swap(target, tensor_list_elm->data);
-    copied = false;
   }
   RecycleBuffer(std::move(tensor_list_elm));
   return copied;

--- a/dali/pipeline/operator/builtin/input_operator.h
+++ b/dali/pipeline/operator/builtin/input_operator.h
@@ -279,12 +279,14 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
    * @param target_data_id Where the ID of the current data shall be injected.
    *                       @see named_pointer_to_tensor_list_t.
    * @param tp TheadPool used to copy the data.
+   *
+   * @return true, if the data was copied to the target, false otherwise
    */
-  void DLL_PUBLIC
+  bool DLL_PUBLIC
   ForwardCurrentData(TensorList<CPUBackend> &target, std::optional<std::string> &target_data_id,
                      ThreadPool &tp);
 
-  void DLL_PUBLIC
+  bool DLL_PUBLIC
   ForwardCurrentData(TensorList<GPUBackend> &target, std::optional<std::string> &target_data_id,
                      cudaStream_t stream = nullptr);
   ///@}
@@ -328,10 +330,23 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
    * @param ws Current workspace.
    * @param depleted Value of the trace.
    */
-  void SetDepletedOperatorTrace(Workspace& ws, bool depleted) {
+  void SetDepletedOperatorTrace(Workspace &ws, bool depleted) {
     ws.SetOperatorTrace("depleted", depleted ? "true" : "false");
   }
 
+  void MakeOutputUnshareable(Workspace &ws, const TensorList<Backend> &out) {
+    auto &unshareable = ws.GetIterationData()->unshareable_data;
+    auto lock = unshareable.Lock();
+    if (out.IsContiguous()) {
+      unshareable.Add(out.raw_tensor(0), out.nbytes());
+    } else {
+      size_t element_size = out.type_info().size();
+      for (int i = 0; i < out.num_samples(); i++) {
+        const auto &sample = out[i];
+        unshareable.Add(sample.raw_data(), volume(sample.shape()) * element_size);
+      }
+    }
+  }
 
   int device_id_ = -1;
   bool blocking_ = true;
@@ -368,7 +383,7 @@ class InputOperator : public Operator<Backend>, virtual public BatchSizeProvider
     std::lock_guard<std::mutex> busy_lock(busy_m_);
     auto tl_elm = GetEmptyOutputBatch(std::move(data_id));
     tl_elm->copy_requested = false;
-    tl_elm->copy_performed = true;
+    tl_elm->copy_performed = false;
     // set pinned if needed
     if (batch.is_pinned() != tl_elm->data.is_pinned()) {
       tl_elm->data.Reset();

--- a/dali/pipeline/operator/builtin/make_contiguous.h
+++ b/dali/pipeline/operator/builtin/make_contiguous.h
@@ -60,24 +60,15 @@ class MakeContiguousBase : public StatelessOperator<Backend> {
       auto &unshareable = ws.GetIterationData()->unshareable_data;
       auto lock = unshareable.Lock();
       if (!unshareable.Empty()) {
-        if (is_contiguous) {
-          if (unshareable.Contains(input.raw_tensor(0)))
-            pass_through_ = false;
-        } else {
-          for (int i = 0; i < input.num_samples(); i++) {
-            if (unshareable.Contains(input.raw_tensor(i))) {
-              pass_through_ = false;
-              break;
-            }
-          }
-        }
+        assert(is_contiguous);
+        if (unshareable.Contains(input.raw_tensor(0)))
+          pass_through_ = false;
       }
     }
   }
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
     output_desc.resize(1);
-    bool is_contiguous = false;
 
     if (ws.InputIsType<CPUBackend>(0)) {
       auto &input = ws.Input<CPUBackend>(0);

--- a/dali/pipeline/operator/builtin/make_contiguous.h
+++ b/dali/pipeline/operator/builtin/make_contiguous.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,9 +30,10 @@
 namespace dali {
 
 enum class MakeContiguousMode {
-  AlwaysCopy,    //! Always perform a copy.
-  PassThrough,   //! Never copy.
-  Opportunistic  //! If already contiguous, pass through; otherwise copy.
+  AlwaysCopy,       //! Always perform a copy.
+  PassThrough,      //! Never copy.
+  Opportunistic,    //! If already contiguous, pass through; otherwise copy.
+  PipelineOutput,   //! Opportunistic + check against iteration's UnshareableData
 };
 
 template<typename Backend>
@@ -48,21 +49,48 @@ class MakeContiguousBase : public StatelessOperator<Backend> {
 
   virtual inline ~MakeContiguousBase() = default;
 
+  template <typename InputBackend>
+  void SetPassthrough(const Workspace &ws, const TensorList<InputBackend> &input) {
+    bool is_contiguous = input.IsContiguousInMemory();
+    pass_through_ =
+      mode_ == MakeContiguousMode::PassThrough ||
+      ((mode_ == MakeContiguousMode::Opportunistic || mode_ == MakeContiguousMode::PipelineOutput)
+        && is_contiguous);
+    if (pass_through_ && mode_ == MakeContiguousMode::PipelineOutput) {
+      auto &unshareable = ws.GetIterationData()->unshareable_data;
+      auto lock = unshareable.Lock();
+      if (!unshareable.Empty()) {
+        if (is_contiguous) {
+          if (unshareable.Contains(input.raw_tensor(0)))
+            pass_through_ = false;
+        } else {
+          for (int i = 0; i < input.num_samples(); i++) {
+            if (unshareable.Contains(input.raw_tensor(i))) {
+              pass_through_ = false;
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
     output_desc.resize(1);
+    bool is_contiguous = false;
+
     if (ws.InputIsType<CPUBackend>(0)) {
       auto &input = ws.Input<CPUBackend>(0);
       output_desc[0].shape = input.shape();
       output_desc[0].type = input.type();
-      pass_through_ = mode_ == MakeContiguousMode::PassThrough ||
-                      (mode_ == MakeContiguousMode::Opportunistic && input.IsContiguousInMemory());
+      SetPassthrough(ws, input);
     } else {
       auto &input = ws.Input<GPUBackend>(0);
       output_desc[0].shape = input.shape();
       output_desc[0].type = input.type();
-      pass_through_ = mode_ == MakeContiguousMode::PassThrough ||
-                      (mode_ == MakeContiguousMode::Opportunistic && input.IsContiguousInMemory());
+      SetPassthrough(ws, input);
     }
+
     return !pass_through_;
   }
 

--- a/dali/pipeline/operator/builtin/make_contiguous.h
+++ b/dali/pipeline/operator/builtin/make_contiguous.h
@@ -49,24 +49,6 @@ class MakeContiguousBase : public StatelessOperator<Backend> {
 
   virtual inline ~MakeContiguousBase() = default;
 
-  template <typename InputBackend>
-  void SetPassthrough(const Workspace &ws, const TensorList<InputBackend> &input) {
-    bool is_contiguous = input.IsContiguousInMemory();
-    pass_through_ =
-      mode_ == MakeContiguousMode::PassThrough ||
-      ((mode_ == MakeContiguousMode::Opportunistic || mode_ == MakeContiguousMode::PipelineOutput)
-        && is_contiguous);
-    if (pass_through_ && mode_ == MakeContiguousMode::PipelineOutput) {
-      auto &unshareable = ws.GetIterationData()->unshareable_data;
-      auto lock = unshareable.Lock();
-      if (!unshareable.Empty()) {
-        assert(is_contiguous);
-        if (unshareable.Contains(input.raw_tensor(0)))
-          pass_through_ = false;
-      }
-    }
-  }
-
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
     output_desc.resize(1);
 
@@ -123,6 +105,25 @@ class MakeContiguousBase : public StatelessOperator<Backend> {
   bool pass_through_ = false;
   int bytes_per_sample_hint = 0;
   MakeContiguousMode mode_ = MakeContiguousMode::AlwaysCopy;
+
+ private:
+  template <typename InputBackend>
+  void SetPassthrough(const Workspace &ws, const TensorList<InputBackend> &input) {
+    bool is_contiguous = input.IsContiguousInMemory();
+    pass_through_ =
+      mode_ == MakeContiguousMode::PassThrough ||
+      ((mode_ == MakeContiguousMode::Opportunistic || mode_ == MakeContiguousMode::PipelineOutput)
+        && is_contiguous);
+    if (pass_through_ && mode_ == MakeContiguousMode::PipelineOutput) {
+      auto &unshareable = ws.GetIterationData()->unshareable_data;
+      auto lock = unshareable.Lock();
+      if (!unshareable.Empty()) {
+        assert(is_contiguous);
+        if (unshareable.Contains(input.raw_tensor(0)))
+          pass_through_ = false;
+      }
+    }
+  }
 };
 
 

--- a/dali/pipeline/workspace/iteration_data.h
+++ b/dali/pipeline/workspace/iteration_data.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #ifndef DALI_PIPELINE_WORKSPACE_ITERATION_DATA_H_
 #define DALI_PIPELINE_WORKSPACE_ITERATION_DATA_H_
 
+#include <cassert>
 #include <functional>
 #include <map>
 #include <memory>
@@ -84,6 +85,51 @@ class OperatorTraces {
   > map_;
 };
 
+/** Contains data ranges that must not be passed as-is to the pipeline output */
+class UnshareableData {
+ public:
+  auto Lock() const {
+    return std::unique_lock(m_);
+  }
+
+  bool Empty() const {
+    return end_start_.empty();
+  }
+
+  void Add(const void *base, size_t length) {
+    auto start = reinterpret_cast<uintptr_t>(base);
+    auto end = start + length;
+    auto it = end_start_.lower_bound(start);
+    if (it != end_start_.end()) {
+      if (it->first == start) {
+        // another block ends where this one starts - fuse and reinsert
+        start = it->second;  // extend
+        end_start_.erase(it);  // remove the old block - we'll re-insert it
+      } else if (it->second == end) {
+        // another block starts where this one ends - fuse and extend
+        it->second = start;
+        return;
+      }
+    }
+    bool inserted = end_start_.insert({end, start}).second;
+    (void)inserted;  // silence unused variable warning for release builds
+    assert(inserted);
+  }
+
+  bool Contains(const void *ptr) const {
+    auto x = reinterpret_cast<uintptr_t>(ptr);
+    auto it = end_start_.upper_bound(x);  // find the first block than ends after x
+    if (it == end_start_.end())  // no such block?
+      return false;
+    return it->second <= x;  // does the block start before x? If so, then x is covered.
+  }
+
+ private:
+  // Use _end_ pointer as the key to make direct use of upper_bound
+  std::map<uintptr_t, uintptr_t> end_start_;
+  mutable std::mutex m_;
+};
+
 /**
  * Contains the data of an iteration. This data is shared across all Workspaces that belong to
  * a single iteration.
@@ -102,6 +148,7 @@ struct IterationData {
 
   OperatorTraces operator_traces;
   std::shared_ptr<Checkpoint> checkpoint;
+  UnshareableData unshareable_data;
 };
 
 using SharedIterData = std::shared_ptr<IterationData>;

--- a/dali/pipeline/workspace/iteration_data.h
+++ b/dali/pipeline/workspace/iteration_data.h
@@ -97,6 +97,8 @@ class UnshareableData {
   }
 
   void Add(const void *base, size_t length) {
+    if (length == 0)
+      return;
     auto start = reinterpret_cast<uintptr_t>(base);
     auto end = start + length;
     auto it = end_start_.lower_bound(start);

--- a/dali/pipeline/workspace/iteration_data.h
+++ b/dali/pipeline/workspace/iteration_data.h
@@ -118,7 +118,7 @@ class UnshareableData {
 
   bool Contains(const void *ptr) const {
     auto x = reinterpret_cast<uintptr_t>(ptr);
-    auto it = end_start_.upper_bound(x);  // find the first block than ends after x
+    auto it = end_start_.upper_bound(x);  // find the first block that ends after x
     if (it == end_start_.end())  // no such block?
       return false;
     return it->second <= x;  // does the block start before x? If so, then x is covered.

--- a/dali/test/python/test_external_source_parallel.py
+++ b/dali/test/python/test_external_source_parallel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -467,6 +467,78 @@ class TestVsNonParallel:
                 s = seq.at(j)
                 p = par.at(j)
                 assert np.array_equal(s, p)
+
+
+class ArangeSampleCallback:
+    """Per-sample callback returning a unique, fully-populated vector.
+
+    Every sample holds a distinct ``arange`` so that any byte read back from a
+    recycled shared-memory buffer (one a worker reused for a later sample)
+    shows up as a value mismatch.
+    """
+
+    def __init__(self, sample_len, epoch_size):
+        self.sample_len = sample_len
+        self.epoch_size = epoch_size
+
+    def __call__(self, sample_info):
+        idx = sample_info.idx_in_epoch
+        if idx >= self.epoch_size:
+            raise StopIteration
+        return np.arange(idx, idx + self.sample_len, dtype=np.float32)
+
+
+class TestParallelOutputNotRecycled:
+    """Regression test for https://github.com/NVIDIA/DALI/issues/6027.
+
+    In parallel mode ``ExternalSource`` may forward a worker's shared-memory
+    buffer straight to the pipeline output without copying it. The worker is
+    then free to recycle that buffer for a later sample. When the pipeline
+    output aliases the buffer, outputs the user still holds get silently
+    overwritten with unrelated (or garbage) data. The fix tags such buffers as
+    "unshareable" so the pipeline-output ``MakeContiguous`` copies them instead
+    of passing them through.
+
+    The single-sample batch keeps the external source output contiguous, which
+    is the case that triggers the pass-through. Outputs are kept alive without
+    copying and only verified after the whole epoch has run, by which point a
+    recycled buffer would already have been clobbered.
+    """
+
+    def setUp(self):
+        setup_function()
+
+    def tearDown(self):
+        teardown_function()
+
+    @params(1, 4)
+    def test_output_not_recycled(self, num_workers):
+        sample_len = 1536
+        epoch_size = 32
+        pipe = utils.create_pipe(
+            ArangeSampleCallback(sample_len, epoch_size),
+            "cpu",
+            batch_size=1,
+            py_num_workers=num_workers,
+            py_start_method="spawn",
+            parallel=True,
+            device_id=0,
+            batch=False,
+            num_threads=1,
+        )
+        pipe.build()
+        capture_processes(pipe._py_pool)
+        # Hold references to every output without copying the data out. If the
+        # output aliases a worker's shared-memory buffer, running the whole
+        # epoch recycles that buffer and corrupts the earlier outputs.
+        outs = [pipe.run() for _ in range(epoch_size)]
+        for idx, (batch,) in enumerate(outs):
+            assert len(batch) == 1, f"Unexpected batch size at iteration {idx}: {len(batch)}"
+            np.testing.assert_array_equal(
+                np.array(batch[0]),
+                np.arange(idx, idx + sample_len, dtype=np.float32),
+                err_msg=f"Output of iteration {idx} was corrupted by buffer recycling.",
+            )
 
 
 def generator_epoch_size_1():


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
In parallel mode ExternalSource could forward a worker's shared-memory buffer straight to the pipeline output without copying it. The worker was then free to recycle that buffer for a later sample, silently overwriting outputs the user still held (observed as garbage or stale values).

ForwardCurrentData now reports whether it copied the data. When it only swapped the buffer in (no copy), the operator records the output range in the iteration's UnshareableData. The pipeline-output MakeContiguous runs in a new PipelineOutput mode that, before passing a contiguous input through, checks it against UnshareableData and forces a copy if the buffer is one that may be recycled.

Add a regression test that holds every output of an epoch without copying and verifies them only after the epoch has run, which fails if a held buffer was recycled.

See #6027

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
