### PR TITLE
Fix compiled external source tests on Python 3.10

### DIFF
--- a/dali/test/python/experimental_mode/test_compile.py
+++ b/dali/test/python/experimental_mode/test_compile.py
@@ -522,7 +522,11 @@ def test_compile_es_cycle_raise():
         compiled_results = []
         for batch in es_comp.compiled(batch_size=4):
             assert _is_compiled(batch)
-            compiled_results.append(ndd.as_tensor(ndd.cast(batch, dtype=ndd.int32)))
+            compiled_results.append(
+                ndd.as_tensor(
+                    ndd.cast(batch, dtype=ndd.int32),
+                )
+            )
 
         assert len(compiled_results) == 2
         _assert_parity(expected, compiled_results)
@@ -691,8 +695,9 @@ def test_compile_es_feeder():
 
     comp_a, comp_b = [], []
     for batch in es_comp.compiled(batch_size=4):
+        other_batch = other_comp()
         a = ndd.cast(batch, dtype=ndd.int32)
-        b = ndd.cast(other_comp(), dtype=ndd.int32)
+        b = ndd.cast(other_batch, dtype=ndd.int32)
         assert _is_compiled(a) and _is_compiled(b)
         comp_a.append(ndd.as_tensor(a))
         comp_b.append(ndd.as_tensor(b))


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**Other** (*e.g. Documentation, Tests, Configuration*)

## Description:

On Python 3.10, call site detection doesn't work if multiple calls are on the same line. This is currently the case for two tests in `test_compile.py`. This PR fixes this.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply
  - `test_compile.py`: `test_compile_es_cycle_raise`
  - `test_compile.py`: `test_compile_es_feeder`
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
