### PR TITLE
Add CUDA 13 Paddle package variants for Python versions

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -640,12 +640,26 @@ all_packages = [
             ],
             "130": [
                 PckgVer(
-                    "3.4.0.post20260808",
+                    "3.3.1",
                     python_min_ver="3.9",
+                    python_max_ver="3.11",
+                    # Free-threaded Python build is incompatible with numpy<2.
+                    python_free_threaded=False,
+                ),
+                PckgVer(
+                    "3.3.1",
+                    python_min_ver="3.13",
                     python_max_ver="3.13",
                     # Free-threaded Python build is incompatible with numpy<2.
                     python_free_threaded=False,
-                )
+                ),
+                PckgVer(
+                    "3.4.0.post20260808",
+                    python_min_ver="3.12",
+                    python_max_ver="3.12",
+                    # Free-threaded Python build is incompatible with numpy<2.
+                    python_free_threaded=False,
+                ),
             ],
         },
         extra_index="https://www.paddlepaddle.org.cn/packages/stable/cu{cuda_v[0]}{cuda_v[1]}0/",


### PR DESCRIPTION
## Category:

**Other** (Configuration)

## Description:

- Adds CUDA 13 PaddlePaddle 3.3.1 package variants for Python 3.9-3.11 and CPython 3.13,
  as 3.4.0 supports only 3.4.0.

## Additional information:

### Affected modules and functionalities:

- QA dependency setup for `paddlepaddle-gpu` with CUDA 13.

### Key points relevant for the review:

- The new version bounds avoid changing the existing PaddlePaddle 3.4.0 selection.

### Tests:

- [x] Existing tests apply
  - all paddlepaddle tests for pyton other than 3.12
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A