### PR TITLE
Test wds2idx names with spaces

### DIFF
--- a/dali/test/python/reader/test_wds2idx.py
+++ b/dali/test/python/reader/test_wds2idx.py
@@ -30,7 +30,7 @@ def _load_wds2idx():
     return wds2idx
 
 
-def test_wds2idx_gnu_tar_path_accepts_utf8_tar_member_name():
+def test_wds2idx_gnu_tar_path_accepts_non_ascii_tar_member_name_with_spaces():
     if which("tar") is None:
         raise unittest.SkipTest("GNU tar not installed")
 
@@ -39,7 +39,7 @@ def test_wds2idx_gnu_tar_path_accepts_utf8_tar_member_name():
     with tempfile.TemporaryDirectory() as test_dir:
         tar_path = os.path.join(test_dir, "data.tar")
         idx_path = os.path.join(test_dir, "data.idx")
-        member_name = "imgé.jpg"
+        member_name = "my imgé file.jpg"
         payload = b"\xff\xd8\xff\xe0payload"
 
         with tarfile.open(tar_path, "w") as archive:


### PR DESCRIPTION
## Category:

Other

## Description:

Extend the GNU tar regression test for `wds2idx` to cover a tar member name
containing both a non-ASCII character and spaces. This protects the positional
size parsing from regressions when filenames contain spaces.

## Additional information:

### Affected modules and functionalities:

- `dali/test/python/reader/test_wds2idx.py`: GNU tar index generation
  regression coverage.

### Key points relevant for the review:

The test uses `my imgé file.jpg`, ensuring the filename occupies the final
field of GNU tar's verbose output while the size remains parsed from field 2.

### Tests:

- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
