### PR TITLE
Restrict worker result deserialization

### DIFF
--- a/dali/python/nvidia/dali/_multiproc/messages.py
+++ b/dali/python/nvidia/dali/_multiproc/messages.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -262,12 +262,17 @@ class CompletedTask:
 
     @classmethod
     def failed(cls, worker_id, processed):
+        # Worker exceptions can be arbitrary user-defined objects. Only StopIteration has
+        # protocol semantics in the parent; normalize all other errors before serializing them.
+        exception = processed.exception
+        if not isinstance(exception, StopIteration):
+            exception = RuntimeError(str(exception))
         return cls(
             worker_id,
             processed.context_i,
             processed.scheduled_i,
             processed.minibatch_i,
-            exception=processed.exception,
+            exception=exception,
             traceback_str=processed.traceback_str,
         )
 

--- a/dali/python/nvidia/dali/_multiproc/messages.py
+++ b/dali/python/nvidia/dali/_multiproc/messages.py
@@ -262,10 +262,12 @@ class CompletedTask:
 
     @classmethod
     def failed(cls, worker_id, processed):
-        # Worker exceptions can be arbitrary user-defined objects. Only StopIteration has
-        # protocol semantics in the parent; normalize all other errors before serializing them.
+        # Worker exceptions can be arbitrary user-defined objects. Normalize them to the
+        # restricted protocol's built-in exception types before serializing them.
         exception = processed.exception
-        if type(exception) is not StopIteration:
+        if isinstance(exception, StopIteration):
+            exception = StopIteration(str(exception))
+        else:
             exception = RuntimeError(str(exception))
         return cls(
             worker_id,

--- a/dali/python/nvidia/dali/_multiproc/messages.py
+++ b/dali/python/nvidia/dali/_multiproc/messages.py
@@ -265,7 +265,7 @@ class CompletedTask:
         # Worker exceptions can be arbitrary user-defined objects. Only StopIteration has
         # protocol semantics in the parent; normalize all other errors before serializing them.
         exception = processed.exception
-        if not isinstance(exception, StopIteration):
+        if type(exception) is not StopIteration:
             exception = RuntimeError(str(exception))
         return cls(
             worker_id,

--- a/dali/python/nvidia/dali/_multiproc/shared_batch.py
+++ b/dali/python/nvidia/dali/_multiproc/shared_batch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import os
+import pickle  # nosec B403
+
 from nvidia.dali._multiproc import shared_mem
-from nvidia.dali._multiproc.messages import ShmMessageDesc
+from nvidia.dali._multiproc.messages import CompletedTask, ShmMessageDesc
 from nvidia.dali._utils.external_source_impl import (
     assert_cpu_sample_data_type as _assert_cpu_sample_data_type,
     sample_to_numpy as _sample_to_numpy,
 )
-import pickle  # nosec B403
 
 np = None
+
+
+class _WorkerResultUnpickler(pickle.Unpickler):
+    """Unpickler for data written by a worker into a shared-memory chunk.
+
+    Worker results have a fixed, internal object graph. Restricting globals here prevents a
+    compromised worker from invoking an arbitrary callable while the parent reads its result.
+    """
+
+    _allowed_globals = {
+        ("nvidia.dali._multiproc.messages", "CompletedTask"): CompletedTask,
+        ("nvidia.dali._multiproc.shared_batch", "SharedBatchMeta"): None,
+        ("nvidia.dali._multiproc.shared_batch", "SampleMeta"): None,
+        ("numpy", "dtype"): None,
+        ("builtins", "RuntimeError"): RuntimeError,
+        ("builtins", "StopIteration"): StopIteration,
+    }
+
+    def find_class(self, module, name):
+        allowed = self._allowed_globals.get((module, name), ...)
+        if allowed is ...:
+            raise pickle.UnpicklingError(
+                f"global '{module}.{name}' is not permitted in worker shared-memory data"
+            )
+        if allowed is None:
+            if module == "numpy":
+                import_numpy()
+                return np.dtype
+            return globals()[name]
+        return allowed
+
+
+def restricted_pickle_loads(data):
+    """Loads the fixed-format pickle payloads sent from workers to the parent process."""
+    return _WorkerResultUnpickler(io.BytesIO(data)).load()
 
 
 def _div_ceil(a, b):
@@ -159,7 +196,7 @@ def deserialize_sample_meta(buffer: BufShmChunk, shared_batch_meta: SharedBatchM
     if sbm.meta_size == 0:
         return []
     pickled_meta = buffer.buf[sbm.meta_offset : sbm.meta_offset + sbm.meta_size]
-    samples_meta = pickle.loads(pickled_meta)  # nosec B301
+    samples_meta = restricted_pickle_loads(pickled_meta)
     return samples_meta
 
 
@@ -293,6 +330,10 @@ def read_shm_message(shm_chunk: BufShmChunk, shm_message):
     if shm_message.shm_capacity != shm_chunk.capacity:
         shm_chunk.resize(shm_message.shm_capacity, trunc=False)
     buffer = shm_chunk.buf[shm_message.offset : shm_message.offset + shm_message.num_bytes]
+    # Messages written by the parent may contain user-provided batch arguments and are trusted
+    # parent-to-child input. Worker-to-parent messages have a fixed protocol and are restricted.
+    if shm_message.worker_id >= 0:
+        return restricted_pickle_loads(buffer)
     return pickle.loads(buffer)  # nosec B301
 
 

--- a/dali/test/python/test_external_source_parallel_shared_batch.py
+++ b/dali/test/python/test_external_source_parallel_shared_batch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 
 import os
 import multiprocessing
+import pickle
 import socket
 from contextlib import closing, contextmanager
 import numpy as np
@@ -24,12 +25,23 @@ from nvidia.dali._multiproc.shared_batch import (
     SharedBatchWriter,
     SharedBatchMeta,
     deserialize_batch,
+    restricted_pickle_loads,
 )
 from nvidia.dali._multiproc.shared_queue import ShmQueue
 from nvidia.dali._multiproc.messages import ShmMessageDesc
 
 from test_utils import RandomlyShapedDataIterator
 from nose_utils import raises
+
+
+class UnsafePicklePayload:
+    def __reduce__(self):
+        return eval, ("1 + 1",)  # nosec B307
+
+
+def test_restricted_unpickler_rejects_unsafe_globals():
+    payload = pickle.dumps(UnsafePicklePayload())
+    raises(pickle.UnpicklingError, "not permitted")(restricted_pickle_loads)(payload)
 
 
 def check_serialize_deserialize(batch):

--- a/dali/test/python/test_external_source_parallel_shared_batch.py
+++ b/dali/test/python/test_external_source_parallel_shared_batch.py
@@ -17,6 +17,7 @@ import os
 import multiprocessing
 import pickle
 import socket
+from types import SimpleNamespace
 from contextlib import closing, contextmanager
 import numpy as np
 
@@ -28,7 +29,7 @@ from nvidia.dali._multiproc.shared_batch import (
     restricted_pickle_loads,
 )
 from nvidia.dali._multiproc.shared_queue import ShmQueue
-from nvidia.dali._multiproc.messages import ShmMessageDesc
+from nvidia.dali._multiproc.messages import CompletedTask, ShmMessageDesc
 
 from test_utils import RandomlyShapedDataIterator
 from nose_utils import raises
@@ -42,6 +43,23 @@ class UnsafePicklePayload:
 def test_restricted_unpickler_rejects_unsafe_globals():
     payload = pickle.dumps(UnsafePicklePayload())
     raises(pickle.UnpicklingError, "not permitted")(restricted_pickle_loads)(payload)
+
+
+class CustomStopIteration(StopIteration):
+    pass
+
+
+def test_restricted_unpickler_normalizes_stop_iteration_subclasses():
+    processed = SimpleNamespace(
+        context_i=0,
+        scheduled_i=0,
+        minibatch_i=0,
+        exception=CustomStopIteration("done"),
+        traceback_str="",
+    )
+    completed = CompletedTask.failed(0, processed)
+    unpickled = restricted_pickle_loads(pickle.dumps(completed))
+    assert type(unpickled.exception) is RuntimeError
 
 
 def check_serialize_deserialize(batch):

--- a/dali/test/python/test_external_source_parallel_shared_batch.py
+++ b/dali/test/python/test_external_source_parallel_shared_batch.py
@@ -59,7 +59,7 @@ def test_restricted_unpickler_normalizes_stop_iteration_subclasses():
     )
     completed = CompletedTask.failed(0, processed)
     unpickled = restricted_pickle_loads(pickle.dumps(completed))
-    assert type(unpickled.exception) is RuntimeError
+    assert type(unpickled.exception) is StopIteration
 
 
 def check_serialize_deserialize(batch):


### PR DESCRIPTION
## Category:
Bug fix

## Description:
Restrict deserialization of worker-to-parent shared-memory results to the internal multiprocessing protocol object graph.

**Addresses:**
The multiprocessing subsystem uses pickle.loads() to deserialize data from shared memory regions written by worker processes. In `shared_batch.py`, both `deserialize_sample_meta()` (line 162) and `read_shm_message()` (line 296) call `pickle.loads()` on data read from shared memory buffers. If a worker process is compromised (e.g., through a malicious data source callback), it could write crafted pickle payloads to shared memory that would achieve arbitrary code execution in the parent process when deserialized.

## Additional information:

### Affected modules and functionalities:
- Parallel ExternalSource worker result messages and shared-batch metadata

### Key points relevant for the review:
- Parent-to-worker task data remains trusted and supports generic user batch arguments.
- Worker-to-parent result data accepts only internal result/metadata classes, NumPy dtypes, `RuntimeError`, and `StopIteration`.
- Non-`StopIteration` worker exceptions are normalized before serialization.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_external_source_parallel_shared_batch.test_restricted_unpickler_rejects_unsafe_globals
    -test_external_source_parallel_shared_batch.test_restricted_unpickler_normalizes_stop_iteration_subclasses
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
