### PR TITLE
Use python-build for package artifacts

### DIFF
--- a/dali_tf_plugin/make_dali_tf_sdist.sh
+++ b/dali_tf_plugin/make_dali_tf_sdist.sh
@@ -18,7 +18,7 @@ cmake .. \
       -DTIMESTAMP=${DALI_TIMESTAMP} \
       -DGIT_SHA=${GIT_SHA}
 make -j install
-python setup.py sdist
+python -m build --sdist --no-isolation
 mkdir -p /dali_tf_sdist
 cp dist/*.tar.gz /dali_tf_sdist
 popd

--- a/docker/Dockerfile.make_sdist_plugins
+++ b/docker/Dockerfile.make_sdist_plugins
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt update && apt install -y python3 python3-pip build-essential git wget && \
-    python3 -m pip install "setuptools>=70" scikit-build && \
+    python3 -m pip install "setuptools>=70" build scikit-build && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /root/.cache/pip/
 

--- a/docker/build_helper.sh
+++ b/docker/build_helper.sh
@@ -143,11 +143,11 @@ if [ "${BUILD_PYTHON}" = "ON" ]; then
     # use stored as a compression method to make it faster as bundle-wheel.sh need to repack anyway
     # call setup.py to avoid slow copy to tmp dir
     pushd dali/python
-    python setup.py bdist_wheel \
-        --verbose \
-        --compression=stored \
-        --python-tag=py3 \
-        --plat-name=${WHL_PLATFORM_NAME}
+    python -m build --wheel --no-isolation \
+        -C--global-option=--verbose \
+        -C--global-option=--compression=stored \
+        -C--global-option=--python-tag=py3 \
+        -C--global-option="--plat-name=${WHL_PLATFORM_NAME}"
     popd
     mv dali/python/dist/*.whl ./
 

--- a/docker/build_helper.sh
+++ b/docker/build_helper.sh
@@ -141,13 +141,13 @@ bundle_wheel() {
 
 if [ "${BUILD_PYTHON}" = "ON" ]; then
     # use stored as a compression method to make it faster as bundle-wheel.sh need to repack anyway
-    # call setup.py to avoid slow copy to tmp dir
+    # avoid isolated venv creation and use dependencies already installed in the image
     pushd dali/python
     python -m build --wheel --no-isolation \
         -C--global-option=--verbose \
-        -C--global-option=--compression=stored \
-        -C--global-option=--python-tag=py3 \
-        -C--global-option="--plat-name=${WHL_PLATFORM_NAME}"
+        -C--build-option=--compression=stored \
+        -C--build-option=--python-tag=py3 \
+        -C--build-option="--plat-name=${WHL_PLATFORM_NAME}"
     popd
     mv dali/python/dist/*.whl ./
 

--- a/plugins/setup.py.in
+++ b/plugins/setup.py.in
@@ -47,7 +47,8 @@ def require(req_spec: str) -> None:
             sys.exit(1)
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] != 'sdist':
+    # PEP 517 uses egg_info to query requirements before creating an sdist.
+    if len(sys.argv) > 1 and sys.argv[1] not in ('sdist', 'egg_info'):
         try:
             os.environ['DALI_PRELOAD_PLUGINS'] = ""  # no need to load plugins
             import nvidia.dali as dali

--- a/plugins/video/CMakeLists.txt
+++ b/plugins/video/CMakeLists.txt
@@ -33,7 +33,7 @@ add_custom_command(
     TARGET dali-plugin-video
     POST_BUILD
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/pkg_src
-    COMMAND ${PYTHON_EXECUTABLE} setup.py sdist)
+    COMMAND ${PYTHON_EXECUTABLE} -m build --sdist --no-isolation)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/pkg_src/dist
         DESTINATION . FILES_MATCHING PATTERN "*.tar.gz")


### PR DESCRIPTION
## Category:

Other

## Description:

Modernize package artifact creation by replacing direct `setup.py` invocations
with `python -m build`. The change uses the standard build frontend while
retaining the existing non-isolated container-build behavior.

## Additional information:

### Affected modules and functionalities:

- DALI Python wheel packaging in `docker/build_helper.sh`.
- TensorFlow plugin source-distribution packaging.
- Video plugin source-distribution packaging.

### Key points relevant for the review:

- Existing wheel options are forwarded as backend configuration settings.
- `--no-isolation` preserves use of dependencies installed in the build image.

### Tests:

- [x] Existing tests apply
  - build passes
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
