### PR TITLE
Fix free-threaded Python 3.13 QA dependency constraints

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -620,8 +620,42 @@ all_packages = [
     CudaPackageExtraIndex(
         "torchvision",
         {
-            "120": [PckgVer("0.22.1+cu128", python_min_ver="3.9", python_max_ver="3.13")],
-            "130": [PckgVer("0.26.0+cu130", python_min_ver="3.10", python_max_ver="3.14")],
+            "120": [
+                PckgVer("0.22.1+cu128", python_min_ver="3.9", python_max_ver="3.12"),
+                PckgVer(
+                    "0.22.1+cu128",
+                    python_min_ver="3.13",
+                    python_max_ver="3.13",
+                    python_free_threaded=False,
+                ),
+                # Pillow 12.2.0 is the latest version that provides a wheel for Python 3.13t.
+                PckgVer(
+                    "0.22.1+cu128",
+                    python_min_ver="3.13",
+                    python_max_ver="3.13",
+                    python_free_threaded=True,
+                    constraints=["pillow==12.2.0"],
+                ),
+                PckgVer("0.22.1+cu128", python_min_ver="3.14"),
+            ],
+            "130": [
+                PckgVer("0.26.0+cu130", python_min_ver="3.10", python_max_ver="3.12"),
+                PckgVer(
+                    "0.26.0+cu130",
+                    python_min_ver="3.13",
+                    python_max_ver="3.13",
+                    python_free_threaded=False,
+                ),
+                # Pillow 12.2.0 is the latest version that provides a wheel for Python 3.13t.
+                PckgVer(
+                    "0.26.0+cu130",
+                    python_min_ver="3.13",
+                    python_max_ver="3.13",
+                    python_free_threaded=True,
+                    constraints=["pillow==12.2.0"],
+                ),
+                PckgVer("0.26.0+cu130", python_min_ver="3.14"),
+            ],
         },
         extra_index="https://download.pytorch.org/whl/",
     ),
@@ -649,6 +683,14 @@ all_packages = [
                     "0.6.0",
                     python_min_ver="3.10",
                     python_max_ver="3.13",
+                    python_free_threaded=False,
+                    dependencies=["jaxlib"],
+                ),
+                PckgVer(
+                    "0.6.0",
+                    python_min_ver="3.13",
+                    python_max_ver="3.13",
+                    python_free_threaded=True,
                     dependencies=["jaxlib"],
                     constraints=["scipy==1.17.1"],
                 ),
@@ -657,9 +699,22 @@ all_packages = [
                 PckgVer(
                     "0.9.0.1",
                     python_min_ver="3.11",
-                    python_max_ver="3.14",
+                    python_max_ver="3.13",
+                    python_free_threaded=False,
+                    dependencies=["jaxlib"],
+                ),
+                PckgVer(
+                    "0.9.0.1",
+                    python_min_ver="3.13",
+                    python_max_ver="3.13",
+                    python_free_threaded=True,
                     dependencies=["jaxlib"],
                     constraints=["scipy==1.17.1"],
+                ),
+                PckgVer(
+                    "0.9.0.1",
+                    python_min_ver="3.14",
+                    dependencies=["jaxlib"],
                 ),
             ],
         },


### PR DESCRIPTION
## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)

## Description:
- Splits the `torchvision` and JAX package matrices by Python version and free-threaded mode.
- Constrains Pillow to 12.2.0 for free-threaded Python 3.13 `torchvision` installs on
  CUDA 12.8 and CUDA 13.0, avoiding the unsupported Pillow 12.3.0 source build.
- Limits JAX's `scipy==1.17.1` constraint to free-threaded Python 3.13, where that
  version provides a compatible wheel.
- Extends CUDA 12.8 `torchvision` package resolution to Python 3.14 and later.

## Additional information:

### Affected modules and functionalities:
- QA package resolution for JAX and `torchvision` across Python and CUDA variants.

### Key points relevant for the review:
- All constrained variants are mutually exclusive: only free-threaded Python 3.13
  receives the Pillow or SciPy constraint; other supported variants use their default
  dependency resolution.

### Tests:
- [x] Existing tests apply
  - `L1_TL1_superres_pytorch--py313t--1GPU_CUDA13_always`
  - tests for Python 3.13t
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
