### PR TITLE
Fix zero-sized batches in debug mode pipelines.

### DIFF
--- a/dali/c_api_2/data_objects.h
+++ b/dali/c_api_2/data_objects.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -726,6 +726,8 @@ class TensorListWrapper : public ITensorList {
     if (!tl_->IsDenseTensor())
       throw std::runtime_error(
         "Only a densely packed list of tensors of uniform shape can be viewed as a Tensor.");
+    if (tl_->num_samples() == 0)
+        throw std::runtime_error("An empty list of tensors cannot be converted to a tensor.");
 
     auto t = std::make_shared<Tensor<Backend>>();
     auto buf = unsafe_owner(*tl_);

--- a/dali/operators/image/remap/warp_affine_params.h
+++ b/dali/operators/image/remap/warp_affine_params.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,7 +98,9 @@ class WarpAffineParamProvider
           << shape.sample_dim() << "-D elements with varying size.";
       } else {
         ss << "\nThe actual input is a list with " << shape.num_samples() << " "
-          << shape.sample_dim() << "-D elements with shape " << shape[0];
+          << shape.sample_dim() << "-D elements";
+        if (shape.num_samples() > 0)
+          ss << " with shape " << shape[0];
       }
       ss << "\n";
       return ss.str();
@@ -110,7 +112,7 @@ class WarpAffineParamProvider
     } else {
       DALI_ENFORCE(shape.num_samples() == num_samples_ &&
                    is_uniform(shape) &&
-                   shape[0] == mat_shape,
+                   (shape.num_samples() == 0 || shape[0] == mat_shape),
                    error_message());
     }
   }

--- a/dali/pipeline/operator/eager_operator.h
+++ b/dali/pipeline/operator/eager_operator.h
@@ -262,6 +262,7 @@ EagerOperator<Backend>::RunImpl(
   DALI_ENFORCE(batch_size <= max_batch_size_,
                make_string("Expected batch size lower or equal to max batch size. Requested: ",
                            batch_size, " > ", max_batch_size_));
+  bool is_split_or_merge = IsSplitOrMerge(op_spec_.GetSchema());
   // Convert and add inputs to the workspace.
   for (size_t in_idx = 0; in_idx < inputs.size(); ++in_idx) {
     auto tensor_in = std::make_shared<WSInputType>();
@@ -272,7 +273,7 @@ EagerOperator<Backend>::RunImpl(
       batch_size = cur_batch_size;
     }
 
-    if (!IsSplitOrMerge(op_spec_.GetSchema())) {
+    if (!is_split_or_merge) {
       DALI_ENFORCE(cur_batch_size == batch_size,
                    make_string("Expected uniform batch size in a single operator. Expected: ",
                                batch_size, ", input ", in_idx, " batch size: ", cur_batch_size));
@@ -308,7 +309,7 @@ EagerOperator<Backend>::RunImpl(
   ws_.SetBatchSizes(batch_size);
 
   // Setup outputs.
-  if (batch_size) {
+  if (batch_size || is_split_or_merge) {
     if (op_->Setup(output_desc, ws_)) {
       for (size_t i = 0; i < num_outputs_; ++i) {
         ws_.Output<OutBackend>(i).Resize(output_desc[i].shape, output_desc[i].type,

--- a/dali/pipeline/operator/eager_operator.h
+++ b/dali/pipeline/operator/eager_operator.h
@@ -39,7 +39,7 @@ namespace dali {
 
 template <typename Backend>
 std::shared_ptr<TensorList<Backend>> AsContiguousOutput(std::shared_ptr<TensorList<Backend>> in) {
-  if (in->IsContiguous()) {
+  if (in->IsContiguousInMemory()) {
     return in;
   } else {
     auto result = std::make_shared<TensorList<Backend>>();
@@ -308,14 +308,19 @@ EagerOperator<Backend>::RunImpl(
   ws_.SetBatchSizes(batch_size);
 
   // Setup outputs.
-  if (op_->Setup(output_desc, ws_)) {
+  if (batch_size) {
+    if (op_->Setup(output_desc, ws_)) {
+      for (size_t i = 0; i < num_outputs_; ++i) {
+        ws_.Output<OutBackend>(i).Resize(output_desc[i].shape, output_desc[i].type,
+                                                  BatchContiguity::Contiguous);
+      }
+    }
+    op_->Run(ws_);
+  } else {
     for (size_t i = 0; i < num_outputs_; ++i) {
-      ws_.Output<OutBackend>(i).Resize(output_desc[i].shape, output_desc[i].type,
-                                                BatchContiguity::Contiguous);
+      ws_.Output<OutBackend>(i).Reset();
     }
   }
-
-  op_->Run(ws_);
 
   for (size_t i = 0; i < num_outputs_; ++i) {
     outputs[i] = AsContiguousOutput<OutBackend>(ws_.template OutputPtr<OutBackend>(i));


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
This change skips the execution of operators in debug pipelines when the batch size is zero - this happens sometimes with conditional execution.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
`test_pipeline_debug.test_arg_inputs_scoped_uninitialized`
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
