### PR TITLE
Fix conda custom operator build and self-tests

### DIFF
--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,4 +41,6 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ ${CMAKE_SOURCE_DIR}/dali
         DESTINATION include
         FILES_MATCHING
           PATTERN "*_test.h" EXCLUDE
-          PATTERN "*.h")
+          PATTERN "*.h"
+          # float16.h, a public header, includes dali/util/half.hpp.
+          PATTERN "*.hpp")

--- a/dali/python/nvidia/dali/sysconfig.py
+++ b/dali/python/nvidia/dali/sysconfig.py
@@ -24,11 +24,22 @@ def get_include_dir():
     # Import inside the function to avoid circular import as dali imports sysconfig
     import nvidia.dali as dali
 
-    package_include_dir = os.path.join(os.path.dirname(dali.__file__), "include")
+    package_dir = os.path.realpath(os.path.dirname(dali.__file__))
+    package_include_dir = os.path.join(package_dir, "include")
     conda_prefix = os.environ.get("CONDA_PREFIX")
-    conda_include_dir = os.path.join(conda_prefix, "include") if conda_prefix else None
+    if conda_prefix:
+        conda_prefix = os.path.realpath(conda_prefix)
+        conda_include_dir = os.path.join(conda_prefix, "include")
+        package_is_in_conda_prefix = os.path.commonpath((package_dir, conda_prefix)) == conda_prefix
+    else:
+        conda_include_dir = None
+        package_is_in_conda_prefix = False
 
-    if conda_include_dir and os.path.isdir(os.path.join(conda_include_dir, "dali")):
+    if (
+        package_is_in_conda_prefix
+        and conda_include_dir
+        and os.path.isdir(os.path.join(conda_include_dir, "dali"))
+    ):
         return conda_include_dir
 
     return package_include_dir

--- a/dali/python/nvidia/dali/sysconfig.py
+++ b/dali/python/nvidia/dali/sysconfig.py
@@ -29,10 +29,14 @@ def get_include_dir():
     conda_prefix = os.environ.get("CONDA_PREFIX")
     if conda_prefix:
         conda_prefix = os.path.realpath(conda_prefix)
+        # An active Conda environment may import DALI from another location.
+        # Use its headers only when it also supplies the imported package.
         package_is_in_conda_prefix = os.path.commonpath((package_dir, conda_prefix)) == conda_prefix
     else:
         package_is_in_conda_prefix = False
 
+    # Conda packages headers separately in libdali-devel. Fall back to the
+    # package-bundled headers when that optional package is not installed.
     if package_is_in_conda_prefix and os.path.isdir(os.path.join(conda_prefix, "include", "dali")):
         return os.path.join(conda_prefix, "include")
 
@@ -47,6 +51,8 @@ def get_lib_dir():
     """
     import nvidia.dali as dali
 
+    # Unlike headers, Conda's bindings package keeps prebuilt DALI libraries
+    # alongside the Python package.
     return os.path.dirname(dali.__file__)
 
 

--- a/dali/python/nvidia/dali/sysconfig.py
+++ b/dali/python/nvidia/dali/sysconfig.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,14 @@ def get_include_dir():
     # Import inside the function to avoid circular import as dali imports sysconfig
     import nvidia.dali as dali
 
-    return os.path.join(os.path.dirname(dali.__file__), "include")
+    package_include_dir = os.path.join(os.path.dirname(dali.__file__), "include")
+    conda_prefix = os.environ.get("CONDA_PREFIX")
+    conda_include_dir = os.path.join(conda_prefix, "include") if conda_prefix else None
+
+    if conda_include_dir and os.path.isdir(os.path.join(conda_include_dir, "dali")):
+        return conda_include_dir
+
+    return package_include_dir
 
 
 def get_lib_dir():

--- a/dali/python/nvidia/dali/sysconfig.py
+++ b/dali/python/nvidia/dali/sysconfig.py
@@ -29,18 +29,12 @@ def get_include_dir():
     conda_prefix = os.environ.get("CONDA_PREFIX")
     if conda_prefix:
         conda_prefix = os.path.realpath(conda_prefix)
-        conda_include_dir = os.path.join(conda_prefix, "include")
         package_is_in_conda_prefix = os.path.commonpath((package_dir, conda_prefix)) == conda_prefix
     else:
-        conda_include_dir = None
         package_is_in_conda_prefix = False
 
-    if (
-        package_is_in_conda_prefix
-        and conda_include_dir
-        and os.path.isdir(os.path.join(conda_include_dir, "dali"))
-    ):
-        return conda_include_dir
+    if package_is_in_conda_prefix and os.path.isdir(os.path.join(conda_prefix, "include", "dali")):
+        return os.path.join(conda_prefix, "include")
 
     return package_include_dir
 

--- a/dali/test/python/test_plugin_manager.py
+++ b/dali/test/python/test_plugin_manager.py
@@ -103,6 +103,20 @@ class TestLoadedPlugin(unittest.TestCase):
                 with mock.patch.object(dali, "__file__", package_file):
                     assert dali_sysconfig.get_include_dir() == conda_include_dir
 
+    def test_sysconfig_falls_back_without_conda_devel_package(self):
+        import nvidia.dali.sysconfig as dali_sysconfig
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            conda_prefix = os.path.join(tmp_dir, "conda")
+            package_dir = os.path.join(
+                conda_prefix, "lib", "python", "site-packages", "nvidia", "dali"
+            )
+            package_file = os.path.join(package_dir, "__init__.py")
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": conda_prefix}):
+                with mock.patch.object(dali, "__file__", package_file):
+                    assert dali_sysconfig.get_include_dir() == os.path.join(package_dir, "include")
+
     def test_sysconfig_avoids_mismatched_conda_headers(self):
         import nvidia.dali.sysconfig as dali_sysconfig
 

--- a/dali/test/python/test_plugin_manager.py
+++ b/dali/test/python/test_plugin_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import unittest
 import os
 import numpy as np
 import tempfile
+from unittest import mock
 
 test_bin_dir = os.path.dirname(dali.__file__) + "/test"
 batch_size = 4
@@ -86,6 +87,34 @@ class TestLoadedPlugin(unittest.TestCase):
         assert "" != dali_sysconfig.get_link_flags()
         assert "" != dali_sysconfig.get_include_dir()
         assert "" != dali_sysconfig.get_lib_dir()
+
+    def test_sysconfig_uses_conda_headers_for_conda_package(self):
+        import nvidia.dali.sysconfig as dali_sysconfig
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            conda_prefix = os.path.join(tmp_dir, "conda")
+            conda_include_dir = os.path.join(conda_prefix, "include")
+            package_file = os.path.join(
+                conda_prefix, "lib", "python", "site-packages", "nvidia", "dali", "__init__.py"
+            )
+            os.makedirs(os.path.join(conda_include_dir, "dali"))
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": conda_prefix}):
+                with mock.patch.object(dali, "__file__", package_file):
+                    assert dali_sysconfig.get_include_dir() == conda_include_dir
+
+    def test_sysconfig_avoids_mismatched_conda_headers(self):
+        import nvidia.dali.sysconfig as dali_sysconfig
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            conda_prefix = os.path.join(tmp_dir, "conda")
+            package_dir = os.path.join(tmp_dir, "wheel", "nvidia", "dali")
+            package_file = os.path.join(package_dir, "__init__.py")
+            os.makedirs(os.path.join(conda_prefix, "include", "dali"))
+
+            with mock.patch.dict(os.environ, {"CONDA_PREFIX": conda_prefix}):
+                with mock.patch.object(dali, "__file__", package_file):
+                    assert dali_sysconfig.get_include_dir() == os.path.join(package_dir, "include")
 
     def test_load_unexisting_library(self):
         with self.assertRaises(RuntimeError):

--- a/qa/TL0_cpu_only/test_nofw.sh
+++ b/qa/TL0_cpu_only/test_nofw.sh
@@ -27,20 +27,7 @@ test_body() {
     "dali_test.bin" \
     "dali_operator_test.bin"
   do
-    for DIRNAME in \
-      "../../build/dali/python/nvidia/dali" \
-      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
-    do
-        if [ -x "$DIRNAME/test/$BINNAME" ]; then
-            FULLPATH="$DIRNAME/test/$BINNAME"
-            break
-        fi
-    done
-
-    if [[ -z "$FULLPATH" ]]; then
-        echo "ERROR: $BINNAME not found"
-        exit 1
-    fi
+    FULLPATH="$(find_test_bin "$BINNAME")"
 
     "$FULLPATH" --gtest_filter="*CpuOnly*:*CApi*/0.*-*0.UseCopyKernel:*ForceNoCopyFail:*daliOutputCopySamples"
   done

--- a/qa/TL0_multigpu/test_body.sh
+++ b/qa/TL0_multigpu/test_body.sh
@@ -17,20 +17,7 @@ test_gtest() {
     "dali_test.bin" \
     "dali_operator_test.bin"
   do
-    for DIRNAME in \
-      "../../build/dali/python/nvidia/dali" \
-      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
-    do
-        if [ -x "$DIRNAME/test/$BINNAME" ]; then
-            FULLPATH="$DIRNAME/test/$BINNAME"
-            break
-        fi
-    done
-
-    if [[ -z "$FULLPATH" ]]; then
-        echo "ERROR: $BINNAME not found"
-        exit 1
-    fi
+    FULLPATH="$(find_test_bin "$BINNAME")"
 
     "$FULLPATH" --gtest_filter="*MultiGPU*"
   done

--- a/qa/TL0_self-test-exec2/test.sh
+++ b/qa/TL0_self-test-exec2/test.sh
@@ -5,20 +5,7 @@ test_body() {
     "dali_test.bin" \
     "dali_operator_test.bin"
   do
-    for DIRNAME in \
-      "../../build/dali/python/nvidia/dali" \
-      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
-    do
-        if [ -x "$DIRNAME/test/$BINNAME" ]; then
-            FULLPATH="$DIRNAME/test/$BINNAME"
-            break
-        fi
-    done
-
-    if [[ -z "$FULLPATH" ]]; then
-        echo "ERROR: $BINNAME not found"
-        exit 1
-    fi
+    FULLPATH="$(find_test_bin "$BINNAME")"
 
     DALI_USE_EXEC2=1 "$FULLPATH"
   done

--- a/qa/TL0_self-test-exec2_tegra/test.sh
+++ b/qa/TL0_self-test-exec2_tegra/test.sh
@@ -5,20 +5,7 @@ test_body() {
     "dali_test.bin" \
     "dali_operator_test.bin"
   do
-    for DIRNAME in \
-      "../../build/dali/python/nvidia/dali" \
-      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
-    do
-        if [ -x "$DIRNAME/test/$BINNAME" ]; then
-            FULLPATH="$DIRNAME/test/$BINNAME"
-            break
-        fi
-    done
-
-    if [[ -z "$FULLPATH" ]]; then
-        echo "ERROR: $BINNAME not found"
-        exit 1
-    fi
+    FULLPATH="$(find_test_bin "$BINNAME")"
 
     # LMDB seems to be greedy when mmaps memory, disable it as well
     # for some reason mmap based test tends to fail on some runners due to disc issue, so

--- a/qa/TL0_self-test/test.sh
+++ b/qa/TL0_self-test/test.sh
@@ -7,20 +7,7 @@ test_body() {
     "dali_test.bin" \
     "dali_operator_test.bin"
   do
-    for DIRNAME in \
-      "../../build/dali/python/nvidia/dali" \
-      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
-    do
-        if [ -x "$DIRNAME/test/$BINNAME" ]; then
-            FULLPATH="$DIRNAME/test/$BINNAME"
-            break
-        fi
-    done
-
-    if [[ -z "$FULLPATH" ]]; then
-        echo "ERROR: $BINNAME not found"
-        exit 1
-    fi
+    FULLPATH="$(find_test_bin "$BINNAME")"
 
     DALI_USE_EXEC2=0 "$FULLPATH"
   done

--- a/qa/TL0_self-test_tegra/test.sh
+++ b/qa/TL0_self-test_tegra/test.sh
@@ -7,20 +7,7 @@ test_body() {
     "dali_test.bin" \
     "dali_operator_test.bin"
   do
-    for DIRNAME in \
-      "../../build/dali/python/nvidia/dali" \
-      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
-    do
-        if [ -x "$DIRNAME/test/$BINNAME" ]; then
-            FULLPATH="$DIRNAME/test/$BINNAME"
-            break
-        fi
-    done
-
-    if [[ -z "$FULLPATH" ]]; then
-        echo "ERROR: $BINNAME not found"
-        exit 1
-    fi
+    FULLPATH="$(find_test_bin "$BINNAME")"
 
     # LMDB seems to be greedy when mmaps memory, disable it as well
     # for some reason mmap based test tends to fail on some runners due to disc issue, so

--- a/qa/TL0_self_test_arch_next/test.sh
+++ b/qa/TL0_self_test_arch_next/test.sh
@@ -11,20 +11,7 @@ test_body() {
     "dali_test.bin" \
     "dali_operator_test.bin"
   do
-    for DIRNAME in \
-      "../../build/dali/python/nvidia/dali" \
-      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
-    do
-        if [ -x "$DIRNAME/test/$BINNAME" ]; then
-            FULLPATH="$DIRNAME/test/$BINNAME"
-            break
-        fi
-    done
-
-    if [[ -z "$FULLPATH" ]]; then
-        echo "ERROR: $BINNAME not found"
-        exit 1
-    fi
+    FULLPATH="$(find_test_bin "$BINNAME")"
 
     "$FULLPATH" --gtest_filter="HwDecoder*"
   done

--- a/qa/TL1_self-test_conda/test.sh
+++ b/qa/TL1_self-test_conda/test.sh
@@ -12,12 +12,28 @@ test_body() {
     "dali_test.bin" \
     "dali_operator_test.bin"
   do
-    # use `which` to invoke test binary with full path so
-    # https://google.github.io/googletest/advanced.html#death-test-styles which runs tests in
-    # a separate process don't use PATH to discover the file location and fails
+    FULLPATH=""
+    for DIRNAME in \
+      "../../build/dali/python/nvidia/dali" \
+      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
+    do
+        if [ -x "$DIRNAME/test/$BINNAME" ]; then
+            FULLPATH="$DIRNAME/test/$BINNAME"
+            break
+        fi
+    done
+
+    if [[ -z "$FULLPATH" ]]; then
+        echo "ERROR: $BINNAME not found"
+        exit 1
+    fi
+
+    # Invoke the test binary with an absolute path so
+    # https://google.github.io/googletest/advanced.html#death-test-styles tests that run in
+    # a separate process do not rely on PATH to find the executable.
     # PackedBFrames test is disabled because it doesn't work with the conda upstream build
     # of FFMpeg
-    $(which $BINNAME) --gtest_filter="*:-*PackedBFrames*"
+    DALI_USE_EXEC2=0 "$FULLPATH" --gtest_filter="*:-*PackedBFrames*"
   done
 }
 

--- a/qa/TL1_self-test_conda/test.sh
+++ b/qa/TL1_self-test_conda/test.sh
@@ -12,7 +12,7 @@ test_body() {
     "dali_test.bin" \
     "dali_operator_test.bin"
   do
-    FULLPATH="$(find_test_bin "$BINNAME")"
+    FULLPATH="$(find_test_bin "$BINNAME" conda)"
 
     # Invoke the test binary with an absolute path so
     # https://google.github.io/googletest/advanced.html#death-test-styles tests that run in

--- a/qa/TL1_self-test_conda/test.sh
+++ b/qa/TL1_self-test_conda/test.sh
@@ -14,11 +14,11 @@ test_body() {
   do
     FULLPATH=""
     for DIRNAME in \
-      "../../build/dali/python/nvidia/dali" \
-      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
+      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')" \
+      "../../build/dali/python/nvidia/dali"
     do
         if [ -x "$DIRNAME/test/$BINNAME" ]; then
-            FULLPATH="$DIRNAME/test/$BINNAME"
+            FULLPATH="$(readlink -f "$DIRNAME/test/$BINNAME")"
             break
         fi
     done
@@ -33,7 +33,7 @@ test_body() {
     # a separate process do not rely on PATH to find the executable.
     # PackedBFrames test is disabled because it doesn't work with the conda upstream build
     # of FFMpeg
-    DALI_USE_EXEC2=0 "$FULLPATH" --gtest_filter="*:-*PackedBFrames*"
+    "$FULLPATH" --gtest_filter="*:-*PackedBFrames*"
   done
 }
 

--- a/qa/TL1_self-test_conda/test.sh
+++ b/qa/TL1_self-test_conda/test.sh
@@ -12,21 +12,7 @@ test_body() {
     "dali_test.bin" \
     "dali_operator_test.bin"
   do
-    FULLPATH=""
-    for DIRNAME in \
-      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')" \
-      "../../build/dali/python/nvidia/dali"
-    do
-        if [ -x "$DIRNAME/test/$BINNAME" ]; then
-            FULLPATH="$(readlink -f "$DIRNAME/test/$BINNAME")"
-            break
-        fi
-    done
-
-    if [[ -z "$FULLPATH" ]]; then
-        echo "ERROR: $BINNAME not found"
-        exit 1
-    fi
+    FULLPATH="$(find_test_bin "$BINNAME")"
 
     # Invoke the test binary with an absolute path so
     # https://google.github.io/googletest/advanced.html#death-test-styles tests that run in

--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -26,6 +26,37 @@ function version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)"
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
 function version_eq() { test "$1" == "$2"; }
 
+# Finds a self-test binary and prints its canonical path.  Conda self-tests must
+# prefer the package installed in the active environment; other suites prefer
+# the local build tree so they test the code built by the current job.
+find_test_bin() {
+    local bin_name="$1"
+    local package_dir
+    local local_build_dir="../../build/dali/python/nvidia/dali"
+    local candidate
+    local -a candidates
+
+    package_dir="$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' \
+        2>/dev/null || echo '')"
+
+    if [ -n "${CONDA_PREFIX:-}" ] && [ -n "$package_dir" ] &&
+       [[ "$(readlink -f "$package_dir")" == "$(readlink -f "$CONDA_PREFIX")"/* ]]; then
+        candidates=("$package_dir/test/$bin_name" "$local_build_dir/test/$bin_name")
+    else
+        candidates=("$local_build_dir/test/$bin_name" "$package_dir/test/$bin_name")
+    fi
+
+    for candidate in "${candidates[@]}"; do
+        if [ -x "$candidate" ]; then
+            readlink -f "$candidate"
+            return 0
+        fi
+    done
+
+    echo "ERROR: $bin_name not found" >&2
+    return 1
+}
+
 if [ -n "$gather_pip_packages" ]
 then
     # early exit

--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -26,11 +26,12 @@ function version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)"
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
 function version_eq() { test "$1" == "$2"; }
 
-# Finds a self-test binary and prints its canonical path.  Conda self-tests must
-# prefer the package installed in the active environment; other suites prefer
-# the local build tree so they test the code built by the current job.
+# Finds a self-test binary and prints its canonical path. Pass `conda` to prefer
+# the package installed in the active Conda environment; other suites prefer the
+# local build tree so they test the code built by the current job.
 find_test_bin() {
     local bin_name="$1"
+    local prefer_conda_package="${2:-}"
     local package_dir
     local local_build_dir="../../build/dali/python/nvidia/dali"
     local candidate
@@ -39,7 +40,8 @@ find_test_bin() {
     package_dir="$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' \
         2>/dev/null || echo '')"
 
-    if [ -n "${CONDA_PREFIX:-}" ] && [ -n "$package_dir" ] &&
+    if [ "$prefer_conda_package" = "conda" ] && [ -n "${CONDA_PREFIX:-}" ] &&
+       [ -n "$package_dir" ] &&
        [[ "$(readlink -f "$package_dir")" == "$(readlink -f "$CONDA_PREFIX")"/* ]]; then
         candidates=("$package_dir/test/$bin_name" "$local_build_dir/test/$bin_name")
     else

--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -55,7 +55,7 @@ find_test_bin() {
         fi
     done
 
-    echo "ERROR: $bin_name not found" >&2
+    echo "ERROR: Self-test binary '$bin_name' was not found. Searched: ${candidates[*]}." >&2
     return 1
 }
 


### PR DESCRIPTION
Fix conda custom-operator builds and self-tests.

## Category:

Bug fix

## Description:

Make DALI's Conda integration consistently select artifacts from the active
environment while retaining the existing wheel and local-build fallbacks:

- Select `$CONDA_PREFIX/include/dali` only when the imported DALI package is
  also under that prefix and `libdali-devel` supplies the headers.
- Continue linking against the package-local prebuilt libraries, and install
  public `.hpp` headers with the existing public `.h` headers.
- Centralize C++ self-test binary discovery in `find_test_bin`. All eight
  affected suites use it, so a missing binary cannot reuse a path found in a
  previous loop iteration. The helper returns a canonical executable path for
  GoogleTest death tests; it selects the imported package first for a DALI
  package under the active Conda prefix, and otherwise retains local-build-first
  lookup.

## Additional information:

### Affected modules and functionalities:

- `nvidia.dali.sysconfig` include flags for custom-operator builds.
- Installation of public DALI C++ headers for `libdali-devel`.
- C++ self-test binary discovery in the TL0, TL1 Conda, CPU-only, Tegra, and
  multi-GPU QA suites.

### Key points relevant for the review:

- A Conda prefix is used only when it matches the imported DALI package;
  mismatched `PYTHONPATH` and Conda installations retain package-local headers.
- Conda-installed DALI packages are preferred by the Conda self-test, while
  non-Conda suites continue to prefer the local build produced by their job.
- The helper has one search-order implementation and returns a nonzero status
  when no executable is found.
- `libdali.so` intentionally remains package-local because the bindings package
  contains the prebuilt libraries.

### Tests:

- [x] New tests added
  - [x] Python tests
    - `dali/test/python/test_plugin_manager.py`: matching, mismatched, and
      missing-`libdali-devel` Conda header-path selection.
  - [ ] GTests
  - [ ] Benchmark
  - [x] Other
    - Shell syntax checks for the helper and all eight affected QA scripts.
    - Focused helper check for local-build-first, Conda-package-first, and
      missing-binary behavior.
- [x] Existing tests apply
  - TL1 Conda self-test discovery and the custom-operator notebook build run in
    CI.
- [ ] N/A

## Checklist

### Documentation

- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements

- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: N/A
