### PR TITLE
Stop bundling FFmpeg libraries in Conda package

### DIFF
--- a/conda/dali_native_libs/recipe/build.sh
+++ b/conda/dali_native_libs/recipe/build.sh
@@ -100,7 +100,6 @@ cmake -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda \
       ..
 make -j"$(nproc --all)"
 
-# bundle FFmpeg to make sure DALI ships and uses own version
 fname_with_sha256() {
     HASH=$(sha256sum $1 | cut -c1-8)
     BASENAME=$(basename $1)
@@ -110,11 +109,6 @@ fname_with_sha256() {
 }
 
 DEPS_LIST=(
-    "$PREFIX/lib/libavformat.so.62"
-    "$PREFIX/lib/libavcodec.so.62"
-    "$PREFIX/lib/libavfilter.so.11"
-    "$PREFIX/lib/libavutil.so.60"
-    "$PREFIX/lib/libswscale.so.9"
     "lib/libcvcuda.so.0"
     "lib/libnvcv_types.so.0"
 )

--- a/conda/dali_native_libs/recipe/meta.yaml
+++ b/conda/dali_native_libs/recipe/meta.yaml
@@ -80,7 +80,10 @@ requirements:
     - zlib
     - libjpeg-turbo
     - libopencv >=4.13,<5
-    - ffmpeg
+    # FFmpeg 8.1.2 needs libjxl.so.0.11, but its metadata permits libjxl 0.12.
+    # Remove these pins once FFmpeg is rebuilt for the newer libjxl ABI.
+    - ffmpeg =8.1.2
+    - libjxl <0.12
     - lmdb
     - libtiff
     - libsndfile
@@ -95,7 +98,8 @@ requirements:
   run:
     - libjpeg-turbo
     - libopencv >=4.13,<5
-    - ffmpeg
+    - ffmpeg =8.1.2
+    - libjxl <0.12
     - lmdb
     - libtiff
     - libsndfile


### PR DESCRIPTION
## Category:

Bug fix

## Description:

Fixes the Conda build environment selecting libjxl 0.12 for FFmpeg 8.1.2. That FFmpeg build requires libjxl.so.0.11, so importing the just-built DALI Python backend during stub generation fails before packaging begins.

Pins FFmpeg to 8.1.2 and libjxl below 0.12 in the host requirements. The pins are temporary and should be removed once FFmpeg is rebuilt for the newer libjxl ABI. The PR also stops packaging DALI-private FFmpeg shared libraries, so the final package uses Conda-provided FFmpeg and its dependency closure.

## Additional information:

### Affected modules and functionalities:

Conda native-libraries recipe, Python stub generation, and FFmpeg runtime loading.

### Key points relevant for the review:

- The host pins unblock the build by selecting the libjxl ABI required by FFmpeg 8.1.2.
- The comment records when the pins can be removed.
- FFmpeg libraries are no longer copied into DALI-private hashed paths.

### Tests:

- [x] Existing tests apply
  - conda build
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A