### PR TITLE
Skip Paddle iterator tests with ASan

### DIFF
--- a/qa/TL0_FW_iterators/test_paddlepaddle.sh
+++ b/qa/TL0_FW_iterators/test_paddlepaddle.sh
@@ -10,7 +10,8 @@ do_once() {
 }
 
 test_body() {
-    # it takes very long time to run it with sanitizers on and provides little value so turn it off
+    # Paddle 3.4's libpir reports an external alloc/dealloc mismatch during ASan teardown.
+    # Keep the framework coverage in regular CI, but skip it under sanitizers until Paddle fixes it.
     if [ -z "$DALI_ENABLE_SANITIZERS" ]; then
         for fw in "paddle"; do
             python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
@@ -19,8 +20,8 @@ test_body() {
                 --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
         done
         ${python_new_invoke_test} -A 'paddle' test_fw_iterators_detection
+        ${python_new_invoke_test} -A 'paddle' test_fw_iterators
     fi
-    ${python_new_invoke_test} -A 'paddle' test_fw_iterators
 }
 
 pushd ../..


### PR DESCRIPTION
## Category:

Other (Tests, Configuration)

## Description:

Skips the Paddle iterator QA suite when AddressSanitizer is enabled. Paddle 3.4's
external `libpir` library reports an alloc/dealloc mismatch during Python shutdown,
after the DALI iterator tests have completed successfully. Regular CI continues to
run the full Paddle iterator coverage.

## Additional information:

### Affected modules and functionalities:

- `qa/TL0_FW_iterators/test_paddlepaddle.sh`: Paddle iterator QA execution in
  sanitizer jobs.

### Key points relevant for the review:

- The workaround is scoped to Paddle sanitizer runs; it does not disable ASan
  mismatch detection globally or suppress DALI errors.
- Remove the exclusion after a CUDA 13 Paddle wheel fixes the `libpir` teardown
  mismatch.

### Tests:

- [x] Existing tests apply
  - `qa/TL0_FW_iterators/test_paddlepaddle.sh` runs the existing Paddle iterator
    suite in non-sanitizer jobs.
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation

- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
