### PR TITLE
Add CUDA 13.4 build configuration

### DIFF
--- a/docker/Dockerfile.cuda134.aarch64.deps
+++ b/docker/Dockerfile.cuda134.aarch64.deps
@@ -1,0 +1,61 @@
+ARG TOOLKIT_BASE_IMAGE=ubuntu:24.04
+FROM ${TOOLKIT_BASE_IMAGE} AS cuda
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN CUDA_SUBVERSION=13.4.0-1 && \
+    CUFILE_VERSION=1.19.0.95-1 && \
+    CUDA_VERSION_MAJOR=13 && \
+    CUDA_VERSION_MINOR=4 && \
+    apt-get update && \
+    apt-get install wget software-properties-common -y && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/3bf863cc.pub && \
+    add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/ /" && \
+    apt-get update && \
+    apt install -y \
+        cuda-minimal-build-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR}=${CUDA_SUBVERSION} \
+        cuda-nvdisasm-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        cuda-nvml-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        cuda-nvtx-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcurand-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcurand-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libnpp-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libnpp-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libnvjpeg-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libnvjpeg-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcufft-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcufft-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcusolver-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcublas-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        cuda-compat-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcufile-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR}=${CUFILE_VERSION} && \
+    mkdir /tmp/nvcomp && cd /tmp/nvcomp && \
+    wget https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-5.2.0.10_cuda13-archive.tar.xz && \
+    tar -xf * && \
+    cp -r nvcomp-linux-sbsa-5.2.0.10_cuda13-archive/include/* /usr/local/cuda/include/ && \
+    cp -r nvcomp-linux-sbsa-5.2.0.10_cuda13-archive/lib/* /usr/local/cuda/lib64/ && \
+    cd / && rm -rf /tmp/nvcomp && \
+    mv /usr/local/cuda/bin/fatbinary /usr/local/cuda/bin/fatbinary_org && \
+    echo '#!/bin/bash' > /usr/local/cuda/bin/fatbinary && \
+    echo 'real_fatbinary=$(which fatbinary_org || which fatbinary)' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'if [ -z "$real_fatbinary" ]; then' >> /usr/local/cuda/bin/fatbinary && \
+    echo '    echo "Error: Could not find real fatbinary executable" >&2' >> /usr/local/cuda/bin/fatbinary && \
+    echo '    exit 1' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'fi' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'args=()' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'while [ $# -gt 0 ]; do' >> /usr/local/cuda/bin/fatbinary && \
+    echo '    case "$1" in' >> /usr/local/cuda/bin/fatbinary && \
+    echo '        --image=*)' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            specs=$1' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            new_spec=$(echo "$specs" | sed "s/image=/image3=/g" | sed "s/profile=sm_/kind=elf,sm=/g")' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            args+=("${new_spec[@]}")' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            ;;' >> /usr/local/cuda/bin/fatbinary && \
+    echo '        *)' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            args+=("$1")' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            ;;' >> /usr/local/cuda/bin/fatbinary && \
+    echo '    esac' >> /usr/local/cuda/bin/fatbinary && \
+    echo '    shift' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'done' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'exec "$real_fatbinary" "${args[@]}"' >> /usr/local/cuda/bin/fatbinary && \
+    chmod a+x /usr/local/cuda/bin/fatbinary && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.cuda134.aarch64.deps
+++ b/docker/Dockerfile.cuda134.aarch64.deps
@@ -3,10 +3,11 @@ FROM ${TOOLKIT_BASE_IMAGE} AS cuda
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN CUDA_SUBVERSION=13.4.0-1 && \
-    CUFILE_VERSION=1.19.0.95-1 && \
+RUN CUDA_SUBVERSION=13.4.1-1 && \
+    CUFILE_VERSION=1.19.0.109-1 && \
     CUDA_VERSION_MAJOR=13 && \
     CUDA_VERSION_MINOR=4 && \
+    NVCOMP_VERSION=5.3.0.16 && \
     apt-get update && \
     apt-get install wget software-properties-common -y && \
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/3bf863cc.pub && \
@@ -30,10 +31,10 @@ RUN CUDA_SUBVERSION=13.4.0-1 && \
         cuda-compat-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
         libcufile-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR}=${CUFILE_VERSION} && \
     mkdir /tmp/nvcomp && cd /tmp/nvcomp && \
-    wget https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-5.2.0.10_cuda13-archive.tar.xz && \
+    wget https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-${NVCOMP_VERSION}_cuda13-archive.tar.xz && \
     tar -xf * && \
-    cp -r nvcomp-linux-sbsa-5.2.0.10_cuda13-archive/include/* /usr/local/cuda/include/ && \
-    cp -r nvcomp-linux-sbsa-5.2.0.10_cuda13-archive/lib/* /usr/local/cuda/lib64/ && \
+    cp -r nvcomp-linux-sbsa-${NVCOMP_VERSION}_cuda13-archive/include/* /usr/local/cuda/include/ && \
+    cp -r nvcomp-linux-sbsa-${NVCOMP_VERSION}_cuda13-archive/lib/* /usr/local/cuda/lib64/ && \
     cd / && rm -rf /tmp/nvcomp && \
     mv /usr/local/cuda/bin/fatbinary /usr/local/cuda/bin/fatbinary_org && \
     echo '#!/bin/bash' > /usr/local/cuda/bin/fatbinary && \

--- a/docker/Dockerfile.cuda134.x86_64.deps
+++ b/docker/Dockerfile.cuda134.x86_64.deps
@@ -3,10 +3,11 @@ FROM ${TOOLKIT_BASE_IMAGE} AS cuda
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN CUDA_SUBVERSION=13.4.0-1 && \
-    CUFILE_VERSION=1.19.0.95-1 && \
+RUN CUDA_SUBVERSION=13.4.1-1 && \
+    CUFILE_VERSION=1.19.0.109-1 && \
     CUDA_VERSION_MAJOR=13 && \
     CUDA_VERSION_MINOR=4 && \
+    NVCOMP_VERSION=5.3.0.16 && \
     apt-get update && \
     apt-get install wget software-properties-common -y && \
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub && \
@@ -30,10 +31,10 @@ RUN CUDA_SUBVERSION=13.4.0-1 && \
         cuda-compat-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
         libcufile-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR}=${CUFILE_VERSION} && \
     mkdir /tmp/nvcomp && cd /tmp/nvcomp && \
-    wget https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-5.2.0.10_cuda13-archive.tar.xz && \
+    wget https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-${NVCOMP_VERSION}_cuda13-archive.tar.xz && \
     tar -xf * && \
-    cp -r nvcomp-linux-x86_64-5.2.0.10_cuda13-archive/include/* /usr/local/cuda/include/ && \
-    cp -r nvcomp-linux-x86_64-5.2.0.10_cuda13-archive/lib/* /usr/local/cuda/lib64/ && \
+    cp -r nvcomp-linux-x86_64-${NVCOMP_VERSION}_cuda13-archive/include/* /usr/local/cuda/include/ && \
+    cp -r nvcomp-linux-x86_64-${NVCOMP_VERSION}_cuda13-archive/lib/* /usr/local/cuda/lib64/ && \
     cd / && rm -rf /tmp/nvcomp && \
     mv /usr/local/cuda/bin/fatbinary /usr/local/cuda/bin/fatbinary_org && \
     echo '#!/bin/bash' > /usr/local/cuda/bin/fatbinary && \

--- a/docker/Dockerfile.cuda134.x86_64.deps
+++ b/docker/Dockerfile.cuda134.x86_64.deps
@@ -1,0 +1,61 @@
+ARG TOOLKIT_BASE_IMAGE=ubuntu:24.04
+FROM ${TOOLKIT_BASE_IMAGE} AS cuda
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN CUDA_SUBVERSION=13.4.0-1 && \
+    CUFILE_VERSION=1.19.0.95-1 && \
+    CUDA_VERSION_MAJOR=13 && \
+    CUDA_VERSION_MINOR=4 && \
+    apt-get update && \
+    apt-get install wget software-properties-common -y && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub && \
+    add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" && \
+    apt-get update && \
+    apt install -y \
+        cuda-minimal-build-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR}=${CUDA_SUBVERSION} \
+        cuda-nvdisasm-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        cuda-nvml-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        cuda-nvtx-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcurand-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcurand-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libnpp-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libnpp-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libnvjpeg-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libnvjpeg-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcufft-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcufft-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcusolver-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcublas-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        cuda-compat-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR} \
+        libcufile-dev-${CUDA_VERSION_MAJOR}-${CUDA_VERSION_MINOR}=${CUFILE_VERSION} && \
+    mkdir /tmp/nvcomp && cd /tmp/nvcomp && \
+    wget https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-5.2.0.10_cuda13-archive.tar.xz && \
+    tar -xf * && \
+    cp -r nvcomp-linux-x86_64-5.2.0.10_cuda13-archive/include/* /usr/local/cuda/include/ && \
+    cp -r nvcomp-linux-x86_64-5.2.0.10_cuda13-archive/lib/* /usr/local/cuda/lib64/ && \
+    cd / && rm -rf /tmp/nvcomp && \
+    mv /usr/local/cuda/bin/fatbinary /usr/local/cuda/bin/fatbinary_org && \
+    echo '#!/bin/bash' > /usr/local/cuda/bin/fatbinary && \
+    echo 'real_fatbinary=$(which fatbinary_org || which fatbinary)' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'if [ -z "$real_fatbinary" ]; then' >> /usr/local/cuda/bin/fatbinary && \
+    echo '    echo "Error: Could not find real fatbinary executable" >&2' >> /usr/local/cuda/bin/fatbinary && \
+    echo '    exit 1' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'fi' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'args=()' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'while [ $# -gt 0 ]; do' >> /usr/local/cuda/bin/fatbinary && \
+    echo '    case "$1" in' >> /usr/local/cuda/bin/fatbinary && \
+    echo '        --image=*)' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            specs=$1' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            new_spec=$(echo "$specs" | sed "s/image=/image3=/g" | sed "s/profile=sm_/kind=elf,sm=/g")' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            args+=("${new_spec[@]}")' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            ;;' >> /usr/local/cuda/bin/fatbinary && \
+    echo '        *)' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            args+=("$1")' >> /usr/local/cuda/bin/fatbinary && \
+    echo '            ;;' >> /usr/local/cuda/bin/fatbinary && \
+    echo '    esac' >> /usr/local/cuda/bin/fatbinary && \
+    echo '    shift' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'done' >> /usr/local/cuda/bin/fatbinary && \
+    echo 'exec "$real_fatbinary" "${args[@]}"' >> /usr/local/cuda/bin/fatbinary && \
+    chmod a+x /usr/local/cuda/bin/fatbinary && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,7 +5,7 @@ a build environment
 
 To change build configuration please export appropriate env variables (for exact meaning please check the README):
 PYVER=[default 3.10, required only by Run image]
-CUDA_VERSION=[default 13.0, accepts also 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.7, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3 and 13.4]
+CUDA_VERSION=[default 13.4, accepts also 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.7, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3 and 13.4]
 NVIDIA_BUILD_ID=[default 12345]
 CREATE_WHL=[default YES]
 CREATE_RUNNER=[default NO]
@@ -49,7 +49,7 @@ then
      [ $CUDA_VER != "125" ] && [ $CUDA_VER != "126" ] && [ $CUDA_VER != "128" ] && [ $CUDA_VER != "129" ] && [ $CUDA_VER != "130" ] && \
      [ $CUDA_VER != "131" ] && [ $CUDA_VER != "132" ] && [ $CUDA_VER != "133" ] && [ $CUDA_VER != "134" ]
   then
-      echo "Wrong CUDA_VERSION=$CUDA_VERSION provided. Only 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3 and 13.4 are supported"
+      echo "Wrong CUDA_VERSION=$CUDA_VERSION provided. Only 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3 and 13.4 are supported."
       exit 1
   fi
 else

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,7 +5,7 @@ a build environment
 
 To change build configuration please export appropriate env variables (for exact meaning please check the README):
 PYVER=[default 3.10, required only by Run image]
-CUDA_VERSION=[default 13.0, accepts also 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.7, 12.8, 12.9, 13.0, 13.1, 13.2 and 13.3]
+CUDA_VERSION=[default 13.0, accepts also 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.7, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3 and 13.4]
 NVIDIA_BUILD_ID=[default 12345]
 CREATE_WHL=[default YES]
 CREATE_RUNNER=[default NO]
@@ -40,16 +40,16 @@ shift $((OPTIND - 1))
 export ARCH=${ARCH:-x86_64}
 export PYVER=${PYVER:-3.10}
 export PYV=${PYVER/./}
-export CUDA_VERSION=${CUDA_VERSION:-13.3}
+export CUDA_VERSION=${CUDA_VERSION:-13.4}
 export CUDA_VER=${CUDA_VERSION//./}
 
 if [ "${CUDA_VERSION%%\.*}" ]
 then
   if [ $CUDA_VER != "120" ] && [ $CUDA_VER != "121" ] && [ $CUDA_VER != "122" ] && [ $CUDA_VER != "123" ] && [ $CUDA_VER != "124" ] && \
      [ $CUDA_VER != "125" ] && [ $CUDA_VER != "126" ] && [ $CUDA_VER != "128" ] && [ $CUDA_VER != "129" ] && [ $CUDA_VER != "130" ] && \
-     [ $CUDA_VER != "131" ] && [ $CUDA_VER != "132" ] && [ $CUDA_VER != "133" ]
+     [ $CUDA_VER != "131" ] && [ $CUDA_VER != "132" ] && [ $CUDA_VER != "133" ] && [ $CUDA_VER != "134" ]
   then
-      echo "Wrong CUDA_VERSION=$CUDA_VERSION provided. Only 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.8, 12.9, 13.0, 13.1, 13.2 and 13.3 are supported"
+      echo "Wrong CUDA_VERSION=$CUDA_VERSION provided. Only 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3 and 13.4 are supported"
       exit 1
   fi
 else

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -37,10 +37,10 @@ Building Python Wheel
 Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If needed,
 set the following environment variables:
 
-* | CUDA_VERSION - CUDA toolkit version (12.9 and 13.3 are officially supported,
-    12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.8, 13.0, 13.1 and 13.2 are deprecated
+* | CUDA_VERSION - CUDA toolkit version (12.9 and 13.4 are officially supported,
+    12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.8, 13.0, 13.1, 13.2 and 13.3 are deprecated
     and may not work).
-  | The default is ``13.3``. Thanks to CUDA extended compatibility mode, CUDA 12.x wheels are named as
+  | The default is ``13.4``. Thanks to CUDA extended compatibility mode, CUDA 12.x wheels are named as
     CUDA 12.0 because it can work with the CUDA 12.0 R525.x driver
     family. Same applies to CUDA 13.x. Please update to the latest recommended driver version in that family.
   | If the value of the CUDA_VERSION is prefixed with `.` then any value ``.XX.Y`` can be passed,


### PR DESCRIPTION
## Category:

**Other** (Configuration)

## Description:

Add CUDA 13.4 dependency-image configurations for x86_64 and aarch64, make
CUDA 13.4 the default Docker build version, and update the compilation
documentation.

## Additional information:

### Affected modules and functionalities:

- Docker CUDA dependency images for x86_64 and aarch64
- Docker build CUDA-version selection and validation
- Compilation documentation

### Key points relevant for the review:

- Both architecture-specific Dockerfiles pin the CUDA 13.4 and cuFile package
  versions.
- The Dockerfiles have no cuda-repo.nvidia.com sources; they use only the
  public NVIDIA developer-download repository.

### Tests:

- [x] Existing tests apply
  - build process
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

## Checklist

### Documentation

- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [x] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements

- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A

**JIRA TASK**: DALI-4810
