### PR TITLE
Fix use-after-free in C API checkpointing test

### DIFF
--- a/dali/c_api_2/op_test/complex_pipeline_test.cc
+++ b/dali/c_api_2/op_test/complex_pipeline_test.cc
@@ -264,9 +264,11 @@ void RunCheckpointingTest(Pipeline &ref, daliPipeline_h pipe1, daliPipeline_h pi
   daliPipelineOutputs_h out1_h{};
   CHECK_DALI(daliPipelinePopOutputs(pipe1, &out1_h));
   CHECK_DALI(daliPipelineOutputsDestroy(out1_h));
+  out1_h = nullptr;
   CHECK_DALI(daliPipelineRun(pipe1));
   CHECK_DALI(daliPipelinePopOutputs(pipe1, &out1_h));
   CHECK_DALI(daliPipelineOutputsDestroy(out1_h));
+  out1_h = nullptr;
   CHECK_DALI(daliPipelineRun(pipe1));
   CHECK_DALI(daliPipelinePopOutputs(pipe1, &out1_h));
   CHECK_DALI(daliPipelineOutputsDestroy(out1_h));


### PR DESCRIPTION
## Category

Bug fix (non-breaking change which fixes an issue)

## Description

`RunCheckpointingTest` reuses a single `daliPipelineOutputs_h` across three pop/destroy cycles:

```c
daliPipelineOutputs_h out1_h{};
CHECK_DALI(daliPipelinePopOutputs(pipe1, &out1_h));
CHECK_DALI(daliPipelineOutputsDestroy(out1_h));
CHECK_DALI(daliPipelineRun(pipe1));
CHECK_DALI(daliPipelinePopOutputs(pipe1, &out1_h));   // only writes *out on success
CHECK_DALI(daliPipelineOutputsDestroy(out1_h));
```

`CHECK_DALI` is `EXPECT_EQ`, which is non-fatal, and the C API convention shared with the CUDA
runtime is that output parameters are not modified on a non-success return. So if
`daliPipelinePopOutputs` fails, execution continues with `out1_h` still holding the handle freed
by the preceding `daliPipelineOutputsDestroy`, and the next destroy double-frees it. Coverity
flags this as a use-after-free.

This clears the handle after each destroy that is followed by another pop, so the failure path
sees `nullptr` instead of a dangling handle. The test keeps using the raw C API for output
handles, as it is intentionally a C API test.

A previous change addressed the checkpoint handle in this same function; this covers the output
handle, which Coverity still reports.

## Additional information

**Affected modules and functionalities:**

`dali/c_api_2/op_test/complex_pipeline_test.cc` - `RunCheckpointingTest`

**Key points relevant for the review:**

Test-only change. `daliPipelineOutputsDestroy(nullptr)` returns an error rather than success
(`ToPointer` throws `NullHandle`), so the trailing `CHECK_DALI` would report on the failure path -
but that path only executes when the test has already failed, and it is memory-safe. The same
situation already exists for the first destroy, since `out1_h` is value-initialized to `nullptr`.

## Checklist

### Tests

- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation

- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

## DALI team only

### Requirements

* Implements new requirements
* Affects existing requirements
* N/A

### JIRA TASK: DALI-4883
