### PR TITLE
Warn about S3 SSL and plugin preload environment settings

### DIFF
--- a/dali/plugin/plugin_manager.cc
+++ b/dali/plugin/plugin_manager.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -99,8 +99,11 @@ void PluginManager::LoadDefaultPlugins() {
   static bool run_once = []() {
     std::string preload_plugins_str = "default";
     const char* dali_preload_plugins = std::getenv("DALI_PRELOAD_PLUGINS");
-    if (dali_preload_plugins)
+    if (dali_preload_plugins) {
       preload_plugins_str = dali_preload_plugins;
+      DALI_WARN(make_string("DALI_PRELOAD_PLUGINS is set; loading plugins from ",
+                            preload_plugins_str));
+    }
     if (preload_plugins_str == "default") {
       PluginManager::LoadDirectory(DefaultPluginPath(), false, true);
     } else {

--- a/dali/util/s3_client_manager.h
+++ b/dali/util/s3_client_manager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include <string>
 #include <utility>
 #include "dali/core/common.h"
+#include "dali/core/error_handling.h"
 #include "dali/pipeline/util/thread_pool.h"
 
 namespace dali {
@@ -63,6 +64,9 @@ struct S3ClientManager {
     auto no_verify_ptr = std::getenv("DALI_S3_NO_VERIFY_SSL");
     if (no_verify_ptr) {
       config.verifySSL = std::atoi(no_verify_ptr) == 0;
+      DALI_WARN(make_string("DALI_S3_NO_VERIFY_SSL is set to ", no_verify_ptr,
+                            "; SSL certificate verification is ",
+                            config.verifySSL ? "enabled." : "disabled."));
     }
     client_ = std::make_unique<Aws::S3::S3Client>(std::move(config));
   }


### PR DESCRIPTION
## Category:
Other

## Description:
Warn when environment variables alter S3 TLS verification or automatic plugin loading. This makes security-sensitive runtime configuration visible in process logs.

**Addresses:**
The S3ClientManager constructor reads the `DALI_S3_NO_VERIFY_SSL` environment variable and, if set to a non-zero value, disables SSL certificate verification for all S3 connections. This enables man-in-the-middle attacks against S3 data transfers. The logic is inverted: `config.verifySSL = std::atoi(no_verify_ptr) == 0` means setting the variable to any non-zero value disables verification.

The `LoadDefaultPlugins()` function reads the `DALI_PRELOAD_PLUGINS` environment variable and uses its value as paths to load shared libraries via dlopen(). If an attacker can control this environment variable (e.g., in a shared hosting environment), they can cause DALI to load arbitrary shared libraries, achieving code execution in the DALI process. The variable is processed at library initialization time without any validation of the paths.

## Additional information:

### Affected modules and functionalities:
- S3 client configuration through `DALI_S3_NO_VERIFY_SSL`
- Automatic plugin loading through `DALI_PRELOAD_PLUGINS`

### Key points relevant for the review:
- The existing configuration behavior is unchanged; only warnings are added.
- Plugin library paths continue to be logged by the existing `LoadLibrary` logging.

### Tests:
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
