### PR TITLE
Support random ops in transparent pipelining

### DIFF
--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from ._eval_context import EvalContext
     from ._external_source import ExternalSource  # noqa: F401
     from ._ops import Operator, Reader
+    from .random import RNG
 
 
 def _nvtx_range(message: str):
@@ -58,14 +59,14 @@ class State(enum.Enum):
 
 
 class SupportsCompile(Protocol):
-    """A class supporting being used as a source of a compile graph."""
+    """Interface for sources that support compiled iteration."""
 
     _compiled_iter: "CompiledEpochIterator | None"
 
-    def _wire_pipeline(self, source: "CompileSource") -> tuple: ...
-    def _shape_result(self, source: "CompileSource", batches: tuple) -> Any: ...
-    def _transfer_into(self, pipe: Pipeline) -> bool: ...
     def _make_epoch_iterator(self, batch_size: int) -> "CompiledEpochIterator": ...
+    def _wire_pipeline(self, source: "CompileSource") -> tuple: ...
+    def _transfer_into(self, pipe: Pipeline) -> bool: ...
+    def _shape_result(self, source: "CompileSource", batches: tuple) -> Any: ...
     def _teardown_compile(self) -> None: ...
 
 

--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -19,7 +19,6 @@ import threading
 import types
 import warnings
 from abc import ABC, abstractmethod
-from collections import deque
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Generic, NamedTuple, NoReturn, Protocol, TypeVar
@@ -159,17 +158,6 @@ class _CallTrie:
             frame = frame.f_back
         return current.nodes.get(op)
 
-    def prune(self, nodes: set[CompileNode]) -> None:
-        """Remove graph nodes and any branches left empty by the removal."""
-        self.nodes = {op: node for op, node in self.nodes.items() if node not in nodes}
-        for child in self.children.values():
-            child.prune(nodes)
-        self.children = {
-            code_loc: child
-            for code_loc, child in self.children.items()
-            if child.nodes or child.children
-        }
-
 
 class CompiledBatch(Batch):
     """A Batch that carries compile-graph provenance."""
@@ -209,126 +197,114 @@ def _wrap_captured_result(
     return wrapped if is_tuple else wrapped[0]
 
 
-class CompiledRNG:
-    """Manage one RNG across tracing and compiled execution.
+def _raise_rng_desync() -> NoReturn:
+    raise RuntimeError(
+        "The RNG of a compiled operator was used unexpectedly: the number of random draws per "
+        "iteration changed or the RNG was modified outside the loop"
+    )
 
-    The public RNG advances when the Python body consumes a compiled random call. A backend clone
-    feeds the pipeline and may advance ahead due to prefetch. The call index verifies that the
-    Python body consumes the prefetched results in trace order.
+
+class CompiledRNG:
+    """Schedule one RNG's states across tracing and compiled execution.
+
+    A captured operator must see the words the eager path would have reached, but the pipeline
+    draws iterations ahead of the body. The schedule is therefore predicted from the tracing
+    iteration: `period` words per iteration, each captured call at a fixed offset within it.
     """
 
     __slots__ = (
         "rng",
         "batch_size",
-        "nodes",
-        "_used_eagerly",
-        "_pipeline_rng",
+        "calls",
+        "period",
         "_version",
-        "_next_call",
+        "_clone",
+        "_in_flight",
+        "_start_pos",
     )
 
-    def __init__(self, rng: _random.RNG, batch_size: int):
+    def __init__(self, rng: _random.RNG, batch_size: int, start_pos: int):
         self.rng = rng
         self.batch_size = batch_size
-        self.nodes: list[CompileNode] = []  # Operators that this rng is assigned to
-        self._used_eagerly = False
-        self._pipeline_rng = None  # Clone of rng's generator, advanced in parallel
-        self._version = 0
-        self._next_call = 0
 
-    def record_use(self, node: CompileNode | None) -> None:
-        """Record one traced use."""
-        if node is None:
-            self._used_eagerly = True
-            return
+        self.calls: list[tuple[CompileNode, int]] = []  # node, and where in an iteration it draws
+        self.period = 0
+        self._version = rng._version
+        self._clone = None  # the pipeline draws its states from this copy of the generator
+        self._in_flight = 0  # iterations scheduled but not yet consumed
+        self._start_pos = start_pos  # where the current iteration begins
 
-        if node.random_state_ref is None:
-            node.random_state_ref = CompileRef(self, len(self.nodes))
-            self.nodes.append(node)
-            return
-
-        # random_state_ref already present: same call site hit twice
-        owner = node.random_state_ref.owner
-        assert isinstance(owner, CompiledRNG)
-        owner._used_eagerly = True
-        self._used_eagerly = True
-
-    @property
-    def needs_pruning(self) -> bool:
-        return self._used_eagerly and bool(self.nodes)
-
-    def prune(self, nodes: set[CompileNode]) -> bool:
-        self.nodes = [node for node in self.nodes if node not in nodes]
-        for call_index, node in enumerate(self.nodes):
-            node.random_state_ref = CompileRef(self, call_index)
-        return bool(self.nodes)
+    def record_call(self, node: CompileNode) -> None:
+        node.random_state_ref = CompileRef(self, len(self.calls))
+        self.calls.append((node, self.rng._draws - _random._STATE_WORDS - self._start_pos))
 
     def sync(self) -> None:
-        self._pipeline_rng, self._version = self.rng._snapshot_backend()
+        """Start scheduling, now that the traced iteration has given us the period."""
+        self.period = self.rng._draws - self._start_pos
+        self._clone, self._version = self.rng._snapshot_backend()
+        self._start_pos = self.rng._draws
+        self._in_flight = 0
 
-    def check_version(self) -> None:
-        if self._version != self.rng._version:
-            raise RuntimeError("The RNG of a compiled operator was modified outside the loop.")
+    def resync(self) -> None:
+        """Resync at epoch boundary"""
+        self._clone, _ = self.rng._snapshot_backend()
+        self._in_flight = 0
 
-    def consume_call(self, call_index: int, actual_rng: _random.RNG) -> None:
-        if self.rng is not actual_rng:
-            raise RuntimeError("A compiled operator was called with a different RNG.")
-        self.check_version()
-        if call_index < self._next_call:
-            raise RuntimeError("A compiled random operator may be called only once per step.")
-        if call_index != self._next_call:
-            raise RuntimeError(
-                "Compiled operators sharing an RNG must be called in the same order."
-            )
+    def begin_step(self) -> None:
+        """Take up the iteration whose outputs are about to be consumed."""
+        if self.rng._draws != self._start_pos or self.rng._version != self._version:
+            _raise_rng_desync()
 
+        if not self._in_flight:
+            _raise_rng_desync()
+        self._in_flight -= 1
+
+    def consume_call(self, call_index: int, actual_rng: _random.RNG) -> bool:
+        """True to use the pipeline's state for this call, False to draw eagerly instead."""
+        expected = self._start_pos + self.calls[call_index][1]
+        if self.rng._draws > expected:
+            return False  # already drawn: the site ran twice, or its first run went eager
+        if actual_rng is not self.rng or actual_rng._version != self._version:
+            _raise_rng_desync()
+        if actual_rng._draws != expected:
+            _raise_rng_desync()
         self.rng.advance(_random._STATE_WORDS)
-        self._version = self.rng._version
-        self._next_call += 1
+        return True
 
     def finish_step(self) -> None:
-        if self._next_call != len(self.nodes):
-            raise RuntimeError("A compiled random operator was not consumed this step")
-        self._next_call = 0
+        if self.rng._draws != self._start_pos + self.period or self.rng._version != self._version:
+            _raise_rng_desync()
+        self._start_pos += self.period
 
     def _draw_states(self) -> tuple[Any, ...]:
-        random_words = (_random._draw_state(self._pipeline_rng.next) for _ in self.nodes)
-        return tuple(
-            Batch.broadcast(_random._state_tensor(words), self.batch_size).evaluate()._storage
-            for words in random_words
-        )
+        """Draw the states for one iteration.
+
+        The clone enters on the first word that iteration draws and leaves on the first word of
+        the next one, so only the gaps between offsets are ever needed.
+        """
+        states = []
+        drawn = 0
+        for _, offset in self.calls:
+            if skip := offset - drawn:  # offsets increase, so never negative
+                self._clone.skipahead(skip)
+            words = _random._draw_state(self._clone.next)
+            drawn = offset + _random._STATE_WORDS
+            states.append(
+                Batch.broadcast(_random._state_tensor(words), self.batch_size).evaluate()._storage
+            )
+        if tail := self.period - drawn:
+            self._clone.skipahead(tail)  # onto the next iteration's first word
+        self._in_flight += 1
+        return tuple(states)
 
     def _wire_source(self) -> tuple:
-        return tuple(fn.external_source(self._draw_states, len(self.nodes), device="cpu"))
-
-
-def _find_nodes_to_prune(
-    nodes: Sequence[CompileNode],
-    rngs: Sequence[CompiledRNG],
-) -> set[CompileNode]:
-    """Find nodes made eager by dependencies or shared RNGs."""
-    dependents: dict[CompileNode, list[CompileNode]] = {}
-    for node in nodes:
-        for ref in itertools.chain(node.inputs, node.kwargs.values()):
-            if isinstance(ref, CompileRef) and isinstance(ref.owner, CompileNode):
-                dependents.setdefault(ref.owner, []).append(node)
-
-    queue = deque(node for rng in rngs if rng.needs_pruning for node in rng.nodes)
-    nodes_to_prune: set[CompileNode] = set()
-
-    while queue:
-        node = queue.popleft()
-        if node in nodes_to_prune:
-            continue
-
-        nodes_to_prune.add(node)
-        queue.extend(dependents.get(node, ()))
-
-        if node.random_state_ref is not None:
-            rng = node.random_state_ref.owner
-            assert isinstance(rng, CompiledRNG)
-            queue.extend(rng.nodes)
-
-    return nodes_to_prune
+        return tuple(
+            fn.external_source(
+                self._draw_states,
+                num_outputs=len(self.calls),
+                device="cpu",
+            )
+        )
 
 
 class CompileContext:
@@ -501,28 +477,32 @@ class CompileContext:
         self._call_trie.insert(call_chain, op_class, node)
         return node
 
-    def _record_rng_use(self, rng: _random.RNG, captured_node: CompileNode | None) -> None:
-        compiled_rng = self.rngs.get(rng)
-        if compiled_rng is None:
-            compiled_rng = CompiledRNG(rng, self.batch_size)
-            self.rngs[rng] = compiled_rng
-        compiled_rng.record_use(captured_node)
+    def _rng_on_draw(self, rng: _random.RNG) -> None:
+        """Anchor an RNG at its first traced draw. Fires for bare generator calls too."""
+        if rng not in self.rngs:
+            self.rngs[rng] = CompiledRNG(rng, self.batch_size, rng._draws)
 
-    def _prune_rng_nodes(self) -> None:
-        nodes_to_prune = _find_nodes_to_prune(self.nodes, tuple(self.rngs.values()))
-        if nodes_to_prune:
-            warnings.warn(
-                "An RNG was used both by a capturable random operator and by a non-capturable "
-                "random call, or a capturable random call site was used more than once during "
-                "tracing. Affected operators and everything depending on them run eagerly."
+    def _record_rng_use(
+        self,
+        rng: _random.RNG,
+        captured_node: CompileNode,
+        frame: types.FrameType,
+    ) -> None:
+        if captured_node.random_state_ref is not None:
+            # Warning points to the user's call site
+            warnings.warn_explicit(
+                "A random operator call site runs more than once per iteration. Only the first "
+                "call each iteration uses the compiled pipeline; the rest run eagerly.",
+                UserWarning,
+                frame.f_code.co_filename,
+                frame.f_lineno,
             )
-        self.nodes = [node for node in self.nodes if node not in nodes_to_prune]
-        self._call_trie.prune(nodes_to_prune)
-        self.rngs = {
-            rng: compiled_rng
-            for rng, compiled_rng in self.rngs.items()
-            if compiled_rng.prune(nodes_to_prune)
-        }
+            return
+        self.rngs[rng].record_call(captured_node)
+
+    def _drop_unused_rngs(self) -> None:
+        """Discard the generators the body only drew from directly; they schedule nothing."""
+        self.rngs = {rng: compiled for rng, compiled in self.rngs.items() if compiled.calls}
 
     def _assign_output_offsets(self) -> None:
         offset = 0
@@ -537,7 +517,7 @@ class CompileContext:
                 "compile=True was specified but no operators were captured during tracing. "
                 "Falling back to dynamic mode.",
             )
-        self._prune_rng_nodes()
+        self._drop_unused_rngs()
         if not self.nodes:
             self._teardown()
             return
@@ -591,21 +571,19 @@ class CompileContext:
             self._teardown()
             raise
 
-        self._check_rng_versions()
+        with self._invalidate_on_error():
+            for rng in self.rngs.values():
+                rng.begin_step()
+
         self._results.clear()
         for owner in itertools.chain(self.sources, self.nodes):
             self._results[owner] = self._wrap_outputs(owner, pipeline_outputs)
         return self.result_for(self.sources[0])
 
-    def _check_rng_versions(self) -> None:
+    def _resync_rngs(self) -> None:
         with self._invalidate_on_error():
             for rng in self.rngs.values():
-                rng.check_version()
-
-    def _resync_rngs(self) -> None:
-        self._check_rng_versions()
-        for rng in self.rngs.values():
-            rng.sync()
+                rng.resync()
 
     def _wrap_outputs(
         self, owner: "CompileSource | CompileNode", pipeline_outputs: Sequence
@@ -670,12 +648,22 @@ class CompileContext:
             compiled_rng = ref.owner
             assert isinstance(compiled_rng, CompiledRNG)
             with self._invalidate_on_error():
-                compiled_rng.consume_call(ref.output_index, rng)
-            return self.result_for(node)
+                if compiled_rng.consume_call(ref.output_index, rng):
+                    return self.result_for(node)
 
-        if rng in self.rngs:
-            self._fail("A captured RNG was used by a non-compiled random operator.")
+        # The eager call draws where the schedule already expects it to.
         return None
+
+
+def _note_rng_draw(self: _random.RNG) -> None:
+    """`RNG._on_draw`, installed below."""
+    ctx = CompileContext.current()
+    if ctx is not None and ctx.state is State.TRACING:
+        ctx._rng_on_draw(self)
+
+
+# Intercept on `RNG` rather than in `_compile_intercept`, which bare generator RNG calls bypass.
+_random.RNG._on_draw = _note_rng_draw
 
 
 _Compilable = TypeVar("_Compilable", bound=SupportsCompile)
@@ -1003,8 +991,8 @@ def _compile_intercept(
             if capturable
             else None
         )
-        if is_random:
-            compile_ctx._record_rng_use(rng, node)
+        if is_random and node is not None:
+            compile_ctx._record_rng_use(rng, node, frame)
 
         if node is None:
             return result

--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -19,9 +19,10 @@ import threading
 import types
 import warnings
 from abc import ABC, abstractmethod
+from collections import deque
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generic, NamedTuple, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, NamedTuple, NoReturn, Protocol, TypeVar
 
 import numpy as np
 
@@ -29,6 +30,7 @@ import nvidia.dali.types as dali_types
 from nvidia.dali import fn
 from nvidia.dali.pipeline import Pipeline
 
+from . import random as _random
 from ._batch import Batch
 from ._call_site import (
     CallChain,
@@ -45,7 +47,6 @@ if TYPE_CHECKING:
     from ._eval_context import EvalContext
     from ._external_source import ExternalSource  # noqa: F401
     from ._ops import Operator, Reader
-    from .random import RNG
 
 
 def _nvtx_range(message: str):
@@ -93,6 +94,7 @@ class CompileNode:
     num_outputs: int
     device: Device | None = None
     pipeline_output_offset: int | None = dataclasses.field(default=None, repr=False)
+    random_state_ref: "CompileRef | None" = dataclasses.field(default=None, repr=False)
 
 
 def _value_matches(actual: Any, expected: Any) -> bool:
@@ -116,7 +118,7 @@ def _value_matches(actual: Any, expected: Any) -> bool:
 class CompileRef(NamedTuple):
     """Reference to one output of a compile graph node."""
 
-    owner: "CompileSource | CompileNode"
+    owner: "CompileSource | CompileNode | CompiledRNG"
     output_index: int
 
 
@@ -157,6 +159,17 @@ class _CallTrie:
             frame = frame.f_back
         return current.nodes.get(op)
 
+    def prune(self, nodes: set[CompileNode]) -> None:
+        """Remove graph nodes and any branches left empty by the removal."""
+        self.nodes = {op: node for op, node in self.nodes.items() if node not in nodes}
+        for child in self.children.values():
+            child.prune(nodes)
+        self.children = {
+            code_loc: child
+            for code_loc, child in self.children.items()
+            if child.nodes or child.children
+        }
+
 
 class CompiledBatch(Batch):
     """A Batch that carries compile-graph provenance."""
@@ -181,6 +194,143 @@ class CompiledBatch(Batch):
             self._compile_iteration = None
 
 
+def _wrap_captured_result(
+    node: CompileNode,
+    result: Batch | tuple[Batch, ...],
+    iteration: int,
+) -> CompiledBatch | tuple[CompiledBatch, ...]:
+    """Wrap an eager result with its compile provenance."""
+    is_tuple = isinstance(result, tuple)
+    result = result if is_tuple else (result,)
+    wrapped = tuple(
+        CompiledBatch.from_batch(batch, CompileRef(node, i), iteration)
+        for i, batch in enumerate(result)
+    )
+    return wrapped if is_tuple else wrapped[0]
+
+
+class CompiledRNG:
+    """Manage one RNG across tracing and compiled execution.
+
+    The public RNG advances when the Python body consumes a compiled random call. A backend clone
+    feeds the pipeline and may advance ahead due to prefetch. The call index verifies that the
+    Python body consumes the prefetched results in trace order.
+    """
+
+    __slots__ = (
+        "rng",
+        "batch_size",
+        "nodes",
+        "_used_eagerly",
+        "_pipeline_rng",
+        "_version",
+        "_next_call",
+    )
+
+    def __init__(self, rng: _random.RNG, batch_size: int):
+        self.rng = rng
+        self.batch_size = batch_size
+        self.nodes: list[CompileNode] = []  # Operators that this rng is assigned to
+        self._used_eagerly = False
+        self._pipeline_rng = None  # Clone of rng's generator, advanced in parallel
+        self._version = 0
+        self._next_call = 0
+
+    def record_use(self, node: CompileNode | None) -> None:
+        """Record one traced use."""
+        if node is None:
+            self._used_eagerly = True
+            return
+
+        if node.random_state_ref is None:
+            node.random_state_ref = CompileRef(self, len(self.nodes))
+            self.nodes.append(node)
+            return
+
+        # random_state_ref already present: same call site hit twice
+        owner = node.random_state_ref.owner
+        assert isinstance(owner, CompiledRNG)
+        owner._used_eagerly = True
+        self._used_eagerly = True
+
+    @property
+    def needs_pruning(self) -> bool:
+        return self._used_eagerly and bool(self.nodes)
+
+    def prune(self, nodes: set[CompileNode]) -> bool:
+        self.nodes = [node for node in self.nodes if node not in nodes]
+        for call_index, node in enumerate(self.nodes):
+            node.random_state_ref = CompileRef(self, call_index)
+        return bool(self.nodes)
+
+    def sync(self) -> None:
+        self._pipeline_rng, self._version = self.rng._snapshot_backend()
+
+    def check_version(self) -> None:
+        if self._version != self.rng._version:
+            raise RuntimeError("The RNG of a compiled operator was modified outside the loop.")
+
+    def consume_call(self, call_index: int, actual_rng: _random.RNG) -> None:
+        if self.rng is not actual_rng:
+            raise RuntimeError("A compiled operator was called with a different RNG.")
+        self.check_version()
+        if call_index < self._next_call:
+            raise RuntimeError("A compiled random operator may be called only once per step.")
+        if call_index != self._next_call:
+            raise RuntimeError(
+                "Compiled operators sharing an RNG must be called in the same order."
+            )
+
+        self.rng.advance(_random._STATE_WORDS)
+        self._version = self.rng._version
+        self._next_call += 1
+
+    def finish_step(self) -> None:
+        if self._next_call != len(self.nodes):
+            raise RuntimeError("A compiled random operator was not consumed this step")
+        self._next_call = 0
+
+    def _draw_states(self) -> tuple[Any, ...]:
+        random_words = (_random._draw_state(self._pipeline_rng.next) for _ in self.nodes)
+        return tuple(
+            Batch.broadcast(_random._state_tensor(words), self.batch_size).evaluate()._storage
+            for words in random_words
+        )
+
+    def _wire_source(self) -> tuple:
+        return tuple(fn.external_source(self._draw_states, len(self.nodes), device="cpu"))
+
+
+def _find_nodes_to_prune(
+    nodes: Sequence[CompileNode],
+    rngs: Sequence[CompiledRNG],
+) -> set[CompileNode]:
+    """Find nodes made eager by dependencies or shared RNGs."""
+    dependents: dict[CompileNode, list[CompileNode]] = {}
+    for node in nodes:
+        for ref in itertools.chain(node.inputs, node.kwargs.values()):
+            if isinstance(ref, CompileRef) and isinstance(ref.owner, CompileNode):
+                dependents.setdefault(ref.owner, []).append(node)
+
+    queue = deque(node for rng in rngs if rng.needs_pruning for node in rng.nodes)
+    nodes_to_prune: set[CompileNode] = set()
+
+    while queue:
+        node = queue.popleft()
+        if node in nodes_to_prune:
+            continue
+
+        nodes_to_prune.add(node)
+        queue.extend(dependents.get(node, ()))
+
+        if node.random_state_ref is not None:
+            rng = node.random_state_ref.owner
+            assert isinstance(rng, CompiledRNG)
+            queue.extend(rng.nodes)
+
+    return nodes_to_prune
+
+
 class CompileContext:
     """Manages the compile state (TRACING -> COMPILED or DISABLED)."""
 
@@ -191,6 +341,7 @@ class CompileContext:
         self.batch_size = batch_size
         self.sources: list[CompileSource] = []  # only sources[0] is iterated on
         self.nodes: list[CompileNode] = []
+        self.rngs: dict[_random.RNG, CompiledRNG] = {}
         self._call_trie = _CallTrie()
         self.pipeline: Pipeline | None = None
         self._results: dict[CompileSource | CompileNode, tuple[CompiledBatch, ...]] = {}
@@ -265,14 +416,27 @@ class CompileContext:
             if source not in self._read_this_step:
                 self._fail("An ExternalSource was not consumed this step")
 
+        if self.state is State.COMPILED:
+            with self._invalidate_on_error():
+                for rng in self.rngs.values():
+                    rng.finish_step()
+
     def _teardown(self) -> None:
         self.state = State.DISABLED
         for source in self.sources:
             source.compilable._teardown_compile()
 
-    def _fail(self, message: str):
+    def _fail(self, message: str) -> NoReturn:
         self._teardown()
         raise RuntimeError(message)
+
+    @contextmanager
+    def _invalidate_on_error(self):
+        try:
+            yield
+        except RuntimeError:
+            self._teardown()
+            raise
 
     @staticmethod
     def _compute_kwarg_casts(op: type["Operator"], raw_kwargs: Mapping[str, CompiledBatch | Any]):
@@ -293,40 +457,78 @@ class CompileContext:
     @_nvtx_range("Recording operator")
     def record(
         self,
-        call_chain: CallChain,
+        frame: types.FrameType,
         op_class: type["Operator"],
+        inputs: Sequence[Any],
+        kwargs: Mapping[str, Any],
+        result: Any,
         backend: str,
-        inputs: Sequence[CompileRef | Any],
-        kwargs: Mapping[str, CompileRef | Any],
-        raw_kwargs: Mapping[str, CompiledBatch | Any],
-        num_outputs: int,
-        device: Device | None = None,
+        device: Device | None,
     ) -> CompileNode | None:
+        from ._source_analysis import classify
+
+        classification = classify(frame, inputs, kwargs)
+        if classification is None:
+            return None
+
+        captured_inputs, captured_kwargs = classification
+        call_chain = build_call_chain(frame)
         if existing := self._call_trie.find(call_chain, op_class):
             if (
-                len(existing.inputs) != len(inputs)
-                or existing.kwargs.keys() != kwargs.keys()
+                len(existing.inputs) != len(captured_inputs)
+                or existing.kwargs.keys() != captured_kwargs.keys()
                 or existing.device != device
             ):
                 return None
-            if not all(_value_matches(a, e) for a, e in zip(inputs, existing.inputs)):
+            if not all(_value_matches(a, e) for a, e in zip(captured_inputs, existing.inputs)):
                 return None
-            if not all(_value_matches(kwargs[name], e) for name, e in existing.kwargs.items()):
+            if not all(
+                _value_matches(captured_kwargs[name], e) for name, e in existing.kwargs.items()
+            ):
                 return None
             return existing
 
         node = CompileNode(
             op_class=op_class,
             backend=backend,
-            inputs=inputs,
-            kwargs=kwargs,
-            kwarg_casts=self._compute_kwarg_casts(op_class, raw_kwargs),
-            num_outputs=num_outputs,
+            inputs=captured_inputs,
+            kwargs=captured_kwargs,
+            kwarg_casts=self._compute_kwarg_casts(op_class, kwargs),
+            num_outputs=len(result) if isinstance(result, tuple) else 1,
             device=device,
         )
         self.nodes.append(node)
         self._call_trie.insert(call_chain, op_class, node)
         return node
+
+    def _record_rng_use(self, rng: _random.RNG, captured_node: CompileNode | None) -> None:
+        compiled_rng = self.rngs.get(rng)
+        if compiled_rng is None:
+            compiled_rng = CompiledRNG(rng, self.batch_size)
+            self.rngs[rng] = compiled_rng
+        compiled_rng.record_use(captured_node)
+
+    def _prune_rng_nodes(self) -> None:
+        nodes_to_prune = _find_nodes_to_prune(self.nodes, tuple(self.rngs.values()))
+        if nodes_to_prune:
+            warnings.warn(
+                "An RNG was used both by a capturable random operator and by a non-capturable "
+                "random call, or a capturable random call site was used more than once during "
+                "tracing. Affected operators and everything depending on them run eagerly."
+            )
+        self.nodes = [node for node in self.nodes if node not in nodes_to_prune]
+        self._call_trie.prune(nodes_to_prune)
+        self.rngs = {
+            rng: compiled_rng
+            for rng, compiled_rng in self.rngs.items()
+            if compiled_rng.prune(nodes_to_prune)
+        }
+
+    def _assign_output_offsets(self) -> None:
+        offset = 0
+        for node in itertools.chain(self.sources, self.nodes):
+            node.pipeline_output_offset = offset
+            offset += node.num_outputs
 
     @_nvtx_range("Building pipeline")
     def build_pipeline(self, ctx: "EvalContext") -> None:
@@ -335,11 +537,14 @@ class CompileContext:
                 "compile=True was specified but no operators were captured during tracing. "
                 "Falling back to dynamic mode.",
             )
+        self._prune_rng_nodes()
+        if not self.nodes:
             self._teardown()
             return
 
         self._assign_output_offsets()
 
+        compiled_rngs = tuple(self.rngs.values())
         transferred = False
         try:
             pipe = Pipeline(
@@ -349,7 +554,9 @@ class CompileContext:
                 prefetch_queue_depth=2,
             )
             with pipe:
-                _wire_compile_graph(self.sources, self.nodes)
+                _wire_compile_graph(self.sources, self.nodes, compiled_rngs)
+            for rng in compiled_rngs:
+                rng.sync()
             for source in self.sources:
                 transferred |= source.compilable._transfer_into(pipe)
             pipe.build()
@@ -383,10 +590,22 @@ class CompileContext:
         except Exception:
             self._teardown()
             raise
+
+        self._check_rng_versions()
         self._results.clear()
         for owner in itertools.chain(self.sources, self.nodes):
             self._results[owner] = self._wrap_outputs(owner, pipeline_outputs)
         return self.result_for(self.sources[0])
+
+    def _check_rng_versions(self) -> None:
+        with self._invalidate_on_error():
+            for rng in self.rngs.values():
+                rng.check_version()
+
+    def _resync_rngs(self) -> None:
+        self._check_rng_versions()
+        for rng in self.rngs.values():
+            rng.sync()
 
     def _wrap_outputs(
         self, owner: "CompileSource | CompileNode", pipeline_outputs: Sequence
@@ -416,15 +635,15 @@ class CompileContext:
         return _value_matches(actual, expected)
 
     @_nvtx_range("Getting compiled result")
-    def get_compiled_result(
+    def _find_compiled_node(
         self,
         frame: types.FrameType,
         op_class: type["Operator"],
         inputs: Sequence[Any],
         kwargs: Mapping[str, Any],
         device: Device | None = None,
-    ) -> Any | None:
-        """Return pre-built result for a known call site, or None."""
+    ) -> CompileNode | None:
+        """Find a compiled node matching this call."""
         node = self._call_trie.lookup(frame, op_class)
         if node is None:
             return None
@@ -442,15 +661,21 @@ class CompileContext:
             return None
         if not all(self._matches(kwargs[name], expected) for name, expected in node.kwargs.items()):
             return None
-        if node not in self._results:
-            return None
-        return self.result_for(node)
+        return node
 
-    def _assign_output_offsets(self) -> None:
-        offset = 0
-        for node in itertools.chain(self.sources, self.nodes):
-            node.pipeline_output_offset = offset
-            offset += node.num_outputs
+    def _resolve_random_call(self, node: CompileNode | None, rng: _random.RNG) -> Any | None:
+        """Return a compiled random result, or None to request eager fallback."""
+        if node is not None and node.random_state_ref is not None:
+            ref = node.random_state_ref
+            compiled_rng = ref.owner
+            assert isinstance(compiled_rng, CompiledRNG)
+            with self._invalidate_on_error():
+                compiled_rng.consume_call(ref.output_index, rng)
+            return self.result_for(node)
+
+        if rng in self.rngs:
+            self._fail("A captured RNG was used by a non-compiled random operator.")
+        return None
 
 
 _Compilable = TypeVar("_Compilable", bound=SupportsCompile)
@@ -495,6 +720,8 @@ class CompiledEpochIterator(ABC, Generic[_Compilable]):
         except GeneratorExit:
             self._on_break()
             raise
+        if ctx.state is State.DISABLED:
+            raise RuntimeError("The compiled loop was invalidated and cannot continue.")
         ctx._require_consumed()
 
     @abstractmethod
@@ -593,7 +820,7 @@ class _ReaderEpochIterator(CompiledEpochIterator["Reader"]):
 
     def _on_break(self):
         # consumer aborted mid-step, extra sources already advanced, fail safe
-        if len(self._compile_ctx.sources) > 1:
+        if len(self._compile_ctx.sources) > 1 or self._compile_ctx.rngs:
             self._compile_ctx._teardown()
 
 
@@ -624,6 +851,8 @@ class _ExternalSourceEpochIterator(CompiledEpochIterator["ExternalSource"]):
     def _compiled(self):
         ctx = self._compile_ctx
         ctx._reset_stop()
+        if ctx._iteration > 0:  # a previous epoch's reset discarded prefetched states
+            ctx._resync_rngs()
         while (batches := self._next_batches()) is not None:
             yield from self._emit_step(batches)
         assert ctx.pipeline is not None
@@ -646,7 +875,11 @@ def make_iterator(compilable: SupportsCompile, batch_size: int) -> CompiledEpoch
 
 
 @_nvtx_range("Graph Wiring")
-def _wire_compile_graph(sources: Sequence[CompileSource], nodes: Sequence[CompileNode]) -> None:
+def _wire_compile_graph(
+    sources: Sequence[CompileSource],
+    nodes: Sequence[CompileNode],
+    rngs: Sequence[CompiledRNG],
+) -> None:
     """Wire the compile graph into a Pipeline. Must be called inside ``with pipe:``."""
     from ._op_builder import _scalar_decay
 
@@ -654,6 +887,9 @@ def _wire_compile_graph(sources: Sequence[CompileSource], nodes: Sequence[Compil
     for source in sources:
         for i, out in enumerate(source.compilable._wire_pipeline(source)):
             datanode_map[CompileRef(source, i)] = out
+    for rng in rngs:
+        for i, out in enumerate(rng._wire_source()):
+            datanode_map[CompileRef(rng, i)] = out
 
     for node in nodes:
         positional = [
@@ -676,6 +912,10 @@ def _wire_compile_graph(sources: Sequence[CompileSource], nodes: Sequence[Compil
         for name, kw_node in kw_nodes.items():
             kw_nodes[name] = kw_node.cpu()
 
+        # Inject random state nodes
+        if node.random_state_ref is not None:
+            kw_nodes["_random_state"] = datanode_map[node.random_state_ref].cpu()
+
         op = node.op_class._legacy_op(device=node.backend, **kw_scalars)
         out = op(*positional, **kw_nodes)
 
@@ -696,14 +936,16 @@ def _compile_intercept(
 ) -> types.FunctionType:
     """Wrap an fn_call to intercept operator calls for transparent pipelining."""
     from ._op_builder import _resolve_backend
-    from ._source_analysis import classify
+    from ._ops import _infer_batch_size
+
+    is_random = op_class._has_random_state_arg
 
     @mark_transparent
     def wrapper(*inputs, batch_size=None, device=None, **raw_kwargs):
         batch_size = unwrap_invariant(batch_size)
         device, backend = _resolve_backend(op_class, device, inputs, op_name=op_name)
         compile_ctx = CompileContext.current()
-        if compile_ctx is None:
+        if compile_ctx is None or compile_ctx.state is State.DISABLED:
             return fn_call(
                 *inputs, batch_size=batch_size, device=device, _backend=backend, **raw_kwargs
             )
@@ -716,11 +958,26 @@ def _compile_intercept(
                 *inputs, batch_size=batch_size, device=device, _backend=backend, **raw_kwargs
             )
 
+        if is_random:
+            rng = _random._resolve_rng(raw_kwargs.get("rng"))
+            graph_kwargs = {name: value for name, value in raw_kwargs.items() if name != "rng"}
+        else:
+            graph_kwargs = raw_kwargs
+
         if compile_ctx.state is State.COMPILED:
             compile_ctx.check_batch_size(batch_size)
-            result = compile_ctx.get_compiled_result(
-                frame, op_class, inputs, raw_kwargs, device=device
-            )
+            node = compile_ctx._find_compiled_node(frame, op_class, inputs, graph_kwargs, device)
+            if not is_random:
+                result = compile_ctx.result_for(node) if node is not None else None
+            else:
+                if node is not None and batch_size is None:
+                    actual_batch_size = _infer_batch_size(*inputs, **graph_kwargs)
+                    if actual_batch_size != compile_ctx.batch_size:
+                        raise RuntimeError(
+                            f"Compiled random operator cannot change batch_size from "
+                            f"{compile_ctx.batch_size} to {actual_batch_size}."
+                        )
+                result = compile_ctx._resolve_random_call(node, rng)
             if result is not None:
                 return result
             return fn_call(
@@ -731,33 +988,26 @@ def _compile_intercept(
         result = fn_call(
             *inputs, batch_size=batch_size, device=device, _backend=backend, **raw_kwargs
         )
-
-        if op_class._is_stateful:
-            return result
-
-        classification = classify(frame, inputs, raw_kwargs)
-        if classification is None:
-            return result
-
-        classified_inputs, classified_kwargs = classification
-        results = result if isinstance(result, tuple) else (result,)
-        node = compile_ctx.record(
-            call_chain=build_call_chain(frame),
-            op_class=op_class,
-            backend=backend,
-            inputs=classified_inputs,
-            kwargs=classified_kwargs,
-            raw_kwargs=raw_kwargs,
-            num_outputs=len(results),
-            device=device,
+        if not is_random:
+            capturable = not op_class._is_stateful
+        else:
+            outputs = result if isinstance(result, tuple) else (result,)
+            capturable = all(
+                isinstance(output, Batch) and output.batch_size == compile_ctx.batch_size
+                for output in outputs
+            )
+        node = (
+            compile_ctx.record(
+                frame, op_class, inputs, graph_kwargs, result, backend=backend, device=device
+            )
+            if capturable
+            else None
         )
+        if is_random:
+            compile_ctx._record_rng_use(rng, node)
+
         if node is None:
             return result
-
-        new_results = tuple(
-            CompiledBatch.from_batch(batch, CompileRef(node, i), compile_ctx._iteration)
-            for i, batch in enumerate(results)
-        )
-        return new_results[0] if not isinstance(result, tuple) else new_results
+        return _wrap_captured_result(node, result, compile_ctx._iteration)
 
     return wrapper

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -319,7 +319,7 @@ class Operator:
         if cls._has_random_state_arg:
             from . import random
 
-            rng = random._resolve_rng(unwrap_invariant(raw_kwargs.pop("rng", None)))
+            rng = random._resolve_rng(raw_kwargs.pop("rng", None))
 
             # Only one random state tensor is created per call, not per sample.
             raw_kwargs["_random_state"] = random._state_tensor(random._draw_state(rng))

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -22,7 +22,7 @@ import numpy as np
 import nvidia.dali as dali
 import nvidia.dali.backend_impl as _b
 
-from . import _compile, _device, _eval_context, _invocation, _type
+from . import _compile, _device, _eval_context, _invocation
 from ._batch import Batch, _get_batch_size
 from ._batch import as_batch as _as_batch
 from ._device import Device, DeviceLike
@@ -319,24 +319,10 @@ class Operator:
         if cls._has_random_state_arg:
             from . import random
 
-            rng = unwrap_invariant(raw_kwargs.pop("rng", None))
-            if rng is None:
-                rng = random.get_default_rng()
-            if not isinstance(rng, random.RNG):
-                raise ValueError(
-                    f"rng must be an instance of nvidia.dali.experimental.dynamic.random.RNG, "
-                    f"but got {type(rng)}"
-                )
+            rng = random._resolve_rng(unwrap_invariant(raw_kwargs.pop("rng", None)))
 
-            # Use the provided RNG to generate 7 random uint32 values.
-            # This creates a fixed-size random state tensor.
-            # 7 uint32 words = 224 bits; required is 194 bits (operator reads first 25 bytes).
             # Only one random state tensor is created per call, not per sample.
-            raw_kwargs["_random_state"] = Tensor(
-                [rng() for _ in range(7)],
-                dtype=_type.uint32,
-                device="cpu",
-            )
+            raw_kwargs["_random_state"] = random._state_tensor(random._draw_state(rng))
 
         inputs = []
         kwargs = {}

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -18,15 +18,21 @@ This module also contains functional wrappers for random operators (e.g., unifor
 that are dynamically added during module initialization.
 """
 
+import operator as _operator
 import random as _random
 import threading as _threading
+import typing as _typing
 
 import nvidia.dali.backend_impl as _b
+
+from ._tensor import Tensor as _Tensor
+from ._type import uint32 as _uint32
 
 # Note: __all__ is intentionally not defined here to allow help() to show
 # dynamically added random operator functions (uniform, normal, etc.)
 
 
+@_typing.final
 class RNG:
     """Random number generator for DALI dynamic mode operations.
 
@@ -54,15 +60,16 @@ class RNG:
     """
 
     def __init__(self, seed=None, state=None):
-        if seed is not None:
-            if state is not None:
+        self._pending_draws = 0
+        self._version = 0
+        if state is not None:
+            if seed is not None:
                 raise ValueError("Cannot specify both `seed` and `state`")
-            self._rng = _b._Philox4x32_10(seed & 0xFFFFFFFFFFFFFFFF, 0, 0)
-        elif state is not None:
-            self._rng = _b._Philox4x32_10(state)
+            self.set_state(state)
         else:
-            seed = _random.randint(0, 0xFFFFFFFFFFFFFFFF)
-            self._rng = _b._Philox4x32_10(seed, 0, 0)
+            if seed is None:
+                seed = _random.randint(0, 0xFFFFFFFFFFFFFFFF)
+            self.seed = seed
 
     def __call__(self):
         """Generate a random uint32 value.
@@ -72,6 +79,8 @@ class RNG:
         int
             A random uint32 value (as Python int, but in range [0, 2^32-1]).
         """
+        self._flush_pending()
+        self._version += 1
         return self._rng.next()
 
     @property
@@ -84,6 +93,28 @@ class RNG:
         The seed is truncated to 64 bits.
         """
         self._rng = _b._Philox4x32_10(value & 0xFFFFFFFFFFFFFFFF, 0, 0)
+        self._pending_draws = 0
+        self._version += 1
+
+    def advance(self, n: _typing.SupportsIndex) -> None:
+        """Advance the generator by ``n`` draws, equivalent to ``n`` calls to ``self()``.
+
+        The advance is deferred and applied lazily on the next observation of the generator
+        (a draw, a state read, a clone or a repr), coalescing repeated advances into a single
+        backend skip-ahead.
+
+        Parameters
+        ----------
+        n : int
+            A uint64 number of draws to skip.
+        """
+        n = _operator.index(n)
+        if n < 0:
+            raise ValueError("Cannot advance by a negative number")
+
+        if n:
+            self._pending_draws += n
+            self._version += 1
 
     def clone(self):
         """Create a new RNG with the same state
@@ -122,7 +153,7 @@ class RNG:
         Opaque state object. This object can be converted to a string and that string can be used
         later to set the state or construct an RNG.
         """
-        return self._rng.get_state()
+        return self.get_state()
 
     @state.setter
     def state(self, value):
@@ -131,9 +162,9 @@ class RNG:
         Parameters
         ----------
         value : object | str
-            Either a state object obtained from another RNG instance of its string representation
+            A state object obtained from another RNG instance or its string representation.
         """
-        self._rng.set_state(value)
+        self.set_state(value)
 
     def get_state(self, *, cuda_stream=None):
         """Returns the internal state of the generator.
@@ -144,7 +175,7 @@ class RNG:
 
         Parameters
         ----------
-        cuda_stream: Any
+        cuda_stream : Any
             Not used.
 
         Returns
@@ -152,6 +183,7 @@ class RNG:
         Opaque state object. The object can be converted to a string with ``str(state)`` and
         later used to set the state or construct an RNG.
         """
+        self._flush_pending()
         return self._rng.get_state()
 
     def set_state(self, value):
@@ -167,7 +199,17 @@ class RNG:
             Either a state object obtained from :func:`get_state` (or the :attr:`state`
             property) or its string representation.
         """
-        self._rng.set_state(value)
+        self._rng = _b._Philox4x32_10(value)
+        self._pending_draws = 0
+        self._version += 1
+
+    def _flush_pending(self) -> None:
+        if pending := self._pending_draws:
+            self._rng.skipahead(pending)
+            self._pending_draws = 0
+
+    def _snapshot_backend(self):
+        return _b._Philox4x32_10(self.state), self._version
 
 
 # Thread-local storage for the default RNG
@@ -220,3 +262,26 @@ def set_seed(seed):
     >>> # result1 and result2 should be identical
     """
     get_default_rng().seed = seed
+
+
+_STATE_WORDS = 7  # whole uint32 words needed for the backend's 25-byte state
+
+
+def _draw_state(next_uint32: _typing.Callable[[], int]) -> list[int]:
+    return [next_uint32() for _ in range(_STATE_WORDS)]
+
+
+def _state_tensor(words: list[int]):
+    """CPU uint32 tensor holding one drawn random state."""
+    return _Tensor(words, dtype=_uint32, device="cpu")
+
+
+def _resolve_rng(rng: _typing.Any) -> RNG:
+    """Return a validated RNG, using the thread-local default when omitted."""
+    if rng is None:
+        rng = get_default_rng()
+    if not isinstance(rng, RNG):
+        rng_class = f"{RNG.__module__}.{RNG.__qualname__}"
+        user_class = f"{type(rng).__module__}.{type(rng).__qualname__}"
+        raise ValueError(f"rng must be an instance of {rng_class}, but got {user_class}")
+    return rng

--- a/dali/python/nvidia/dali/experimental/dynamic/random.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/random.py
@@ -61,6 +61,7 @@ class RNG:
 
     def __init__(self, seed=None, state=None):
         self._pending_draws = 0
+        self._draws = 0
         self._version = 0
         if state is not None:
             if seed is not None:
@@ -79,8 +80,9 @@ class RNG:
         int
             A random uint32 value (as Python int, but in range [0, 2^32-1]).
         """
+        self._on_draw()
         self._flush_pending()
-        self._version += 1
+        self._draws += 1
         return self._rng.next()
 
     @property
@@ -113,8 +115,9 @@ class RNG:
             raise ValueError("Cannot advance by a negative number")
 
         if n:
+            self._on_draw()
             self._pending_draws += n
-            self._version += 1
+            self._draws += n
 
     def clone(self):
         """Create a new RNG with the same state
@@ -210,6 +213,11 @@ class RNG:
 
     def _snapshot_backend(self):
         return _b._Philox4x32_10(self.state), self._version
+
+    def _on_draw(self) -> None:
+        """Called before this consuming a random word.
+        Replaced on the class by the compile layer, if applicable.
+        """
 
 
 # Thread-local storage for the default RNG

--- a/dali/test/python/experimental_mode/test_compile.py
+++ b/dali/test/python/experimental_mode/test_compile.py
@@ -30,9 +30,11 @@ images_root = os.path.join(dali_extra_path, "db", "single", "jpeg")
 
 
 def _assert_parity(expected, actual):
-    """Assert two result lists match element-wise; lengths must be equal."""
-    for e, a in zip(expected, actual, strict=True):
-        np.testing.assert_array_equal(e, a)
+    if isinstance(expected, (list, tuple)):
+        for e, a in zip(expected, actual, strict=True):
+            _assert_parity(e, a)
+    else:
+        np.testing.assert_array_equal(expected, actual)
 
 
 def test_compile_mode_stickiness():
@@ -879,3 +881,238 @@ def _es_batch_size_runtime():
 def test_compile_es_batch_size_errors(scenario, exc, glob):
     with assert_raises(exc, glob=glob):
         scenario()
+
+
+# Tests for random operators
+
+
+def _uniform(rng):
+    return ndd.random.uniform(batch_size=4, range=[0.0, 1.0], shape=[5], rng=rng)
+
+
+def _collect_random(reader, op, rng, *, compiled=False, epochs=1, observe_state=False):
+    values: list[tuple[ndd.Tensor, ...]] = []
+    states: list[str] = []
+    for _ in range(epochs):
+        epoch = reader.next_epoch(batch_size=4, compile=compiled)
+        for _ in epoch:
+            result = op(rng)
+            outputs = result if isinstance(result, tuple) else (result,)
+            if compiled:
+                assert all(_is_compiled(x) for x in outputs)
+            values.append(tuple(ndd.as_tensor(x, device="cpu") for x in outputs))
+            if observe_state:
+                states.append(str(rng.state))
+    return values, states
+
+
+def _assert_random_parity(op, *, epochs=1, observe_state=False):
+    values = []
+    states = []
+    for compiled in (False, True):
+        rng = ndd.random.RNG(seed=42)
+        result, observed_states = _collect_random(
+            ndd.readers.File(file_root=images_root, pad_last_batch=True),
+            op,
+            rng,
+            compiled=compiled,
+            epochs=epochs,
+            observe_state=observe_state,
+        )
+        values.append(result)
+        states.append((observed_states, str(rng.state)))
+
+    _assert_parity(*values)
+    assert states[0] == states[1]
+
+
+def test_compile_random_parity():
+    # Explicit rng
+    _assert_random_parity(_uniform, epochs=3, observe_state=True)
+
+    # Default rng
+    ndd.random.set_seed(123)
+    dynamic, _ = _collect_random(ndd.readers.File(file_root=images_root), _uniform, None)
+    dynamic_state = str(ndd.random.get_default_rng().state)
+
+    ndd.random.set_seed(123)
+    compiled, _ = _collect_random(
+        ndd.readers.File(file_root=images_root), _uniform, None, compiled=True
+    )
+
+    _assert_parity(dynamic, compiled)
+    assert dynamic_state == str(ndd.random.get_default_rng().state)
+
+
+def test_compile_random_es_cycle_reset():
+    dynamic_es = _es(2, cycle="raise", batch_size=4)
+    dynamic_rng = ndd.random.RNG(seed=4)
+    dynamic = []
+    for _ in range(3):
+        try:
+            while True:
+                dynamic_es()
+                dynamic.append(ndd.as_tensor(_uniform(dynamic_rng), device="cpu"))
+        except StopIteration:
+            pass
+
+    compiled_es = _es(2, cycle="raise", batch_size=4)
+    compiled_rng = ndd.random.RNG(seed=4)
+    compiled = []
+    for _ in range(3):
+        for _ in compiled_es.compiled(batch_size=4):
+            result = _uniform(compiled_rng)
+            assert _is_compiled(result)
+            compiled.append(ndd.as_tensor(result, device="cpu"))
+
+    _assert_parity(dynamic, compiled)
+    assert str(dynamic_rng.state) == str(compiled_rng.state)
+
+
+def test_compile_random_multiple_rngs():
+    def rng_calls(rngs):
+        rng, independent_rng = rngs
+        first = ndd.random.uniform(batch_size=4, range=[0.0, 1.0], shape=[3], rng=rng)
+        second = ndd.random.uniform(batch_size=4, range=[0.0, 1.0], shape=[3], rng=rng)
+        independent = ndd.random.uniform(
+            batch_size=4, range=[0.0, 1.0], shape=[3], rng=independent_rng
+        )
+        return first, second, independent
+
+    dynamic_rngs = ndd.random.RNG(seed=8), ndd.random.RNG(seed=8)
+    dynamic, _ = _collect_random(
+        ndd.readers.File(file_root=images_root),
+        rng_calls,
+        dynamic_rngs,
+        compiled=False,
+    )
+
+    compiled_rngs = ndd.random.RNG(seed=8), ndd.random.RNG(seed=8)
+    compiled, _ = _collect_random(
+        ndd.readers.File(file_root=images_root),
+        rng_calls,
+        compiled_rngs,
+        compiled=True,
+    )
+
+    _assert_parity(dynamic, compiled)
+    assert [str(rng.state) for rng in dynamic_rngs] == [str(rng.state) for rng in compiled_rngs]
+
+
+@params(False, True)
+def test_compile_random_repeated_callsite(different_rngs):
+    def make_rngs():
+        first = ndd.random.RNG(seed=10)
+        return (first, ndd.random.RNG(seed=11)) if different_rngs else (first, first)
+
+    def body(rngs, batch):
+        repeated = []
+        for rng in rngs:
+            x = ndd.random.uniform(batch_size=4, shape=[3], rng=rng)
+            repeated.append(x)
+        independent = ndd.cast(batch, dtype=ndd.float32)
+        return (*repeated, independent)
+
+    dynamic_rngs = make_rngs()
+    dynamic = []
+    dynamic_es = _es(3, batch_size=4)
+    for _ in range(3):
+        outputs = body(dynamic_rngs, dynamic_es())
+        dynamic.append(tuple(ndd.as_tensor(output, device="cpu") for output in outputs))
+
+    compiled_rngs = make_rngs()
+    compiled = []
+    compiled_es = _es(3, batch_size=4)
+    with assert_warns(UserWarning, glob="call site was used more than once"):
+        for step, batch in enumerate(compiled_es.compiled(batch_size=4)):
+            first, second, independent = body(compiled_rngs, batch)
+            assert _is_compiled(first) == (step == 0)
+            assert _is_compiled(second) == (step == 0)
+            assert _is_compiled(independent)
+            compiled.append(
+                tuple(
+                    ndd.as_tensor(output, device="cpu") for output in (first, second, independent)
+                )
+            )
+
+    _assert_parity(dynamic, compiled)
+    assert [str(rng.state) for rng in dynamic_rngs] == [str(rng.state) for rng in compiled_rngs]
+
+
+def test_compile_random_eager_fallback():
+    dynamic_reader = ndd.readers.File(file_root=images_root)
+    compiled_reader = ndd.readers.File(file_root=images_root)
+
+    def body(rngs, labels):
+        fallback_rng, linked_rng = rngs
+        independent = ndd.cast(labels, dtype=ndd.float32)
+        early = ndd.random.uniform(batch_size=4, shape=[3], rng=linked_rng)
+        early_dependent = ndd.cast(early, dtype=ndd.float64)
+        captured = ndd.random.uniform(batch_size=4, shape=[3], rng=fallback_rng)
+        bridge = ndd.noise.gaussian(captured, rng=linked_rng)
+        eager = ndd.random.uniform(shape=3, rng=fallback_rng)  # no batch size, fallback to eager
+        return independent, early, early_dependent, captured, bridge, eager
+
+    dynamic_rngs = ndd.random.RNG(seed=2), ndd.random.RNG(seed=3)
+    dynamic = []
+    for _, labels in dynamic_reader.next_epoch(batch_size=4):
+        outputs = body(dynamic_rngs, labels)
+        dynamic.append(tuple(ndd.as_tensor(x, device="cpu") for x in outputs))
+
+    compiled_rngs = ndd.random.RNG(seed=2), ndd.random.RNG(seed=3)
+    compiled = []
+    with assert_warns(UserWarning, glob="both"):
+        for step, (_, labels) in enumerate(compiled_reader.next_epoch(batch_size=4, compile=True)):
+            outputs = body(compiled_rngs, labels)
+            independent, early, early_dependent, captured, bridge, eager = outputs
+
+            assert _is_compiled(independent)
+            for output in (early, early_dependent, captured, bridge):
+                assert _is_compiled(output) == (step == 0)
+            assert isinstance(eager, ndd.Tensor)
+            assert not _is_compiled(eager)
+
+            compiled.append(tuple(ndd.as_tensor(x, device="cpu") for x in outputs))
+
+    _assert_parity(dynamic, compiled)
+    assert [str(rng.state) for rng in dynamic_rngs] == [str(rng.state) for rng in compiled_rngs]
+
+
+def test_compile_random_rng_reuse():
+    reference = ndd.random.RNG(seed=9)
+    expected, _ = _collect_random(
+        ndd.readers.File(file_root=images_root),
+        _uniform,
+        reference,
+        epochs=2,
+        compiled=False,
+    )
+
+    rng = ndd.random.RNG(seed=9)
+    first_reader = ndd.readers.File(file_root=images_root)
+    first, _ = _collect_random(first_reader, _uniform, rng, compiled=True)
+    second, _ = _collect_random(
+        ndd.readers.File(file_root=images_root),
+        _uniform,
+        rng,
+        compiled=True,
+    )
+
+    _assert_parity(expected, first + second)
+    assert str(reference.state) == str(rng.state)
+    with assert_raises(RuntimeError, glob="modified outside*loop"):
+        _collect_random(first_reader, _uniform, rng, compiled=True)
+
+
+def test_compile_random_gpu():
+    if _backend.GetCUDADeviceCount() == 0:
+        raise SkipTest("At least 1 GPU needed for the GPU random test")
+    _assert_random_parity(
+        lambda rng: ndd.random.uniform(
+            batch_size=4,
+            range=[0.0, 1.0],
+            shape=[5],
+            rng=rng,
+            device="gpu",
+        )
+    )

--- a/dali/test/python/experimental_mode/test_compile.py
+++ b/dali/test/python/experimental_mode/test_compile.py
@@ -890,20 +890,35 @@ def _uniform(rng):
     return ndd.random.uniform(batch_size=4, range=[0.0, 1.0], shape=[5], rng=rng)
 
 
-def _collect_random(reader, op, rng, *, compiled=False, epochs=1, observe_state=False):
-    values: list[tuple[ndd.Tensor, ...]] = []
-    states: list[str] = []
+def _collect_outputs(body, *, compile, epochs=1, reader=None):
+    """Drive `body(step)` over epochs of one reader, from a single call site.
+    Returns whatever the bodies returned, as host tensors.
+    """
+    reader = reader or ndd.readers.File(file_root=images_root, pad_last_batch=True)
+    values, step = [], 0
     for _ in range(epochs):
-        epoch = reader.next_epoch(batch_size=4, compile=compiled)
-        for _ in epoch:
-            result = op(rng)
+        for _ in reader.next_epoch(batch_size=4, compile=compile):
+            result = body(step)
+            if result is not None:
+                outputs = result if isinstance(result, tuple) else (result,)
+                values.append(tuple(ndd.as_tensor(x, device="cpu") for x in outputs))
+            step += 1
+    return values
+
+
+def _collect_random(reader, op, rng, *, compile=False, epochs=1, observe_state=False):
+    states: list[str] = []
+
+    def body(_):
+        result = op(rng)
+        if compile:
             outputs = result if isinstance(result, tuple) else (result,)
-            if compiled:
-                assert all(_is_compiled(x) for x in outputs)
-            values.append(tuple(ndd.as_tensor(x, device="cpu") for x in outputs))
-            if observe_state:
-                states.append(str(rng.state))
-    return values, states
+            assert all(_is_compiled(x) for x in outputs)
+        if observe_state:
+            states.append(str(rng.state))
+        return result
+
+    return _collect_outputs(body, compile=compile, epochs=epochs, reader=reader), states
 
 
 def _assert_random_parity(op, *, epochs=1, observe_state=False):
@@ -915,7 +930,7 @@ def _assert_random_parity(op, *, epochs=1, observe_state=False):
             ndd.readers.File(file_root=images_root, pad_last_batch=True),
             op,
             rng,
-            compiled=compiled,
+            compile=compiled,
             epochs=epochs,
             observe_state=observe_state,
         )
@@ -937,7 +952,7 @@ def test_compile_random_parity():
 
     ndd.random.set_seed(123)
     compiled, _ = _collect_random(
-        ndd.readers.File(file_root=images_root), _uniform, None, compiled=True
+        ndd.readers.File(file_root=images_root), _uniform, None, compile=True
     )
 
     _assert_parity(dynamic, compiled)
@@ -984,7 +999,7 @@ def test_compile_random_multiple_rngs():
         ndd.readers.File(file_root=images_root),
         rng_calls,
         dynamic_rngs,
-        compiled=False,
+        compile=False,
     )
 
     compiled_rngs = ndd.random.RNG(seed=8), ndd.random.RNG(seed=8)
@@ -992,7 +1007,7 @@ def test_compile_random_multiple_rngs():
         ndd.readers.File(file_root=images_root),
         rng_calls,
         compiled_rngs,
-        compiled=True,
+        compile=True,
     )
 
     _assert_parity(dynamic, compiled)
@@ -1023,34 +1038,32 @@ def test_compile_random_repeated_callsite(different_rngs):
     compiled_rngs = make_rngs()
     compiled = []
     compiled_es = _es(3, batch_size=4)
-    with assert_warns(UserWarning, glob="call site was used more than once"):
+    with assert_warns(UserWarning, glob="runs more than once per iteration"):
         for step, batch in enumerate(compiled_es.compiled(batch_size=4)):
-            first, second, independent = body(compiled_rngs, batch)
-            assert _is_compiled(first) == (step == 0)
-            assert _is_compiled(second) == (step == 0)
-            assert _is_compiled(independent)
-            compiled.append(
-                tuple(
-                    ndd.as_tensor(output, device="cpu") for output in (first, second, independent)
-                )
-            )
+            outputs = body(compiled_rngs, batch)
+            first, repeated, independent = outputs
+            # The node carries one state, which the first call takes; only the repeat is eager.
+            assert _is_compiled(repeated) == (step == 0)
+            for output in (first, independent):
+                assert _is_compiled(output)
+            compiled.append(tuple(ndd.as_tensor(output, device="cpu") for output in outputs))
 
     _assert_parity(dynamic, compiled)
     assert [str(rng.state) for rng in dynamic_rngs] == [str(rng.state) for rng in compiled_rngs]
 
 
-def test_compile_random_eager_fallback():
+def test_compile_random_shares_rng_with_uncapturable():
     dynamic_reader = ndd.readers.File(file_root=images_root)
     compiled_reader = ndd.readers.File(file_root=images_root)
 
     def body(rngs, labels):
-        fallback_rng, linked_rng = rngs
+        shared_rng, other_rng = rngs
         independent = ndd.cast(labels, dtype=ndd.float32)
-        early = ndd.random.uniform(batch_size=4, shape=[3], rng=linked_rng)
+        early = ndd.random.uniform(batch_size=4, shape=[3], rng=other_rng)
         early_dependent = ndd.cast(early, dtype=ndd.float64)
-        captured = ndd.random.uniform(batch_size=4, shape=[3], rng=fallback_rng)
-        bridge = ndd.noise.gaussian(captured, rng=linked_rng)
-        eager = ndd.random.uniform(shape=3, rng=fallback_rng)  # no batch size, fallback to eager
+        captured = ndd.random.uniform(batch_size=4, shape=[3], rng=shared_rng)
+        bridge = ndd.noise.gaussian(captured, rng=other_rng)
+        eager = ndd.random.uniform(shape=3, rng=shared_rng)  # no batch size, so not capturable
         return independent, early, early_dependent, captured, bridge, eager
 
     dynamic_rngs = ndd.random.RNG(seed=2), ndd.random.RNG(seed=3)
@@ -1061,18 +1074,17 @@ def test_compile_random_eager_fallback():
 
     compiled_rngs = ndd.random.RNG(seed=2), ndd.random.RNG(seed=3)
     compiled = []
-    with assert_warns(UserWarning, glob="both"):
-        for step, (_, labels) in enumerate(compiled_reader.next_epoch(batch_size=4, compile=True)):
-            outputs = body(compiled_rngs, labels)
-            independent, early, early_dependent, captured, bridge, eager = outputs
+    for _, labels in compiled_reader.next_epoch(batch_size=4, compile=True):
+        outputs = body(compiled_rngs, labels)
+        *captured_outputs, eager = outputs
 
-            assert _is_compiled(independent)
-            for output in (early, early_dependent, captured, bridge):
-                assert _is_compiled(output) == (step == 0)
-            assert isinstance(eager, ndd.Tensor)
-            assert not _is_compiled(eager)
+        # Only `eager` runs eagerly: sharing `shared_rng` with it costs others nothing
+        for output in captured_outputs:
+            assert _is_compiled(output)
+        assert isinstance(eager, ndd.Tensor)
+        assert not _is_compiled(eager)
 
-            compiled.append(tuple(ndd.as_tensor(x, device="cpu") for x in outputs))
+        compiled.append(tuple(ndd.as_tensor(x, device="cpu") for x in outputs))
 
     _assert_parity(dynamic, compiled)
     assert [str(rng.state) for rng in dynamic_rngs] == [str(rng.state) for rng in compiled_rngs]
@@ -1085,23 +1097,23 @@ def test_compile_random_rng_reuse():
         _uniform,
         reference,
         epochs=2,
-        compiled=False,
+        compile=False,
     )
 
     rng = ndd.random.RNG(seed=9)
     first_reader = ndd.readers.File(file_root=images_root)
-    first, _ = _collect_random(first_reader, _uniform, rng, compiled=True)
+    first, _ = _collect_random(first_reader, _uniform, rng, compile=True)
     second, _ = _collect_random(
         ndd.readers.File(file_root=images_root),
         _uniform,
         rng,
-        compiled=True,
+        compile=True,
     )
 
     _assert_parity(expected, first + second)
     assert str(reference.state) == str(rng.state)
     with assert_raises(RuntimeError, glob="modified outside*loop"):
-        _collect_random(first_reader, _uniform, rng, compiled=True)
+        _collect_random(first_reader, _uniform, rng, compile=True)
 
 
 def test_compile_random_gpu():
@@ -1116,3 +1128,128 @@ def test_compile_random_gpu():
             device="gpu",
         )
     )
+
+
+def _assert_body_parity(make_body, *, epochs=1, seed=11):
+    """The same body eagerly and compiled: identical values and identical final RNG state."""
+    runs = []
+    for compiled in (False, True):
+        rng = ndd.random.RNG(seed=seed)
+        runs.append(
+            (_collect_outputs(make_body(rng), compile=compiled, epochs=epochs), str(rng.state))
+        )
+
+    _assert_parity(runs[0][0], runs[1][0])
+    assert runs[0][1] == runs[1][1]
+
+
+@params("extra call after", "dropped call", "restore state")
+def test_compile_random_contract_violation(kind):
+    # Every way a body can draw differently than when it was traced
+    rng = ndd.random.RNG(seed=21)
+
+    def body(step):
+        deviates = step > 0
+        if deviates and kind == "restore state":
+            rng.state = rng.state  # same position, but the generator was replaced
+
+        _uniform(rng)
+
+        if deviates and kind == "extra call after":
+            ndd.random.uniform(shape=3, rng=rng)
+        elif not deviates and kind == "dropped call":
+            ndd.random.uniform(shape=3, rng=rng)  # traced, then never drawn again
+
+    with assert_raises(RuntimeError, glob="used unexpectedly"):
+        _collect_outputs(body, compile=True)
+
+
+@params("bare before", "bare between")
+def test_compile_random_untracked_draws(kind):
+    # Draws the operator interception never sees still have to be accounted for
+    def make_body(rng):
+        def body(_):
+            if kind == "bare before":
+                rng()
+            first = _uniform(rng)
+            if kind == "bare between":
+                rng()
+                return first, _uniform(rng)
+            return first
+
+        return body
+
+    _assert_body_parity(make_body)
+
+
+class _AttributeArgBody:
+    """A random operator the graph cannot record, because `self.prob` is an attribute."""
+
+    def __init__(self, rng):
+        self.rng = rng
+        self.prob = 0.5
+
+    def body(self, _):
+        unrecordable = ndd.random.coin_flip(batch_size=4, probability=self.prob, rng=self.rng)
+        return unrecordable, _uniform(self.rng)
+
+
+def test_compile_random_shares_rng_with_unrecordable():
+    _assert_body_parity(lambda rng: _AttributeArgBody(rng).body)
+
+    seen = []
+    holder = _AttributeArgBody(ndd.random.RNG(seed=11))
+    _collect_outputs(
+        lambda step: seen.append(tuple(map(_is_compiled, holder.body(step)))), compile=True
+    )
+    assert seen and all(captured for _, captured in seen), seen
+    assert not any(unrecordable for unrecordable, _ in seen), seen
+
+
+def test_compile_random_repeated_callsite_first_falls_back():
+    # A repeated site whose *first* call falls back on an input mismatch
+    rng = ndd.random.RNG(seed=53)
+    source_rng = ndd.random.RNG(seed=54)
+    eager_input = ndd.random.uniform(batch_size=4, shape=[3], rng=ndd.random.RNG(seed=55))
+
+    def body(step):
+        compiled_input = ndd.random.uniform(batch_size=4, shape=[3], rng=source_rng)
+        inputs = [eager_input, compiled_input] if step == 3 else [compiled_input] * 2
+        for source in inputs:  # one call site, two calls, fed differently on step 3
+            ndd.noise.gaussian(source, rng=rng)
+
+    with assert_warns(UserWarning, glob="runs more than once per iteration"):
+        _collect_outputs(body, compile=True)
+
+
+@params("advance", "seed")
+def test_compile_random_touched_between_es_epochs(kind):
+    # Recovery re-bases on the generator, so anything that moved it in between must be rejected
+    es = _es(2, cycle="raise", batch_size=4)
+    rng = ndd.random.RNG(seed=71)
+
+    def epoch():
+        for _ in es.compiled(batch_size=4):
+            _uniform(rng)
+
+    epoch()
+    if kind == "advance":
+        rng.advance(4)
+    else:
+        rng.seed = 72
+
+    with assert_raises(RuntimeError, glob="used unexpectedly"):
+        epoch()
+
+
+def test_compile_random_rng_reuse_one_period_gap():
+    rng = ndd.random.RNG(seed=101)
+    reader = ndd.readers.File(file_root=images_root)
+    _collect_random(reader, _uniform, rng, compile=True)
+
+    probe = ndd.random.RNG()
+    _uniform(probe)  # one captured operator per iteration, so its draws are one period
+    rng.advance(probe._draws)
+
+    with assert_raises(RuntimeError, glob="used unexpectedly"):
+        _collect_random(reader, _uniform, rng, compile=True)

--- a/dali/test/python/experimental_mode/test_random.py
+++ b/dali/test/python/experimental_mode/test_random.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import nvidia.dali.experimental.dynamic as ndd
+from typing import SupportsIndex
 import numpy as np
 from nose2.tools import cartesian_params, params
 from nose_utils import assert_raises, raises
 
-
-def asnumpy(tensor_or_batch):
-    """Convert a DALI dynamic tensor to numpy array."""
-    return np.array(ndd.as_tensor(tensor_or_batch, device="cpu"))
-
+import nvidia.dali.experimental.dynamic as ndd
 
 ops = {
     "uniform": ndd._ops.random.Uniform,
@@ -50,25 +46,25 @@ def test_rng_argument(device_type, batch_size, api_type, opname):
         if api_type == "ops":
             if op_instance is None:
                 op_instance = ops[opname](device=device_type, max_batch_size=batch_size)
-            result1 = op_instance(batch_size=batch_size, rng=rng, **op_args[opname])
+            result = op_instance(batch_size=batch_size, rng=rng, **op_args[opname])
         else:
-            result1 = fn[opname](
+            result = fn[opname](
                 batch_size=batch_size, rng=rng, device=device_type, **op_args[opname]
             )
 
         # Verify result type and shape
         if batch_size is not None:
-            assert isinstance(result1, ndd.Batch), f"Expected Batch, got {type(result1)}"
-            result1_np = asnumpy(result1)
-            assert result1_np.shape == (
+            assert isinstance(result, ndd.Batch), f"Expected Batch, got {type(result)}"
+            tensor = ndd.as_tensor(result, device="cpu")
+            assert tensor.shape == (
                 batch_size,
                 10,
-            ), f"Expected shape ({batch_size}, 10), got {result1_np.shape}"
+            ), f"Expected shape ({batch_size}, 10), got {tensor.shape}"
         else:
-            assert isinstance(result1, ndd.Tensor), f"Expected Tensor, got {type(result1)}"
-            result1_np = asnumpy(result1)
-            assert result1_np.shape == (10,), f"Expected shape (10,), got {result1_np.shape}"
-        return result1_np
+            assert isinstance(result, ndd.Tensor), f"Expected Tensor, got {type(result)}"
+            tensor = result.cpu()
+            assert tensor.shape == (10,), f"Expected shape (10,), got {tensor.shape}"
+        return tensor
 
     rng1 = ndd.random.RNG(seed=1234)
     rng2 = ndd.random.RNG(seed=1234)
@@ -94,14 +90,13 @@ def test_rng_seed_exclusion(device_type):
     uniform_op2 = ndd._ops.random.Uniform(device=device_type, seed=42)
     result1 = uniform_op1(range=[0.0, 1.0], shape=[10], rng=rng1)  # This should override the seed
     result2 = uniform_op2(range=[0.0, 1.0], shape=[10], rng=rng2)  # This should override the seed
-    result_np1 = asnumpy(result1)
-    assert result_np1.shape == (10,)
-    result_np2 = asnumpy(result2)
-    assert result_np2.shape == (10,)
+
+    assert result1.shape == (10,)
+    assert result2.shape == (10,)
 
     # expected to be different because of different random states
     # regardless of the initial seed
-    assert not np.array_equal(result_np1, result_np2)
+    assert not np.array_equal(result1.cpu(), result2.cpu())
 
 
 def test_rng_clone():
@@ -136,15 +131,10 @@ def test_rng_clone():
     rng5 = rng4.clone()
 
     result1 = ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng4)
-    result1_np = asnumpy(result1)
-
     result2 = ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng5)
-    result2_np = asnumpy(result2)
 
     # Results should be identical since clones have the same seed
-    assert np.array_equal(
-        result1_np, result2_np
-    ), "Cloned RNGs should produce identical operator results"
+    assert np.array_equal(result1, result2), "Cloned RNGs should produce identical operator results"
 
 
 @raises(ValueError, glob="both")
@@ -158,9 +148,9 @@ def test_batch_permutation_requires_batch_size():
 
     batch_size = 4
     result = ndd.batch_permutation(batch_size=batch_size, rng=ndd.random.RNG(seed=1234))
-    result_np = asnumpy(result)
-    assert result_np.shape == (batch_size,)
-    assert sorted(result_np.tolist()) == list(range(batch_size))
+    tensor = ndd.as_tensor(result, device="cpu")
+    assert tensor.shape == (batch_size,)
+    assert np.array_equal(np.sort(tensor), np.arange(batch_size))
 
 
 def test_rng_set_seed():
@@ -176,13 +166,13 @@ def test_rng_set_seed():
 
     # Explicit RNG instance with operators
     rng.seed = 1234
-    result1_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng))
+    result1 = ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng)
     rng.seed = 1234
-    result2_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng))
-    assert np.array_equal(result1_np, result2_np)
+    result2 = ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng)
+    assert np.array_equal(result1, result2)
     rng.seed = 5678  # Different seed
-    result3_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng))
-    assert not np.array_equal(result1_np, result3_np)
+    result3 = ndd.random.uniform(range=[0.0, 1.0], shape=[10], rng=rng)
+    assert not np.array_equal(result1, result3)
 
     # Default RNG
     ndd.random.set_seed(9876)
@@ -196,10 +186,30 @@ def test_rng_set_seed():
 
     # Default RNG with operators
     ndd.random.set_seed(1111)
-    result1_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10]))
+    result1 = ndd.random.uniform(range=[0.0, 1.0], shape=[10])
     ndd.random.set_seed(1111)
-    result2_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10]))
-    assert np.array_equal(result1_np, result2_np)
+    result2 = ndd.random.uniform(range=[0.0, 1.0], shape=[10])
+    assert np.array_equal(result1, result2)
     ndd.random.set_seed(2222)  # Different seed
-    result3_np = asnumpy(ndd.random.uniform(range=[0.0, 1.0], shape=[10]))
-    assert not np.array_equal(result1_np, result3_np)
+    result3 = ndd.random.uniform(range=[0.0, 1.0], shape=[10])
+    assert not np.array_equal(result1, result3)
+
+
+@params(
+    (0, (0,)),
+    (1, (1, 2)),
+    (2, (np.int64(2), np.uint64(3))),
+)
+def test_rng_advance_matches(offset: int, advances: tuple[SupportsIndex, ...]):
+    rng = ndd.random.RNG(seed=7)
+    for _ in range(offset):
+        rng()
+    reference = rng.clone()
+
+    for n in advances:
+        rng.advance(n)
+
+    for _ in range(sum(int(n) for n in advances)):
+        reference()
+
+    assert [rng() for _ in range(5)] == [reference() for _ in range(5)]


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**New feature** (*non-breaking change which adds functionality*)

## Description:

This PR add support for random operators in transparent pipelining, ensuring parity between eager and compiled modes. When parity is not possible, operators fall back to eager mode when detected during tracing, or error out if a discrepancy happens after tracing.

## Additional information:

### Affected modules and functionalities:

Dynamic mode, transparent pipelining

### Key points relevant for the review:

- Is the parity between compiled and eager mode preserved?
- Are there cases where we could be less conservative?

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply
  - `test_compile.py`
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

Transparent pipelining doesn't have documentation yet.

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4670
<!--- DALI-XXXX or NA --->
