### PR TITLE
Add ndd.compile.invariant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ valgrind-out.txt
 **/.ipynb_checkpoints
 .dockerignore
 wheelhouse
-compile
-compile_debug
 .idea
 .vscode
 cmake-build-*

--- a/dali/python/nvidia/dali/experimental/dynamic/__init__.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/__init__.py
@@ -32,5 +32,6 @@ from . import math  # noqa: F401
 from . import random  # noqa: F401
 from . import checkpoint  # noqa: F401
 from . import pytorch as pytorch  # noqa: F401
+from . import compile as compile  # noqa: F401
 
 _ops._initialize()

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch.py
@@ -34,6 +34,7 @@ from ._tensor import as_tensor as _as_tensor
 from ._tensor import tensor as _tensor
 from ._type import DType, DTypeLike
 from ._type import dtype as _dtype
+from .compile._invariant import unwrap_invariant_args, unwrap_invariants
 
 
 def _backend_device(backend: _backend.TensorListCPU | _backend.TensorListGPU) -> Device:
@@ -214,6 +215,7 @@ class Batch:
         invocation_result: "_invocation.InvocationResult | None" = None,
         copy: bool = False,
     ):
+        tensors, dtype, device, layout = unwrap_invariant_args(tensors, dtype, device, layout)
         assert isinstance(layout, str) or layout is None
         if device is not None and not isinstance(device, Device):
             device = _device(device)
@@ -456,6 +458,7 @@ class Batch:
         ``as_batch([tensor(sample, dtype=dtype, device=device)] * batch_size)``
         but is much more efficient.
         """
+        sample, batch_size, device, dtype = unwrap_invariant_args(sample, batch_size, device, dtype)
         if isinstance(sample, Batch):
             raise ValueError("Cannot broadcast a Batch")
         if _is_tensor_type(sample):
@@ -468,7 +471,7 @@ class Batch:
         import numpy as np
 
         with Batch._nvtx_to_numpy_and_stack:
-            arr = np.array(sample)
+            arr = np.array(unwrap_invariants(sample))
             converted_dtype_id = None
             if arr.dtype == np.float64:
                 arr = arr.astype(np.float32)
@@ -941,6 +944,7 @@ def batch(
         If not specified, the layout is inferred from the input tensors.
     """
     if isinstance(tensors, Batch):
+        tensors, dtype, device, layout = unwrap_invariant_args(tensors, dtype, device, layout)
         b = tensors.to_device(device or tensors.device, force_copy=True)
         if dtype is not None and b.dtype != dtype:
             from . import cast
@@ -993,6 +997,7 @@ def as_batch(
         If not specified, the layout is inferred from the input tensors.
     """
     if isinstance(tensors, Batch):
+        tensors, dtype, device, layout = unwrap_invariant_args(tensors, dtype, device, layout)
         b = tensors
         if device is not None:
             b = tensors.to_device(device)

--- a/dali/python/nvidia/dali/experimental/dynamic/_batch2tensor.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_batch2tensor.py
@@ -17,6 +17,7 @@ from . import _device, _invocation, _op_builder
 from ._batch import Batch, Tensor, as_batch, batch
 from ._call_site import mark_transparent, resolve_callsite_frame
 from ._nvtx import NVTXRange
+from .compile._invariant import unwrap_invariant, unwrap_invariant_args
 
 
 def is_uniform(shape):
@@ -49,6 +50,7 @@ class BatchToTensor:
         batch_size=None,
         device=None,
     ):
+        batch, device = unwrap_invariant_args(batch, device)
         if not isinstance(batch, Batch):
             batch = _op_builder._to_batch(batch, batch_size)
         with BatchToTensor._nvtx_construct_invocation:
@@ -102,7 +104,7 @@ class BatchToTensor:
                 t = _pad(input_batch).evaluate()._storage.as_tensor()
 
             if layout:
-                t.set_layout(layout)
+                t.set_layout(unwrap_invariant(layout))
             return t
 
 

--- a/dali/python/nvidia/dali/experimental/dynamic/_compile.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_compile.py
@@ -39,6 +39,7 @@ from ._call_site import (
 )
 from ._device import Device
 from ._nvtx import NVTXRange
+from .compile._invariant import is_invariant, unwrap_invariant, unwrap_invariants
 
 if TYPE_CHECKING:
     from ._eval_context import EvalContext
@@ -91,6 +92,24 @@ class CompileNode:
     num_outputs: int
     device: Device | None = None
     pipeline_output_offset: int | None = dataclasses.field(default=None, repr=False)
+
+
+def _value_matches(actual: Any, expected: Any) -> bool:
+    if is_invariant(expected):
+        if not is_invariant(actual):
+            raise RuntimeError(
+                "An argument marked with ndd.compile.invariant when captured must remain marked."
+            )
+        return True
+
+    if expected is None:
+        return actual is None
+
+    try:
+        result = actual == expected
+        return result if isinstance(result, bool) else np.all(result).item()
+    except Exception:
+        return False
 
 
 class CompileRef(NamedTuple):
@@ -284,12 +303,16 @@ class CompileContext:
     ) -> CompileNode | None:
         if existing := self._call_trie.find(call_chain, op_class):
             if (
-                existing.inputs == inputs
-                and existing.kwargs == kwargs
-                and existing.device == device
+                len(existing.inputs) != len(inputs)
+                or existing.kwargs.keys() != kwargs.keys()
+                or existing.device != device
             ):
-                return existing
-            return None
+                return None
+            if not all(_value_matches(a, e) for a, e in zip(inputs, existing.inputs)):
+                return None
+            if not all(_value_matches(kwargs[name], e) for name, e in existing.kwargs.items()):
+                return None
+            return existing
 
         node = CompileNode(
             op_class=op_class,
@@ -380,19 +403,16 @@ class CompileContext:
 
     def _matches(self, actual: Any, expected: Any) -> bool:
         """Check if an actual value matches the expected traced value."""
-        if isinstance(expected, CompileRef):
+        if type(expected) is CompileRef:
+            actual = unwrap_invariant(actual)
             return (
                 isinstance(actual, CompiledBatch)
                 and actual._compile_ref == expected
                 and actual._compile_iteration == self._iteration
             )
-        if expected is None:
-            return actual is None
         if isinstance(actual, Batch):
             return False
-
-        result = actual == expected
-        return result if isinstance(result, bool) else np.all(result).item()
+        return _value_matches(actual, expected)
 
     @_nvtx_range("Getting compiled result")
     def get_compiled_result(
@@ -637,13 +657,16 @@ def _wire_compile_graph(sources: Sequence[CompileSource], nodes: Sequence[Compil
     for node in nodes:
         positional = [
             datanode_map[x] if isinstance(x, CompileRef) else _scalar_decay(x)
-            for x in node.inputs
+            for x in map(unwrap_invariants, node.inputs)
             if x is not None
         ]
-        kw_nodes = {k: datanode_map[v] for k, v in node.kwargs.items() if isinstance(v, CompileRef)}
-        kw_scalars = {
-            k: _scalar_decay(v) for k, v in node.kwargs.items() if not isinstance(v, CompileRef)
-        }
+        kw_nodes, kw_scalars = {}, {}
+        for name, value in node.kwargs.items():
+            value = unwrap_invariants(value)
+            if isinstance(value, CompileRef):
+                kw_nodes[name] = datanode_map[value]
+            elif value is not None:
+                kw_scalars[name] = _scalar_decay(value)
 
         # Cast kwargs when necessary
         for name, dtype in node.kwarg_casts.items():
@@ -676,6 +699,7 @@ def _compile_intercept(
 
     @mark_transparent
     def wrapper(*inputs, batch_size=None, device=None, **raw_kwargs):
+        batch_size = unwrap_invariant(batch_size)
         device, backend = _resolve_backend(op_class, device, inputs, op_name=op_name)
         compile_ctx = CompileContext.current()
         if compile_ctx is None:

--- a/dali/python/nvidia/dali/experimental/dynamic/_external_source.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_external_source.py
@@ -27,6 +27,7 @@ from ._device import device as _as_device
 from ._nvtx import NVTXRange
 from ._tensor import Tensor, as_tensor
 from ._type import DTypeLike
+from .compile._invariant import unwrap_invariant, unwrap_invariant_args
 
 if TYPE_CHECKING:
     from ._eval_context import EvalContext
@@ -134,6 +135,9 @@ class ExternalSource:
         layout: str | Sequence[str] | None = None,
         dtype: DTypeLike | Sequence[DTypeLike] | None = None,
     ):
+        source, num_outputs, cycle, device = unwrap_invariant_args(
+            source, num_outputs, cycle, device
+        )
         callback, source_desc = get_callback_from_source(source, cycle)
         assert source_desc is not None  # `source` is never None here, so a callback is built
         if source_desc.has_inputs:
@@ -176,6 +180,7 @@ class ExternalSource:
         # - while tracing, pull and register the source as a feeder
         # - while executing a compiled context, return the traced feeder's result
 
+        batch_size = unwrap_invariant(batch_size)
         ctx = _compile.CompileContext.current()
         if ctx is None or ctx.state is _compile.State.DISABLED:
             if self._role in (_Role.FEEDER, _Role.ROOT):
@@ -203,6 +208,7 @@ class ExternalSource:
         They are prefetched, so they are polled ahead of the loop body and breaking out may discard
         already-pulled items.
         """
+        batch_size = unwrap_invariant(batch_size)
         if self._role is _Role.EAGER:
             raise RuntimeError("This ExternalSource was already used eagerly")
         if self._role is _Role.FEEDER:

--- a/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_op_builder.py
@@ -31,6 +31,7 @@ from ._eval_mode import EvalMode
 from ._nvtx import NVTXRange
 from ._tensor import Tensor
 from ._tensor import tensor as to_tensor
+from .compile._invariant import unwrap_invariant, unwrap_invariants
 
 
 def is_external(x):
@@ -42,6 +43,7 @@ def is_external(x):
 
 
 def _scalar_decay(x):
+    x = unwrap_invariants(x)
     if isinstance(x, _device.Device):
         return x.device_type
     if isinstance(x, _type.DType):
@@ -215,13 +217,14 @@ def build_constructor(schema, op_class):
     # Note: Base __init__ will keep the **kwargs
     def init(self, max_batch_size, name, **kwargs):
         if is_reader:
-            actual_tensor_arg_names = {
-                arg_name for arg_name in tensor_arg_names if kwargs.get(arg_name) is not None
-            }
+            actual_tensor_arg_names = set()
             tensor_args = {}
             for arg_name in tensor_arg_names:
-                arg = kwargs.get(arg_name)
-                if arg is None or isinstance(arg, (int, float, bool, str, tuple, list)):
+                arg = unwrap_invariant(kwargs.get(arg_name))
+                if arg is None:
+                    continue
+                actual_tensor_arg_names.add(arg_name)
+                if isinstance(arg, (int, float, bool, str, tuple, list)):
                     continue
                 if isinstance(arg, Batch):
                     raise ValueError("Readers cannot be constructed with batch keyword arguments")
@@ -325,10 +328,13 @@ def build_call_function(schema, op_class):
     @mark_transparent
     @NVTXRange(f"__call__: {op_class._op_name}", category="op_builder")
     def call(self, *raw_args, batch_size=None, _process_params=True, **raw_kwargs):
+        batch_size = unwrap_invariant(batch_size)
         self._pre_call(*raw_args, **raw_kwargs)
 
         if op_class._is_reader and self._tensor_arg_names:
-            actual_kwargs = {name for name, value in raw_kwargs.items() if value is not None}
+            actual_kwargs = {
+                name for name, value in raw_kwargs.items() if unwrap_invariant(value) is not None
+            }
             overlap = actual_kwargs & self._tensor_arg_names
             if overlap:
                 raise ValueError(
@@ -410,13 +416,12 @@ def _resolve_backend(
 
     Returns (resolved_device, backend).
     """
+    device = unwrap_invariant(device)
     if device is None:
 
         def infer_device():
             for arg in inputs:
-                if arg is None:
-                    continue
-                dev = _ops._get_input_device(arg)
+                dev = _ops._get_input_device(unwrap_invariant(arg))
                 if dev is not None and dev.device_type == "gpu":
                     return dev
             return _device.Device.CPU
@@ -508,16 +513,17 @@ def build_fn_wrapper(op, fn_name=None, add_to_module=True):
             batch_size = _ops._infer_batch_size(*inputs, **raw_kwargs)
         _check_batch_size_available(op, batch_size)
         max_batch_size = _next_pow2(batch_size or 1)
-        init_args = {
-            arg: _scalar_decay(value)
-            for arg, value in raw_kwargs.items()
-            if value is not None and arg != "max_batch_size" and arg in fixed_args
-        }
-        call_args = {
-            arg: _scalar_decay(value)
-            for arg, value in raw_kwargs.items()
-            if value is not None and arg in tensor_args
-        }
+        init_args = {}
+        call_args = {}
+        for arg, value in raw_kwargs.items():
+            if arg == "max_batch_size":
+                continue
+            if arg in fixed_args:
+                value = _scalar_decay(value)
+                if value is not None:
+                    init_args[arg] = value
+            elif arg in tensor_args:
+                call_args[arg] = value
 
         inputs, call_args = op._process_params(_backend, device, batch_size, *inputs, **call_args)
 

--- a/dali/python/nvidia/dali/experimental/dynamic/_ops.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_ops.py
@@ -28,6 +28,7 @@ from ._batch import as_batch as _as_batch
 from ._device import Device, DeviceLike
 from ._nvtx import NVTXRange
 from ._tensor import Tensor, as_tensor
+from .compile._invariant import unwrap_invariant, unwrap_invariant_args
 
 _nvtx_to_tensor = NVTXRange("to_tensor", category="op_builder")
 
@@ -114,7 +115,8 @@ _nvtx_infer_batch_size = NVTXRange("_infer_batch_size", category="op_builder")
 def _infer_batch_size(*raw_args, **raw_kwargs):
     batch_size = None
     with _nvtx_infer_batch_size:
-        for i, x in enumerate(list(raw_args) + list(raw_kwargs.values())):
+        for x in list(raw_args) + list(raw_kwargs.values()):
+            x = unwrap_invariant(x)
             x_batch_size = _get_batch_size(x)
             if x_batch_size is not None:
                 if batch_size is not None:
@@ -175,6 +177,7 @@ class Operator:
         device : Device or str, optional
             The device where the operation is executed.
         """
+        max_batch_size, name = unwrap_invariant_args(max_batch_size, name)
         self._lock = Lock()
         self._name = name
         self._max_batch_size = max_batch_size
@@ -316,7 +319,7 @@ class Operator:
         if cls._has_random_state_arg:
             from . import random
 
-            rng = raw_kwargs.pop("rng", None)
+            rng = unwrap_invariant(raw_kwargs.pop("rng", None))
             if rng is None:
                 rng = random.get_default_rng()
             if not isinstance(rng, random.RNG):
@@ -361,6 +364,7 @@ class Operator:
 
         def convert_args(convert_fn):
             for i, inp in enumerate(raw_args):
+                inp = unwrap_invariant(inp)
                 if inp is None:
                     continue
                 actual_input_device = _get_input_device(inp)
@@ -369,6 +373,7 @@ class Operator:
                 inp = convert_fn(inp, device=input_device)
                 inputs.append(inp)
             for k, v in raw_kwargs.items():
+                v = unwrap_invariant(v)
                 if v is None:
                     continue
                 dtype = cls._argument_conversion_map[k]
@@ -997,6 +1002,7 @@ class Reader(Operator):
             If True, transparently compile operator sequences into a pipeline for prefetching.
             Once used in compiled mode, the reader cannot switch back.
         """
+        batch_size = unwrap_invariant(batch_size)
         self._check_not_disabled()
 
         batch_size = self._get_batch_size(batch_size)
@@ -1046,6 +1052,7 @@ class Reader(Operator):
     def get_metadata(self, batch_size: int | None = None) -> ReaderMeta:
         """Returns the metadata of the underlying reader operator"""
 
+        batch_size = unwrap_invariant(batch_size)
         batch_size = self._get_batch_size(batch_size)
         self._init_backend(None, (), self._process_tensor_args(batch_size))
         try:

--- a/dali/python/nvidia/dali/experimental/dynamic/_source_analysis.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_source_analysis.py
@@ -35,12 +35,15 @@ from libcst.metadata import (
     Scope,
     ScopeProvider,
 )
+
 from nvidia.dali.types import DALIDataType, DALIImageType, DALIInterpType
 
 from ._call_site import CodeLoc, resolve_callsite_frame
 from ._compile import CompiledBatch, CompileRef
 from ._device import Device
 from ._type import DType
+from .compile._invariant import invariant, is_dunder
+from .compile._invariant import is_invariant as _is_explicit_invariant
 
 _DALI_CONST_TYPES = (Device, DType, DALIDataType, DALIInterpType, DALIImageType)
 
@@ -311,20 +314,15 @@ class _Classifier:
     Each argument is either an already captured batch, invariant or not capturable.
     """
 
-    module_info: ModuleInfo
+    module_info: ModuleInfo | None
     frame: types.FrameType
 
     def classify(
         self, inputs: tuple[Any, ...], raw_kwargs: dict[str, Any]
     ) -> tuple[list[CompileRef | Any], dict[str, CompileRef | Any]] | None:
-        call = self.module_info.call_at(self.frame)
-        if call is None:
-            return None
-
-        split = _split_call_args(call)
-        if split is None:
-            return None
-        pos_nodes, kw_nodes = split
+        call = self.module_info.call_at(self.frame) if self.module_info is not None else None
+        source_args = _split_call_args(call) if call is not None else None
+        pos_nodes, kw_nodes = source_args or ((), {})
 
         try:
             classified_inputs: list[CompileRef | Any] = []
@@ -343,9 +341,11 @@ class _Classifier:
             return None  # an argument is neither a CompiledBatch nor a capturable constant
         return classified_inputs, classified_kwargs
 
-    def _capture_arg(self, node: cst.BaseExpression | None, value: Any) -> CompileRef | Any:
+    def _capture_arg(self, node: cst.BaseExpression | None, value: Any) -> Any:
         if isinstance(value, CompiledBatch):
             return value._compile_ref
+        if _is_explicit_invariant(value):
+            return value
         if node is not None and self.is_invariant(node):
             return value
         raise _Unresolved
@@ -367,19 +367,49 @@ class _Classifier:
             case cst.Attribute():
                 # We can't accept any attributes, even if the base is a local name.
                 # Mutability and aliasing makes them hard to reliably track.
-                return self._is_dali_chain(node)
+                return self._is_explicit_invariant_expr(node) or self._is_dali_chain(node)
+            case cst.Call():
+                return self._is_explicit_invariant_expr(node)
+        return False
+
+    def _is_explicit_invariant_expr(self, expr: cst.BaseExpression) -> bool:
+        """Check if an expression corresponds to something wrapped with ndd.invariant"""
+        match expr:
+            case cst.Name():
+                try:
+                    return _is_explicit_invariant(_safe_resolve(expr, self.frame))
+                except _Unresolved:
+                    return False
+            case cst.Call():
+                try:
+                    return _safe_resolve(expr.func, self.frame) is invariant
+                except _Unresolved:
+                    return False
+            case cst.NamedExpr(value=value):
+                return self._is_explicit_invariant_expr(value)
+            case cst.Attribute(value=base, attr=attr):
+                # dunder attributes don't propagate the invariant property
+                return not is_dunder(attr.value) and self._is_explicit_invariant_expr(base)
         return False
 
     def _is_name_invariant(self, name_node: cst.Name) -> bool:
+        try:
+            value = _safe_resolve(name_node, self.frame)
+        except _Unresolved:
+            return False
+
+        if _is_explicit_invariant(value):
+            return True
+
+        if self.module_info is None:
+            return False
+
         binding = self.module_info.binding(name_node)
         if binding is None or not self._is_binding_invariant(binding, name_node):
             return False
         # A named mutable is a live handle the user can alias and mutate.
         # It's hard to prove that they are invariant.
-        try:
-            return _is_immutable_value(_safe_resolve(name_node, self.frame))
-        except _Unresolved:
-            return False
+        return _is_immutable_value(value)
 
     def _is_binding_invariant(self, binding: Binding, name_node: cst.Name) -> bool:
         """True if `name_node`'s binding is invariant (captured name re-roots at live owner)."""
@@ -505,8 +535,4 @@ def classify(
 ) -> tuple[list[CompileRef | Any], dict[str, CompileRef | Any]] | None:
     """Classify operator args as captured constants / CompileRefs, or None to run eager."""
     mi = _get_module_info(frame.f_code.co_filename)
-    if mi is None:
-        return None
-
-    classifier = _Classifier(mi, frame)
-    return classifier.classify(inputs, raw_kwargs)
+    return _Classifier(mi, frame).classify(inputs, raw_kwargs)

--- a/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_tensor.py
@@ -16,8 +16,9 @@ import copy
 from typing import TYPE_CHECKING, Any, SupportsInt, Union
 
 import numpy as np
-import nvidia.dali.backend as _backend
+
 import nvidia.dali._tensor_formatting as _tensor_formatting
+import nvidia.dali.backend as _backend
 import nvidia.dali.types
 from nvidia.dali._typing import TensorLike
 
@@ -29,6 +30,7 @@ from ._eval_context import EvalContext as _EvalContext
 from ._type import DType
 from ._type import dtype as _dtype
 from ._type import type_id as _type_id
+from .compile._invariant import unwrap_invariant_args, unwrap_invariants
 
 if TYPE_CHECKING:
     from ._batch import Batch
@@ -135,6 +137,7 @@ class Tensor:
         invocation_result: _invocation.InvocationResult | None = None,
         copy: bool = False,
     ):
+        data, dtype, device, layout = unwrap_invariant_args(data, dtype, device, layout)
         if layout is None:
             layout = ""
         elif not isinstance(layout, str):
@@ -268,7 +271,7 @@ class Tensor:
                         numpy_type = nvidia.dali.types.to_numpy_type(dtype.type_id)
 
                     self._storage = _backend.TensorCPU(
-                        np.array(data, dtype=numpy_type),
+                        np.array(unwrap_invariants(data), dtype=numpy_type),
                         layout,
                         False,
                     )
@@ -279,7 +282,7 @@ class Tensor:
                     self._wraps_external_data = False
                     self._dtype = dtype
                 else:
-                    arr = np.array(data)
+                    arr = np.array(unwrap_invariants(data))
                     # DALI doesn't support int64 and float64, so we need to convert them to int32
                     # and float32, respectively.
                     converted_dtype_id = None

--- a/dali/python/nvidia/dali/experimental/dynamic/compile/__init__.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/compile/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._invariant import invariant as invariant  # noqa: F401

--- a/dali/python/nvidia/dali/experimental/dynamic/compile/_invariant.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/compile/_invariant.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+from types import MethodType
+from typing import Any, ClassVar, Generic, TypeGuard, TypeVar, cast
+
+from typing_extensions import TypeVarTuple, Unpack
+
+_T = TypeVar("_T")
+_Ts = TypeVarTuple("_Ts")
+
+
+def invariant(value: _T) -> _T:
+    """Mark `value` as invariant for transparent pipelining.
+
+    The marker is an unchecked promise that the value represented by the returned object will not
+    change between compiled iterations. It lets transparent pipelining capture values whose
+    stability cannot be proven from source, such as module globals.
+
+    During compiled replay, a corresponding present argument must remain marked; removing the
+    marker raises ``RuntimeError``.
+
+    The returned object is a proxy propagating the invariant property to attributes, while
+    protocol operations, calls, indexing, iteration, conversions, and method calls return their
+    ordinary results.
+
+    Proxy transparency is best-effort: identity, exact type and C-API checks, native layout and
+    buffers, copying, serialization, metaclass-only protocols, and special methods supplied by
+    non-callable descriptors are not preserved.
+
+    Parameters
+    ----------
+    value
+        Any Python value to mark as invariant.
+
+    Returns
+    -------
+    Same as `value`
+        A proxy for `value`, or `value` itself if it is already an invariant proxy.
+    """
+    if is_invariant(value):
+        return cast(_T, value)
+
+    wrapped_type = type(value)
+    proxy_type = _proxy_types.get(wrapped_type)
+    if proxy_type is None:
+        proxy_type = _proxy_types.setdefault(wrapped_type, _make_proxy_type(wrapped_type))
+    return cast(_T, proxy_type(value))
+
+
+def is_dunder(name: str) -> bool:
+    return len(name) > 4 and name.startswith("__") and name.endswith("__")
+
+
+class _InvariantProxy(Generic[_T]):
+    __slots__ = ("__value",)
+    _wrapped_type: ClassVar[type]
+
+    def __init__(self, value: _T) -> None:
+        object.__setattr__(self, "_InvariantProxy__value", value)
+
+    def __getattribute__(self, name: str) -> Any:
+        value = object.__getattribute__(self, "_InvariantProxy__value")
+        if is_dunder(name):
+            return getattr(value, name)
+        attribute = getattr(value, name)
+        if isinstance(attribute, MethodType) and attribute.__self__ is value:
+            return MethodType(attribute.__func__, self)
+        return invariant(attribute)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(object.__getattribute__(self, "_InvariantProxy__value"), name, value)
+
+    def __delattr__(self, name: str) -> None:
+        delattr(object.__getattribute__(self, "_InvariantProxy__value"), name)
+
+
+_proxy_types: dict[type, type[_InvariantProxy[Any]]] = {}
+
+
+def is_invariant(value: object) -> TypeGuard[_InvariantProxy[Any]]:
+    return isinstance(value, _InvariantProxy)
+
+
+def unwrap_invariant(value: _T | _InvariantProxy[_T]) -> _T:
+    if is_invariant(value):
+        # Resolve Python's private name mangling
+        return object.__getattribute__(value, "_InvariantProxy__value")
+    return cast(_T, value)
+
+
+def unwrap_invariant_args(*values: Unpack[_Ts]) -> tuple[Unpack[_Ts]]:
+    return cast("tuple[Unpack[_Ts]]", tuple(unwrap_invariant(value) for value in values))
+
+
+def unwrap_invariants(value: Any) -> Any:
+    """Recursively unwrap exact built-in containers, reusing unchanged containers."""
+    value = unwrap_invariant(value)
+    if isinstance(value, type) and issubclass(value, _InvariantProxy):
+        return value._wrapped_type
+
+    type_ = type(value)
+    if type_ not in (list, tuple, dict):
+        return value
+
+    items = tuple(value.items()) if type_ is dict else value
+    unwrapped_items = tuple(unwrap_invariants(item) for item in items)
+    return value if all(a is b for a, b in zip(items, unwrapped_items)) else type_(unwrapped_items)
+
+
+def _is_descriptor(value: Any) -> bool:
+    for base in type.__getattribute__(type(value), "__mro__"):
+        attributes = type.__getattribute__(base, "__dict__")
+        if "__get__" in attributes:
+            return attributes["__get__"] is not None
+    return False
+
+
+class _DunderForwarder:
+    """Forward a callable special method from the wrapped type to its invariant proxy."""
+
+    __slots__ = ("_name", "_definition", "_wrapped_type")
+
+    def __init__(self, name: str, definition: Any, wrapped_type: type) -> None:
+        self._name = name
+        self._definition = definition
+        self._wrapped_type = wrapped_type
+
+    def __get__(self, proxy: _InvariantProxy[Any] | None, owner: type | None = None) -> Any:
+        return self if proxy is None else MethodType(self, proxy)
+
+    def __call__(self, proxy: _InvariantProxy[Any], *args: Any, **kwargs: Any) -> Any:
+        value = unwrap_invariant(proxy)
+        # Descriptor binding uses None for class access, not for the None singleton.
+        if value is None:
+            method = partial(self._definition, None)
+        elif _is_descriptor(self._definition):
+            # Bypass the descriptor instance's attribute hooks.
+            method = object.__getattribute__(self._definition, "__get__")(value, self._wrapped_type)
+        else:
+            method = self._definition
+
+        if self._name == "__call__":
+            return method(*args, **kwargs)
+        if self._name in ("__setitem__", "__set__"):
+            target, value = args
+            return method(unwrap_invariants(target), value)
+
+        return method(
+            *(unwrap_invariants(arg) for arg in args),
+            **{name: unwrap_invariants(arg) for name, arg in kwargs.items()},
+        )
+
+
+_EXCLUDED_DUNDERS = {
+    # The proxy owns attribute delegation.
+    "__delattr__",
+    "__getattr__",
+    "__getattribute__",
+    "__setattr__",
+    # Construction and finalization apply to the proxy itself.
+    "__del__",
+    "__init__",
+    "__new__",
+    # Class hooks apply to the generated proxy type.
+    "__class_getitem__",
+    "__init_subclass__",
+    "__mro_entries__",
+    "__prepare__",
+    "__subclasshook__",
+    # The proxy keeps its own identity, layout, and metadata.
+    "__annotations__",
+    "__base__",
+    "__bases__",
+    "__class__",
+    "__dict__",
+    "__doc__",
+    "__module__",
+    "__mro__",
+    "__name__",
+    "__qualname__",
+    "__slots__",
+    "__weakref__",
+    # Copying and serialization cannot preserve the marker reliably.
+    "__copy__",
+    "__deepcopy__",
+    "__getinitargs__",
+    "__getnewargs__",
+    "__getnewargs_ex__",
+    "__getstate__",
+    "__reduce__",
+    "__reduce_ex__",
+    "__replace__",
+    "__setstate__",
+}
+
+
+def _make_proxy_type(wrapped_type: type) -> type[_InvariantProxy[Any]]:
+    # Build a namespace to forward dunders to the new type.
+    # Regular attributes and methods are forwarded by _InvariantProxy directly.
+    namespace = {
+        "__module__": __name__,
+        "__slots__": (),
+        "_wrapped_type": wrapped_type,
+    }
+    definitions: dict[str, Any] = {}
+    for base in type.__getattribute__(wrapped_type, "__mro__"):
+        for name, definition in type.__getattribute__(base, "__dict__").items():
+            if is_dunder(name) and name not in _EXCLUDED_DUNDERS:
+                definitions.setdefault(name, definition)
+
+    for name, definition in definitions.items():
+        if definition is None:
+            namespace[name] = None
+        elif callable(definition):
+            namespace[name] = _DunderForwarder(name, definition, wrapped_type)
+
+    name = f"_Invariant_{type.__getattribute__(wrapped_type, '__name__')}"
+    return type(name, (_InvariantProxy,), namespace)

--- a/dali/test/python/experimental_mode/test_compile_invariants.py
+++ b/dali/test/python/experimental_mode/test_compile_invariants.py
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import importlib.util
+import os
 import pathlib
 import tempfile
-import functools
-import os
 from collections.abc import Callable
 
 import numpy as np
+from ndd_utils import _is_compiled
+from nose_utils import assert_raises
+from test_utils import get_dali_extra_path
+
 import nvidia.dali.experimental.dynamic as ndd
 import nvidia.dali.types
-from ndd_utils import _is_compiled
 from nvidia.dali.types import DALIDataType
-from test_utils import get_dali_extra_path
 
 dali_extra_path = get_dali_extra_path()
 images_root = os.path.join(dali_extra_path, "db", "single", "jpeg")
@@ -68,10 +70,19 @@ def compiled_test(*, expect_captured: bool):
 
 _MODULE_DTYPE = ndd.float32
 _GLOBAL_ANGLE = 60
+_INVARIANT_ANGLE = ndd.compile.invariant(0.0)
+_INVARIANT_SIZE = ndd.compile.invariant(4)
 
 
 class _Cfg:
     DTYPE = ndd.float32
+
+
+class _InvariantCfg:
+    angle = 60
+
+
+_INVARIANT_CFG = ndd.compile.invariant(_InvariantCfg())
 
 
 class _DaliHolder:
@@ -389,6 +400,38 @@ def test_param_default_name(images):
     return rotate(images)
 
 
+@compiled_test(expect_captured=True)
+def test_invariant_marker(images):
+    angle = ndd.compile.invariant(10) + _INVARIANT_CFG.angle
+    return ndd.rotate(images, angle=angle, fill_value=ndd.compile.invariant(None))
+
+
+@compiled_test(expect_captured=True)
+def test_invariant_marker_parameter(images):
+    def rotate(imgs, angle):
+        return ndd.rotate(imgs, angle=angle)
+
+    return rotate(images, _INVARIANT_ANGLE)
+
+
+@compiled_test(expect_captured=True)
+def test_invariant_marker_list(images):
+    images = ndd.resize(images, size=[_INVARIANT_SIZE, _INVARIANT_SIZE])
+    size = ndd.compile.invariant([4, 4])
+    return ndd.resize(images, size=size)
+
+
+@compiled_test(expect_captured=True)
+def test_invariant_marker_without_source(images):
+    source = """
+def transform(images, angle):
+    return ndd.rotate(images, angle=angle)
+"""
+    namespace = {"ndd": ndd}
+    exec(compile(source, "<source-unavailable>", "exec"), namespace)
+    return namespace["transform"](images, _INVARIANT_ANGLE)
+
+
 # Tests for rejected cases
 
 
@@ -576,3 +619,18 @@ def test_param_global_arg(images):
         return ndd.rotate(imgs, angle=crop)
 
     return augment(images, _GLOBAL_ANGLE)
+
+
+@compiled_test(expect_captured=False)
+def test_invariant_marker_with_global(images):
+    angle = ndd.compile.invariant(0.0) + _GLOBAL_ANGLE
+    return ndd.rotate(images, angle=angle)
+
+
+def test_invariant_marker_removed():
+    es = ndd.ExternalSource(lambda: ndd.zeros(batch_size=2, shape=(4, 4, 3), layout="HWC"))
+    angles = iter((ndd.compile.invariant(0.0), 0.0))
+
+    with assert_raises(RuntimeError, glob="marked with ndd.compile.invariant*remain marked"):
+        for images in es.compiled(batch_size=2):
+            ndd.rotate(images, angle=next(angles))

--- a/dali/test/python/experimental_mode/test_invariant.py
+++ b/dali/test/python/experimental_mode/test_invariant.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import nvidia.dali.experimental.dynamic as ndd
+from nose2.tools import params
+from nose_utils import assert_raises
+from nvidia.dali.experimental.dynamic.compile._invariant import (
+    is_invariant,
+    unwrap_invariant,
+    unwrap_invariants,
+)
+
+
+@params((None,), (1,), ("text",), ([1],), (int,))
+def test_invariant_marker(value):
+    marked = ndd.compile.invariant(value)
+    assert marked == value
+    assert is_invariant(marked)
+    assert isinstance(marked, type(value))
+    assert unwrap_invariant(marked) is value
+    assert ndd.compile.invariant(marked) is marked
+
+
+def test_invariant_attributes():
+    class Value:
+        def __init__(self):
+            self.item = []
+
+        def get_item(self):
+            return self.item
+
+    value = Value()
+    marked = ndd.compile.invariant(value)
+    assert is_invariant(marked.item)
+    assert is_invariant(marked.get_item())
+    assert not is_invariant(value.item)
+
+    replacement = ndd.compile.invariant([1])
+    marked.item = replacement
+    assert value.item is replacement
+    del marked.item
+    assert not hasattr(value, "item")
+
+
+def test_invariant_magic_methods():
+    assert ndd.compile.invariant(2) + ndd.compile.invariant(3) == 5
+    assert 7 - ndd.compile.invariant(2) == 5
+    assert ndd.compile.invariant([1, 2])[ndd.compile.invariant(0)] == 1
+    assert list(ndd.compile.invariant([1, 2])) == [1, 2]
+
+    value = ndd.compile.invariant(object())
+    assert ndd.compile.invariant(lambda x: x)(value) is value
+    np.testing.assert_array_equal(np.asarray(ndd.compile.invariant(np.asarray([1, 2]))), [1, 2])
+
+    with assert_raises(TypeError, glob="unhashable type"):
+        hash(ndd.compile.invariant([1, 2]))
+
+
+def test_invariant_unwrap():
+    marked = ndd.compile.invariant(1)
+    original = [marked, (marked,)]
+    assert unwrap_invariants(original) == [1, (1,)]
+    assert original[0] is marked
+
+    unchanged = [1, (2,)]
+    assert unwrap_invariants(unchanged) is unchanged
+    assert unwrap_invariants({marked: marked}) == {1: 1}
+
+    class Iterable:
+        def __iter__(self):
+            raise AssertionError("unwrap must not iterate user values")
+
+    value = Iterable()
+    assert unwrap_invariants(ndd.compile.invariant(value)) is value
+
+
+def test_invariant_api_inputs():
+    data = ndd.compile.invariant([np.asarray([1, 2]), np.asarray([3, 4])])
+    batch = ndd.as_batch(data)
+    dense = ndd.as_tensor(batch, pad=ndd.compile.invariant(False))
+    np.testing.assert_array_equal(dense, [[1, 2], [3, 4]])
+
+    images = ndd.as_batch([np.zeros((4, 4, 3), dtype=np.uint8) for _ in range(2)], layout="HWC")
+    output = ndd.rotate(
+        images,
+        batch_size=ndd.compile.invariant(2),
+        device=ndd.compile.invariant("cpu"),
+        angle=ndd.compile.invariant(0.0),
+    )
+    np.testing.assert_array_equal(ndd.as_tensor(output, pad=True), ndd.as_tensor(images, pad=True))
+
+    source = ndd.ExternalSource(
+        ndd.compile.invariant(iter([np.asarray([1, 2, 3], dtype=np.int32)])),
+        device=ndd.compile.invariant("cpu"),
+    )
+    np.testing.assert_array_equal(source(), [1, 2, 3])


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**New feature** (*non-breaking change which adds functionality*)

## Description:

For an operator to be captured in transparent pipelining, we require all of its arguments to be either outputs of another captured operator or constants. We statically detect invariant function parameters, local variables and closure cells. However, it is not tractable to extend this static analysis to e.g. module globals or attributes.

This PR introduces `ndd.compile.invariant`, which allows marking any variable as invariant in order for it to be blindly trusted during capture in transparent pipelining. This function returns a proxy object that tries to be as close as possible to the original object and is undistinguishable from it in most cases:

```pycon
>>> x = [1, 2, 3]
>>> y = ndd.compile.invariant(x); print(y)
[1, 2, 3]
>>> y.append(4)
>>> print(x)
[1, 2, 3, 4]
>>> y + [5]
[1, 2, 3, 4, 5]
>>> isinstance(y, list)
True
>>> type(y)
<class 'nvidia.dali.experimental.dynamic.compile._invariant._Invariant_list'>
```

Objects marked with `ndd.compile.invariant` also propagate their invariant property to their attributes, allowing for such cases:
```py
args = parser.parse()
args = ndd.compile.invariant(args)

...

for jpegs, labels in reader.next_epoch(batch_size=32, compile=True):
    images = ndd.decoders.image(
        jpegs,
        device=args.device,
        output_type=types.RGB,
        hw_decoder_load=args.hw_load,
        preallocate_width_hint=args.width_hint,
        preallocate_height_hint=args.height_hint,
    )
```

## Additional information:

### Affected modules and functionalities:

Dynamic mode, transparent pipelining

### Key points relevant for the review:

Two things to review:
- `ndd.compile.invariant` itself
- Its integration in ndd and transparent pipelining

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [X] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4818
<!--- DALI-XXXX or NA --->
