### PR TITLE
Fix parallel external source test swapped parameters

### DIFF
--- a/dali/test/python/test_external_source_parallel.py
+++ b/dali/test/python/test_external_source_parallel.py
@@ -297,11 +297,11 @@ class TestExceptionPropagation:
         teardown_function()
 
     @cartesian_params(
-        [(StopIteration, StopIteration), (utils.CustomException, Exception)],
         [1, 4],
+        [(StopIteration, StopIteration), (utils.CustomException, Exception)],
         [1, 15, 150],
     )
-    def test_exception_propagation(self, exceptions, batch_size, num_workers):
+    def test_exception_propagation(self, num_workers, exceptions, batch_size):
         raised, expected = exceptions
         callback = utils.ExtCallback((4, 4), 250, np.int32, exception_class=raised)
         pipe = utils.create_pipe(
@@ -362,11 +362,11 @@ class TestLayout:
         teardown_function()
 
     @cartesian_params(
-        [((4,), "X"), ((4, 4), "XY"), ((4, 4, 4), "XYZ")],
         [1, 4],
+        [((4,), "X"), ((4, 4), "XY"), ((4, 4, 4), "XYZ")],
         [1, 256, 600],
     )
-    def test_layout(self, inputs_description, batch_size, num_workers):
+    def test_layout(self, num_workers, inputs_description, batch_size):
         dims, layout = inputs_description
         callback = utils.ExtCallback(dims, 1024, "int32")
         pipe = utils.create_pipe(


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
This PR fixes the swapped num_workers/batch_size, which resulted in running out of handles.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
