### PR TITLE
Validate NPY shape sizes before allocation

### DIFF
--- a/dali/util/numpy.cc
+++ b/dali/util/numpy.cc
@@ -302,11 +302,12 @@ size_t HeaderData::size() const {
   size_t result = 1;
   for (auto dim : shape) {
     auto extent = static_cast<size_t>(dim);
-    DALI_ENFORCE(extent == 0 || result <= std::numeric_limits<size_t>::max() / extent,
+    size_t product;
+    DALI_ENFORCE(!__builtin_mul_overflow(result, extent, &product),
                  make_string("Numpy array shape is too large: requested ", result, " * ",
                              extent, " elements exceeds the maximum ",
                              std::numeric_limits<size_t>::max(), " elements."));
-    result *= extent;
+    result = product;
   }
   return result;
 }
@@ -316,11 +317,12 @@ size_t HeaderData::nbytes() const {
     return 0_uz;
   auto elements = size();
   auto item_size = type_info->size();
-  DALI_ENFORCE(elements == 0 || item_size <= std::numeric_limits<size_t>::max() / elements,
+  size_t bytes;
+  DALI_ENFORCE(!__builtin_mul_overflow(elements, item_size, &bytes),
                make_string("Numpy array is too large: requested ", elements, " * ", item_size,
                            " bytes exceeds the maximum ", std::numeric_limits<size_t>::max(),
                            " bytes."));
-  return item_size * elements;
+  return bytes;
 }
 
 Tensor<CPUBackend> ReadTensor(InputStream *src, bool pinned) {

--- a/dali/util/numpy.cc
+++ b/dali/util/numpy.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "dali/util/numpy.h"
+#include <cerrno>
+#include <limits>
 #include <string>
 #include <vector>
 #include <memory>
@@ -76,8 +78,10 @@ void SkipFieldName(const char*& ptr, const char (&name)[N]) {
 template <typename T = int64_t>
 T ParseInteger(const char*& ptr) {
   char *out_ptr = const_cast<char*>(ptr);  // strtol takes a non-const pointer
+  errno = 0;
   T value = static_cast<T>(strtol(ptr, &out_ptr, 10));
   DALI_ENFORCE(out_ptr != ptr, "Parse error: expected a number.");
+  DALI_ENFORCE(errno != ERANGE, "Parse error: integer is out of range.");
   ptr = out_ptr;
   return value;
 }
@@ -150,7 +154,9 @@ void ParseHeaderContents(HeaderData& target, const std::string_view header) {
   SkipSpaces(hdr);
   while (*hdr != ')') {
     // ParseInteger already skips the leading spaces (strtol does).
-    target.shape.shape.push_back(ParseInteger<int64_t>(hdr));
+    auto dim = ParseInteger<int64_t>(hdr);
+    DALI_ENFORCE(dim >= 0, "Numpy array dimensions must be non-negative.");
+    target.shape.shape.push_back(dim);
     SkipSpaces(hdr);
     DALI_ENFORCE(TrySkip(hdr, ",") || target.shape.size() > 1,
                  "The first number in a tuple must be followed by a comma.");
@@ -290,11 +296,28 @@ DALIDataType HeaderData::type() const {
 }
 
 size_t HeaderData::size() const {
-  return volume(shape);
+  size_t result = 1;
+  for (auto dim : shape) {
+    auto extent = static_cast<size_t>(dim);
+    DALI_ENFORCE(extent == 0 || result <= std::numeric_limits<size_t>::max() / extent,
+                 make_string("Numpy array shape is too large: requested ", result, " * ",
+                             extent, " elements exceeds the maximum ",
+                             std::numeric_limits<size_t>::max(), " elements."));
+    result *= extent;
+  }
+  return result;
 }
 
 size_t HeaderData::nbytes() const {
-  return type_info ? type_info->size() * size() : 0_uz;
+  if (!type_info)
+    return 0_uz;
+  auto elements = size();
+  auto item_size = type_info->size();
+  DALI_ENFORCE(elements == 0 || item_size <= std::numeric_limits<size_t>::max() / elements,
+               make_string("Numpy array is too large: requested ", elements, " * ", item_size,
+                           " bytes exceeds the maximum ", std::numeric_limits<size_t>::max(),
+                           " bytes."));
+  return item_size * elements;
 }
 
 Tensor<CPUBackend> ReadTensor(InputStream *src, bool pinned) {

--- a/dali/util/numpy.cc
+++ b/dali/util/numpy.cc
@@ -303,7 +303,8 @@ size_t HeaderData::size() const {
   for (auto dim : shape) {
     auto extent = static_cast<size_t>(dim);
     size_t product;
-    DALI_ENFORCE(!__builtin_mul_overflow(result, extent, &product),
+    const bool overflow = __builtin_mul_overflow(result, extent, &product);
+    DALI_ENFORCE(!overflow,
                  make_string("Numpy array shape is too large: requested ", result, " * ",
                              extent, " elements exceeds the maximum ",
                              std::numeric_limits<size_t>::max(), " elements."));
@@ -318,7 +319,8 @@ size_t HeaderData::nbytes() const {
   auto elements = size();
   auto item_size = type_info->size();
   size_t bytes;
-  DALI_ENFORCE(!__builtin_mul_overflow(elements, item_size, &bytes),
+  const bool overflow = __builtin_mul_overflow(elements, item_size, &bytes);
+  DALI_ENFORCE(!overflow,
                make_string("Numpy array is too large: requested ", elements, " * ", item_size,
                            " bytes exceeds the maximum ", std::numeric_limits<size_t>::max(),
                            " bytes."));

--- a/dali/util/numpy.cc
+++ b/dali/util/numpy.cc
@@ -78,10 +78,13 @@ void SkipFieldName(const char*& ptr, const char (&name)[N]) {
 template <typename T = int64_t>
 T ParseInteger(const char*& ptr) {
   char *out_ptr = const_cast<char*>(ptr);  // strtol takes a non-const pointer
+  const auto saved_errno = errno;
   errno = 0;
   T value = static_cast<T>(strtol(ptr, &out_ptr, 10));
+  const bool out_of_range = errno == ERANGE;
+  errno = saved_errno;
   DALI_ENFORCE(out_ptr != ptr, "Parse error: expected a number.");
-  DALI_ENFORCE(errno != ERANGE, "Parse error: integer is out of range.");
+  DALI_ENFORCE(!out_of_range, "Parse error: integer is out of range.");
   ptr = out_ptr;
   return value;
 }

--- a/dali/util/numpy_test.cc
+++ b/dali/util/numpy_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <limits>
 #include <string>
 #include <vector>
 #include "dali/util/numpy.h"
@@ -72,6 +73,13 @@ TEST(NumpyLoaderTest, RejectsInvalidOrOverflowingShape) {
   ParseHeaderContents(
       target, "{'descr':'<f4','fortran_order':False,'shape':(4294967296,4294967296),}");
   EXPECT_THROW(target.size(), std::runtime_error);
+  EXPECT_THROW(target.nbytes(), std::runtime_error);
+
+  auto byte_overflow_shape =
+      std::to_string(std::numeric_limits<size_t>::max() / sizeof(uint64_t) + 1);
+  ParseHeaderContents(target, "{'descr':'<u8','fortran_order':False,'shape':(" +
+                                  byte_overflow_shape + ",),}");
+  EXPECT_NO_THROW(target.size());
   EXPECT_THROW(target.nbytes(), std::runtime_error);
 }
 

--- a/dali/util/numpy_test.cc
+++ b/dali/util/numpy_test.cc
@@ -63,6 +63,18 @@ TEST(NumpyLoaderTest, ParseHeaderError) {
   }
 }
 
+TEST(NumpyLoaderTest, RejectsInvalidOrOverflowingShape) {
+  HeaderData target;
+  EXPECT_THROW(
+      ParseHeaderContents(target, "{'descr':'<f4','fortran_order':False,'shape':(-1,),}"),
+      std::runtime_error);
+
+  ParseHeaderContents(
+      target, "{'descr':'<f4','fortran_order':False,'shape':(4294967296,4294967296),}");
+  EXPECT_THROW(target.size(), std::runtime_error);
+  EXPECT_THROW(target.nbytes(), std::runtime_error);
+}
+
 TEST(NumpyLoaderTest, ParseHeaderDoesNotReadPastStringView) {
   HeaderData target;
   std::string header = "{'descr':'<f4','fortran_order':False,'shape':(";

--- a/dali/util/numpy_test.cc
+++ b/dali/util/numpy_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <cerrno>
 #include <limits>
 #include <string>
 #include <vector>
@@ -81,6 +82,16 @@ TEST(NumpyLoaderTest, RejectsInvalidOrOverflowingShape) {
                                   byte_overflow_shape + ",),}");
   EXPECT_NO_THROW(target.size());
   EXPECT_THROW(target.nbytes(), std::runtime_error);
+}
+
+TEST(NumpyLoaderTest, ParseHeaderPreservesErrno) {
+  HeaderData target;
+  const auto saved_errno = errno;
+  errno = EDOM;
+  ParseHeaderContents(target, "{'descr':'<f4','fortran_order':False,'shape':(1,),}");
+  const auto parsed_errno = errno;
+  errno = saved_errno;
+  EXPECT_EQ(parsed_errno, EDOM);
 }
 
 TEST(NumpyLoaderTest, ParseHeaderDoesNotReadPastStringView) {


### PR DESCRIPTION
## Category:
Bug fix

## Description:
Reject invalid and overflowing NumPy array shapes before an allocation or file read can use a wrapped element or byte count.

**Addresses:**
When parsing numpy (.npy) files, the `ParseHeaderContents` function reads arbitrary int64_t shape values from the file header. The `volume()` function multiplies all shape dimensions together without overflow checking. The result is used in `HeaderData::nbytes()` which computes `type_info->size() * size()` (both size_t). A crafted .npy file with shape dimensions whose product overflows int64_t (e.g., shape=(2^32, 2^32)) would cause `volume()` to return a small or negative value, leading to an undersized memory allocation in `Tensor::Resize()`, followed by a buffer overflow when reading file data into the undersized buffer.

## Additional information:

### Affected modules and functionalities:
- NumPy `.npy` header parsing and `HeaderData` size calculation

### Key points relevant for the review:
- Reject negative and out-of-range dimensions.
- Check both element-count and byte-count multiplication.
- Errors report the requested multiplication terms and the maximum `size_t` limit.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
    - NumpyLoaderTest.RejectsInvalidOrOverflowingShape
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
