### PR TITLE
Respect user warning filters in Python deprecation warnings

### DIFF
--- a/dali/python/nvidia/dali/backend.py
+++ b/dali/python/nvidia/dali/backend.py
@@ -52,9 +52,9 @@ _ExecutorFlags.__invert__ = lambda x: _ExecutorFlags(~x.value)
 
 
 def deprecation_warning(what):
-    # show only this warning
+    # show by default, but honor warning filters configured by the user
     with warnings.catch_warnings():
-        warnings.simplefilter("default")
+        warnings.simplefilter("default", append=True)
         warnings.warn(what, Warning, stacklevel=2)
 
 

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -43,9 +43,9 @@ DataNode.__module__ = __name__  # move to pipeline
 
 
 def _show_deprecation_warning(deprecated, in_favor_of):
-    # show only this warning
+    # show by default, but honor warning filters configured by the user
     with warnings.catch_warnings():
-        warnings.simplefilter("default")
+        warnings.simplefilter("default", append=True)
         warnings.warn(
             "{} is deprecated, please use {} instead".format(deprecated, in_favor_of),
             Warning,

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -395,6 +395,22 @@ def test_dtype_deprecation_warning():
         assert "Calling '.dtype()' is deprecated, please use '.dtype' instead" == str(w[-1].message)
 
 
+def test_backend_deprecation_warning_honors_user_filters():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.filterwarnings("ignore")
+        dali.backend.deprecation_warning("backend deprecation warning filter check")
+        assert len(w) == 0
+
+
+def test_backend_deprecation_warning_shown_by_default():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("default")
+        dali.backend.deprecation_warning("backend deprecation warning default check")
+        assert len(w) == 1
+        assert w[0].category is Warning
+        assert "backend deprecation warning default check" == str(w[0].message)
+
+
 def test_dtype_placeholder_equivalence():
     dali_types = types._all_types
     np_types = list(map(dali_type_to_np, dali_types))

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -404,7 +404,7 @@ def test_backend_deprecation_warning_honors_user_filters():
 
 def test_backend_deprecation_warning_shown_by_default():
     with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("default")
+        warnings.resetwarnings()
         dali.backend.deprecation_warning("backend deprecation warning default check")
         assert len(w) == 1
         assert w[0].category is Warning

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1781,7 +1781,7 @@ def test_deprecation_warning_honors_user_filters():
 
 def test_deprecation_warning_shown_by_default():
     with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("default")
+        warnings.resetwarnings()
         _show_deprecation_warning("another_deprecated_test_argument", "other_replacement")
         assert len(w) == 1
         assert w[0].category is Warning

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -20,6 +20,7 @@ import nvidia.dali.types as types
 import nvidia.dali.tfrecord as tfrec
 import nvidia.dali as dali
 from nvidia.dali import pipeline_def
+from nvidia.dali.pipeline import _show_deprecation_warning
 import numpy as np
 import os
 import random
@@ -1769,6 +1770,26 @@ def test_image_type_deprecation():
             "in a future release."
         )
         assert expected_msg == str(w[-1].message)
+
+
+def test_deprecation_warning_honors_user_filters():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.filterwarnings("ignore")
+        _show_deprecation_warning("deprecated_test_argument", "replacement_test_argument")
+        assert len(w) == 0
+
+
+def test_deprecation_warning_shown_by_default():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("default")
+        _show_deprecation_warning("another_deprecated_test_argument", "other_replacement")
+        assert len(w) == 1
+        assert w[0].category is Warning
+        expected_msg = (
+            "another_deprecated_test_argument is deprecated, "
+            "please use other_replacement instead"
+        )
+        assert expected_msg == str(w[0].message)
 
 
 @raises(TypeError, glob="unexpected*output_dtype*dtype")


### PR DESCRIPTION
### Category
Bug fix

### Description

DALI's Python deprecation warnings that use the base `Warning` category could not be silenced. `deprecation_warning` in `backend.py` and `_show_deprecation_warning` in `pipeline.py` wrap `warnings.warn` in `catch_warnings()` plus `simplefilter("default")`, which discards every filter the user configured, so even `warnings.filterwarnings("ignore")` cannot hide them (issue #4396).

This PR appends the filter instead of replacing the list: `simplefilter("default", append=True)`. User-configured filters keep priority, and when the user has configured nothing the builtin default action still shows each warning once per location, so out-of-the-box behavior is unchanged.

The tradeoff from the #4396 discussion is accepted deliberately for these two helpers: users who silence warnings will no longer see their messages. The issue reporter asked for exactly this and the maintainer invited a PR to improve it.

Fixes #4396

### Additional information

#### Affected modules and functionalities
Python frontend only:
- `dali/python/nvidia/dali/backend.py`: `deprecation_warning`
- `dali/python/nvidia/dali/pipeline.py`: `_show_deprecation_warning`

#### Key points relevant for the review
- Scope note: three other sites use the same pattern but warn with category `DeprecationWarning` (`_handle_arg_deprecations`, `_handle_op_deprecation`, `save_graph_to_dot_file`'s `show_ids`). They are left unchanged on purpose. CPython's startup filters include `('ignore', None, DeprecationWarning, ...)`, and first match wins, so an appended default can never outrank it: on a stock interpreter those warnings would become hidden by default, a regression against the intent stated in #4396. Verified with observed output simulating the real call chain (user module -> internal module -> helper with stacklevel=2):

```
DW append  : printed=False      <- would be a regression, so not done
DW replace : printed=True       <- current behavior kept
Warn append: printed=True       <- this PR's change, still shown by default
```

Honoring user filters at the `DeprecationWarning` sites needs a different mechanism (custom category or filter-list surgery) and is better discussed separately; happy to follow up if maintainers want it.
- Existing deprecation tests keep working: they record inside `simplefilter("always")`, which outranks the appended default.
- `plugin/base_iterator.py` already uses plain `warnings.warn` and needed no change.

#### Tests
- [x] New tests added
  - [x] Python tests: `test_pipeline.py`: `test_deprecation_warning_honors_user_filters`, `test_deprecation_warning_shown_by_default`

Run on this machine (Windows, DALI wheel does not install here, so the package itself could not be imported):

```
$ python -m flake8 --config .flake8 dali/python/nvidia/dali/backend.py dali/python/nvidia/dali/pipeline.py dali/test/python/test_pipeline.py && echo FLAKE8_OK
0
FLAKE8_OK

$ python -m black --check --config pyproject.toml <same files>
All done! ✨ 🍰 ✨
3 files would be left unchanged.
```

Standalone verification of the mechanism with the exact patched helper body:

```
old simplefilter(default): user set ignore-all: shown=True
old simplefilter(default): no user filters     : shown=True
new simplefilter(default,append): user set ignore-all: shown=False
new simplefilter(default,append): no user filters     : shown=True
```

Both new tests pass standalone against the patched helper logic, run twice each to rule out registry dedup surprises, and a control run confirms the old helper would fail `test_deprecation_warning_honors_user_filters`.

Not run: the full `L0_*` suites and the new tests inside the real package. DALI has no Windows build/wheel, so those require the Linux CI environment. Please treat CI as the authoritative run.

### Checklist

#### Documentation
- [x] Existing documentation applies

### DALI team only

#### Requirements
- [ ] Implements requirements
- [x] N/A

#### REQ IDs
N/A

#### JIRA TASK
NA

---

AI assistance disclosure: this change was developed with the help of an AI coding agent under my direction. I reviewed and verified every line, ran all checks quoted above, and take full responsibility for the contribution. Commits are authored and Signed-off by me.
