### PR TITLE
Promote scalars to constants in ndd arithmetic operators

### DIFF
--- a/dali/operators/math/expressions/arithmetic.cc
+++ b/dali/operators/math/expressions/arithmetic.cc
@@ -142,9 +142,9 @@ Examples::
   add(&0 mul(&1 $0:int8))
   add(&0 rand()))code",
             DALIDataType::DALI_STRING, false)
-    .AddOptionalArg<std::vector<int32_t>>("integer_constants", "", nullptr, true)
+    .AddOptionalArg<std::vector<int32_t>>("integer_constants", "", nullptr)
     .NumInput(1, 64)  // Some arbitrary number that needs to be validated in operator
-    .AddOptionalArg<std::vector<float>>("real_constants", "", nullptr, true)
+    .AddOptionalArg<std::vector<float>>("real_constants", "", nullptr)
     .NumOutput(1)
     .MakeDocHidden()
     .OutputNDim(0, [](const OpSpec &spec)->std::optional<int> {

--- a/dali/python/nvidia/dali/experimental/dynamic/_arithmetic.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_arithmetic.py
@@ -14,11 +14,6 @@
 
 
 import numbers
-from typing import Any
-
-
-def _implicitly_convertible(value: Any):
-    return isinstance(value, (numbers.Real, list, tuple))
 
 
 def _arithm_op(name: str, *args):
@@ -26,21 +21,42 @@ def _arithm_op(name: str, *args):
     from ._batch import Batch
     from ._tensor import Tensor, as_tensor
 
-    # scalar arguments are turned into tensors
-    argsstr = " ".join(f"&{i}" for i in range(len(args)))
-    gpu = any(arg.device.device_type == "gpu" for arg in args if isinstance(arg, (Tensor, Batch)))
+    tensor_args = [arg for arg in args if isinstance(arg, (Tensor, Batch))]
+    gpu = any(arg.device.device_type == "gpu" for arg in tensor_args)
 
-    new_args = []
-    for arg in args:
+    def to_input(arg):
         if not isinstance(arg, (Tensor, Batch)):
-            if gpu and _implicitly_convertible(arg):
-                arg = as_tensor(arg, device="gpu")
-            else:
-                arg = as_tensor(arg)
+            device = "gpu" if gpu and isinstance(arg, (numbers.Real, list, tuple)) else None
+            arg = as_tensor(arg, device=device)
 
         if (arg.device.device_type == "gpu") != gpu:
             raise ValueError("Cannot mix GPU and CPU inputs.")
 
-        new_args.append(arg)
+        return arg
 
-    return _arithmetic_generic_op(*new_args, expression_desc=f"{name}({argsstr})")
+    # only reachable from math functions called with only scalars, e.g. ndd.math.max(2, 3)
+    if not tensor_args and args:
+        args = (to_input(args[0]), *args[1:])
+
+    desc, inputs, integers, reals = [], [], [], []
+    for arg in args:
+        type_ = type(arg)
+        if type_ is bool:
+            desc.append(f"${len(integers)}:bool")
+            integers.append(int(arg))
+        elif type_ is int:
+            desc.append(f"${len(integers)}:int32")
+            integers.append(arg)
+        elif type_ is float:
+            desc.append(f"${len(reals)}:float32")
+            reals.append(arg)
+        else:
+            desc.append(f"&{len(inputs)}")
+            inputs.append(to_input(arg))
+
+    return _arithmetic_generic_op(
+        *inputs,
+        expression_desc=f"{name}({' '.join(desc)})",
+        integer_constants=integers or None,
+        real_constants=reals or None,
+    )

--- a/dali/python/nvidia/dali/experimental/dynamic/_arithmetic.py
+++ b/dali/python/nvidia/dali/experimental/dynamic/_arithmetic.py
@@ -45,6 +45,8 @@ def _arithm_op(name: str, *args):
             desc.append(f"${len(integers)}:bool")
             integers.append(int(arg))
         elif type_ is int:
+            if (arg >> 31) not in (0, -1):
+                raise OverflowError(f"Integer constant {arg} is out of range for int32.")
             desc.append(f"${len(integers)}:int32")
             integers.append(arg)
         elif type_ is float:


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**Bug fix** (*non-breaking change which fixes an issue*)

## Description:

Currently, integers and floats are not promoted to constants in ndd arithmetic operators. This PR fixes it.

With `a` and `b` two 64x224x224x3 batches of uint8 images on the GPU, `0.4 * a + 0.6 * b` takes around **640 us** to run on main and below **230 us** on this branch.

One important detail is that all bool/int/floats are currently promoted to constants, forcing the creation of a new operator instance each time. PR https://github.com/NVIDIA/DALI/pull/6476 addresses this issue.

## Additional information:

### Affected modules and functionalities:

Airthmetic ops

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply: `test_arithm_ops.py` 
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [X] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
