### PR TITLE
Reject non-string COCO file names

### DIFF
--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -26,6 +26,26 @@
 namespace dali {
 namespace detail {
 
+const char *JsonTypeName(int type) {
+  switch (type) {
+    case rapidjson::kNullType:
+      return "null";
+    case rapidjson::kFalseType:
+    case rapidjson::kTrueType:
+      return "boolean";
+    case rapidjson::kObjectType:
+      return "object";
+    case rapidjson::kArrayType:
+      return "array";
+    case rapidjson::kStringType:
+      return "string";
+    case rapidjson::kNumberType:
+      return "number";
+    default:
+      return "unknown";
+  }
+}
+
 struct ImageInfo {
   std::string filename_;
   int original_id_;
@@ -235,8 +255,11 @@ void ParseImageInfo(LookaheadParser &parser, std::vector<ImageInfo> &image_infos
       } else if (0 == std::strcmp(internal_key, "height")) {
           image_info.height_ = parser.GetInt();
       } else if (0 == std::strcmp(internal_key, "file_name")) {
-          DALI_ENFORCE(parser.PeekType() == kStringType,
-                       "Invalid COCO annotation: `file_name` must be a string.");
+          if (parser.PeekType() != kStringType) {
+            throw std::invalid_argument(make_string(
+                "Invalid COCO annotation: `file_name` must be a string, got ",
+                JsonTypeName(parser.PeekType()), "."));
+          }
           image_info.filename_ = parser.GetString();
       } else {
         parser.SkipValue();

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -235,6 +235,8 @@ void ParseImageInfo(LookaheadParser &parser, std::vector<ImageInfo> &image_infos
       } else if (0 == std::strcmp(internal_key, "height")) {
           image_info.height_ = parser.GetInt();
       } else if (0 == std::strcmp(internal_key, "file_name")) {
+          DALI_ENFORCE(parser.PeekType() == kStringType,
+                       "Invalid COCO annotation: `file_name` must be a string.");
           image_info.filename_ = parser.GetString();
       } else {
         parser.SkipValue();

--- a/dali/test/python/reader/test_coco.py
+++ b/dali/test/python/reader/test_coco.py
@@ -138,6 +138,15 @@ def coco_invalid_bbox_pipe(annotations_file):
     return inputs, boxes, labels
 
 
+@pipeline_def(batch_size=1, num_threads=1, device_id=None)
+def coco_invalid_filename_pipe(annotations_file, file_root):
+    inputs, boxes, labels = fn.readers.coco(
+        file_root=file_root,
+        annotations_file=annotations_file,
+    )
+    return inputs, boxes, labels
+
+
 @params([], [1, 2, 3], [1, 2, 3, 4, 5])
 def test_operator_coco_reader_rejects_invalid_bbox_size(bbox):
     annotations = {
@@ -171,6 +180,27 @@ def test_operator_coco_reader_rejects_invalid_bbox_size(bbox):
             ValueError,
             pipe.run,
             glob="*Invalid COCO annotation: `bbox` must contain exactly 4 values*",
+        )
+
+
+@params(None, 123, True, {})
+def test_operator_coco_reader_rejects_non_string_filename(filename):
+    annotations = {
+        "images": [{"id": 1, "width": 640, "height": 480, "file_name": filename}],
+        "categories": [],
+        "annotations": [],
+    }
+
+    with tempfile.TemporaryDirectory() as annotations_dir:
+        annotations_file = os.path.join(annotations_dir, "instances.json")
+        with open(annotations_file, "w") as f:
+            json.dump(annotations, f)
+
+        pipe = coco_invalid_filename_pipe(annotations_file, annotations_dir)
+        assert_raises(
+            RuntimeError,
+            pipe.run,
+            glob="*Invalid COCO annotation: `file_name` must be a string*",
         )
 
 

--- a/dali/test/python/reader/test_coco.py
+++ b/dali/test/python/reader/test_coco.py
@@ -130,16 +130,7 @@ def test_operator_coco_reader_label_remap(avoid_remap):
 
 
 @pipeline_def(batch_size=1, num_threads=1, device_id=None)
-def coco_invalid_bbox_pipe(annotations_file):
-    inputs, boxes, labels = fn.readers.coco(
-        file_root=file_root,
-        annotations_file=annotations_file,
-    )
-    return inputs, boxes, labels
-
-
-@pipeline_def(batch_size=1, num_threads=1, device_id=None)
-def coco_invalid_filename_pipe(annotations_file, file_root):
+def coco_invalid_annotations_pipe(annotations_file, file_root):
     inputs, boxes, labels = fn.readers.coco(
         file_root=file_root,
         annotations_file=annotations_file,
@@ -175,7 +166,7 @@ def test_operator_coco_reader_rejects_invalid_bbox_size(bbox):
         with open(annotations_file, "w") as f:
             json.dump(annotations, f)
 
-        pipe = coco_invalid_bbox_pipe(annotations_file)
+        pipe = coco_invalid_annotations_pipe(annotations_file, file_root)
         assert_raises(
             ValueError,
             pipe.run,
@@ -183,7 +174,7 @@ def test_operator_coco_reader_rejects_invalid_bbox_size(bbox):
         )
 
 
-@params((None, "null"), (123, "number"), (True, "boolean"), ({}, "object"))
+@params((None, "null"), (123, "number"), (True, "boolean"), ({}, "object"), ([], "array"))
 def test_operator_coco_reader_rejects_non_string_filename(filename, filename_type):
     annotations = {
         "images": [{"id": 1, "width": 640, "height": 480, "file_name": filename}],
@@ -196,7 +187,7 @@ def test_operator_coco_reader_rejects_non_string_filename(filename, filename_typ
         with open(annotations_file, "w") as f:
             json.dump(annotations, f)
 
-        pipe = coco_invalid_filename_pipe(annotations_file, annotations_dir)
+        pipe = coco_invalid_annotations_pipe(annotations_file, annotations_dir)
         assert_raises(
             ValueError,
             pipe.run,

--- a/dali/test/python/reader/test_coco.py
+++ b/dali/test/python/reader/test_coco.py
@@ -183,8 +183,8 @@ def test_operator_coco_reader_rejects_invalid_bbox_size(bbox):
         )
 
 
-@params(None, 123, True, {})
-def test_operator_coco_reader_rejects_non_string_filename(filename):
+@params((None, "null"), (123, "number"), (True, "boolean"), ({}, "object"))
+def test_operator_coco_reader_rejects_non_string_filename(filename, filename_type):
     annotations = {
         "images": [{"id": 1, "width": 640, "height": 480, "file_name": filename}],
         "categories": [],
@@ -198,9 +198,9 @@ def test_operator_coco_reader_rejects_non_string_filename(filename):
 
         pipe = coco_invalid_filename_pipe(annotations_file, annotations_dir)
         assert_raises(
-            RuntimeError,
+            ValueError,
             pipe.run,
-            glob="*Invalid COCO annotation: `file_name` must be a string*",
+            glob=f"*Invalid COCO annotation: `file_name` must be a string, got {filename_type}*",
         )
 
 


### PR DESCRIPTION
## Category:

**Bug fix**

## Description:

Reject non-string `file_name` values in COCO annotations before assigning them to `std::string`. This prevents a null-pointer dereference in `fn.readers.coco` when processing malformed annotations.

## Additional information:

### Affected modules and functionalities:

- COCO reader JSON annotation parsing
- Python COCO reader validation tests

### Key points relevant for the review:

- `file_name` is checked for a JSON string token before calling `GetString()`.
- Invalid values produce a catchable `RuntimeError` with a clear diagnostic.

### Tests:

- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_coco.py‎:test_operator_coco_reader_rejects_non_string_filename
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation

- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements

- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: DALI-4801