### PR TITLE
Suggest a remedy when as_array hits a non-uniform tensor list

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1758,7 +1758,10 @@ void ExposeTensorListCPU(py::module &m) {
             DALI_ENFORCE(IsValidType(tl.type()), "Cannot produce "
                 "buffer info for tensor w/ invalid type.");
             DALI_ENFORCE(tl.IsDenseTensor(),
-                        "Tensors in the list must have the same shape");
+                        "Cannot produce a numpy array: the tensors in the list "
+                        "do not all have the same shape. Pad or crop the "
+                        "samples to a common shape, or check is_dense_tensor() "
+                        "beforehand.");
             raw_mutable_data = contiguous_raw_mutable_data(tl);
           }
 


### PR DESCRIPTION
### Category
Other (error message clarity)

### Description

When `as_array()` is called on a tensor list whose samples do not all share one shape, the enforce at `dali/python/backend_impl.cc` fails with only:

```
Tensors in the list must have the same shape
```

Issue #3714 shows users repeatedly reading this as a reader bug and not knowing the remedy. The behavior itself is correct and stays unchanged: a non-dense list cannot be viewed as one numpy array. This PR only rewords the message to state the requirement and the fix, matching the guidance given in that issue:

```
Cannot produce a numpy array: the tensors in the list do not all have the same shape. Pad or crop the samples to a common shape, or check is_dense_tensor() beforehand.
```

Fixes #3714

### Additional information

#### Affected modules and functionalities
Python bindings: `TensorListCPU.as_array` error path only. One string literal changed, no behavioral change.

#### Key points relevant for the review
- The old text appears nowhere else for this code path; no test asserts it (the similar string in `test_multipaste.py` belongs to a different operator).
- `is_dense_tensor()` is already exposed on both `TensorListCPU` and `TensorListGPU` bindings, so pointing users at it is accurate.

#### Tests
- [x] N/A

No new test added: this is an error-message wording change inside a C++ enforce, verified by inspection; existing suites are unaffected since no assertion matches the old text. Compile and L0 runs require the Linux CI environment (this contribution was prepared on Windows where DALI does not build), so please treat CI as the authoritative build check.

### Checklist

#### Documentation
- [x] Existing documentation applies

### DALI team only

#### Requirements
- [ ] Implements requirements
- [x] N/A

#### REQ IDs
N/A

#### JIRA TASK
NA

---

AI assistance disclosure: this change was developed with the help of an AI coding agent under my direction. I reviewed and verified every line and take full responsibility for the contribution. Commits are authored and Signed-off by me.
