### PR TITLE
Fix wds2idx parsing with spaced tar owners

### DIFF
--- a/dali/test/python/reader/test_wds2idx.py
+++ b/dali/test/python/reader/test_wds2idx.py
@@ -54,3 +54,31 @@ def test_wds2idx_gnu_tar_path_accepts_utf8_tar_member_name():
         _, name, size = entries[0]
         assert name == member_name
         assert size == len(payload)
+
+
+def test_wds2idx_gnu_tar_path_accepts_member_owner_with_space():
+    if which("tar") is None:
+        raise unittest.SkipTest("GNU tar not installed")
+
+    wds2idx = _load_wds2idx()
+
+    with tempfile.TemporaryDirectory() as test_dir:
+        tar_path = os.path.join(test_dir, "data.tar")
+        idx_path = os.path.join(test_dir, "data.idx")
+        member_name = "sample.bin"
+        payload = b"payload"
+
+        with tarfile.open(tar_path, "w", format=tarfile.USTAR_FORMAT) as archive:
+            info = tarfile.TarInfo(name=member_name)
+            info.size = len(payload)
+            info.uname = "owner name"
+            info.gname = "group"
+            archive.addfile(info, io.BytesIO(payload))
+
+        with wds2idx.IndexCreator(tar_path, idx_path, verbose=False) as creator:
+            entries = list(creator._get_data_tar())
+
+        assert len(entries) == 1
+        _, name, size = entries[0]
+        assert name == member_name
+        assert size == len(payload)

--- a/tools/wds2idx.py
+++ b/tools/wds2idx.py
@@ -89,7 +89,7 @@ class IndexCreator:
             stderr=subprocess.PIPE,
         )
         tar_types_sizes_proc = subprocess.Popen(  # nosec B603, B607
-            ["tar", "--verbose", "--list", "--file", self.uri],
+            ["tar", "--verbose", "--list", "--numeric-owner", "--file", self.uri],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )


### PR DESCRIPTION
## Category:

**Bug fix**

## Description:

Fixes `wds2idx` parsing of GNU tar verbose output when a tar entry's owner or group name contains whitespace. The GNU tar fast path now requests numeric owner/group fields, keeping the size column stable.

## Additional information:

### Affected modules and functionalities:

- `tools/wds2idx.py` GNU tar index-generation path.

### Key points relevant for the review:

- The numeric-owner option avoids parsing attacker-controlled owner/group text while retaining the existing fast path.

### Tests:

- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - dali.test.python.reader.test_wds2idx
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: DALI-4804
