### PR TITLE
Fix a dynamic mode thread-safety test

### DIFF
--- a/dali/test/python/experimental_mode/test_eval_context.py
+++ b/dali/test/python/experimental_mode/test_eval_context.py
@@ -448,6 +448,8 @@ def test_global_thread_pool_thread_safety():
     # The test also checks that there are no unnecessary updates to the default thread pool and
     # that the threads see the same thread pool objects.
     num_workers = 8
+    min_threads = 1
+    max_threads = 32
     results = [set() for _ in range(num_workers)]
     prev_pool = [None] * num_workers
     stop_event = threading.Event()
@@ -485,7 +487,7 @@ def test_global_thread_pool_thread_safety():
 
     # Start the workers at the first value in the sweep. Otherwise they may observe the
     # platform default first and record two different pools if that value occurs in the sweep.
-    ndd.set_num_threads(1)
+    ndd.set_num_threads(min_threads)
     run_event.set()
     for t in threads:
         t.start()
@@ -493,7 +495,7 @@ def test_global_thread_pool_thread_safety():
     all_thread_counts_seen = False
     try:
         for _ in range(3):
-            for n in range(1, 33):
+            for n in range(min_threads, max_threads + 1):
                 ndd.set_num_threads(n)
                 time.sleep(0.01)
             # Pause the workers
@@ -509,7 +511,7 @@ def test_global_thread_pool_thread_safety():
             assert len(combined_results) == len(
                 set(p.num_threads for p in combined_results)
             ), "The number of pool objects is different than the number of distinct thread counts."
-            if len(combined_results) == 32:
+            if len(combined_results) == max_threads - min_threads + 1:
                 all_thread_counts_seen = True
             ndd.set_num_threads(1)
             for r in results:

--- a/dali/test/python/experimental_mode/test_eval_context.py
+++ b/dali/test/python/experimental_mode/test_eval_context.py
@@ -482,10 +482,13 @@ def test_global_thread_pool_thread_safety():
         threading.Thread(target=worker, kwargs={"idx": idx}, daemon=True)
         for idx in range(num_workers)
     ]
+
+    # Start the workers at the first value in the sweep. Otherwise they may observe the
+    # platform default first and record two different pools if that value occurs in the sweep.
+    ndd.set_num_threads(1)
+    run_event.set()
     for t in threads:
         t.start()
-
-    run_event.set()
 
     all_thread_counts_seen = False
     try:


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**Other** (*e.g. Documentation, Tests, Configuration*)

## Description:

In dynamic mode, the test `test_global_thread_pool_thread_safety` fails consistently with free-threaded Python but can also theoretically (although less likely in practice) fail with regular Python.

The issue stems from the fact that the default number of state differs from the first value of `n` in the loop so if a thread creates a thread pool before entering the for loop, it then gets recreated.

This PR fixes it by setting the default number of threads to `1` before starting the threads.

## Additional information:

### Affected modules and functionalities:

Dynamic mode test.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
