### PR TITLE
Coverity static analysis findings - July 2026

### DIFF
--- a/dali/operators/imgcodec/util/convert_test.cc
+++ b/dali/operators/imgcodec/util/convert_test.cc
@@ -299,14 +299,15 @@ class ConvertOrientationTest : public ::testing::Test {
     auto input_buf = MakeInput();
     TensorShape<> in_shape{kH, kW, kC};
     TensorShape<> out_shape{out_h, out_w, kC};
-    ConstSampleView<CPUBackend> in_view(input_buf.data(), in_shape, DALI_UINT8);
+    ConstSampleView<CPUBackend> in_view(input_buf.data(), std::move(in_shape), DALI_UINT8);
     std::vector<uint8_t> output_buf(out_h * out_w * kC, 0xFF);
-    SampleView<CPUBackend> out_view(output_buf.data(), out_shape, DALI_UINT8);
+    SampleView<CPUBackend> out_view(output_buf.data(), std::move(out_shape), DALI_UINT8);
 
     nvimgcodecOrientation_t orientation{
         NVIMGCODEC_STRUCTURE_TYPE_ORIENTATION, sizeof(nvimgcodecOrientation_t),
         nullptr, rotated, flip_x, flip_y};
-    ConvertCPU(out_view, "HWC", DALI_RGB, in_view, "HWC", DALI_RGB, {}, orientation);
+    ConvertCPU(std::move(out_view), "HWC", DALI_RGB, std::move(in_view),
+               "HWC", DALI_RGB, {}, orientation);
     EXPECT_EQ(output_buf, expected);
   }
 };

--- a/dali/operators/imgcodec/util/convert_test.cc
+++ b/dali/operators/imgcodec/util/convert_test.cc
@@ -299,15 +299,14 @@ class ConvertOrientationTest : public ::testing::Test {
     auto input_buf = MakeInput();
     TensorShape<> in_shape{kH, kW, kC};
     TensorShape<> out_shape{out_h, out_w, kC};
-    ConstSampleView<CPUBackend> in_view(input_buf.data(), std::move(in_shape), DALI_UINT8);
+    ConstSampleView<CPUBackend> in_view(input_buf.data(), in_shape, DALI_UINT8);
     std::vector<uint8_t> output_buf(out_h * out_w * kC, 0xFF);
-    SampleView<CPUBackend> out_view(output_buf.data(), std::move(out_shape), DALI_UINT8);
+    SampleView<CPUBackend> out_view(output_buf.data(), out_shape, DALI_UINT8);
 
     nvimgcodecOrientation_t orientation{
         NVIMGCODEC_STRUCTURE_TYPE_ORIENTATION, sizeof(nvimgcodecOrientation_t),
         nullptr, rotated, flip_x, flip_y};
-    ConvertCPU(std::move(out_view), "HWC", DALI_RGB, std::move(in_view),
-               "HWC", DALI_RGB, {}, orientation);
+    ConvertCPU(out_view, "HWC", DALI_RGB, in_view, "HWC", DALI_RGB, {}, orientation);
     EXPECT_EQ(output_buf, expected);
   }
 };

--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <limits>
+#include <optional>
 #include <utility>
 #include "dali/pipeline/util/thread_pool.h"
 #if NVML_ENABLED
@@ -30,6 +31,7 @@ namespace dali {
 OldThreadPool::OldThreadPool(int num_thread, int device_id, bool set_affinity, const char* name)
     : threads_(num_thread) {
   DALI_ENFORCE(num_thread > 0, "Thread pool must have non-zero size");
+  tl_errors_.resize(num_thread);
 #if NVML_ENABLED
   // We use NVML only for setting thread affinity
   if (device_id != CPU_ONLY_DEVICE_ID && set_affinity) {
@@ -42,7 +44,6 @@ OldThreadPool::OldThreadPool(int num_thread, int device_id, bool set_affinity, c
                                         i, device_id, set_affinity,
                                         make_string("[DALI][TP", i, "]", name)));
   }
-  tl_errors_.resize(num_thread);
 }
 
 OldThreadPool::~OldThreadPool() {
@@ -134,8 +135,9 @@ void OldThreadPool::ThreadMain(int thread_id, int device_id, bool set_affinity,
                             const std::string &name) {
   this_thread_idx_ = thread_id;
   SetThreadName(name.c_str());
-  DeviceGuard g(device_id);
+  std::optional<DeviceGuard> device_guard;
   try {
+    device_guard.emplace(device_id);
 #if NVML_ENABLED
     if (set_affinity) {
       const char *env_affinity = std::getenv("DALI_AFFINITY_MASK");

--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -15,7 +15,6 @@
 #include <chrono>
 #include <cstdlib>
 #include <limits>
-#include <optional>
 #include <utility>
 #include "dali/pipeline/util/thread_pool.h"
 #if NVML_ENABLED
@@ -135,9 +134,8 @@ void OldThreadPool::ThreadMain(int thread_id, int device_id, bool set_affinity,
                             const std::string &name) {
   this_thread_idx_ = thread_id;
   SetThreadName(name.c_str());
-  std::optional<DeviceGuard> device_guard;
+  DeviceGuard g(device_id);
   try {
-    device_guard.emplace(device_id);
 #if NVML_ENABLED
     if (set_affinity) {
       const char *env_affinity = std::getenv("DALI_AFFINITY_MASK");

--- a/dali/pipeline/util/worker_thread.cc
+++ b/dali/pipeline/util/worker_thread.cc
@@ -17,6 +17,7 @@
 
 #include <exception>
 #include <iostream>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 
@@ -64,21 +65,11 @@ WorkerThreadImpl::~WorkerThreadImpl() {
 
 void WorkerThreadImpl::Shutdown() {
   // Wait for work to find errors
-  if (running_) {
-    WaitForWork(false);
+  WaitForWork(false);
+  ForceStop();
 
-    // Mark the thread as not running
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      running_ = false;
-    }
-    cv_.notify_one();
-  } else {
-    ForceStop();
-  }
   // Join the thread
   if (thread_.joinable()) {
-    ForceStop();
     thread_.join();
   }
 }
@@ -137,8 +128,9 @@ bool WorkerThreadImpl::WaitForInit() {
 
 void WorkerThreadImpl::ThreadMain(int device_id, bool set_affinity, const std::string &name) {
   SetThreadName(name.c_str());
-  DeviceGuard g(device_id);
+  std::optional<DeviceGuard> device_guard;
   try {
+    device_guard.emplace(device_id);
     if (set_affinity) {
 #if NVML_ENABLED
       nvml::SetCPUAffinity();
@@ -156,7 +148,7 @@ void WorkerThreadImpl::ThreadMain(int device_id, bool set_affinity, const std::s
 
   barrier_.Wait();
 
-  while (running_) {
+  while (true) {
     // Check the queue for work
     std::unique_lock<std::mutex> lock(mutex_);
     while (work_queue_.empty() && running_) {

--- a/dali/pipeline/util/worker_thread.cc
+++ b/dali/pipeline/util/worker_thread.cc
@@ -148,7 +148,7 @@ void WorkerThreadImpl::ThreadMain(int device_id, bool set_affinity, const std::s
 
   barrier_.Wait();
 
-  while (true) {
+  while (running_) {
     // Check the queue for work
     std::unique_lock<std::mutex> lock(mutex_);
     while (work_queue_.empty() && running_) {


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**Other** (*e.g. Documentation, Tests, Configuration*)

## Description:

### Issues fixed

<dl>
<dt>CIDs 27279466 (<code>MISSING_LOCK</code>) and 27279471 (<code>LOCK_EVASION</code>)</dt>
<dd>Simplified worker shutdown to wait, stop under the existing synchronization, and join.
This removes the unlocked check of <code>running_</code> and the check-then-lock pattern.</dd>

<dt>CIDs 27279468, 27279470 and 27279472 (<code>UNCAUGHT_EXCEPT</code>)</dt>
<dd>Moved worker <code>DeviceGuard</code> construction inside the existing exception handler
while preserving its lifetime for the whole worker thread.</dd>
</dl>

## Additional information:

### Affected modules and functionalities:

- dali/operators/imgcodec/util/convert_test.cc
- dali/pipeline/util/thread_pool.cc
- dali/pipeline/util/worker_thread.cc

### Key points relevant for the review:

Were some of the fixed issues false positives?

### Tests:

- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-4805
<!--- DALI-XXXX or NA --->
