### PR TITLE
Reconfigure NVDEC decoder for increased surface requirements

### DIFF
--- a/dali/operators/video/legacy/reader/nvdecoder/cuvideodecoder.cc
+++ b/dali/operators/video/legacy/reader/nvdecoder/cuvideodecoder.cc
@@ -187,8 +187,9 @@ int CUVideoDecoder::initialize(CUVIDEOFORMAT* format) {
                     CUVideoDecoder::reconfigure(format->coded_height, format->coded_width,
                                                  num_decode_surfaces);
                 } else {
-                    DALI_FAIL("Encountered a dynamic video resolution change. Install Nvidia driver"
-                              " version >=396 (x86) or >=415 (Power PC)");
+                    DALI_FAIL("Encountered a dynamic video resolution or decode-surface requirement "
+                              "change. Install Nvidia driver version >=396 (x86) or >=415 "
+                              "(Power PC).");
                 }
                 return decoder_info_.ulNumDecodeSurfaces;
             }

--- a/dali/operators/video/legacy/reader/nvdecoder/cuvideodecoder.cc
+++ b/dali/operators/video/legacy/reader/nvdecoder/cuvideodecoder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 #include "dali/operators/video/legacy/reader/nvdecoder/cuvideoparser.h"
 #include "dali/operators/video/legacy/reader/nvdecoder/nvdecoder.h"
 #include "dali/core/error_handling.h"
+
+#include <algorithm>
 
 namespace dali {
 
@@ -120,7 +122,8 @@ CUVideoDecoder& CUVideoDecoder::operator=(CUVideoDecoder&& other) {
     return *this;
 }
 
-void CUVideoDecoder::reconfigure(unsigned int height, unsigned int width) {
+void CUVideoDecoder::reconfigure(unsigned int height, unsigned int width,
+                                 unsigned int num_decode_surfaces) {
     DALI_ENFORCE(NVCUVID_API_EXISTS(cuvidReconfigureDecoder),
                  "cuvidReconfigureDecoder API is not available.");
 
@@ -154,6 +157,8 @@ void CUVideoDecoder::reconfigure(unsigned int height, unsigned int width) {
     decoder_info_.ulTargetHeight = decoder_info_.ulHeight = height;
     reconfigParams.ulTargetHeight = reconfigParams.ulHeight = height;
 
+    decoder_info_.ulNumDecodeSurfaces =
+        std::max(decoder_info_.ulNumDecodeSurfaces, static_cast<unsigned long>(num_decode_surfaces));
     reconfigParams.ulNumDecodeSurfaces = decoder_info_.ulNumDecodeSurfaces;
 
 
@@ -169,17 +174,24 @@ int CUVideoDecoder::initialize(CUVIDEOFORMAT* format) {
         if (format->bit_depth_chroma_minus8 != decoder_info_.bitDepthMinus8) {
             NVCUVID_CALL(cuvidDestroyDecoder(decoder_));
             decoder_ = {};
-        } else if ((format->coded_width != decoder_info_.ulWidth) ||
-            (format->coded_height != decoder_info_.ulHeight)) {
-            if (NVCUVID_API_EXISTS(cuvidReconfigureDecoder)) {
-              LOG_LINE << "reconfigure decoder";
-              CUVideoDecoder::reconfigure(format->coded_height, format->coded_width);
-            } else {
-             DALI_FAIL("Encountered a dynamic video resolution change. Install Nvidia driver"
-                       " version >=396 (x86) or >=415 (Power PC)");
-            }
-            return 1;
         } else {
+            auto num_decode_surfaces = format->min_num_decode_surfaces == 0
+                                           ? 20UL
+                                           : static_cast<unsigned long>(format->min_num_decode_surfaces) +
+                                                 additional_decode_surfaces_;
+            if ((format->coded_width != decoder_info_.ulWidth) ||
+                (format->coded_height != decoder_info_.ulHeight) ||
+                (num_decode_surfaces > decoder_info_.ulNumDecodeSurfaces)) {
+                if (NVCUVID_API_EXISTS(cuvidReconfigureDecoder)) {
+                    LOG_LINE << "reconfigure decoder";
+                    CUVideoDecoder::reconfigure(format->coded_height, format->coded_width,
+                                                 num_decode_surfaces);
+                } else {
+                    DALI_FAIL("Encountered a dynamic video resolution change. Install Nvidia driver"
+                              " version >=396 (x86) or >=415 (Power PC)");
+                }
+                return decoder_info_.ulNumDecodeSurfaces;
+            }
             return 1;
         }
     }

--- a/dali/operators/video/legacy/reader/nvdecoder/cuvideodecoder.h
+++ b/dali/operators/video/legacy/reader/nvdecoder/cuvideodecoder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2018, 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class CUVideoDecoder {
 
   operator CUvideodecoder() const;
 
-  void reconfigure(unsigned int height, unsigned int width);
+  void reconfigure(unsigned int height, unsigned int width, unsigned int num_decode_surfaces);
   int initialize(CUVIDEOFORMAT* format);
   bool initialized() const;
 


### PR DESCRIPTION
Reconfigure NVDEC decoder for increased surface requirements

## Category:

Bug fix

## Description:

Fixes the legacy NVDEC video reader when consecutive clips require different decode-surface capacities. The decoder now reconfigures when the next stream requires more surfaces, preventing DPB exhaustion and out-of-presentation-order frame callbacks.

Fixes #5665.

## Additional information:

### Affected modules and functionalities:

- Legacy GPU video reader, CUVideoDecoder
- Decoder reconfiguration when resolution or minimum decode-surface requirements increase

### Key points relevant for the review:

- Preserve the largest configured ulNumDecodeSurfaces value during reconfiguration.
- Reconfigure when CUVIDEOFORMAT min_num_decode_surfaces exceeds the active decoder capacity, even if coded resolution is unchanged.

### Tests:

- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [x] Other
    - Retested provided repro in #5665
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A