### PR TITLE
Disable XLA command buffers in JAX examples

### DIFF
--- a/docs/examples/custom_operations/jax_operator_basic.ipynb
+++ b/docs/examples/custom_operations/jax_operator_basic.ipynb
@@ -21,12 +21,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "xla-command-buffers-note",
+   "metadata": {},
+   "source": [
+    "DALI's background thread synchronizes the device to keep exported buffers alive, which invalidates the CUDA graphs that XLA captures for its command buffers. We disable command buffers before anything imports JAX."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "47616ab0",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
+    "\n",
     "import nvidia.dali.fn as fn\n",
     "from nvidia.dali.plugin.jax import data_iterator\n",
     "\n",

--- a/docs/examples/custom_operations/jax_operator_multi_gpu.ipynb
+++ b/docs/examples/custom_operations/jax_operator_multi_gpu.ipynb
@@ -31,6 +31,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "xla-command-buffers-note",
+   "metadata": {},
+   "source": [
+    "DALI's background thread synchronizes the device to keep exported buffers alive, which invalidates the CUDA graphs that XLA captures for its command buffers. We disable command buffers before anything imports JAX."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "77c7fa95",
@@ -48,6 +56,10 @@
     }
    ],
    "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
+    "\n",
     "import subprocess\n",
     "\n",
     "subprocess.Popen([\"python3.10\", \"jax_operator_multi_gpu_process_1.py\"])"

--- a/docs/examples/frameworks/jax/flax-basic_example.ipynb
+++ b/docs/examples/frameworks/jax/flax-basic_example.ipynb
@@ -15,6 +15,14 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DALI's background thread synchronizes the device to keep exported buffers alive, which invalidates the CUDA graphs that XLA captures for its command buffers. We disable command buffers before anything imports JAX."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -28,6 +36,8 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
+    "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
     "\n",
     "training_data_path = os.path.join(\n",
     "    os.environ[\"DALI_EXTRA_PATH\"], \"db/MNIST/training/\"\n",

--- a/docs/examples/frameworks/jax/index.rst
+++ b/docs/examples/frameworks/jax/index.rst
@@ -1,6 +1,15 @@
 JAX Framework
 =================
 
+.. note::
+
+   DALI keeps the buffers it exports through DLPack alive by synchronizing the device from a
+   background thread. This invalidates the CUDA graphs that XLA captures for its command buffers,
+   which surfaces as ``CUDA_ERROR_STREAM_CAPTURE_INVALIDATED``.
+
+   The examples below disable command buffers with the ``XLA_FLAGS`` environment variable. This is
+   necessary when combining DALI with ``jax.jit``.
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/examples/frameworks/jax/jax-basic_example.ipynb
+++ b/docs/examples/frameworks/jax/jax-basic_example.ipynb
@@ -13,12 +13,22 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DALI's background thread synchronizes the device to keep exported buffers alive, which invalidates the CUDA graphs that XLA captures for its command buffers. We disable command buffers before anything imports JAX, since `XLA_FLAGS` is only read when the JAX backend initializes."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
+    "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
     "\n",
     "training_data_path = os.path.join(\n",
     "    os.environ[\"DALI_EXTRA_PATH\"], \"db/MNIST/training/\"\n",
@@ -131,44 +141,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`jax.jit` traces, compiles, and caches functions lazily on first invocation for a given input signature. During this process, XLA may capture CUDA graphs, which forbids some CUDA calls that DALI's background thread uses internally. Since subsequent calls to the JAX function with  inputs of the same shape and dtype don't trigger compilation again, we can work around this by warming up with dummy inputs before starting any DALI workload:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import jax.numpy as jnp\n",
-    "\n",
-    "model = init_model()\n",
-    "dummy_images = jnp.empty(\n",
-    "    (batch_size, image_size * image_size), dtype=jnp.float32\n",
-    ")\n",
-    "dummy_labels = jnp.empty((batch_size, num_classes), dtype=jnp.float32)\n",
-    "_ = update(model, {\"images\": dummy_images, \"labels\": dummy_labels})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-warning\">\n",
-    "\n",
-    "   Warning<br>\n",
-    "   \n",
-    "   If you skip this step, CUDA graph capture will happen on the first call to `update` and may overlap with DALI's execution, causing CUDA errors in JAX.\n",
-    "   \n",
-    "   Alternatively, you can disable XLA command buffers entirely by setting `XLA_FLAGS=\"--xla_gpu_enable_command_buffer=\"`, at the cost of some performance.\n",
-    "   \n",
-    "</div>"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -178,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -202,6 +174,7 @@
    "source": [
     "print(\"Starting training\")\n",
     "\n",
+    "model = init_model()\n",
     "num_epochs = 5\n",
     "\n",
     "for epoch in range(num_epochs):\n",

--- a/docs/examples/frameworks/jax/jax-multigpu_example.ipynb
+++ b/docs/examples/frameworks/jax/jax-multigpu_example.ipynb
@@ -24,6 +24,14 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DALI's background thread synchronizes the device to keep exported buffers alive, which invalidates the CUDA graphs that XLA captures for its command buffers. We disable command buffers before anything imports JAX."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -38,6 +46,10 @@
     }
    ],
    "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
+    "\n",
     "import jax\n",
     "from jax.sharding import PositionalSharding, Mesh\n",
     "from jax.experimental import mesh_utils\n",

--- a/docs/examples/frameworks/jax/pax-basic_example.ipynb
+++ b/docs/examples/frameworks/jax/pax-basic_example.ipynb
@@ -13,12 +13,22 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DALI's background thread synchronizes the device to keep exported buffers alive, which invalidates the CUDA graphs that XLA captures for its command buffers. We disable command buffers before anything imports JAX."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
+    "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
     "\n",
     "training_data_path = os.path.join(\n",
     "    os.environ[\"DALI_EXTRA_PATH\"], \"db/MNIST/training/\"\n",

--- a/qa/TL0_jupyter/test_jax.sh
+++ b/qa/TL0_jupyter/test_jax.sh
@@ -4,6 +4,8 @@ pip_packages='jupyter numpy matplotlib jax flax'
 target_dir=./docs/examples
 
 test_body() {
+    export XLA_FLAGS="--xla_gpu_enable_command_buffer="
+
     test_files=(
         "frameworks/jax/jax-basic_example.ipynb"
     )

--- a/qa/TL1_jupyter_conda/test_jax.sh
+++ b/qa/TL1_jupyter_conda/test_jax.sh
@@ -9,6 +9,8 @@ prolog=(enable_conda)
 epilog=(disable_conda)
 
 test_body() {
+    export XLA_FLAGS="--xla_gpu_enable_command_buffer="
+
     test_files=(
         "frameworks/jax/jax-basic_example.ipynb"
     )


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**Other** (*e.g. Documentation, Tests, Configuration*)

## Description:

PR https://github.com/NVIDIA/DALI/pull/6286 changed the JAX training example to compile its `jax.jit` function before DALI runs. This doesn't actually fix the issue of XLA doing CUDA graph captures while DALI is running since even after the function is compiled, it's possible that XLA needs to capture new CUDA graphs.

This PR recommends setting the environment variable `XLA_FLAGS` to disable XLA command buffer.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [X] RST
  - [X] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
