### PR TITLE
docs: fix minor typos in documentation

### DIFF
--- a/docs/auto_aug/augmentations.rst
+++ b/docs/auto_aug/augmentations.rst
@@ -63,7 +63,7 @@ Augmentations
 
 Here is a list of callable :meth:`~nvidia.dali.auto_aug.core._augmentation.Augmentation` instances
 defined by DALI. Note that the ``mag_to_param``, ``param_device`` and ``name`` parameters were
-ommitted from the :py:func:`@augmentation <nvidia.dali.auto_aug.core.augmentation>` decorator listing
+omitted from the :py:func:`@augmentation <nvidia.dali.auto_aug.core.augmentation>` decorator listing
 for simplicity.
 
 To adjust the range of parameter, use the ``augmentation`` method

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -350,7 +350,7 @@ Optional CMake Build Parameters
 -  ``BUILD_NVML`` - build with ``NVIDIA Management Library`` (``NVML``) support (default: ON)
 -  ``BUILD_CUFILE`` - build with ``GPU Direct Storage`` support (default: ON)
 -  ``BUILD_NVIMAGECODEC`` - build with ``NVIDIA nvImageCodec library`` support (default: ON)
--  ``VERBOSE_LOGS`` - enables verbose loging in DALI. (default: OFF)
+-  ``VERBOSE_LOGS`` - enables verbose logging in DALI. (default: OFF)
 -  ``WERROR`` - treat all build warnings as errors (default: OFF)
 -  ``BUILD_DALI_NODEPS`` - disables support for third party libraries that are normally expected to be available in the system
 

--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -18,7 +18,7 @@ Default: 1
 If nonzero, DALI uses a memory pool for device memory; otherwise plain ``cudaMalloc`` is used.
 
 .. warning::
-    Specify 0 for debugging only, doing so will drastically degrade performace.
+    Specify 0 for debugging only, doing so will drastically degrade performance.
 
 `DALI_USE_VMM`
 --------------
@@ -42,7 +42,7 @@ If nonzero, DALI uses a memory pool for device-accessible host memory; otherwise
 ``cudaMallocHost`` is used.
 
 .. warning::
-    Specify 0 for debugging only, doing so will drastically degrade performace.
+    Specify 0 for debugging only, doing so will drastically degrade performance.
 
 `DALI_USE_CUDA_MALLOC_ASYNC`
 ----------------------------
@@ -89,7 +89,7 @@ Values: floating point, >=1
 
 Default: 1.1
 
-When greather than 1, buffers are allocated with allowance to avoid frequent reallocation.
+When greater than 1, buffers are allocated with allowance to avoid frequent reallocation.
 
 `DALI_HOST_BUFFER_GROWTH_FACTOR`
 --------------------------------
@@ -164,7 +164,7 @@ Values: 0, 1
 Default: 0
 
 If set, DALI will use the default execution model (as if ``exec_dynamic=True`` was set in the Pipeline)
-whenever the default asychronous pipelined execution with uniform queue size is specified.
+whenever the default asynchronous pipelined execution with uniform queue size is specified.
 Enabling this flag can potentially improve memory consumption.
 
 .. note::

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -51,7 +51,7 @@ The resulting graph is:
 .. _processing_graph_structure:
 
 .. important::
-    The pipeline definition function is excuted only once, when the pipeline is built,
+    The pipeline definition function is executed only once, when the pipeline is built,
     and typically returns a ``dali.DataNode`` object or a tuple of thereof.
     For convenience, it's possible to return other types, such as NumPy arrays, but those
     are treated as constants and evaluated only once.


### PR DESCRIPTION
Fixes various minor typos in DALI documentation (ommitted -> omitted, loging -> logging, performace -> performance, asychronous -> asynchronous, excuted -> executed, etc).