### PR TITLE
Install missing python-build module in Jetson build image

### DIFF
--- a/docker/Dockerfile.build.aarch64-linux
+++ b/docker/Dockerfile.build.aarch64-linux
@@ -58,7 +58,7 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
         curl -O https://bootstrap.pypa.io/get-pip.py; \
     fi && python3 get-pip.py && rm get-pip.py && \
     # decouple libclang and clang installation so libclang changes are not overriden by clang
-    pip install clang==14.0 && pip install libclang==14.0.1 flake8 bandit "black[jupyter]"==26.5.1 && \
+    pip install clang==14.0 && pip install libclang==14.0.1 flake8 bandit "black[jupyter]"==26.5.1 build && \
     rm -rf /root/.cache/pip/ && \
     cd /tmp && git clone https://github.com/NixOS/patchelf && cd patchelf && \
     ./bootstrap.sh && ./configure --prefix=/usr/ && make -j install && cd / && rm -rf /tmp/patchelf && \


### PR DESCRIPTION
## Category:

Other

## Description:

Adds the Python `build` package to the aarch64/Jetson build image. This makes the package available to build steps that invoke `python -m build`.

## Additional information:

### Affected modules and functionalities:

- `docker/Dockerfile.build.aarch64-linux`: aarch64/Jetson build-image Python tooling.

### Key points relevant for the review:

- The change only adds the missing `build` dependency to the existing pip installation.

### Tests:

- [x] Existing tests apply
  - Jetpack build pipeline
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A