### PR TITLE
Prevent stale code ids in the transparent functions registry

### DIFF
--- a/dali/python/nvidia/dali/experimental/dynamic/_call_site.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_call_site.py
@@ -14,6 +14,7 @@
 
 import sys
 import types
+import weakref
 from typing import TypeAlias
 
 from ._nvtx import NVTXRange
@@ -32,7 +33,11 @@ def mark_transparent(func: types.FunctionType) -> types.FunctionType:
     Transparent frames are skipped by :func:`resolve_callsite_frame`.
     Follows ``__wrapped__`` decorator chains.
     """
-    _transparent_codes.add(id(func.__code__))
+    code = func.__code__
+    code_id = id(code)
+    if code_id not in _transparent_codes:
+        _transparent_codes.add(code_id)
+        weakref.finalize(code, _transparent_codes.discard, code_id)
     wrapped = getattr(func, "__wrapped__", None)
     if wrapped is not None:
         mark_transparent(wrapped)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**Bug fix** (*non-breaking change which fixes an issue*)

## Description:

PR https://github.com/NVIDIA/DALI/pull/6420 optimized the transparent functions registry lookups by storing code ids instead of code objects directly. This works because all functions decorated with `@mark_transparent` live in DALI and are kept alive by DALI. This is however a problem in tests as some tests use `_op_builder.build_fn_wrapper` to create temporary functions. For instance:
https://github.com/NVIDIA/DALI/blob/433c7b065601500f0fe75208da631a8ae04014a5/dali/test/python/experimental_mode/test_arg_conversion.py#L28

When those temporary wrappers die, a stale code id is left in the registry. It can then be reused, resulting in wrong results and tests failing when they shouldn't. This issue can also occur outside of tests if DALI gets manually reloaded. This can lead to operators being executed eagerly in capture mode when they shouldn't or in the worst cases silently incorrect results.

This PR fixes this by discarding stale ids when code objects die. This uses `weakref.finalize` instead of `WeakValueDictionary` because the latter would introduce an unnecessary overhead in `resolve_callsite_frame`.

## Additional information:

### Affected modules and functionalities:

Dynamic mode (not only capture mode)

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply
  - `test_capture_invariants.py`: `test_invariant_marker_without_source`
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [X] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
